### PR TITLE
PP-309: fix for strict_ordering not working

### DIFF
--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -575,6 +575,8 @@ query_server_info(status *pol, struct batch_status *server)
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp == '\0')
 				sinfo->policy->backfill_depth = count;
+			if (count == 0)
+				sinfo->policy->backfill = 0;
 		}
 
 		attrp = attrp->next;

--- a/test/tests/pbs_strict_ordering.py
+++ b/test/tests/pbs_strict_ordering.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and distribute
+# them - whether embedded or bundled with other software - under a commercial
+# license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+import os
+import string
+import time
+
+from ptl.utils.pbs_testsuite import *
+
+
+class Test_strict_ordering_without_backfill(PBSTestSuite):
+
+    """
+    Test strict ordering when backfilling is truned off
+    """
+    @timeout(1800)
+    def test_t1(self):
+
+        a = {'resources_available.ncpus': 4}
+        self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
+
+        rv = self.scheduler.set_sched_config(
+            {'round_robin': 'false all', 'by_queue': 'false prime', 
+	     'by_queue': 'false non_prime', 'strict_ordering': 'true all', 
+	     'help_starving_jobs': 'false all'})
+        self.assertTrue(rv)
+
+        a = {'backfill_depth': 0}
+        rv = self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.assertTrue(rv)
+
+        j1 = Job(TEST_USER)
+        a = {'Resource_List.select': '1:ncpus=2',
+             'Resource_List.walltime': 9999}
+        j1.set_sleep_time(9999)
+        j1.set_attributes(a)
+        j1 = self.server.submit(j1)
+
+        j2 = Job(TEST_USER)
+        a = {'Resource_List.select': '1:ncpus=3',
+             'Resource_List.walltime': 9999}
+        j2.set_sleep_time(9999)
+        j2.set_attributes(a)
+        j2 = self.server.submit(j2)
+
+        j3 = Job(TEST_USER)
+        a = {'Resource_List.select': '1:ncpus=2',
+             'Resource_List.walltime': 9999}
+        j3.set_sleep_time(9999)
+        j3.set_attributes(a)
+        j3 = self.server.submit(j3)
+	try:
+	    rv = self.server.expect(JOB, {'comment': 'Not Running: Job would break strict sorted order'}, id=j3,
+                           offset=2, max_attempts=2, interval=2)
+	except PtlExpectError, e:
+	    self.assertTrue(False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Enter your JIRA issue id below -->
<!--- If a JIRA issue is not available, please first create one at pbspro.atlassian.net -->
PP-309

#### Problem description
Problem with strict_ordering, jobs running when they shouldn't have

#### Cause / Analysis
Problem is that we deprecated "backfill"option from sched_config and used it as true by default. Now even when we set backfill_depth to 0 it is still considered as backfill true and never stops running jobs because of strict ordering.


#### Solution description
consider backfilling as false when backfill_depth is set to 0


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [x] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [x] I have attached automated (PTL)/manual test logs to the associated Jira ticket.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

