### PR TITLE
PP-491: Very short "qsub --" style jobs sometimes do not show stdout/…

### DIFF
--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -5447,8 +5447,8 @@ bld_env_variables(struct var_table *vtable, char *name, char *value)
 
 /**
  * @brief
- * 	catchinter = catch death of writer child and/or shell child of interactive
- *	When one dies, kill off the other; there is no mercy in this family.
+ *	catchinter = catch death of writer child of interactive job
+ *	and kill off the shell child.
  *
  * @param[in] sig - signal number
  *
@@ -5468,12 +5468,9 @@ catchinter(int sig)
 	if (pid == writerpid) {
 		kill(shellpid, SIGKILL);
 		(void)wait(&status);
-	} else {
-		kill(writerpid, SIGKILL);
-		(void)wait(&status);
+		mom_reader_go = 0;
+		x11_reader_go = 0;
 	}
-	mom_reader_go = 0;
-	x11_reader_go = 0;
 }
 /**
  * @brief


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-491](https://pbspro.atlassian.net/browse/PP-491)**

#### Problem description
* When interactive jobs submitted with short time executables, we are not getting the
  output every time.

#### Cause / Analysis
* When interactive jobs submitted with short time executables, once the execution of the 
  executable process is done we are killing the output writer process as well.

#### Solution description
* Once the executable process dies we will not kill the writer process, this allows the writer to 
   read the output and exit gracefully. 
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

…err, race condition