### PR TITLE
PP-249: merging pbs.conf and pbs.conf.version

### DIFF
--- a/src/cmds/scripts/pbs_postinstall.in
+++ b/src/cmds/scripts/pbs_postinstall.in
@@ -245,6 +245,15 @@ script)
 		echo "***"
 		exit 1
 	fi
+	# if both conf files are present merge the files but precedence should be given to newconf
+        if [ -f "$newconf" -a -f "$conf" ]; then
+                while IFS='=' read -r key value
+                do
+                    if [ -z `grep -q "$key" "$newconf" && echo $?` ]; then
+                        echo "$key=$value" >> "$newconf"
+                    fi
+                done < "$conf"
+        fi
 	# The INSTALL script may have already created newconf. If it
 	# did, leave it alone. If not, and an existing configuration
 	# file is present, adapt it by substituting the new value


### PR DESCRIPTION
#### Issue
* PP-249

#### Problem
* The port info is missing in the new conf file created by post install script, if an existing conf file contains port info and install script is generating pbs.conf.version without port info.

#### Cause
* The post install script is not considering parameters which are present in pbs.conf but not in pbs.conf.version

#### Solution
* post install script should merge both conf files by giving precedence to pbs.conf.version


