### PR TITLE
PP-260: Fix a memory leak in svr_func.c

### DIFF
--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -5022,7 +5022,7 @@ is_vnode_prov_done(char * vnode)
 	remove_prov_record(pnode->nd_name);
 	prov_track_save(); /* save tracking table since its modified now */
 
-	free(prov_vnode_info);
+	free_pvnfo(prov_vnode_info);
 
 	/*
 	 * since one provisioning was finished, we have space
@@ -5965,14 +5965,14 @@ check_and_enqueue_provisioning(job *pjob, int *need_prov)
 		 */
 		if ((prov_vnode_info->pvnfo_vnode = strdup(prov_vnode_list[i])) == NULL) {
 			free(prov_vnode_list);
-			free(prov_vnode_info);
+			free_pvnfo(prov_vnode_info);
 			if (aoe_req)
 				free(aoe_req);
 			return PBSE_SYSTEM;
 		}
 		if ((prov_vnode_info->pvnfo_aoe_req = strdup(aoe_req)) == NULL) {
-			free(prov_vnode_info->pvnfo_vnode);
 			free(prov_vnode_list);
+			free_pvnfo(prov_vnode_info);
 			free(prov_vnode_info);
 			if (aoe_req)
 				free(aoe_req);


### PR DESCRIPTION
#### Issue
* PP-260

#### Problem
* There was a memory leak when freeing provision vnode data.

#### Cause
* The structure itself was being freed, but the vnode data it pointed to was not.

#### Solution
* Call free_pvnfo() to free the structure and its components.


