### PR TITLE
PP-270: Node/queue association is ignored when node_group_key is only…

### DIFF
--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -1133,7 +1133,6 @@ create_placement_sets(status *policy, server_info *sinfo)
 {
 	int i;
 	int is_success = 1;
-	node_info **ngroup_nodes;
 	char *resstr[] = {"host", NULL};
 	int num;
 
@@ -1184,19 +1183,26 @@ create_placement_sets(status *policy, server_info *sinfo)
 	}
 
 	for (i = 0; sinfo->queues[i] != NULL; i++) {
+		node_info **ngroup_nodes;
+		char **ngkey;
 		queue_info *qinfo = sinfo->queues[i];
 
 		if (qinfo->has_nodes)
 			qinfo->allpart = create_specific_nodepart(policy, "all", qinfo->nodes);
 
-		if (sinfo->node_group_enable && qinfo->node_group_key !=NULL) {
+		if (sinfo->node_group_enable && (qinfo->has_nodes || qinfo->node_group_key)) {
 			if (qinfo->has_nodes)
 				ngroup_nodes = qinfo->nodes;
 			else
 				ngroup_nodes = sinfo->unassoc_nodes;
+			
+			if(qinfo->node_group_key)
+				ngkey = qinfo->node_group_key;
+			else
+				ngkey = sinfo->node_group_key;
 
 			qinfo->nodepart = create_node_partitions(policy, ngroup_nodes,
-				qinfo->node_group_key, NP_CREATE_REST, &(qinfo->num_parts));
+				ngkey, NP_CREATE_REST, &(qinfo->num_parts));
 			if (qinfo->nodepart != NULL) {
 				qsort(qinfo->nodepart, qinfo->num_parts,
 					sizeof(node_partition *), cmp_placement_sets);

--- a/test/tests/pbs_nodes_queues.py
+++ b/test/tests/pbs_nodes_queues.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+# 
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+# 
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free 
+# Software Foundation, either version 3 of the License, or (at your option) any 
+# later version.
+# 
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+# 
+# You should have received a copy of the GNU Affero General Public License along 
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+# 
+# Commercial License Information: 
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General 
+# Public License agreement ("AGPL"), except where a separate commercial license 
+# agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+# 
+# Altair’s dual-license business model allows companies, individuals, and 
+# organizations to create proprietary derivative works of PBS Pro and distribute 
+# them - whether embedded or bundled with other software - under a commercial 
+# license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™", 
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's 
+# trademark licensing policies.
+
+from ptl.utils.pbs_testsuite import *
+
+
+class TestNodesQueues(PBSTestSuite):
+
+    def setUp(self):
+        PBSTestSuite.setUp(self)
+        self.server.add_resource('foo', 'string', 'h')
+
+        a = {'resources_available.ncpus': 4}
+        self.server.create_vnodes(
+            'vnode', a, 8, self.mom, attrfunc=self.cust_attr)
+
+        a = {'queue_type': 'execution', 'started': 't', 'enabled': 't'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
+
+        self.server.manager(MGR_CMD_SET, NODE, {
+                            'queue': 'workq2'}, id='vnode[0]')
+        self.server.manager(MGR_CMD_SET, NODE, {
+                            'queue': 'workq2'}, id='vnode[1]')
+        self.server.manager(MGR_CMD_SET, NODE, {
+                            'queue': 'workq2'}, id='vnode[2]')
+        self.server.manager(MGR_CMD_SET, NODE, {
+                            'queue': 'workq2'}, id='vnode[3]')
+
+        self.server.manager(MGR_CMD_SET, SERVER, {'node_group_key': 'foo'})
+        self.server.manager(MGR_CMD_SET, SERVER, {'node_group_enable': 't'})
+
+    def cust_attr(self, name, totnodes, numnode, attrib):
+        a = {}
+        if numnode % 2 == 0:
+            a['resources_available.foo'] = 'A'
+        else:
+            a['resources_available.foo'] = 'B'
+        return dict(attrib.items() + a.items())
+
+    def tearDown(self):
+        PBSTestSuite.tearDown(self)
+        self.server.manager(MGR_CMD_UNSET, NODE, 'queue', id='vnode[0]')
+        self.server.manager(MGR_CMD_UNSET, NODE, 'queue', id='vnode[1]')
+        self.server.manager(MGR_CMD_UNSET, NODE, 'queue', id='vnode[2]')
+        self.server.manager(MGR_CMD_UNSET, NODE, 'queue', id='vnode[3]')
+
+    def test_node_queue_assoc_ignored(self):
+        """
+        Issue with node grouping and nodes associated with queues.  If
+        node_grouping is set at the server level, node/queue association is
+        not honored
+        """
+
+        a = {'Resource_List.select': '2:ncpus=1', 'Resource_List.place': 'vscatter', 'queue': 'workq2'}
+        j = Job(TEST_USER, attrs=a)
+        jid=self.server.submit(j)
+        self.server.expect(JOB, 'exec_vnode', id=jid, op=SET)
+        nodes = j.get_vnodes(j.exec_vnode)
+        self.assertTrue((nodes[0] == 'vnode[0]' and nodes[1] == 'vnode[2]') or (nodes[0] == 'vnode[1]' and nodes[1] == 'vnode[3]'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Enter your JIRA issue id below -->
<!--- If a JIRA issue is not available, please first create one at pbspro.atlassian.net -->
* PP-270

#### Problem description
Node/queue association is ignored when node_group_key is set at the server level and not the queue level

#### Cause / Analysis
The scheduler will use a queue's placement sets if they are available. The scheduler would only create queue level placement sets if node_group_key was set at the queue. Since no placement sets were on the queue, the server's sets would be used. The server's placement sets do not enforce node/queue association.
#### Solution description
Create placement sets for a queue if the queue has nodes associated with it or the queue has a node_group_key set

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [x] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [x] I have attached automated (PTL)/manual test logs to the associated Jira ticket.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
