### PR TITLE
PP-351: Correcting PTL test case to check for substate = 42 instead o…

### DIFF
--- a/test/tests/pbs_Rrecord_resources_used.py
+++ b/test/tests/pbs_Rrecord_resources_used.py
@@ -134,9 +134,9 @@ class Test_Rrecord_with_resources_used(PBSTestSuite):
         jid3s1 = subjobs[1]['id']
 
         # Wait for the jobs to start running.
-        self.server.expect(JOB, {ATTR_state: 'R'}, jid1)
-        self.server.expect(JOB, {ATTR_state: 'R'}, jid2)
-        self.server.expect(JOB, {ATTR_state: 'R'}, jid3s1)
+        self.server.expect(JOB, {ATTR_substate: '42'}, jid1)
+        self.server.expect(JOB, {ATTR_substate: '42'}, jid2)
+        self.server.expect(JOB, {ATTR_substate: '42'}, jid3s1)
 
         # Verify that accounting logs have Resource_List.<resource> value
         m = self.server.accounting_match(
@@ -314,9 +314,9 @@ class Test_Rrecord_with_resources_used(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'},
                             expect=True)
 
-        self.server.expect(JOB, {ATTR_state: 'R'}, jid1)
-        self.server.expect(JOB, {ATTR_state: 'R'}, jid2)
-        self.server.expect(JOB, {ATTR_state: 'R'}, jid3s1)
+        self.server.expect(JOB, {ATTR_substate: '42'}, jid1)
+        self.server.expect(JOB, {ATTR_substate: '42'}, jid2)
+        self.server.expect(JOB, {ATTR_substate: '42'}, jid3s1)
 
         # qrerun the jobs and wait for them to start running.
         self.server.rerunjob(jobid=jid1)
@@ -371,10 +371,10 @@ class Test_Rrecord_with_resources_used(PBSTestSuite):
         jid3s1 = subjobs[1]['id']
 
         # Verify that the jobs have started running.
-        self.server.expect(JOB, {ATTR_state: 'R', 'run_count': 1}, jid1)
-        self.server.expect(JOB, {ATTR_state: 'R', 'run_count': 1}, jid2)
+        self.server.expect(JOB, {ATTR_substate: '42', 'run_count': 1}, jid1)
+        self.server.expect(JOB, {ATTR_substate: '42', 'run_count': 1}, jid2)
         self.server.expect(JOB, {ATTR_state: 'B'}, jid3)
-        self.server.expect(JOB, {ATTR_state: 'R', 'run_count': 1}, jid3s1)
+        self.server.expect(JOB, {ATTR_substate: '42', 'run_count': 1}, jid3s1)
 
         # Verify that the accounting logs have Resource_List.<resource> but no
         # R records.
@@ -475,8 +475,8 @@ class Test_Rrecord_with_resources_used(PBSTestSuite):
         jid2 = self.server.submit(j2)
 
         # Verify that the jobs have started running.
-        self.server.expect(JOB, {ATTR_state: 'R', 'run_count': 1}, jid1)
-        self.server.expect(JOB, {ATTR_state: 'R', 'run_count': 1}, jid2)
+        self.server.expect(JOB, {ATTR_substate: '42', 'run_count': 1}, jid1)
+        self.server.expect(JOB, {ATTR_substate: '42', 'run_count': 1}, jid2)
 
         # Verify that the accounting logs have Resource_List.<resource> but no
         # R records.
@@ -562,10 +562,10 @@ class Test_Rrecord_with_resources_used(PBSTestSuite):
         jid3s1 = subjobs[1]['id']
 
         # Verify that the jobs have started running.
-        self.server.expect(JOB, {ATTR_state: 'R', 'run_count': 1}, jid1)
-        self.server.expect(JOB, {ATTR_state: 'R', 'run_count': 1}, jid2)
+        self.server.expect(JOB, {ATTR_substate: '42', 'run_count': 1}, jid1)
+        self.server.expect(JOB, {ATTR_substate: '42', 'run_count': 1}, jid2)
         self.server.expect(JOB, {ATTR_state: 'B'}, jid3)
-        self.server.expect(JOB, {ATTR_state: 'R', 'run_count': 1}, jid3s1)
+        self.server.expect(JOB, {ATTR_substate: '42', 'run_count': 1}, jid3s1)
 
         # Verify that the accounting logs have Resource_List.<resource> but no
         # R records.


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-351](https://pbspro.atlassian.net/browse/PP-351)**

#### Problem description
* QA testing found that the PTL test cases where failing intermittently.

#### Cause / Analysis
* On some systems, the jobs never started running. The reported state was 'R' but substate was 41 i.e. prerun, when the mom process was killed. This caused the 'R' record to not have any information on resources_used. 

#### Solution description
* The PTL test cases now check for substate to be 42.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

…f state = 'R'