### PR TITLE
PP-582: PBS commands throwing error on a Client type of installation node

### DIFF
--- a/src/cmds/scripts/pbs_postinstall.in
+++ b/src/cmds/scripts/pbs_postinstall.in
@@ -890,7 +890,7 @@ client)
 	INSTALL_PACKAGE=$1
 	PBS_VERSION="${2:-@PBS_VERSION@}"
 	newpbs_exec="${3:-@prefix@}"
-	newpbs_home=''
+	newpbs_home='@PBS_SERVER_HOME@'
 	if [ ! -x "$newpbs_exec/bin/qstat" ]; then
 		echo "***"
 		echo "*** Unable to locate PBS Pro executables!"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-582](https://pbspro.atlassian.net/browse/PP-582)**

#### Problem description
* PBS commands throw error when run from a node with client type of installation with new rpm installation changes.

export PATH=$PATH:/opt/pbs/bin:/opt/pbs/sbin/
qsub – /bin/sleep 40
pbsconf error: pbs conf variables not found: PBS_HOME
qsub: cannot connect to server (errno=0)

#### Cause / Analysis
*  Since the value for PBS_HOME at client block is NULL, pbs.conf is not having PBS_HOME.

#### Solution description
* The fix is to populate the PBS_HOME with valid path, as like as previous INSTALL script based installation.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__