### PR TITLE
PP-361: Fix functions isAdminPrivilege(), setuser_with_password()....

### DIFF
--- a/src/include/win.h
+++ b/src/include/win.h
@@ -308,7 +308,7 @@ extern BOOL impersonate_user(HANDLE hlogintoken);
 extern BOOL revert_impersonated_user();
 extern int setuser(char *username);
 extern int setuser_with_password(char *username, char *cred_buf,
-	size_t cred_len, int (*decrypt_func)(char *, size_t, char **));
+	size_t cred_len, int (*decrypt_func)(char *, int, size_t, char **));
 extern HANDLE setuser_handle(void);
 extern void setuser_close_handle(void);
 extern int setuid(uid_t uid);	/* mimics UNIX call */

--- a/src/lib/Libwin/accesinfo.c
+++ b/src/lib/Libwin/accesinfo.c
@@ -51,9 +51,7 @@
 #include <aclapi.h>
 #include "pbs_ifl.h"
 #include "pbs_internal.h"
-/**
- * @file	accesinfo.c
- */
+
 
 /**
  * @brief 
@@ -1150,6 +1148,8 @@ make_dir_files_everyone_read(char *path)
 	DIR	*dir;
 	struct	dirent *pdirent;
 	char	dirfile[MAXPATHLEN+1];
+	struct stat sb;
+	int	isdir = 1;
 
 	if (path == NULL || *path == '\0')
 		return;
@@ -1159,6 +1159,15 @@ make_dir_files_everyone_read(char *path)
 	sprintf(logb,"securing %s for read access by Everyone", path);
 	log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_FORCE| PBSEVENT_DEBUG, PBS_EVENTCLASS_FILE, LOG_DEBUG, "", logb);
 	/* If the item is not a directory, we are done. */
+	if (stat(path, &sb) == -1) {
+		sprintf(logb, "\"%s\" does not exist", path);
+		log_err(-1, "make_dir_files_everyone_read", logb);
+		return;
+	}
+	if (!S_ISDIR(sb.st_mode)) {		
+		return;
+	}
+	
 	dir = opendir(path);
 	if (dir == (DIR *)0) {
 		sprintf(logb,"readdir error; %s", path);

--- a/src/lib/Libwin/passwd.c
+++ b/src/lib/Libwin/passwd.c
@@ -55,9 +55,7 @@
 #include <TlHelp32.h>
 #include <shlobj.h>
 #include "ticket.h"
-/**
- * @file	passwd.c
- */
+
 #define	NETWORK_DRIVE_PATHLEN 4  /* Example: "Z:\" */
 #ifndef SECURITY_WIN32
 #define SECURITY_WIN32 1
@@ -1531,8 +1529,8 @@ isLocalAdminMember(char *user)
 {
 	SID	*sid = NULL;
 	char	*gname = NULL;
-	wchar_t	userw[PBS_MAXHOSTNAME+UNLEN+2]; /* domain\user0 */
-	wchar_t	 gnamew[GNLEN+1];
+	wchar_t	userw[PBS_MAXHOSTNAME+UNLEN+2]=L""; /* domain\user0 */
+	wchar_t	 gnamew[GNLEN+1]=L"";
 	LOCALGROUP_MEMBERS_INFO_2 *members = NULL;
 	DWORD	nread = 0;
 	DWORD	totentries = 0;
@@ -1547,7 +1545,7 @@ isLocalAdminMember(char *user)
 	if ((gname=getgrpname(sid)) == NULL) {
 		goto isLocalAdminMember_end;
 	}
-	mbstowcs(userw, user, GNLEN);
+	mbstowcs(userw, user, PBS_MAXHOSTNAME+UNLEN+1);
 	mbstowcs(gnamew, gname, GNLEN);
 
 	if (NetLocalGroupGetMembers(NULL, gnamew, 2, (LPBYTE *)&members,
@@ -1738,8 +1736,8 @@ isAdminPrivilege(char *user)
 	GROUP_USERS_INFO_0 *groups = NULL;
 	DWORD	nread;
 	DWORD	i;
-	char	realuser[UNLEN+1];
-	char	group[GNLEN+1];
+	char	realuser[UNLEN+1]={'\0'};
+	char	group[GNLEN+1]={'\0'};
 	SID		*usid;
 	SID		*gsid;
 	DWORD	grid;
@@ -3942,7 +3940,7 @@ int
 setuser_with_password(char *user,
 	char *cred_buf,
 	size_t cred_len,
-	int (*decrypt_func)(char *, size_t, char **))
+	int (*decrypt_func)(char *, int, size_t, char **))
 {
 
 	SID     *usid;
@@ -3976,7 +3974,7 @@ setuser_with_password(char *user,
 		char *pass = NULL;
 		char *p = NULL;
 
-		if (decrypt_func(cred_buf, cred_len, &pass) != 0) {/* fails */
+		if (decrypt_func(cred_buf, PBS_CREDTYPE_AES, cred_len, &pass) != 0) {/* fails */
 			return (0);
 		}
 		strncpy(thepass, pass, cred_len);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Enter your JIRA issue id below -->
<!--- If a JIRA issue is not available, please first create one at pbspro.atlassian.net -->
* **PP-361: Fix functions isAdminPrivilege(), setuser_with_password(), make_dir_files_everyone_read() to address build and runtime failures.**

#### Problem description
1.Some admin users are wrongly branded non-admin and can not run Windows daemons.
2.setuser_with_password() does not support pbs_decrypt_pwd().
3.There are quite a few readdir() failures in logs.

#### Cause / Analysis
1. Uninitialized buffer in isAdminPrivilege() may cause users with admin permission, declared non-admin incorrectly.
2. setuser_with_password() decrypt_pwd() which is removed, should use pbs_decrypt_pwd().
3. make_dir_files_everyone_read() will check for whether the path is a directory before calling opendir() in order to avoid readdir() failure in logs.

#### Solution description
1. Initialize buffers in isAdminPrivilege().
2. setuser_with_password() is modified to support pbs_decrypt_pwd().
3. make_dir_files_everyone_read() now has check whether the given path is a directory before it calls opendir().

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [ ] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [x] I have attached automated (PTL)/manual test logs to the associated Jira ticket.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

