### PR TITLE
PP-607: Server.manager() uses ssh for remote hosts instead of qmgr's 'server' option

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5963,8 +5963,9 @@ class Server(PBSService):
                    PBS_CMD_MAP[cmd] + ' ', obj_type, attrib, oid, level=level)
 
         c = None  # connection handle
-
-        if (self.get_op_mode() == PTL_CLI or
+        op_mode = self.get_op_mode()
+        
+        if (op_mode == PTL_CLI or
             sudo is not None or
             obj_type in (HOOK, PBS_HOOK) or
             (attrib is not None and ('job_sort_formula' in attrib or
@@ -6041,8 +6042,15 @@ class Server(PBSService):
 
             if as_script:
                 pcmd = ['PBS_CONF_FILE=' + self.client_pbs_conf_file] + pcmd
-
-            ret = self.du.run_cmd(self.hostname, pcmd, sudo=sudo, runas=runas,
+                
+            
+            if op_mode == PTL_CLI:
+                pcmd += [self.hostname]
+                ret = self.du.run_cmd(self.client, pcmd, sudo=sudo, runas=runas,
+                                  level=logging.INFOCLI, as_script=as_script,
+                                  logerr=logerr)
+            else:
+                ret = self.du.run_cmd(self.hostname, pcmd, sudo=sudo, runas=runas,
                                   level=logging.INFOCLI, as_script=as_script,
                                   logerr=logerr)
             rc = ret['rc']

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6037,14 +6037,15 @@ class Server(PBSService):
                 else:
                     sudo = False
 
-            pcmd = [os.path.join(self.pbs_conf['PBS_EXEC'], 'bin', 'qmgr'),
-                    '-c', execcmd]
+            pcmd = [os.path.join(self.pbs_conf['PBS_EXEC'], 'bin', 'qmgr')]
+            if op_mode == PTL_CLI:
+                pcmd += [self.hostname]
+            pcmd += ['-c', execcmd]
 
             if as_script:
                 pcmd = ['PBS_CONF_FILE=' + self.client_pbs_conf_file] + pcmd
 
             if op_mode == PTL_CLI:
-                pcmd += [self.hostname]
                 ret = self.du.run_cmd(self.client, pcmd, sudo=sudo,
                                       runas=runas, level=logging.INFOCLI,
                                       as_script=as_script, logerr=logerr)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5964,7 +5964,7 @@ class Server(PBSService):
 
         c = None  # connection handle
         op_mode = self.get_op_mode()
-        
+
         if (op_mode == PTL_CLI or
             sudo is not None or
             obj_type in (HOOK, PBS_HOOK) or
@@ -6042,17 +6042,16 @@ class Server(PBSService):
 
             if as_script:
                 pcmd = ['PBS_CONF_FILE=' + self.client_pbs_conf_file] + pcmd
-                
-            
+
             if op_mode == PTL_CLI:
                 pcmd += [self.hostname]
-                ret = self.du.run_cmd(self.client, pcmd, sudo=sudo, runas=runas,
-                                  level=logging.INFOCLI, as_script=as_script,
-                                  logerr=logerr)
+                ret = self.du.run_cmd(self.client, pcmd, sudo=sudo,
+                                      runas=runas, level=logging.INFOCLI,
+                                      as_script=as_script, logerr=logerr)
             else:
-                ret = self.du.run_cmd(self.hostname, pcmd, sudo=sudo, runas=runas,
-                                  level=logging.INFOCLI, as_script=as_script,
-                                  logerr=logerr)
+                ret = self.du.run_cmd(self.hostname, pcmd, sudo=sudo,
+                                      runas=runas, level=logging.INFOCLI,
+                                      as_script=as_script, logerr=logerr)
             rc = ret['rc']
             # NOTE: workaround the fact that qmgr overloads the return code in
             # cases where the list returned is empty an error flag is set even


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-607](https://pbspro.atlassian.net/browse/PP-607)**

#### Problem description
* Server.manager() uses ssh for remote hosts instead of qmgr's 'server' option

#### Cause / Analysis
* PTL's Server object's manager() method, which is what triggers the qmgr command (in CLI mode), calls dshutils' run_cmd() with the server's hostname and if that's not a local host, then it does an ssh and runs the qmgr command inside the host. So, it does not internally convert the Server's hostname into the 'server' option to qmgr, which is how it should be executing commands on remote hosts (instead of ssh'ing into them).

#### Solution description
* manager() now ap pends'self.hostname' to the qmgr command string to be executed if PTL is running in CLI mode and passes self.client instead of self.hostname as the 'hosts' argument to run_cmd() so that run_cmd() will not do ssh if the Server object points to a remote server.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
