### PR TITLE
PP-500: Fix abysmal qrerun performance with large spool file staging

### DIFF
--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -69,8 +69,7 @@ extern "C" {
 #define PBS_BATCH_PROT_VER	1
 /* #define PBS_REQUEST_MAGIC (56) */
 /* #define PBS_REPLY_MAGIC   (57) */
-#define SCRIPT_CHUNK_Z (4096)
-#define LARGE_SCRIPT_CHUNK_Z (16384)
+#define SCRIPT_CHUNK_Z (65536)
 #ifndef TRUE
 #define TRUE 1
 #define FALSE 0

--- a/src/lib/Libifl/int_submit.c
+++ b/src/lib/Libifl/int_submit.c
@@ -445,7 +445,7 @@ PBSD_jscript_direct(int c, char *script, int rpp, char **msgid)
 
 	len = strlen(script);
 	do {
-		tosend = (len > LARGE_SCRIPT_CHUNK_Z) ? LARGE_SCRIPT_CHUNK_Z : len;
+		tosend = (len > SCRIPT_CHUNK_Z) ? SCRIPT_CHUNK_Z : len;
 		rc = PBSD_scbuf(c, PBS_BATCH_jobscript, i, p, tosend, (char *)0, JScript, rpp, msgid);
 		i++;
 		p += tosend;

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -737,7 +737,7 @@ cleanup_cred(struct batch_request *preq)
 	return;
 }
 
-#define RT_BLK_SZ 4096
+#define RT_BLK_SZ 65536
 /**
  * @brief
  * 	Called when a job is rerun (qrerun) to copy the job's standard out/error

--- a/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
+++ b/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
@@ -93,6 +93,7 @@ class JobRerunFileTransferPerf(TestPerformance):
         self.logger.info("Job %s took %d seconds to start\n",
                          jid, (now2 - now1))
 
+        # give a few seconds to job to create large spool file
         time.sleep(5)
 
         now1 = int(time.time())

--- a/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
+++ b/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
@@ -1,0 +1,93 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.performance import *
+
+
+class JobRerunFileTransferPerf(TestPerformance):
+    """
+    This test suite is for testing the performance of job script 
+    and job output (stdout) transfers in case of rerun
+    """
+
+    def setUp(self):
+        TestPerformance.setUp(self)
+
+        if len(self.moms) != 2:
+            self.logger.error('test requires two MoMs as input, ' +
+                              '  use -p moms=<mom1>:<mom2>')
+            self.assertEqual(len(self.moms), 2)
+
+        # PBSTestSuite returns the moms passed in as parameters as dictionary
+        # of hostname and MoM object
+        self.momA = self.moms.values()[0]
+        self.momB = self.moms.values()[1]
+        self.momA.delete_vnode_defs()
+        self.momB.delete_vnode_defs()
+
+        self.hostA = self.momA.shortname
+        self.hostB = self.momB.shortname
+
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 4095}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'job_requeue_timeout': 1000}, expect=True)
+
+    @timeout(600) 
+    def test_huge_job_file(self):
+        j = Job(TEST_USER, attrs={ATTR_N: 'huge_job_file', 'Resource_List.select': '1:host=%s' % self.momB.shortname})
+
+        test = []
+        test += ['dd if=/dev/zero of=file bs=1024 count=0 seek=250000\n']
+        test += ['cat file\n']
+        test += ['sleep 10000\n']
+
+        j.create_script(test, hostname=self.server.client)
+
+	now1 = int(time.time())
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=30, interval=5)
+	now2 = int(time.time())
+	self.logger.info("Job %s took %d seconds to start\n", jid, (now2 - now1))
+
+        time.sleep(5)
+
+	now1 = int(time.time())
+	self.server.rerunjob(jid)
+        self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=500, interval=5)
+	now2 = int(time.time())
+	self.logger.info("Job %s took %d seconds to rerun\n", jid, (now2 - now1))
+

--- a/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
+++ b/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
@@ -63,34 +63,40 @@ class JobRerunFileTransferPerf(TestPerformance):
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
 
-        rv = self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 4095}, expect=True)
+        rv = self.server.manager(MGR_CMD_SET, SERVER, {
+                                 'log_events': 4095}, expect=True)
         self.assertTrue(rv)
 
-        rv = self.server.manager(MGR_CMD_SET, SERVER, {'job_requeue_timeout': 1000}, expect=True)
+        rv = self.server.manager(MGR_CMD_SET, SERVER, {
+                                 'job_requeue_timeout': 1000}, expect=True)
         self.assertTrue(rv)
 
-    @timeout(600) 
+    @timeout(600)
     def test_huge_job_file(self):
-        j = Job(TEST_USER, attrs={ATTR_N: 'huge_job_file', 'Resource_List.select': '1:host=%s' % self.momB.shortname})
+        j = Job(TEST_USER, attrs={
+                ATTR_N: 'huge_job_file', 'Resource_List.select': '1:host=%s' % self.momB.shortname})
 
         test = []
         test += ['dd if=/dev/zero of=file bs=1024 count=0 seek=250000\n']
         test += ['cat file\n']
         test += ['sleep 10000\n']
 
-	j.create_script(test, hostname=self.server.client)
+        j.create_script(test, hostname=self.server.client)
 
-	now1 = int(time.time())
-	jid = self.server.submit(j)
-	self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=30, interval=5)
-	now2 = int(time.time())
-	self.logger.info("Job %s took %d seconds to start\n", jid, (now2 - now1))
+        now1 = int(time.time())
+        jid = self.server.submit(j)
+        self.server.expect(
+            JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=30, interval=5)
+        now2 = int(time.time())
+        self.logger.info("Job %s took %d seconds to start\n",
+                         jid, (now2 - now1))
 
-	time.sleep(5)
+        time.sleep(5)
 
-	now1 = int(time.time())
-	self.server.rerunjob(jid)
-	self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=500, interval=5)
-	now2 = int(time.time())
-	self.logger.info("Job %s took %d seconds to rerun\n", jid, (now2 - now1))
-
+        now1 = int(time.time())
+        self.server.rerunjob(jid)
+        self.server.expect(
+            JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=500, interval=5)
+        now2 = int(time.time())
+        self.logger.info("Job %s took %d seconds to rerun\n",
+                         jid, (now2 - now1))

--- a/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
+++ b/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
@@ -63,8 +63,11 @@ class JobRerunFileTransferPerf(TestPerformance):
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 4095}, expect=True)
-        self.server.manager(MGR_CMD_SET, SERVER, {'job_requeue_timeout': 1000}, expect=True)
+        rv = self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 4095}, expect=True)
+        self.assertTrue(rv)
+
+        rv = self.server.manager(MGR_CMD_SET, SERVER, {'job_requeue_timeout': 1000}, expect=True)
+        self.assertTrue(rv)
 
     @timeout(600) 
     def test_huge_job_file(self):
@@ -87,7 +90,7 @@ class JobRerunFileTransferPerf(TestPerformance):
 
 	now1 = int(time.time())
 	self.server.rerunjob(jid)
-        self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=500, interval=5)
+	self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=500, interval=5)
 	now2 = int(time.time())
 	self.logger.info("Job %s took %d seconds to rerun\n", jid, (now2 - now1))
 

--- a/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
+++ b/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
@@ -41,7 +41,7 @@ from tests.performance import *
 
 class JobRerunFileTransferPerf(TestPerformance):
     """
-    This test suite is for testing the performance of job script 
+    This test suite is for testing the performance of job script
     and job output (stdout) transfers in case of rerun
     """
 
@@ -74,7 +74,8 @@ class JobRerunFileTransferPerf(TestPerformance):
     @timeout(600)
     def test_huge_job_file(self):
         j = Job(TEST_USER, attrs={
-                ATTR_N: 'huge_job_file', 'Resource_List.select': '1:host=%s' % self.momB.shortname})
+                ATTR_N: 'huge_job_file', 'Resource_List.select': '1:host=%s'
+                % self.momB.shortname})
 
         test = []
         test += ['dd if=/dev/zero of=file bs=1024 count=0 seek=250000\n']
@@ -86,7 +87,8 @@ class JobRerunFileTransferPerf(TestPerformance):
         now1 = int(time.time())
         jid = self.server.submit(j)
         self.server.expect(
-            JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=30, interval=5)
+            JOB, {'job_state': 'R', 'substate': 42}, id=jid,
+            max_attempts=30, interval=5)
         now2 = int(time.time())
         self.logger.info("Job %s took %d seconds to start\n",
                          jid, (now2 - now1))
@@ -96,7 +98,8 @@ class JobRerunFileTransferPerf(TestPerformance):
         now1 = int(time.time())
         self.server.rerunjob(jid)
         self.server.expect(
-            JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=500, interval=5)
+            JOB, {'job_state': 'R', 'substate': 42}, id=jid,
+            max_attempts=500, interval=5)
         now2 = int(time.time())
         self.logger.info("Job %s took %d seconds to rerun\n",
                          jid, (now2 - now1))

--- a/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
+++ b/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
@@ -78,15 +78,15 @@ class JobRerunFileTransferPerf(TestPerformance):
         test += ['cat file\n']
         test += ['sleep 10000\n']
 
-        j.create_script(test, hostname=self.server.client)
+	j.create_script(test, hostname=self.server.client)
 
 	now1 = int(time.time())
-        jid = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=30, interval=5)
+	jid = self.server.submit(j)
+	self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=30, interval=5)
 	now2 = int(time.time())
 	self.logger.info("Job %s took %d seconds to start\n", jid, (now2 - now1))
 
-        time.sleep(5)
+	time.sleep(5)
 
 	now1 = int(time.time())
 	self.server.rerunjob(jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-500](https://pbspro.atlassian.net/browse/PP-500)**

#### Problem description
* When a job with a large stdout/err file is rerun, the performance is very bad. 

#### Cause / Analysis
* For files as large as 200 GB, it results in 60k+ transactions from mom to server and the same number back to mom when the file is staged back to mom. This is because the block size being used is 4096 bytes which results in the large number of transactions. The overhead of processing this is also very large at the server. 

#### Solution description
* Since direct TCP connections are being used between the server and mom for these large spool file transfers, it is possible to increase the block size to much larger, ie, 64k. This reduces the number of transactions by 16 times.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

