### PR TITLE
PP-269: spec file must specify libexecdir on SUSE systems (master)

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -214,6 +214,9 @@ cd build
 ../configure \
 	PBS_VERSION=%{version} \
 	--prefix=%{pbs_prefix} \
+%if %{defined suse_version}
+	--libexecdir=%{pbs_prefix}/libexec \
+%endif
 %if %{with alps}
 	--enable-alps \
 %endif


### PR DESCRIPTION
#### Issue
* PP-269

#### Problem
* Must provide libexecdir to configure for SUSE

#### Cause
* SUSE uses <prefix>/lib rather than <prefix>/libexec for libexecdir

#### Solution
* Specify libexecdir when calling configure on SUSE

This fix has already been applied to release_14_1_branch, but is also needed in master.


