### PR TITLE
PP-311: Move to AES broke upgrade of DB that uses DES

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -41,6 +41,7 @@ fi
 
 tmpdir=${PBS_TMPDIR:-${TMPDIR:-"/var/tmp"}}
 PBS_CURRENT_SCHEMA_VER='1.2.0'
+PBS_AES_SWITCH_VER='14.0'
 
 get_db_user() {
 	if [ ! -f "${dbuser_fl}" ]; then
@@ -725,6 +726,11 @@ if [ ! -d "$PBS_HOME" ]; then
 	exit 1
 fi
 
+# Store the old PBS VERSION for later use
+if [ -f "$PBS_HOME/pbs_version" ]; then
+	old_pbs_version=`cat $PBS_HOME/pbs_version`
+fi
+
 # Get the current PBS Pro version from qstat
 if [ -x "$PBS_EXEC/bin/qstat" ]; then
 	pbs_version=`"${PBS_EXEC}/bin/qstat" --version | sed -e 's/^.* = //'`
@@ -869,6 +875,20 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 		if [ $ret -ne 0 ]; then
 			echo "Failed to upgrade PBS Datastore"
 			exit $ret
+		fi
+
+		# We need to regenerate the db_password file since we have changed encryption/decryption
+		# library from DES to AES in PBS Version PBS_AES_SWITCH_VER
+		if [ "$old_pbs_version" \< "${PBS_AES_SWITCH_VER}" ] ;then
+			rm -f  "${PBS_HOME}/server_priv/db_password"
+			err=`${PBS_EXEC}/sbin/pbs_ds_password -r`
+			if [ $? -ne 0 ]; then
+				echo $err
+				echo "Error setting password for PBS Data Service"
+				${server_ctl} stop > /dev/null 2>&1
+				cleanup
+				exit 1
+			fi
 		fi
 	else
 		# Upgrade from FS version to DB


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Enter your JIRA issue id below -->
<!--- If a JIRA issue is not available, please first create one at pbspro.atlassian.net -->
PP-311

#### Problem description
Moving PBS to use AES Encryption from DES broke upgrading PBS from one version to another.

#### Cause / Analysis
"db_password" which is present in $PBS_HOME/server_priv is reused when doing upgrade of PBS from one version to another. This file actually contains the encrypted password for PostgreSQL database. The encryption has been done by using "libdes". Since we have changed the encryption logic to use "libaes" now instead of "libdes", PBS Server is trying to decrypt the password to initialize PBS dataservice which was NOT actually encrypted by using "libaes" and hence the issue. 

#### Solution description
To regenerate the pbs_ds_password file if we are upgrading from PBS having DES encryption to the one having AES.

Test case logs are attached to the JIRA ticket

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added tests to cover my changes. To create automated tests, see **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**.
- [x] All new and existing automated tests have passed. See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**.
- [x] I have attached automated (PTL)/manual test logs to the associated Jira ticket.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

