### PR TITLE
PP-344: qstat build broken on Windows

### DIFF
--- a/src/include/win.h
+++ b/src/include/win.h
@@ -110,6 +110,8 @@
 #define	strtok_r	strtok_s
 #define creat(path, mode)	win_open((path), O_CREAT|O_WRONLY|O_TRUNC, (mode))
 #define _creat(path, mode)	win_open((path), O_CREAT|O_WRONLY|O_TRUNC, (mode))
+#define strtoll _strtoi64
+#define strtoull _strtoui64
 
 #pragma warning(disable:4996) /* disable CRT secure warning */
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Enter your JIRA issue id below -->
<!--- If a JIRA issue is not available, please first create one at pbspro.atlassian.net -->
* **PP-344: qstat build broken on Windows**

#### Problem description
* **qstat build fails on Windows**

#### Cause / Analysis
* **strtoll() is not supported on VS2008 as C99 support is not there.**

#### Solution description
* #define strtoll _strtoi64 , for WIN32

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [ ] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [x] I have attached automated (PTL)/manual test logs to the associated Jira ticket.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

