### PR TITLE
PP-592: Restarting pbs_server causes duplicate accounting records for…

### DIFF
--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -3176,8 +3176,10 @@ Time4resv(struct work_task *ptask)
 		set_scheduler_flag(SCH_SCHEDULE_JOBRESV);
 
 		/*notify the relevant persons that the reservation time has arrived*/
-		svr_mailownerResv(presv, MAIL_BEGIN, MAIL_NORMAL, "");
-		account_resvstart(presv);
+		if(presv->ri_qs.ri_tactive == time_now){
+			svr_mailownerResv(presv, MAIL_BEGIN, MAIL_NORMAL, "");
+			account_resvstart(presv);
+		}
 
 		if ((ptask = set_task(WORK_Timed, time_now + 60,
 			Time4resv1, presv)) != 0) {
@@ -3810,6 +3812,11 @@ eval_resvState(resc_resv *presv, enum resvState_discrim s, int relVal,
 				else
 					*psub = RESV_RUNNING;
 				*pstate = RESV_RUNNING;
+				if (presv->ri_qs.ri_tactive < 
+					presv->ri_wattr[RESV_ATR_start].at_val.at_long)
+					/*Assigning time_now to indicate when reservation become active
+ 					 *to help in fend off accounting on server restart*/
+					presv->ri_qs.ri_tactive = time_now;
 			}
 		}
 	} else if (s == RESVSTATE_req_deleteReservation) {

--- a/test/tests/functional/pbs_dup_acc_log_for_resv.py
+++ b/test/tests/functional/pbs_dup_acc_log_for_resv.py
@@ -1,0 +1,62 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under a
+# commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestDupAccLogForResv(TestFunctional):
+    """
+    This test suite is for testing duplicate records in accounting log
+    for start of reservations.
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+    def test_accounting_logs(self):
+        r1 = Reservation(TEST_USER)
+        a = {'Resource_List.select': '1:ncpus=1', 'reserve_start': int(
+            time.time() + 5), 'reserve_end': int(time.time() + 60)}
+        r1.set_attributes(a)
+        r1id = self.server.submit(r1)
+        time.sleep(8)
+        self.server.restart()
+        m = self.server.accounting_match(
+            msg='.*B;' + r1id, id=r1id, n='ALL', allmatch=True, regexp=True)
+        self.assertNotEqual(m, None)
+        self.assertEqual(len(m), 1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-592](https://pbspro.atlassian.net/browse/PP-592)**

#### Problem description
* Restarting pbs_server causes duplicate accounting records for reservations

#### Cause / Analysis
* Server creates work task for reservation creation and when server restarts, accounting logs are writing within the work task.

#### Solution description
* Assigned actual reservation start time to presv->ri_qs.ri_tactive and same is used to avoid printing duplicate accounting logs for reservation.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

… reservations