### PR TITLE
PP-301 :Scheduler does not import python math module

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -207,7 +207,7 @@ schedinit(int argc, char *argv[])
 	snprintf(buf, sizeof(buf), "%s/python/lib/python2.7", pbs_conf.pbs_exec_path);
 	PyList_Append(path, PyString_FromString(buf));
 
-	snprintf(buf, sizeof(buf), ":%s/python/lib/python2.7/lib-dynload", pbs_conf.pbs_exec_path);
+	snprintf(buf, sizeof(buf), "%s/python/lib/python2.7/lib-dynload", pbs_conf.pbs_exec_path);
 	PyList_Append(path, PyString_FromString(buf));
 
 	PySys_SetObject("path", path);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Enter your JIRA issue id below -->
<!--- If a JIRA issue is not available, please first create one at pbspro.atlassian.net -->
* PP-301

#### Problem description
Scheduler does not import python math module

#### Cause / Analysis
An extra colon before the import of math module 

#### Solution description
*Removing the extra colon imports the math module correctly

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [x] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [x] I have attached automated (PTL)/manual test logs to the associated Jira ticket.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

Scheduler does not import python math module