### PR TITLE
PP269: spec file must specify libexecdir on SUSE systems

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -214,6 +214,9 @@ cd build
 ../configure \
 	PBS_VERSION=%{version} \
 	--prefix=%{pbs_prefix} \
+%if %{defined suse_version}
+	--libexecdir=%{pbs_prefix}/libexec \
+%endif
 %if %{with alps}
 	--enable-alps \
 %endif


### PR DESCRIPTION

#### Issue-ID
* PP-269

#### Problem description
* openSUSE uses wrong libexecdir

#### Cause / Analysis
* openSUSE defines libexecdir differently that other distros

#### Solution description
* Override the value of libexecdir for openSUSE
