### PR TITLE
PP-307: spec file must specify libexecdir on SUSE systems

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -214,6 +214,9 @@ cd build
 ../configure \
 	PBS_VERSION=%{version} \
 	--prefix=%{pbs_prefix} \
+%if %{defined suse_version}
+	--libexecdir=%{pbs_prefix}/libexec \
+%endif
 %if %{with alps}
 	--enable-alps \
 %endif


### PR DESCRIPTION
#### Issue-ID
* PP-307

#### Problem description
* spec file must specify libexecdir on SUSE systems

#### Cause / Analysis
* The default libexec directory for SUSE does not match other distros

#### Solution description
* Specify the location of libexecdir when calling configure under SUSE

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [ ] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [x] I have attached automated (PTL)/manual test logs to the associated Jira ticket.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

