### PR TITLE
PP-526: Configure fails, while checking libical library headers

### DIFF
--- a/m4/with_libical.m4
+++ b/m4/with_libical.m4
@@ -73,8 +73,8 @@ AC_DEFUN([PBS_AC_WITH_LIBICAL],
   AC_DEFINE([LIBICAL], [], [Defined when libical is available])
   PKG_CHECK_MODULES([libical_api2],
     [libical >= 2],
-    AC_DEFINE([LIBICAL_API2], [], [Defined when libical version >= 2]),
-    []
-  )
+    [AC_DEFINE([LIBICAL_API2], [], [Defined when libical version >= 2])],
+    [echo "libical version 2 is not available"]
+    )
 ])
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-526](https://pbspro.atlassian.net/browse/PP-526)**

#### Problem description
* Configure fails, while checking libical library headers
* Recent changes in libical m4 cause the configure failure at centos 6.6 platform which has 1) autoconf v2.63 and 2) automake v1.11.1

#### Cause / Analysis
* Latest autoconf v 2.69 is intelligent enough to handle empty slot in package configuration macros. Older versions are hit into syntax error due to lack of handling emply blocks in newly introduced _PKG_CHECK_MODULES_ at _with_libical.m4_ 

#### Solution description
* Instead of leaving empty at _action-if-not-found_ block in PKG_CHECK_MODULES, writing error message will override the default behavior of _exit_ .

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

