### PR TITLE
PP-368: Registering data service to systemd in /etc/init.d/pbs is bro…

### DIFF
--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -228,8 +228,16 @@ oom_protect() {
 # to start the data service by calling pg_ctl.
 # This function also protects the database and the monitoring script from the 
 # OOM on linux.
+# This function checks whether systemd (i.e. systemctl) is available on system or not?
+# If systemctl is available then register database processes with pbs.service
 #
 start_dataservice() {
+	is_systemd=0
+	systemctl --version >/dev/null 2>&1
+	if [ $? -eq 0 ] ; then
+		is_systemd=1
+	fi
+
 	cd ${PBS_HOME}/datastore
 	if [ $? -ne 0 ]; then
 		echo "Could not change directory to ${PBS_HOME}/datastore"
@@ -256,6 +264,37 @@ start_dataservice() {
 			fi
 		fi
 		ret=$?
+
+		if [ $ret -eq 0 -a $is_systemd -eq 1 ] ; then
+			SYSTEMD_CGROUP=`grep ^cgroup /proc/mounts | grep systemd | head -1 | cut -d ' ' -f2`
+			if [ ! -d $SYSTEMD_CGROUP/system.slice/pbs.service ] ; then
+				mkdir -p $SYSTEMD_CGROUP/system.slice/pbs.service
+			fi
+
+			pstmstr_pid_found=0
+			try=0
+			while [ $try -lt 10 -a $pstmstr_pid_found -ne 1 ]
+			do
+				sleep 1
+				if [ -f ${PBS_HOME}/datastore/postmaster.pid ] ; then
+					pstmstr_pid_found=1
+				fi
+				try=`expr $try + 1`
+			done
+
+			if [ $pstmstr_pid_found -eq 1 ] ; then
+				P_PID=`head -n 1 ${PBS_HOME}/datastore/postmaster.pid`
+				if [ -n "$P_PID" ] ; then
+					echo $P_PID >> $SYSTEMD_CGROUP/system.slice/pbs.service/tasks
+					pidlist=`pgrep -P $P_PID`
+					if [ -n "$pidlist" ] ; then
+						for PID in $pidlist; do
+							echo $PID >> $SYSTEMD_CGROUP/system.slice/pbs.service/tasks
+						done
+					fi
+				fi
+			fi
+		fi
 	fi
 	cd ${CWD}
 

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -68,7 +68,6 @@ fi
 
 tmpdir=${PBS_TMPDIR:-${TMPDIR:-"/var/tmp"}}
 ostype=`uname 2>/dev/null`
-is_systemd=0
 #
 # check for special system setup
 case "$ostype" in
@@ -458,24 +457,7 @@ start_pbs() {
 		return 1
 	    fi
 	 fi
-         if [ $is_systemd -eq 1 ] ; then
-             SYSTEMD_CGROUP=`grep ^cgroup /proc/mounts | grep systemd | head -1 | cut -d ' ' -f2`
-             if [ ! -d $SYSTEMD_CGROUP/system.slice/pbs.service ] ; then
-               mkdir -p $SYSTEMD_CGROUP/system.slice/pbs.service
-             fi
-           if [ -f ${PBS_HOME}/datastore/postmaster.pid ] ; then
-             P_PID=`head -n 1 ${PBS_HOME}/datastore/postmaster.pid`
-            if [ -n "$P_PID" ] ; then
-               echo $P_PID >> $SYSTEMD_CGROUP/system.slice/pbs.service/tasks
-               pidlist=`pgrep -P $P_PID`
-               if [ -n "$pidlist" ] ; then
-                 for PID in $pidlist; do
-                   echo $PID >> $SYSTEMD_CGROUP/system.slice/pbs.service/tasks
-                 done
-              fi
-             fi
-           fi
-         fi
+
          if [ -r "${PBS_HOME}/server_priv/qmgr_startup" ]; then
            echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_startup"
            ${PBS_EXEC}/bin/qmgr <"${PBS_HOME}/server_priv/qmgr_startup"
@@ -825,32 +807,22 @@ is_boottime()
 
 pre_start_pbs()
 {
-	# Check whether systemd (i.e. systemctl) is available on system or not?
-	# If systemctl is available then start PBS using the regular mechanism
-	# because systemd will start PBS in the background
-	systemctl --version >/dev/null 2>&1
-	if [ $? -ne 0 ] ; then
-		if is_boottime
-		then
-                        case "$ostype" in
-                                Linux) echo -e "\nStarting PBS in background\c" ;;
-                                *)  echo "\nStarting PBS in background\c" ;;
-                        esac
-			(
-				TEMP_DIR=${PBS_TMPDIR:-${TMPDIR:-"/var/tmp"}}
-				TEMPFILE=${TEMP_DIR}/start_pbs_logs_tmp_$$
-				start_pbs > ${TEMPFILE} 2>&1
-				ret=$?
-				logger -i -t PBS -f ${TEMPFILE}
-				rm -f ${TEMPFILE}
-				exit ${ret}
-			) &
-		else
-			start_pbs
-			exit $?
-		fi
+	if is_boottime
+	then
+		case "$ostype" in
+			Linux) echo -e "\nStarting PBS in background\c" ;;
+			*)  echo "\nStarting PBS in background\c" ;;
+		esac
+		(
+			TEMP_DIR=${PBS_TMPDIR:-${TMPDIR:-"/var/tmp"}}
+			TEMPFILE=${TEMP_DIR}/start_pbs_logs_tmp_$$
+			start_pbs > ${TEMPFILE} 2>&1
+			ret=$?
+			logger -i -t PBS -f ${TEMPFILE}
+			rm -f ${TEMPFILE}
+			exit ${ret}
+		) &
 	else
-		is_systemd=1
 		start_pbs
 		exit $?
 	fi


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->

<!--- Provide a general summary of your changes in the Title above -->
#### Issue-ID

<!--- Replace XXXX below (2 places) with the actual JIRA id -->
- **[PP-368](https://pbspro.atlassian.net/browse/PP-368)**
#### Problem description
- Registering data service to systemd in /etc/init.d/pbs is broken on failover configs
#### Cause / Analysis
- When primary goes down and secondary server decides to come up, if it finds data service running at primary it'll try to kill it first and then try to start its own data service. But this new dataservice processes are not registered to systemd as existing code to register processes is in file "pbs_init.d.in" and same is not invoked again once servers are up at either primary or secondary.
#### Solution description
- Move registering processes code to systemd to pbs_dataservice. 
#### Checklist:

<!--- Use the preview button to see the checkboxes/links properly. -->

<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) _(or)_
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.

****_For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).**_**

…ken on failover configs
