### PR TITLE
Fix for postgresql database paths in pbs_server initialization scripts

### DIFF
--- a/src/cmds/scripts/install_db
+++ b/src/cmds/scripts/install_db
@@ -127,7 +127,7 @@ if [ -z "${PBS_DATA_SERVICE_PORT}" ]; then
 fi
 export PBS_DATA_SERVICE_PORT
 
-bin_dir="${PBS_EXEC}/pgsql/bin"
+bin_dir="${PGSQL_BIN}"
 data_dir="${PBS_HOME}/datastore"
 server_ctl="${PBS_EXEC}/sbin/pbs_dataservice"
 tmp_file="${PBS_HOME}/spool/tmp_inst_$$"

--- a/src/cmds/scripts/pbs_pgsql_env.sh
+++ b/src/cmds/scripts/pbs_pgsql_env.sh
@@ -89,7 +89,12 @@ else
 		echo "\*\*\* psql command is not in PATH"
 		exit 1
 	fi
-	PGSQL_BIN=`dirname $PGSQL_CMD`
+	PGSQL_CONF=`type pg_config 2>/dev/null | cut -d' ' -f3`
+	if [ -z "$PGSQL_CONF" ]; then
+		PGSQL_BIN=`dirname ${PGSQL_CMD}`
+	else
+		PGSQL_BIN=`${PGSQL_CONF} | awk '/BINDIR/{ print $3 }'`
+	fi
 	PGSQL_DIR=`dirname $PGSQL_BIN`
 	[ "$PGSQL_DIR" = "/" ] && PGSQL_DIR=""
 fi


### PR DESCRIPTION
#### Issue
* PP-291

#### Problem
* Path detection from in-path binary parent directory method doesn't work for systems with deep package paths

#### Cause
* `install_db` contains a remainder path from the integrated postgresql installation
* Debian installs postgresql into `/usr/lib/postgresql/VERSION`

#### Solution
* Replaced leftover path in `install_db` by the path detected in `pbs_pgsql_env.sh`
* Replaced path detected by a call/parse of `pg_config` for systems where present


