### PR TITLE
PP-465: qrerun throws error rerunning job has timed out, when big job…

### DIFF
--- a/doc/man1/pbs_server_attributes.7B
+++ b/doc/man1/pbs_server_attributes.7B
@@ -346,6 +346,7 @@ Default: False
 Python type: bool
 
 .IP job_requeue_timeout
+.B Obsolete
 Specifies the length of time that can be taken while requeueing a job.
 .br
 Minimum allowed value: 1 second

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -362,7 +362,7 @@ timeout_rerun_request(struct work_task *pwt)
 		conn_idx = connection_find_actual_index(pjob->ji_rerun_preq->rq_conn);
 	}
 	reply_text(pjob->ji_rerun_preq, PBSE_INTERNAL,
-		"rerunning job has timed out");
+		"Response timed out. Job rerun request still in progress for");
 
 	/* clear no-timeout flag on connection */
 	if (conn_idx != -1)

--- a/test/tests/functional/pbs_test_rerun_timeout_error.py
+++ b/test/tests/functional/pbs_test_rerun_timeout_error.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under a
+# commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestJobRequeueTimeoutErrorMsg(TestFunctional):
+    """
+    This test suite is for testing the new job_requeue_timeout error
+    message that informs the user that the job rerun process is still
+    in progress.
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        if len(self.moms) != 2:
+            self.logger.error('test requires two MoMs as input, ' +
+                              '  use -p moms=<mom1>:<mom2>')
+            self.assertEqual(len(self.moms), 2)
+
+        self.server.set_op_mode(PTL_CLI)
+
+        # PBSTestSuite returns the moms passed in as parameters as dictionary
+        # of hostname and MoM object
+        self.momA = self.moms.values()[0]
+        self.momB = self.moms.values()[1]
+        self.momA.delete_vnode_defs()
+        self.momB.delete_vnode_defs()
+
+        self.hostA = self.momA.shortname
+        self.hostB = self.momB.shortname
+
+        rc = self.server.manager(MGR_CMD_DELETE, NODE, None, "")
+        self.assertEqual(rc, 0)
+
+        islocal = self.du.is_localhost(self.hostA)
+        if islocal is False:
+            rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
+            self.assertEqual(rc, 0)
+        else:
+            rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
+            self.assertEqual(rc, 0)
+
+        rc = self.server.manager(MGR_CMD_SET, SERVER, {
+                                 'job_requeue_timeout': 1}, expect=True)
+        self.assertTrue(rc)
+
+    def test_error_message(self):
+        j = Job(TEST_USER, attrs={ATTR_N: 'job_requeue_timeout'})
+
+        test = []
+        test += ['dd if=/dev/zero of=file bs=1024 count=0 seek=10240\n']
+        test += ['cat file\n']
+        test += ['sleep 30\n']
+
+        j.create_script(test, hostname=self.server.client)
+        jid = self.server.submit(j)
+
+        self.server.expect(
+            JOB, {'job_state': 'R', 'substate': 42}, id=jid, max_attempts=30,
+            interval=2)
+        try:
+            self.server.rerunjob(jid)
+        except PbsRerunError as e:
+            self.assertTrue('qrerun: Response timed out. Job rerun request ' +
+                            'still in progress for' in e.msg[0])


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-465](https://pbspro.atlassian.net/browse/PP-XXXX)**

#### Problem description
* qrerun times out when there are big job files being transferred.

#### Cause / Analysis
* As discussed on the [forum](http://community.pbspro.org/t/pp-465-qrerun-timeouts-when-big-job-files-are-being-copied-from-mom-to-server/288) and documented in the [EDD](https://pbspro.atlassian.net/wiki/display/PD/EDD+for+PP-465) the timeout message is spurious and the server continues the process of rerunning the job even after sending this error to the client.

#### Solution description
* The server attribute job_requeue_timeout is deprecated and the error message is changed to denote that the rerun process is still in progress.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

… files are being moved.