### PR TITLE
PP-421: ACL and Array String attributes use memcpy for overlapping memory blocks

### DIFF
--- a/src/lib/Libattr/attr_fn_acl.c
+++ b/src/lib/Libattr/attr_fn_acl.c
@@ -488,7 +488,7 @@ set_allacl(struct attribute *attr, struct attribute *new, enum batch_op op, int 
 						nsize = strlen(pas->as_string[i]) + 1;
 						pc = pas->as_string[i] + nsize;
 						need = pas->as_next - pc;
-						(void)memcpy(pas->as_string[i], pc, (int)need);
+						(void)memmove(pas->as_string[i], pc, (int)need);
 						pas->as_next -= nsize;
 						/* compact pointers */
 						for (++i; i < pas->as_npointers; i++)

--- a/src/lib/Libattr/attr_fn_arst.c
+++ b/src/lib/Libattr/attr_fn_arst.c
@@ -493,7 +493,7 @@ set_arst(struct attribute *attr, struct attribute *new, enum batch_op op)
 						nsize = strlen(pas->as_string[i]) + 1;
 						pc = pas->as_string[i] + nsize;
 						need = pas->as_next - pc;
-						(void)memcpy(pas->as_string[i], pc, (int)need);
+						(void)memmove(pas->as_string[i], pc, (int)need);
 						pas->as_next -= nsize;
 						/* compact pointers */
 						for (++i; i < pas->as_npointers; i++)


### PR DESCRIPTION
#### Issue-ID
* **[PP-421](https://pbspro.atlassian.net/browse/PP-421)**

#### Problem description
ACL and Array string attributes use memcpy for overlapping memory blocks leading to data corruption.

#### Cause / Analysis


#### Solution description
Replaced memcpy with memmove.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

