### PR TITLE
PP-148: fix for pbs_tclsh dumps core

### DIFF
--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -130,6 +130,8 @@ pbs_tclsh_LDADD = \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
+	$(top_builddir)/src/lib/Libtpp/libtpp.a \
+	$(top_builddir)/src/lib/Libutil/libutil.a \
 	-lpthread \
 	@socket_lib@ \
 	@tcl_lib@

--- a/src/unsupported/pbs_rmget.c
+++ b/src/unsupported/pbs_rmget.c
@@ -47,6 +47,9 @@
 #include "log.h"
 
 
+#define SHOW_NONE 0xff
+int log_mask;
+
 void
 log_rppfail(char *mess)
 {
@@ -56,7 +59,7 @@ log_rppfail(char *mess)
 static void
 log_tppmsg(int level, const char *objname, char *mess)
 {
-	if (level <= LOG_ERR)
+	if ((level | log_mask) <= LOG_ERR)
 		fprintf(stderr, "rpp error: %s\n", mess);
 }
 
@@ -123,6 +126,11 @@ main(int argc, char *argv[])
 			nodename = my_hostname;
 		}
 
+		/* We don't want to show logs related to connecting pbs_comm on console
+		 * this set this flag to ignore it
+		 */
+		log_mask = SHOW_NONE;
+
 		/* set tpp function pointers */
 		set_tpp_funcs(log_tppmsg);
 
@@ -161,6 +169,8 @@ main(int argc, char *argv[])
 
 		rpp_poll(); /* to clear off the read notification */
 
+		/* Once the connection is established we can unset log_mask */
+		log_mask &= ~SHOW_NONE;
 	} else {
 		/* set rpp function pointers */
 		set_rpp_funcs(log_rppfail);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Enter your JIRA issue id below -->
<!--- If a JIRA issue is not available, please first create one at pbspro.atlassian.net -->
PP-148

#### Problem description
pbs_tclsh dumps core when one tries to use openrm with hostname

#### Cause / Analysis
Function pointers of RPP protocol were not initialized.

#### Solution description
Called appropriate function to point the function pointers to the right routine depending on whether we are using TPP or RPP.
NOTE: When we initialize using TPP then client tries to connect to the comm and logs it as Critical message. SInce it is a client we don't want to see any messages as soon as we start the client because that will change the user experience of the command. Thus I've added code to ignore such messages on initialization.
Similar problem existed in pbs_rmget as well and I've modified that as well with this change.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [x] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [x] I have attached automated (PTL)/manual test logs to the associated Jira ticket.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

