### PR TITLE
PP-350: Fix for multiple execjob_launch hooks

### DIFF
--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3002,6 +3002,28 @@ mom_process_hooks(unsigned int hook_event, char *req_user, char *req_host,
 								at_flags |=
 				(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
 			set_job_exit = 1;
+		} else if ((hook_event == HOOK_EVENT_EXECJOB_LAUNCH) && (num_run >= 1)) {
+
+			/*
+			 * If there are multiple execjob_launch hooks,
+			 * we need to cascade the execjob_launch specific
+			 * parameters to the next execjob_launch hook,
+			 * if any of the previous hooks has set these
+			 * values.
+			 */
+
+			if (hook_output != NULL) {
+
+				if (hook_output->progname != NULL) {
+					hook_input->progname = *hook_output->progname;
+				}
+
+				if (hook_output->env != NULL) {
+					hook_input->env = hook_output->env;
+				}
+				hook_input->argv = svrattrl_to_str_array(hook_output->argv);
+			}
+
 		}
 
 		rc = run_hook(phook, hook_event, hook_input,

--- a/test/tests/pbs_multiple_execjob_launch_hook.py
+++ b/test/tests/pbs_multiple_execjob_launch_hook.py
@@ -1,0 +1,98 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero
+# General Public License agreement ("AGPL"), except where a separate
+# commercial license agreement for PBS Pro version 14 or later has been
+# executed in writing with Altair.
+#
+# Altair’s dual-license business model allows companies, individuals,
+# and organizations to create proprietary derivative works of PBS Pro
+# and distribute them - whether embedded or bundled with other software
+# - under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to
+# Altair's trademark licensing policies.
+
+from ptl.utils.pbs_testsuite import *
+
+
+class ExecJobHookTest(PBSTestSuite):
+
+    hooks = {
+        "execjob_hook1":
+        """
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "executing execjob_launch 1" )
+e=pbs.event()
+e.progname = "/usr/bin/echo"
+e.argv=[]
+e.argv.append("launch 1")
+        """,
+        "execjob_hook2":
+        """
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "executing execjob_launch 2" )
+e = pbs.event()
+if (e.progname != "/usr/bin/echo"):
+    pbs.logmsg(pbs.LOG_DEBUG,
+        "Modified progname value did not propagated from launch1 hook")
+    e.reject("")
+else:
+    pbs.logmsg(pbs.LOG_DEBUG,
+        "Modified progname value got updated from launch1")
+        """,
+    }
+
+    def setUp(self):
+        PBSTestSuite.setUp(self)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047},
+                            expect=True)
+
+    def test_multi_execjob_hook(self):
+        """
+        Unsetting ncpus, that is ['ncpus'] = None, in modifyjob hook
+        """
+        hook_names = ["execjob_hook1", "execjob_hook2"]
+        hook_attrib = {'event': 'execjob_launch', 'enabled': 'True',
+                       'order': ''}
+        for hook_name in hook_names:
+            hook_script = self.hooks[hook_name]
+            hook_attrib['order'] = hook_names.index(hook_name) + 1
+            retval = self.server.create_import_hook(hook_name,
+                                                    hook_attrib,
+                                                    hook_script,
+                                                    overwrite=True)
+            self.assertTrue(retval)
+
+        job = Job(TEST_USER1, attrs={ATTR_l: 'select=1:ncpus=1',
+                                     ATTR_e: '/tmp/',
+                                     ATTR_o: '/tmp/'})
+        job.set_sleep_time(1)
+        jid = self.server.submit(job)
+        retval = self.mom.log_match(
+            "Modified progname value got updated from launch1",
+            max_attempts=3, interval=3)
+        self.assertTrue(retval)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace PP-350 below (2 places) with the actual JIRA id -->
* **[PP-350](https://pbspro.atlassian.net/browse/PP-350)**

#### Problem description
* pbs.event().progname and pbs.event().argv settings are not  remembered/propagated under multiple hooks

#### Cause / Analysis
* When we use multiple execjob_launch hooks, the values of execjob_launch hook specific parameters like progname, env and agrv were not getting cascaded to the next hook. It was happening because in run_hook() was setting it to defaults if we do not change the values of these paremeters in the hook.

#### Solution description
* Solution - provide the output of the previous hook as the input to the next hook.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

Addressed comments from Arun.