### PR TITLE
PP-314: Wrong variable used in fix for PP-277

### DIFF
--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -4289,25 +4289,57 @@ job_nodes_inner(struct job *pjob, hnodent **mynp)
 
 				if (hp->hn_port == pbs_rm_port) {
 					int hostmatch = 0;
+					static char node_name[PBS_MAXHOSTNAME + 1] = { '\0' };
+					static char canonical_name[PBS_MAXHOSTNAME + 1] = { '\0' };
 
-					if (strcmp(hp->hn_host, mom_host) == 0) {
-						hostmatch = 1;
-					} else if (pbs_conf.pbs_mom_node_name &&
-							(strcmp(hp->hn_host, pbs_conf.pbs_mom_node_name) == 0)) {
+					/*
+					 * The following block prevents us from having to employ
+					 * yet another global variable to represent the hostname
+					 * of the local node.
+					 */
+					if ((pbs_conf.pbs_use_tcp == 1) && pbs_conf.pbs_leaf_name) {
+						if (strcmp(pbs_conf.pbs_leaf_name, node_name) != 0) {
+							/* PBS_LEAF_NAME has changed or node_name is unitialized */
+							strncpy(node_name, pbs_conf.pbs_leaf_name, PBS_MAXHOSTNAME);
+							node_name[PBS_MAXHOSTNAME] = '\0';
+							/* Need to canonicalize PBS_LEAF_NAME */
+							if (get_fullhostname(node_name, canonical_name,
+									(sizeof(canonical_name) - 1)) != 0) {
+								sprintf(log_buffer,
+									"Failed to get fullhostname from %s for job %s",
+									node_name, pjob->ji_qs.ji_jobid);
+								log_err(errno, __func__, log_buffer);
+								node_name[0] = '\0';
+								canonical_name[0] = '\0';
+								return (PBSE_SYSTEM);
+							}
+						}
+					} else {
+						if (strcmp(mom_host, node_name) != 0) {
+							/* mom_host has changed or node_name is unitialized */
+							strncpy(node_name, mom_host, PBS_MAXHOSTNAME);
+							node_name[PBS_MAXHOSTNAME] = '\0';
+							/* mom_host contains the canonical name */
+							strncpy(canonical_name, mom_host, PBS_MAXHOSTNAME);
+							canonical_name[PBS_MAXHOSTNAME] = '\0';
+						}
+					}
+
+					if (strcmp(hp->hn_host, node_name) == 0) {
 						hostmatch = 1;
 					} else {
 						char namebuf[PBS_MAXHOSTNAME + 1];
 
-						if ((rc = get_fullhostname(hp->hn_host, namebuf,
-								(sizeof(namebuf) - 1))) == 0) {
-							if (strcmp(namebuf, mom_host) == 0)
-								hostmatch = 1;
-						} else {
+						if (get_fullhostname(hp->hn_host, namebuf,
+								(sizeof(namebuf) - 1)) != 0) {
 							sprintf(log_buffer,
 								"Failed to get fullhostname from %s for job %s",
 								hp->hn_host, pjob->ji_qs.ji_jobid);
 							log_err(errno, __func__, log_buffer);
+							return (PBSE_SYSTEM);
 						}
+						if (strcmp(namebuf, canonical_name) == 0)
+							hostmatch = 1;
 					}
 
 					if (hostmatch) {


### PR DESCRIPTION
Use the correct variable when comparing vnode list against local node name

#### Issue-ID
<!--- Enter your JIRA issue id below -->
<!--- If a JIRA issue is not available, please first create one at pbspro.atlassian.net -->
* PP-314

#### Problem description
* The fix for PP-277 was comparing the node names in the job node list against the wrong value.

#### Cause / Analysis
* The root cause was a misunderstanding between the original contributor of the fix and myself. The changes provided for PP-277 were verified to fix the problem, but were incorrect nonetheless. After extensive discussion and review by the original author, it has been agreed that these changes now address the original issue as intended.

#### Solution description
* PP-277 describes a problem where sisters in a multinode job fail to initialize properly because they are unable to find their node identifier in the job's node list. This problem occurs in complex network configurations involving moms with multiple NICs, hostnames, and addresses. The solution is for pbs_mom to check the name against PBS_LEAF_NAME when defined, otherwise use the existing check against mom_host. Because the environment required to test this fix is complex, manual instructions have been added to the comments in PP-277.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [X] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [X] I have attached automated (PTL)/manual test logs to the associated Jira ticket.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

