### PR TITLE
PP-357 Make configure.ac backward compatible with older versions of a…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@
 #  trademark licensing policies.
 #
 
-AC_PREREQ([2.69])
+AC_PREREQ([2.63])
 AC_INIT([pbspro], [14.0.1], [pbssupport@altair.com])
 AC_CONFIG_HEADERS([src/include/pbs_config.h])
 AC_CONFIG_SRCDIR([src/cmds/qmgr.c])
@@ -55,7 +55,8 @@ AC_PROG_INSTALL
 AC_PROG_LN_S
 
 # Automake macros
-AM_PROG_AR
+#AM_PROG_AR macro is defined with automake version >= 1.12
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AM_PROG_CC_C_O
 
 # Initialize libtool
@@ -194,7 +195,8 @@ AC_CHECK_HEADERS([ \
 )
 
 # Checks for typedefs, structures, and compiler characteristics.
-AC_CHECK_HEADER_STDBOOL
+#AC_CHECK_HEADER_STDBOOL macro is defined with autoconf version >= 2.67
+m4_ifdef([AC_CHECK_HEADER_STDBOOL], [AC_CHECK_HEADER_STDBOOL])
 AC_TYPE_UID_T
 AC_TYPE_MODE_T
 AC_TYPE_OFF_T


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

PP-357 Make configure.ac backward compatible with older versions of autotools

#### Problem description
Autogen fails on some platforms

#### Cause / Analysis
Due to autoconf and automake are lesser versions on some platforms. 


#### Solution description
Made min requires version of autoconf version to 2.63, Removed / Modified macros to support older version's of autoconf and automake

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [ ] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [ ] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [x] I have attached automated (PTL)/manual test logs to the associated Jira ticket.

