### PR TITLE
PP-369: Output from qstat -Bf is reportinging a negative value for waiting jobs in state_count

### DIFF
--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1829,6 +1829,12 @@ pbsd_init_reque(job *pjob, int change_state)
 		/* update the state, typically to some form of QUEUED */
 		svr_evaljobstate(pjob, &newstate, &newsubstate, 1);
 		(void)svr_setjobstate(pjob, newstate, newsubstate);
+		if (newstate == JOB_STATE_QUEUED)
+			/* The state count will be incremented in both
+ 			 * svr_setjobstate() and svr_enquejob()
+			 * Decrement here so the counts do not get off
+ 			 */
+			server.sv_jobstates[newstate]--;
 	} else {
 		set_statechar(pjob);
 		/* make sure substate attributes match actual value */

--- a/test/tests/pbs_pp369.py
+++ b/test/tests/pbs_pp369.py
@@ -1,0 +1,58 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and distribute
+# them - whether embedded or bundled with other software - under a commercial
+# license agreement.
+#
+
+from ptl.utils.pbs_testsuite import *
+
+class TestPp369(PBSTestSuite):
+	def test_job_state_count(self):
+		"""
+		test_job_state_count: Testing if jobs in the 'W' state will cuase the state_count to go negative or incorrect.
+		"""
+		#Failing stage-in operation, to put job into the waiting state 
+		a = {ATTR_stagein: 'inputData@' + self.server.hostname + ':/noDir/nofile'}
+		j = Job(TEST_USER, a)
+		jid = self.server.submit(j)
+		self.server.expect(JOB, {'job_state':'W'}, id = jid)
+		#Restart server
+		self.server.restart()
+		qstat = self.server.status(SERVER)
+		self.logger.info("qstat[0]['state_count']:" + qstat[0]['state_count'])
+		state_count = qstat[0]['state_count'].split()
+		all_state_count = 0
+		for s in state_count:
+			state = s.split(':')
+			self.assertGreaterEqual(int(state[1]), 0) 		#Check for negative value 
+			all_state_count = all_state_count + int(state[1])
+		self.logger.info("qstat[0]['total_jobs']:" + qstat[0]['total_jobs'])
+		self.logger.info("all_state_count = %d", all_state_count)
+		self.assertEqual(int(qstat[0]['total_jobs']), all_state_count) 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-369](https://pbspro.atlassian.net/browse/PP-369)**

#### Problem description
* state_count value at server was incorrect

#### Cause / Analysis
* After server gets restart job in waiting state will move to queue state and while state change happen during server restart pbsd_init_reque() increments state_count value twice for a queue job 

#### Solution description
* Please describe your changes in detail for reviewers

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

