### PR TITLE
PP-520: When error occurs while adjusting entity usage count for one limit, other limits should be left unaffected for enque job

### DIFF
--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -414,15 +414,27 @@ svr_enquejob(job *pjob)
 
 	/* update any entity count and entity resources usage for the queue */
 
-	if (((rc = set_entity_ct_sum_max(pjob, pque, INCR)) != 0) ||
-		((rc = set_entity_ct_sum_queued(pjob, pque, INCR)) != 0) ||
-		((rc = set_entity_resc_sum_max(pjob, pque, (attribute*)0, INCR)) != 0) ||
-		((rc = set_entity_resc_sum_queued(pjob, pque, (attribute *)0, INCR)) != 0)) {
-		sprintf(log_buffer, "set entity failed with %d for enque in %s",
-			rc, pque->qu_qs.qu_name);
-		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_NOTICE,
-			pjob->ji_qs.ji_jobid, log_buffer);
+	
+	if ((rc=set_entity_ct_sum_max(pjob, pque, INCR)) != 0) {
+		snprintf(log_buffer, LOG_BUF_SIZE-1, "set_entity_ct_sum_max on queue failed with %d for enqueue in %s", rc, pque->qu_qs.qu_name);
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_NOTICE, pjob->ji_qs.ji_jobid, log_buffer);
 	}
+
+	if ((rc=set_entity_ct_sum_queued(pjob, pque, INCR)) != 0) {
+		snprintf(log_buffer, LOG_BUF_SIZE-1, "set_entity_ct_sum_queued on queue failed with %d for enqueue in %s", rc, pque->qu_qs.qu_name);
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_NOTICE, pjob->ji_qs.ji_jobid, log_buffer);
+	}
+
+	if ((rc=set_entity_resc_sum_max(pjob, pque, (attribute *)0, INCR)) != 0) {
+		snprintf(log_buffer, LOG_BUF_SIZE-1, "set_entity_resc_sum_max on queue failed with %d for enqueue in %s", rc, pque->qu_qs.qu_name);
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_NOTICE, pjob->ji_qs.ji_jobid, log_buffer);
+	}
+
+	if ((rc=set_entity_resc_sum_queued(pjob, pque, (attribute*)0, INCR)) != 0) {
+		snprintf(log_buffer, LOG_BUF_SIZE-1, "set_entity_resc_sum_queued on queue failed with %d for enqueue in %s", rc, pque->qu_qs.qu_name);
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_NOTICE, pjob->ji_qs.ji_jobid, log_buffer);
+	}
+
 
 	/*
 	 * See if we need to do anything special based on type of queue


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-520](https://pbspro.atlassian.net/browse/PP-520)**

#### Problem description
*  When error occurs while adjusting entity usage count for one limit, other limits/resources should be left unaffected
*  Error reporting code path fails to report all of the errors when setting entity count

#### Cause / Analysis
* The use of "||" in the condition for the error reporting means that only one error is reported, but worse, if an error occurs on one call to a set_entity_* function the other functions are also not called.

So if e.g. there is an error on the "max" routines the "queued" routines won't get called, if there is an error somewhere for the server count or resource usage the queue counter and usage are also not going to be updated, etc.

#### Solution description
* Instead of using logical OR (||) , using multiple if cases to pass through all entity adjusting functions.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__