### PR TITLE
PP-277: Multinode jobs may fail to start

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -50,8 +50,10 @@ Name: %{pbs_name}
 Version: %{pbs_version}
 Release: %{pbs_release}
 Source0: %{pbs_dist}
+%if 0%{?opensuse_bs}
 %if %{defined suse_version}
 Source1: %{name}-rpmlintrc
+%endif
 %endif
 Summary: PBS Professional
 License: AGPLv3 with exceptions
@@ -194,7 +196,9 @@ HPC clusters, clouds and supercomputers.
 This package is intended for a client host and provides
 the PBS Professional user commands.
 
-%if 0%{!?opensuse_bs}
+%if 0%{?opensuse_bs}
+# Do not specify debug_package for OBS builds.
+%else
 %if %{defined suse_version}
 %debug_package
 %endif

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -221,6 +221,7 @@ struct pbs_config
 	char *pbs_comm_routers;		/* for this router, the optional list of other routers to talk to */
 	long  pbs_comm_log_events;      /* log_events for pbs_comm process, default 0 */
 	unsigned int pbs_comm_threads;	/* number of threads for router, default 4 */
+	char *pbs_mom_node_name;	/* mom short name used for natural node, default NULL */
 #ifdef WIN32
 	char *pbs_conf_remote_viewer; /* Remote viewer client executable for PBS GUI jobs, alongwith launch options */
 #endif
@@ -282,6 +283,7 @@ extern struct pbs_config pbs_conf;
 #define	PBS_CONF_LICENSE_STRING	"PBS_LICENSE_FILE_LOCATION"	/* LM-X recovery hook */
 #define PBS_CONF_AUTH           "PBS_AUTH_METHOD"
 #define PBS_CONF_SCHEDULER_MODIFY_EVENT	"PBS_SCHEDULER_MODIFY_EVENT"
+#define PBS_CONF_MOM_NODE_NAME	"PBS_MOM_NODE_NAME"
 #ifdef WIN32
 #define PBS_CONF_REMOTE_VIEWER "PBS_REMOTE_VIEWER"	/* Executable for remote viewer application alongwith its launch options, for PBS GUI jobs */
 #endif

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -118,8 +118,9 @@ struct pbs_config pbs_conf = {
 	NULL,					/* for router, default communication routers list */
 	0,					/* default comm logevent mask */
 	4,					/* default number of threads */
+	NULL					/* mom short name override */
 #ifdef WIN32
-	NULL					/* remote viewer launcher executable alongwith launch options */
+	,NULL					/* remote viewer launcher executable alongwith launch options */
 #endif
 };
 
@@ -556,6 +557,10 @@ pbs_loadconf(int reload)
 				if (sscanf(conf_value, "%u", &uvalue) == 1)
 					pbs_conf.sched_modify_event = ((uvalue > 0) ? 1 : 0);
 			}
+			else if (!strcmp(conf_name, PBS_CONF_MOM_NODE_NAME)) {
+				free(pbs_conf.pbs_mom_node_name);
+				pbs_conf.pbs_mom_node_name = strdup(conf_value);
+			}
 #ifdef WIN32
 			else if (!strcmp(conf_name, PBS_CONF_REMOTE_VIEWER)) {
 				free(pbs_conf.pbs_conf_remote_viewer);
@@ -751,24 +756,30 @@ pbs_loadconf(int reload)
 				((uvalue <= 65535) ? uvalue : pbs_conf.pbs_data_service_port);
 	}
 	if ((gvalue = getenv(PBS_CONF_SERVER_HOST_NAME)) != NULL) {
-			free(pbs_conf.pbs_server_host_name);
-			pbs_conf.pbs_server_host_name = strdup(gvalue);
+		free(pbs_conf.pbs_server_host_name);
+		pbs_conf.pbs_server_host_name = strdup(gvalue);
 	}
 	if ((gvalue = getenv(PBS_CONF_PUBLIC_HOST_NAME)) != NULL) {
-			free(pbs_conf.pbs_public_host_name);
-			pbs_conf.pbs_public_host_name = strdup(gvalue);
+		free(pbs_conf.pbs_public_host_name);
+		pbs_conf.pbs_public_host_name = strdup(gvalue);
 	}
 	if ((gvalue = getenv(PBS_CONF_MAIL_HOST_NAME)) != NULL) {
-			free(pbs_conf.pbs_mail_host_name);
-			pbs_conf.pbs_mail_host_name = strdup(gvalue);
+		free(pbs_conf.pbs_mail_host_name);
+		pbs_conf.pbs_mail_host_name = strdup(gvalue);
 	}
 	if ((gvalue = getenv(PBS_CONF_SMTP_SERVER_NAME)) != NULL) {
-			free(pbs_conf.pbs_smtp_server_name);
-			pbs_conf.pbs_smtp_server_name = strdup(gvalue);
+		free(pbs_conf.pbs_smtp_server_name);
+		pbs_conf.pbs_smtp_server_name = strdup(gvalue);
 	}
 	if ((gvalue = getenv(PBS_CONF_OUTPUT_HOST_NAME)) != NULL) {
-			free(pbs_conf.pbs_output_host_name);
-			pbs_conf.pbs_output_host_name = strdup(gvalue);
+		free(pbs_conf.pbs_output_host_name);
+		pbs_conf.pbs_output_host_name = strdup(gvalue);
+	}
+
+	/* support PBS_MOM_NODE_NAME to tell MOM natural node name on server */
+	if ((gvalue = getenv(PBS_CONF_MOM_NODE_NAME)) != NULL) {
+		free(pbs_conf.pbs_mom_node_name);
+		pbs_conf.pbs_mom_node_name = strdup(gvalue);
 	}
 
 	/* rcp_path is inferred from pbs_conf.pbs_exec_path - see below */
@@ -826,6 +837,10 @@ pbs_loadconf(int reload)
 	else if ((pbs_conf.pbs_output_host_name != NULL) &&
 			(strchr(pbs_conf.pbs_output_host_name, ':') != NULL))
 		strcpy(buf, PBS_CONF_OUTPUT_HOST_NAME);
+	else if ((pbs_conf.pbs_mom_node_name != NULL) &&
+			(strchr(pbs_conf.pbs_mom_node_name, ':') != NULL))
+		strcpy(buf, PBS_CONF_MOM_NODE_NAME);
+
 	if (buf[0] != '\0') {
 		fprintf(stderr, "pbsconf error: illegal value for: %s\n", buf);
 		goto err;

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -4289,6 +4289,9 @@ job_nodes_inner(struct job *pjob, hnodent **mynp)
 
 					if (strcmp(hp->hn_host, mom_host) == 0) {
 						hostmatch = 1;
+					} else if (pbs_conf.pbs_mom_node_name &&
+							(strcmp(hp->hn_host, pbs_conf.pbs_mom_node_name) == 0)) {
+						hostmatch = 1;
 					} else {
 						char namebuf[PBS_MAXHOSTNAME + 1];
 


### PR DESCRIPTION
#### Issue
* PP-277

#### Problem
* A sister mom fails to find itself in the node list on multihomed systems.

#### Cause
* The node list created by the server referenced an alternate node name.

#### Solution
* Added PBS_MOM_NODE_NAME as a way of forcing mom to use the name we want.


