### PR TITLE
To fix issue while setting PBS_HOME directory in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -15847,8 +15847,8 @@ if test "${with_pbs_server_home+set}" = set; then :
   withval=$with_pbs_server_home;
 fi
 
-  if test "x$with_server_home" != "x"; then :
-  PBS_SERVER_HOME=$with_server_home
+  if test "x$with_pbs_server_home" != "x"; then :
+  PBS_SERVER_HOME=$with_pbs_server_home
 else
   PBS_SERVER_HOME=/var/spool/pbs
 

--- a/m4/with_server_home.m4
+++ b/m4/with_server_home.m4
@@ -43,8 +43,8 @@ AC_DEFUN([PBS_AC_WITH_SERVER_HOME],
       [Location of the PBS spool directory. Default is /var/spool/pbs]
     )
   )
-  AS_IF([test "x$with_server_home" != "x"],
-    PBS_SERVER_HOME=[$with_server_home],
+  AS_IF([test "x$with_pbs_server_home" != "x"],
+    PBS_SERVER_HOME=[$with_pbs_server_home],
     PBS_SERVER_HOME=[/var/spool/pbs]
   )
   AC_MSG_RESULT([$PBS_SERVER_HOME])


### PR DESCRIPTION
Issue
  PP-267

Problem
    Configure script could not setup HOME directory correctly while following 1) configure, 2) make and 3) make install steps

Cause
 It will affect at the time of setting "--with-pbs-server-home=<DIR>" in configure script.

Solution
Changes required at m4/with_server_home.m4 to test correct variable set by user.
   