### PR TITLE
PP-149: Fix scheduler performance while preempting jobs

### DIFF
--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -82,6 +82,13 @@ enum skip
 	SKIP_NON_NORMAL_JOBS
 };
 
+/* return value of select_index_to_preempt function */
+enum select_job_status
+{
+	NO_JOB_FOUND = -1,	/* fails to find a job to preempt */
+	ERR_IN_SELECT = -2	/* error while selecting a job to preempt */
+};
+
 #define INIT_ARR_SIZE 2048
 
 /* Unspecified resource value */

--- a/src/scheduler/job_info.h
+++ b/src/scheduler/job_info.h
@@ -156,9 +156,9 @@ find_jobs_to_preempt(status *policy, resource_resv *jinfo,
  *      select_job_to_preempt - select the best candidite out of the running
  *                              jobs to preempt
  */
-resource_resv *
-select_job_to_preempt(status *policy, resource_resv *hjob,
-	resource_resv **rjobs, int rc,
+long
+select_index_to_preempt(status *policy, resource_resv *hjob,
+	resource_resv **rjobs, long skipto, schd_error *err,
 	int *fail_list);
 
 /*


### PR DESCRIPTION
#### Issue
PP-149

#### Problem
Preemption is very slow when the high priority job is frequently hitting the hard/soft limits

#### Cause
The way we select the job for preemption takes a lot of time. If we already know the high priority job is going to hit the hard limit then while selecting the pre-emptable job we can select the right job that consumes the exact same resource because of which limits are being hit and also make sure they are from the same entity as that of high priority job.

#### Solution
Changed the way we select the jobs to be preempted. If the high priority job can not run because it is over the limits then we try to select only those jobs which are from the same entity and has the same resource present in it.
With this change I've also added additional code to tackle similar situations when high priority job is not able to run because of insufficient amount of resources.



