### PR TITLE
PP-511: pbs_ical correct icalerror_errors_are_fatal

### DIFF
--- a/m4/with_libical.m4
+++ b/m4/with_libical.m4
@@ -69,5 +69,10 @@ AC_DEFUN([PBS_AC_WITH_LIBICAL],
   AC_SUBST(libical_inc)
   AC_SUBST(libical_lib)
   AC_DEFINE([LIBICAL], [], [Defined when libical is available])
+  PKG_CHECK_MODULES([libical_api2],
+    [libical >= 2],
+    AC_DEFINE([LIBICAL_API2], [], [Defined when libical version >= 2]),
+    []
+  )
 ])
 

--- a/src/lib/Libutil/pbs_ical.c
+++ b/src/lib/Libutil/pbs_ical.c
@@ -110,7 +110,11 @@ get_num_occurrences(char *rrule, time_t dtstart, char *tz)
 	icalerror_clear_errno();
 
 	icalerror_set_error_state(ICAL_PARSE_ERROR, ICAL_ERROR_NONFATAL);
-	icalerror_errors_are_fatal = 0;
+#ifdef LIBICAL_API2
+    icalerror_set_errors_are_fatal(0);
+#else
+    icalerror_errors_are_fatal = 0;
+#endif
 	localzone = icaltimezone_get_builtin_timezone(tz);
 
 	if (localzone == NULL)
@@ -190,8 +194,12 @@ get_occurrence(char *rrule, time_t dtstart, char *tz, int idx)
 	icalerror_clear_errno();
 
 	icalerror_set_error_state(ICAL_PARSE_ERROR, ICAL_ERROR_NONFATAL);
-	icalerror_errors_are_fatal = 0;
-	localzone = icaltimezone_get_builtin_timezone(tz);
+#ifdef LIBICAL_API2
+    icalerror_set_errors_are_fatal(0);
+#else
+    icalerror_errors_are_fatal = 0;
+#endif
+    localzone = icaltimezone_get_builtin_timezone(tz);
 
 	if (localzone == NULL)
 		return -1;
@@ -275,7 +283,11 @@ check_rrule(char *rrule, time_t dtstart, time_t dtend, char *tz, int *err_code)
 	icalerror_clear_errno();
 
 	icalerror_set_error_state(ICAL_PARSE_ERROR, ICAL_ERROR_NONFATAL);
-	icalerror_errors_are_fatal = 0;
+#ifdef LIBICAL_API2
+    icalerror_set_errors_are_fatal(0);
+#else
+    icalerror_errors_are_fatal = 0;
+#endif
 
 	if (tz == NULL || rrule == NULL)
 		return 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-511](https://pbspro.atlassian.net/browse/PP-511)**

#### Problem description
* cannot compile due to non-compatible libical api calls

#### Cause / Analysis
* one should not use icalerror_errors_are_fatal global variable, since it breaks compilation

#### Solution description
* use libical setters instead of using global (undefined) variables

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

corresponding to libical api, setting ical errors are fatal should be handled by getters and setters. global variable is not available.