### PR TITLE
PP-315: Fix for deleting subjob in routing queue

### DIFF
--- a/src/server/job_route.c
+++ b/src/server/job_route.c
@@ -272,6 +272,7 @@ job_route(job *jobp)
 		case JOB_STATE_TRANSIT:
 			return (0);		/* already going, ignore it */
 
+		case JOB_STATE_BEGUN:
 		case JOB_STATE_QUEUED:
 			break;			/* ok to try */
 

--- a/test/tests/pbs_job_array_in_routingqueue.py
+++ b/test/tests/pbs_job_array_in_routingqueue.py
@@ -1,0 +1,95 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero
+# General Public License agreement ("AGPL"), except where a separate
+# commercial license agreement for PBS Pro version 14 or later has been
+# executed in writing with Altair.
+#
+# Altair’s dual-license business model allows companies, individuals,
+# and organizations to create proprietary derivative works of PBS Pro
+# and distribute them - whether embedded or bundled with other software
+# - under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to
+# Altair's trademark licensing policies
+
+from ptl.utils.pbs_testsuite import *
+
+
+class Test_JobArray_In_RoutingQueue(PBSTestSuite):
+    """
+    Test for bug when deleting a subjob of a Job Array in H state in
+    Routing queue causes jobs to fail to route
+    """
+
+    def test_delete_subjob_routingqueue(self):
+
+        dflt_q = self.server.default_queue
+        # Create a route queue with destination to default queue
+        a = {ATTR_qtype: 'route',
+             ATTR_routedest: dflt_q,
+             ATTR_enable: 'True'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='routeq')
+        # Submit an array job in Held state
+        j = Job(TEST_USER, attrs={ATTR_queue: 'routeq',
+                                  ATTR_l + '.ncpus': 1,
+                                  ATTR_h: 'u',
+                                  ATTR_J: '1-2:1',
+                                  ATTR_r: 'y'})
+
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'H'}, jid)
+        self.server.expect(JOB, {ATTR_state + '=Q': 2}, count=True,
+                           id=jid, extend='t')
+        subjobs = self.server.status(JOB, id=jid, extend='t')
+        # Delete one of the subjob
+        self.server.deljob(subjobs[-1]['id'])
+        self.server.expect(JOB, {ATTR_state: 'H'}, jid)
+        self.server.expect(JOB, {ATTR_state + '=Q': 1}, count=True,
+                           id=jid, extend='t')
+        self.server.expect(JOB, {ATTR_state + '=X': 1}, count=True,
+                           id=jid, extend='t')
+        self.server.expect(JOB, {ATTR_queue + '=routeq': 3}, count=True,
+                           id=jid, extend='t')
+        # Release the array and state changed to B
+        self.server.rlsjob(jid, 'u')
+        self.server.expect(JOB, {ATTR_state: 'B'}, jid)
+        self.server.expect(JOB, {ATTR_state + '=Q': 1}, count=True,
+                           id=jid, extend='t')
+        self.server.expect(JOB, {ATTR_state + '=X': 1}, count=True,
+                           id=jid, extend='t')
+        self.server.expect(JOB, {ATTR_queue + '=routeq': 3}, count=True,
+                           id=jid, extend='t')
+        # No errors should be in server logs
+        m = self.server.tracejob_match(
+            msg='(job_route) Request invalid for state of job, state=7',
+            id=jid)
+        self.assertEqual(m, None)
+        # Start routing queue and array jobs queue chnaged to default queue
+        a = {ATTR_start: 'True'}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id='routeq')
+        self.server.expect(JOB, {ATTR_queue + '=workq': 3}, count=True,
+                           id=jid, extend='t')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-315](https://pbspro.atlassian.net/browse/PP-315)**

#### Problem description
* Deleting a subjob of a Job Array in User H state in Routing queue causes jobs to fail to route

#### Cause / Analysis
* Whenever state of a subjob changes to any other state other than queued, the parent array job is set to JOB_STATE_BEGUN. This state(JOB_STATE_BEGUN) of parent job was not handled in job_route(), due to which server fails routing the job.

#### Solution description
*  To allow parent job with JOB_STATE_BEGUN to route.
 
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

Issue: Deleting a subjob of a Job Array in User H state in Routing queue
causes jobs to fail to route