### PR TITLE
PP-515: safe quit mom when multinode jobs present

### DIFF
--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -190,6 +190,7 @@ char           *mom_home;
 char		mom_host[PBS_MAXHOSTNAME+1];
 pid_t		mom_pid;
 int		mom_run_state = 1;
+int		mom_safe_stop = 0;
 char		mom_short_name[PBS_MAXHOSTNAME+1];
 int		next_sample_time = MAX_CHECK_POLL_TIME;
 int		max_check_poll = MAX_CHECK_POLL_TIME;
@@ -628,6 +629,7 @@ extern  void    scan_for_terminated(void);
 /* Local public functions */
 
 void stop_me(int);
+void safe_stop(int);
 #endif
 
 extern	void	cleanup_hooks_workdir(struct work_task *);
@@ -8766,6 +8768,9 @@ main(int argc, char *argv[])
 	act.sa_handler = toolong;	/* handle an alarm call */
 	sigaction(SIGALRM, &act, NULL);
 
+	act.sa_handler = safe_stop;	/* shutdown only if no multinode jobs */
+	sigaction(SIGQUIT, &act, NULL);
+        
 	act.sa_handler = stop_me;	/* shutdown for these */
 	sigaction(SIGINT, &act, NULL);
 	sigaction(SIGTERM, &act, NULL);
@@ -9265,6 +9270,10 @@ main(int argc, char *argv[])
 		if (call_hup != HUP_CLEAR) {
 			process_hup();
 			internal_state_update = UPDATE_MOM_STATE;
+		}
+                
+		if (mom_safe_stop) {
+                    safe_stop(SIGQUIT);
 		}
 #endif
 
@@ -10108,6 +10117,47 @@ stop_me(int sig)
 	mom_run_state = 0;
 	if (sig == SIGTERM)
 		kill_jobs_on_exit = 1;
+}
+
+/**
+ * @brief
+ *	signal handler for SIGQUIT
+ *	quit only if no multinode jobs on node
+ *	do not kill jobs on exit
+ *
+ * @param[in] sig - signal number
+ *
+ * @return 	Void
+ *
+ */
+
+void
+safe_stop(int sig)
+{
+	sprintf(log_buffer, "caught signal %d", sig);
+	log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER,
+		LOG_NOTICE, msg_daemonname, log_buffer);
+
+        switch (sig) {
+		case SIGQUIT:
+			mom_run_state = 0;
+			mom_safe_stop = 1;
+			job *pjob;
+			for (pjob = (job *)GET_NEXT(svr_alljobs);
+				pjob;
+				pjob = (job *)GET_NEXT(pjob->ji_alljobs)) {
+				if (pjob->ji_qs.ji_state == JOB_STATE_RUNNING) {
+					if (pjob->ji_numnodes > 1) {
+						mom_run_state = 1;
+					} 
+				}
+			}                    
+			return;
+		default:
+			break;
+	}
+	
+
 }
 #endif	/* WIN32 */
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-515](https://pbspro.atlassian.net/browse/PP-515)**

#### Problem description
* In the contemporary PBS Pro there is no good way to install new version of mom. 

#### Cause / Analysis
* Restarting mom will lose multinode jobs even if the mom is started with the -p parameter. 

#### Solution description
* In this patch the SIGQUIT signal is caught and the mom is shutdown as soon as no multinode job is present. After such a safe quit you can start the mom with -p parameter again and no jobs are lost. 
On SIGQUIT: 
If no multinode jobs present - quit mom immediately. 
If multinode jobs present - wait to finish multinode jobs, then quit. 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

