### PR TITLE
PP-373: Fix for long -lselect resource request

### DIFF
--- a/test/tests/functional/pbs_validate_job_qsub_attributes.py
+++ b/test/tests/functional/pbs_validate_job_qsub_attributes.py
@@ -1,0 +1,90 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestQsubWithQueuejobHook(TestFunctional):
+    """
+    This test suite validates the job submitted through qsub
+    when queuejob hook is enabled in the PBS complex.
+    """
+
+    hooks = {
+        "queuejob_hook1":
+        """
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "submitted job with long select" )
+        """,
+    }
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+    def test_qsub_long_select_with_hook(self):
+        """
+        This test case validates that, when a long string of resource is
+        requested in qsub through lselect. The requested resource should not
+        get truncated by the server hook infra when there exists a queuejob
+        hook.
+        """
+
+        hook_names = ["queuejob_hook1"]
+        hook_attrib = {'event': 'queuejob', 'enabled': 'True'}
+        for hook_name in hook_names:
+            hook_script = self.hooks[hook_name]
+            retval = self.server.create_import_hook(hook_name,
+                                                    hook_attrib,
+                                                    hook_script,
+                                                    overwrite=True)
+            self.assertTrue(retval)
+
+        # Create a long select statement for the job
+        loop_str = "1:host=testnode"
+        long_select = loop_str
+        for loop_i in range(1, 5120, len(loop_str) + 1):
+            long_select += "+" + loop_str
+
+        select_len = len(long_select)
+        long_select = "select=" + long_select
+        job = Job(TEST_USER1, attrs={ATTR_l: long_select})
+        jid = self.server.submit(job)
+        job_status = self.server.status(JOB, id=jid)
+        select_resource = job_status[0]['Resource_List.select']
+        self.assertTrue(select_len == len(select_resource))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-373](https://pbspro.atlassian.net/browse/PP-373)**

#### Problem description
*  long -lselect=... resources  request gets truncated by hook interface

#### Cause / Analysis
*  In file pbs_python_server_internal.c, function pbs_python_populate_svrattrl_from_python_class has buffer for the resource and value of fix size of HOOK_BUF_SIZE(512). Due to which any resource request greater than 511 characters was getting truncated.

#### Solution description
* Made the resource and val buffers static, and size gets re-allocated as in when larger resource value comes in.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

Issue: long -lselect=...resource truncated by hook interface.