### PR TITLE
PP-123: PBS schedules jobs on nodes without accounting for the reserv…

### DIFF
--- a/test/tests/pbs_reservations.py
+++ b/test/tests/pbs_reservations.py
@@ -1,0 +1,95 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+# 
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+# 
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free 
+# Software Foundation, either version 3 of the License, or (at your option) any 
+# later version.
+# 
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+# 
+# You should have received a copy of the GNU Affero General Public License along 
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+# 
+# Commercial License Information: 
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General 
+# Public License agreement ("AGPL"), except where a separate commercial license 
+# agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+# 
+# Altair’s dual-license business model allows companies, individuals, and 
+# organizations to create proprietary derivative works of PBS Pro and distribute 
+# them - whether embedded or bundled with other software - under a commercial 
+# license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™", 
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's 
+# trademark licensing policies.
+
+from ptl.utils.pbs_testsuite import *
+import time
+
+
+class TestReservations(PBSTestSuite):
+
+    def test_not_honoring_resvs(self):
+        """
+        PBS schedules jobs on nodes without accounting 
+        for the reservation on the node
+        """
+
+        a = {'resources_available.ncpus': 4}
+        self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
+
+        r1 = Reservation(TEST_USER)
+        a = {'Resource_List.select': '1:ncpus=1', 'reserve_start': int(
+            time.time() + 5), 'reserve_end': int(time.time() + 15)}
+        r1.set_attributes(a)
+        r1id = self.server.submit(r1)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, r1id)
+
+        r2 = Reservation(TEST_USER)
+        a = {'Resource_List.select': '1:ncpus=4', 'reserve_start': int(
+            time.time() + 600), 'reserve_end': int(time.time() + 7800)}
+        r2.set_attributes(a)
+        r2id = self.server.submit(r2)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, r2id)
+
+        r1_que = r1id.split('.')[0]
+        for i in range(20):
+            j = Job(TEST_USER)
+            a = {'Resource_List.select': '1:ncpus=1',
+                 'Resource_List.walltime': 10, 'queue': r1_que}
+            j.set_attributes(a)
+            self.server.submit(j)
+
+        j1 = Job(TEST_USER)
+        a = {'Resource_List.select': '1:ncpus=1',
+             'Resource_List.walltime': 7200}
+        j1.set_attributes(a)
+        j1id = self.server.submit(j1)
+
+        j2 = Job(TEST_USER)
+        a = {'Resource_List.select': '1:ncpus=1',
+             'Resource_List.walltime': 7200}
+        j2.set_attributes(a)
+        j2id = self.server.submit(j2)
+
+        a = {'reserve_state': (MATCH_RE, "RESV_BEING_DELETED|7")}
+        self.server.expect(RESV, a, id=r1id, interval=1)
+
+        a = {'scheduling': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        self.server.expect(JOB, {'job_state': 'Q'}, id=j1id)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=j2id)


### PR DESCRIPTION
PTL test for PP-123.  Code was previously committed as pull request #1 

The test does the following:
1. Submit reservation to start in a few seconds and fill it with jobs
2. Submit a future reservation after the first reservation
3. Submit 2 normal jobs with a wall time larger than the second reservation
4. Once the first reservation is in state being-deleted, run a scheduling cycle
5. A fixed system will show the jobs in state Q since they can’t run before the second reservation


#### Checklist:
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [X] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [X] I have attached automated (PTL)/manual test logs to the associated Jira ticket.