### PR TITLE
PP-584: PBS_SCP should only get set in pbs.conf on fresh installs, not upgrades

### DIFF
--- a/src/cmds/scripts/pbs_postinstall.in
+++ b/src/cmds/scripts/pbs_postinstall.in
@@ -254,11 +254,9 @@ create_conf() {
 	[ -z "$PBS_EXEC" ] && echo "PBS_EXEC=$newpbs_exec" >>"$newconf"
 	[ -z "$PBS_HOME" -a -n "$newpbs_home" ] && echo "PBS_HOME=$newpbs_home" >>"$newconf"
 	[ -z "${PBS_CORE_LIMIT}" ] && echo "PBS_CORE_LIMIT=@PBS_CORE_LIMIT@" >>"$newconf"
-	if [ -z "${PBS_SCP}" ] ; then
-		if type scp >/dev/null 2>&1; then
-			PBS_SCP=`type scp | cut -d' ' -f3`
-			echo "PBS_SCP=$PBS_SCP" >>"$newconf"
-		fi
+	if ! [ -d "$oldpbs_exec" ]; then
+		PBS_SCP=`type -P scp`
+		[ -n "$PBS_SCP" ] && echo "PBS_SCP=$PBS_SCP" >>"$newconf"
 	fi
 	
 	


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-584](https://pbspro.atlassian.net/browse/PP-584)**

#### Problem description
* PBS_SCP should only get set in pbs.conf on fresh installs,not upgrades.

#### Cause / Analysis
* Before this code modification, we were adding PBS_SCP (key, value) for all cases of installation.

#### Solution description
* PBS_SCP gets set to the value of type -P scp (very similar to which scp) ONLY IF there is no PBS_EXEC variable set in pbs.conf which points to an actual existing directory. The intent here is to only set PBS_SCP for actual fresh installs, rather than on any upgrade where things are presumably working just fine without it.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
