### PR TITLE
PP-279 Setting 'o.Execution_Time = None ' fails

### DIFF
--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -6950,41 +6950,43 @@ pbsv1mod_meth_is_attrib_val_settable(PyObject *self, PyObject *args, PyObject *k
 
 	/* parse floats nicely since time.time() returns floats */
 
-		if ((py_value != Py_None) && (PyFloat_Check(py_value))) {
-			double	ftime;
-			ret = PyArg_Parse(py_value, "d", &ftime);
-			if (ret != 0)
-				exec_time = (long)ftime;
-		} else {
-			ret = PyArg_Parse(py_value, "l", &exec_time);
-		}
+                if (py_value != Py_None) {
+                        if (PyFloat_Check(py_value)) {
+                                double  ftime;
+                                ret = PyArg_Parse(py_value, "d", &ftime);
+                                if (ret != 0)
+                                        exec_time = (long)ftime;
+                        }else {
+                        ret = PyArg_Parse(py_value, "l", &exec_time);
+                        }
 
 	/* if the parse worked but the time is in the past */
-	if (ret == 0) {
-	   snprintf(log_buffer, LOG_BUF_SIZE-1,
-       	     	   "exec_time could not be parsed");
-	   log_buffer[LOG_BUF_SIZE-1] = '\0';
-           PyErr_SetString(
-		pbs_python_types_table[PP_BADATTR_VALUE_ERR_IDX].t_class,
-						log_buffer);
-	   rc = 1;
-	   goto IAVS_ERROR_EXIT;
-	} else if (exec_time < time(0)) {
-			char    *str_time = NULL;
+                        if (ret == 0) {
+                snprintf(log_buffer, LOG_BUF_SIZE-1,
+                   "exec_time could not be parsed");
+                log_buffer[LOG_BUF_SIZE-1] = '\0';
+                PyErr_SetString(
+                        pbs_python_types_table[PP_BADATTR_VALUE_ERR_IDX].t_class,
+                                                log_buffer);
+                rc = 1;
+                goto IAVS_ERROR_EXIT;
+                } else if (exec_time < time(0)) {
+                        char    *str_time = NULL;
 
-			str_time = ctime(&exec_time);
-			if (str_time != NULL)
-				str_time[strlen(str_time)-1] = '\0';
+                        str_time = ctime(&exec_time);
+                        if (str_time != NULL)
+                                str_time[strlen(str_time)-1] = '\0';
 
-			snprintf(log_buffer, LOG_BUF_SIZE-1,
-				"exec_time '%s' not in the future", (str_time?str_time:""));
-			log_buffer[LOG_BUF_SIZE-1] = '\0';
-			PyErr_SetString(\
-		pbs_python_types_table[PP_BADATTR_VALUE_ERR_IDX].t_class,
-				log_buffer);
-			rc = 1;
-			goto IAVS_ERROR_EXIT;
-		}
+                        snprintf(log_buffer, LOG_BUF_SIZE-1,
+                                "exec_time '%s' not in the future", (str_time?str_time:""));
+                        log_buffer[LOG_BUF_SIZE-1] = '\0';
+                        PyErr_SetString(\
+                pbs_python_types_table[PP_BADATTR_VALUE_ERR_IDX].t_class,
+                                log_buffer);
+                        rc = 1;
+                        goto IAVS_ERROR_EXIT;
+                }
+        }	
 	} else if (strcmp(name, ATTR_runcount) == 0) {
 		long	runcount;
 

--- a/test/tests/pbs_unset_exectime.py
+++ b/test/tests/pbs_unset_exectime.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and distribute
+# them - whether embedded or bundled with other software - under a commercial
+# license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from ptl.utils.pbs_testsuite import *
+
+class Testunset_exectime(PBSTestSuite):
+    """
+    Test that unsetting execution time through hooks does not throw parse error
+    """
+    def test_unset_exectime(self):
+        """
+        Create a hook to unset execution time and check after submitting a job no error messages are logged
+        """
+        hook_name = "exechook"
+        hook_body = """
+import pbs
+e = pbs.event()
+if (e.type is pbs.QUEUEJOB):
+	o = e.job
+    	o.Execution_Time = None
+else:
+	e.reject("unmatched event type!")
+"""
+        a = {'event': 'queuejob', 'enabled': 'True'}
+        self.server.create_import_hook(hook_name, a, hook_body)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047},
+                            expect=True)
+        j = Job(TEST_USER)
+        self.server.submit(j)
+        rv = self.server.log_match("Error evaluating Python script, exec_time could not be parsed",max_attempts=5)
+        self.assertFalse(rv)
+	


### PR DESCRIPTION
#### Issue
* PP-279

#### Problem
* Setting 'o.Execution_Time = None ' fails with error "Error evaluating Python script, exec_time could not be parsed"

#### Cause
* When Execution_Time was setting to None the if condition failed and it was going to else condition where it was parsed as long and it failed

#### Solution
* Separated the if condition , so that flow wont go to else condition where it will be wrongly parsed as long


