### PR TITLE
PP-477: Server crash due to invalid memory access

### DIFF
--- a/src/lib/Libnet/net_server.c
+++ b/src/lib/Libnet/net_server.c
@@ -160,6 +160,10 @@ connection_find_actual_index(int sock)
 
 	int     i, j;
 
+	if (sock < 0) {
+		return (-1); /* Invalid socket! */
+	}
+
 	j = (sock % max_connection); /* hash against socket */
 
 	i = j;

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -353,21 +353,20 @@ static void
 timeout_rerun_request(struct work_task *pwt)
 {
 	job     *pjob = (job *)pwt->wt_parm1;
-	int      conn_idx;
+	int      conn_idx = -1;
 
 	if ((pjob == NULL) || (pjob->ji_rerun_preq == NULL)) {
 		return;	/* nothing to timeout */
 	}
-
+	if (pjob->ji_rerun_preq->rq_conn != PBS_LOCAL_CONNECTION) {
+		conn_idx = connection_find_actual_index(pjob->ji_rerun_preq->rq_conn);
+	}
 	reply_text(pjob->ji_rerun_preq, PBSE_INTERNAL,
 		"rerunning job has timed out");
 
 	/* clear no-timeout flag on connection */
-	if (pjob->ji_rerun_preq->rq_conn != PBS_LOCAL_CONNECTION) {
-		conn_idx = connection_find_actual_index(pjob->ji_rerun_preq->rq_conn);
-		if (conn_idx != -1)
-			svr_conn[conn_idx].cn_authen &= ~PBS_NET_CONN_NOTIMEOUT;
-	}
+	if (conn_idx != -1)
+		svr_conn[conn_idx].cn_authen &= ~PBS_NET_CONN_NOTIMEOUT;
 
 	pjob->ji_rerun_preq = NULL;
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-477](https://pbspro.atlassian.net/browse/PP-477)**

#### Problem description
* Server crash due to invalid memory access 

#### Cause / Analysis
* Pointer to the batch_request is stored in the job, and is used by time out function. However, when the connection is closed, the batch request is found and the connection is set to -1. timeout_rerun_request uses connection which was set to -1 and try to actual connection and hence invalid memory access

#### Solution description
* return from connection_find_actual_index function if the sock is -1 and in timeout_rerun_request the conn_idx is retrieved prior to reply_send 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

