### PR TITLE
PP-272: To fix configure script could not setup HOME directory correctly

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -50,6 +50,10 @@ How to install PBS Pro using the configure script.
 
     ./configure --prefix=/opt/pbs
 
+	For openSUSE systems an additional argument should be passed.
+
+	./configure --prefix=/opt/pbs --libexecdir=/opt/pbs/libexec
+	(See note 4 below)
 
 6. Build PBS Pro by running "make". (See note 3 below)
 
@@ -159,3 +163,6 @@ Note 3: You need to use a POSIX (or nearly POSIX) make. GNU make
   is not guaranteed to work. Don't be surprised if the first thing
   that make does is call configure again.
 
+Note 4: Since openSUSE does not support libexec, post install scripts
+  will go to /lib. With additional argument --libexecdir to configure 
+  we are forcing to use {prefix}/libexec instead of {prefix}/lib.

--- a/INSTALL
+++ b/INSTALL
@@ -5,14 +5,14 @@ How to install PBS Pro using the configure script.
 
 1. Install the prerequisite packages for building PBS Pro.
 
-  For CentOS systems you should run the following commad as root:
+  For CentOS systems you should run the following command as root:
 
     yum install -y gcc make rpm-build libtool hwloc-devel \
       libX11-devel libXt-devel libedit-devel libical-devel \
       ncurses-devel perl postgresql-devel python-devel tcl-devel \
       tk-devel swig expat-devel openssl-devel libXext libXft
 
-  For OpenSUSE systems you should run the following command as root:
+  For openSUSE systems you should run the following command as root:
 
     zypper install gcc make rpm-build libtool hwloc-devel \
       libX11-devel libXt-devel libedit-devel libical-devel \
@@ -24,12 +24,12 @@ How to install PBS Pro using the configure script.
   to the commands below, you should also install a text editor of
   your choosing (vim, emacs, gedit, etc.).
 
-  For CentOS systems you should run the following commad as root:
+  For CentOS systems you should run the following command as root:
 
     yum install -y expat libedit postgresql-server python \
       sendmail sudo tcl tk libical
 
-  For OpenSUSE systems you should run the following command as root:
+  For openSUSE systems you should run the following command as root:
 
     zypper install expat libedit postgresql-server python \
       sendmail sudo tcl tk libical1
@@ -48,12 +48,14 @@ How to install PBS Pro using the configure script.
   parameters displayed in the previous step. (See notes 1 and 2
   below)
 
+  For CentOS systems you should run the following command:
+
     ./configure --prefix=/opt/pbs
 
-	For openSUSE systems an additional argument should be passed.
+  For openSUSE systems (see note 4 below) you should run the
+  following command:
 
-	./configure --prefix=/opt/pbs --libexecdir=/opt/pbs/libexec
-	(See note 4 below)
+    ./configure --prefix=/opt/pbs --libexecdir=/opt/pbs/libexec
 
 6. Build PBS Pro by running "make". (See note 3 below)
 
@@ -163,6 +165,8 @@ Note 3: You need to use a POSIX (or nearly POSIX) make. GNU make
   is not guaranteed to work. Don't be surprised if the first thing
   that make does is call configure again.
 
-Note 4: Since openSUSE does not support libexec, post install scripts
-  will go to /lib. With additional argument --libexecdir to configure 
-  we are forcing to use {prefix}/libexec instead of {prefix}/lib.
+Note 4: The openSUSE rpm package expands %_libexecdir to /opt/pbs/lib
+  rather than /opt/pbs/libexec which causes problems for the post-
+  install scripts. Providing the --libexecdir value to configure 
+  overrides this behavior.
+

--- a/configure
+++ b/configure
@@ -15847,8 +15847,8 @@ if test "${with_pbs_server_home+set}" = set; then :
   withval=$with_pbs_server_home;
 fi
 
-  if test "x$with_server_home" != "x"; then :
-  PBS_SERVER_HOME=$with_server_home
+  if test "x$with_pbs_server_home" != "x"; then :
+  PBS_SERVER_HOME=$with_pbs_server_home
 else
   PBS_SERVER_HOME=/var/spool/pbs
 

--- a/configure
+++ b/configure
@@ -13571,10 +13571,7 @@ for ac_header in  \
 	ctype.h \
 	dirent.h \
 	dlfcn.h \
-	errno.h \
-	error.h \
 	execinfo.h \
-	expat.h \
 	fcntl.h \
 	features.h \
 	float.h \

--- a/configure
+++ b/configure
@@ -13545,6 +13545,7 @@ for ac_header in  \
 	libpq-fe.h \
 	mach/mach.h \
 	nlist.h \
+	sys/eventfd.h \
 	sys/systeminfo.h \
 
 do :
@@ -13609,7 +13610,6 @@ for ac_header in  \
 	syscall.h \
 	syslog.h \
 	sys/epoll.h \
-	sys/eventfd.h \
 	sys/fcntl.h \
 	sys/file.h \
 	sys/ioctl.h \

--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,7 @@ AC_CHECK_HEADERS([ \
 	libpq-fe.h \
 	mach/mach.h \
 	nlist.h \
+	sys/eventfd.h \
 	sys/systeminfo.h \
 ])
 
@@ -150,7 +151,6 @@ AC_CHECK_HEADERS([ \
 	syscall.h \
 	syslog.h \
 	sys/epoll.h \
-	sys/eventfd.h \
 	sys/fcntl.h \
 	sys/file.h \
 	sys/ioctl.h \

--- a/configure.ac
+++ b/configure.ac
@@ -113,7 +113,6 @@ AC_CHECK_HEADERS([ \
 	dirent.h \
 	dlfcn.h \
 	execinfo.h \
-	expat.h \
 	fcntl.h \
 	features.h \
 	float.h \

--- a/m4/with_server_home.m4
+++ b/m4/with_server_home.m4
@@ -43,8 +43,8 @@ AC_DEFUN([PBS_AC_WITH_SERVER_HOME],
       [Location of the PBS spool directory. Default is /var/spool/pbs]
     )
   )
-  AS_IF([test "x$with_server_home" != "x"],
-    PBS_SERVER_HOME=[$with_server_home],
+  AS_IF([test "x$with_pbs_server_home" != "x"],
+    PBS_SERVER_HOME=[$with_pbs_server_home],
     PBS_SERVER_HOME=[/var/spool/pbs]
   )
   AC_MSG_RESULT([$PBS_SERVER_HOME])

--- a/src/include/pbs_config.h.in
+++ b/src/include/pbs_config.h.in
@@ -71,14 +71,8 @@
 /* Define to 1 if you have the `endpwent' function. */
 #undef HAVE_ENDPWENT
 
-/* Define to 1 if you have the <error.h> header file. */
-#undef HAVE_ERROR_H
-
 /* Define to 1 if you have the <execinfo.h> header file. */
 #undef HAVE_EXECINFO_H
-
-/* Define to 1 if you have the <expat.h> header file. */
-#undef HAVE_EXPAT_H
 
 /* Define to 1 if you have the <fcntl.h> header file. */
 #undef HAVE_FCNTL_H

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -5022,7 +5022,7 @@ is_vnode_prov_done(char * vnode)
 	remove_prov_record(pnode->nd_name);
 	prov_track_save(); /* save tracking table since its modified now */
 
-	free(prov_vnode_info);
+	free_pvnfo(prov_vnode_info);
 
 	/*
 	 * since one provisioning was finished, we have space
@@ -5965,15 +5965,14 @@ check_and_enqueue_provisioning(job *pjob, int *need_prov)
 		 */
 		if ((prov_vnode_info->pvnfo_vnode = strdup(prov_vnode_list[i])) == NULL) {
 			free(prov_vnode_list);
-			free(prov_vnode_info);
+			free_pvnfo(prov_vnode_info);
 			if (aoe_req)
 				free(aoe_req);
 			return PBSE_SYSTEM;
 		}
 		if ((prov_vnode_info->pvnfo_aoe_req = strdup(aoe_req)) == NULL) {
-			free(prov_vnode_info->pvnfo_vnode);
 			free(prov_vnode_list);
-			free(prov_vnode_info);
+			free_pvnfo(prov_vnode_info);
 			if (aoe_req)
 				free(aoe_req);
 			return PBSE_SYSTEM;


### PR DESCRIPTION
Issue
PP-272
Problem
Configure script could not setup HOME directory correctly while following 1) configure, 2) make and 3) make install steps
Cause
It will affect at the time of setting "--with-pbs-server-home=dir" in configure script.
Solution
Changes required at m4/with_server_home.m4 to test correct variable set by user.