### PR TITLE
PP-401: preemption not working for host level resources

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2900,17 +2900,24 @@ select_index_to_preempt(status *policy, resource_resv *hjob,
 			case QUEUE_PROJECT_RES_LIMIT_REACHED:
 			case QUEUE_BYPROJECT_RES_LIMIT_REACHED:
 			case INSUFFICIENT_RESOURCE:
-				limitres_injob=0;
-				req_scan=rjobs[i]->resreq;
-				while (req_scan)
+				limitres_injob = 0;
+				for (j = 0; rjobs[i]->select->chunks[j] != NULL; j++)
 				{
-					if ( strcmp(req_scan->name,limitres_name) == 0 &&
-					     req_scan->amount > 0 )
+					req_scan=rjobs[i]->select->chunks[j]->req;
+					while (req_scan)
 					{
-						limitres_injob = 1;
-						break;
+						if ( strcmp(req_scan->name,limitres_name) == 0 )
+						{
+							if ((req_scan->type.is_non_consumable) ||
+								(req_scan->amount > 0)) {
+								limitres_injob = 1;
+								break;
+							}
+						}
+						req_scan = req_scan->next;
 					}
-					req_scan = req_scan->next;
+					if (limitres_injob == 1)
+						 break;
 				}
 
 				break;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### PP-401
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-401](https://pbspro.atlassian.net/browse/PP-401)**

#### Problem description
Preemption is not working for host level or non consumable resources.
When a high priority job requests for a non-consumable chunk level resource it is not able to find any job that it can preempt. 

#### Cause / Analysis
We were searching in the wrong list to find out this chunk level resource and that was the reason that it was failing to preempt any job.

#### Solution description
To look at the right data structure to fetch the desired data and also make sure that we only check the condition "req_scan->amount > 0" for consumable resources only. 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

