### PR TITLE
Compile with_libical for archlinux

### DIFF
--- a/m4/with_libical.m4
+++ b/m4/with_libical.m4
@@ -50,7 +50,9 @@ AC_DEFUN([PBS_AC_WITH_LIBICAL],
   AS_IF([test -r "$libical_dir/include/ical.h"],
     AS_IF([test "$libical_dir" != "/usr"],
       [libical_inc="-I$libical_dir/include"]),
-    AC_MSG_ERROR([libical headers not found.]))
+    AS_IF([test -r "$libical_dir/include/libical/ical.h"],
+      [libical_inc="-I$libical_dir/include/libical"],
+      AC_MSG_ERROR([libical headers not found.])))    
   AS_IF([test "$libical_dir" = "/usr"],
     # Using system installed libical
     AS_IF([test -r "/usr/lib64/libical.so" -o -r "/usr/lib/libical.so" -o -r "/usr/lib/x86_64-linux-gnu/libical.so"],


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-XXXX](https://pbspro.atlassian.net/browse/PP-XXXX)**

#### Problem description
* cannot compile on archlinux

#### Cause / Analysis
* m4 file does not reflect libical localtion on archlinux

#### Solution description
* add libical location for archlinux correctly

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

archlinux has different libical localtion than debian. m4 file should reflect this.