### PR TITLE
PP-343: Fix PBS Build error on Windows

### DIFF
--- a/win_configure/pbs_windows_VS2008.sln
+++ b/win_configure/pbs_windows_VS2008.sln
@@ -366,6 +366,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Libpbsaif", "projects.VS200
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Libutil", "projects.VS2008\Libutil.vcproj", "{625346DC-194A-4E7D-92C4-8F9E10B0BB2A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{0B889879-456F-4F8E-A15E-3C0A7BBF3B25} = {0B889879-456F-4F8E-A15E-3C0A7BBF3B25}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Libpbspython", "projects.VS2008\Libpbspython.vcproj", "{2F37584C-B957-4949-A2EB-A11471AE5FDE}"
 EndProject

--- a/win_configure/projects.VS2008/gen_pbs_version.bat
+++ b/win_configure/projects.VS2008/gen_pbs_version.bat
@@ -1,0 +1,38 @@
+@echo off
+REM this genereates the pbs_version.h file.
+
+
+REM exit if pbs_version.h exists
+if exist "..\..\src\include\pbs_version.h" (
+goto :eof
+)
+
+if exist "..\..\src\include\pbs_version.h.in" ( 
+
+copy "..\..\src\include\pbs_version.h.in" "..\..\src\include\pbs_version.h" 
+
+)
+
+REM find pbs_version from pbspro.spec
+set pbs_specfile= ..\..\pbspro.spec
+for /F "tokens=3 USEBACKQ" %%F IN (`findstr /l /c:" pbs_version " %pbs_specfile%`) DO (
+set var=%%F
+set pbs_ver=PBSPro_%var%
+)
+REM replace PBS_VERSION placeholder value(PBSPro_10.0) 
+REM defined in pbs_version_win.h with pbs_ver
+set oldfile="..\include\pbs_version_win.h"
+set searchstr=PBSPro_10.0
+set repstr=PBSPro_%var%
+if exist "..\include\temp_pbs_version_win.h" (
+del /f /q "..\include\temp_pbs_version_win.h"
+)
+for /f "tokens=1,* delims=]" %%A in ('"type %oldfile%|find /n /v """') do (
+    set "line=%%B"
+    if defined line (
+        call set "line=echo.%%line:%searchstr%=%repstr%%%"
+        for /f "delims=" %%X in ('"echo."%%line%%""') do %%~X >> ..\include\temp_pbs_version_win.h"
+    ) ELSE echo.
+)
+copy "..\include\temp_pbs_version_win.h" "..\include\pbs_version_win.h"
+del /f /q "..\include\temp_pbs_version_win.h"

--- a/win_configure/projects.VS2008/include.vcproj
+++ b/win_configure/projects.VS2008/include.vcproj
@@ -26,6 +26,7 @@
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
+				CommandLine="&quot;$(ProjectDir)gen_pbs_version.bat&quot;"
 			/>
 			<Tool
 				Name="VCCustomBuildTool"
@@ -50,6 +51,7 @@
 			>
 			<Tool
 				Name="VCPreBuildEventTool"
+				CommandLine="&quot;$(ProjectDir)gen_pbs_version.bat&quot;"
 			/>
 			<Tool
 				Name="VCCustomBuildTool"


### PR DESCRIPTION
**Issue-ID**
PP-343

**Problem description**
Fix PBS Build error on Windows

**Cause / Analysis**
pbs_version.h was unavailable.

**Solution description**
Generate pbs_version.h from pbs_version.h.in using VS pre-build event.

Build logs are attached to Jira to indicate the successful build.
**Checklist:**
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [x] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [x] I have attached automated (PTL)/manual test logs to the associated Jira ticket.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

