### PR TITLE
PP-502: Fix for emails/acct log getting truncated.

### DIFF
--- a/src/include/acct.h
+++ b/src/include/acct.h
@@ -1,36 +1,36 @@
 /*
  * Copyright (C) 1994-2016 Altair Engineering, Inc.
  * For more information, contact Altair at www.altair.com.
- *  
+ *
  * This file is part of the PBS Professional ("PBS Pro") software.
- * 
+ *
  * Open Source License Information:
- *  
+ *
  * PBS Pro is free software. You can redistribute it and/or modify it under the
- * terms of the GNU Affero General Public License as published by the Free 
- * Software Foundation, either version 3 of the License, or (at your option) any 
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
  * later version.
- *  
- * PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY 
+ *
+ * PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
- *  
- * You should have received a copy of the GNU Affero General Public License along 
+ *
+ * You should have received a copy of the GNU Affero General Public License along
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
- *  
- * Commercial License Information: 
- * 
- * The PBS Pro software is licensed under the terms of the GNU Affero General 
- * Public License agreement ("AGPL"), except where a separate commercial license 
+ *
+ * Commercial License Information:
+ *
+ * The PBS Pro software is licensed under the terms of the GNU Affero General
+ * Public License agreement ("AGPL"), except where a separate commercial license
  * agreement for PBS Pro version 14 or later has been executed in writing with Altair.
- *  
- * Altair’s dual-license business model allows companies, individuals, and 
- * organizations to create proprietary derivative works of PBS Pro and distribute 
- * them - whether embedded or bundled with other software - under a commercial 
+ *
+ * Altair’s dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of PBS Pro and distribute
+ * them - whether embedded or bundled with other software - under a commercial
  * license agreement.
- * 
- * Use of Altair’s trademarks, including but not limited to "PBS™", 
- * "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's 
+ *
+ * Use of Altair’s trademarks, including but not limited to "PBS™",
+ * "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
  * trademark licensing policies.
  *
  */
@@ -88,6 +88,8 @@ extern void account_jobstr(job *pjob);
 extern void account_jobend(job *pjob, char * used, int type);
 
 extern void set_job_ProvAcctRcd(job *pjob, long time_se, int type);
+
+extern int concat_rescused_to_buffer(char **buffer, int *buffer_size, svrattrl *patlist, char *delim);
 
 #define PROVISIONING_STARTED 1
 #define PROVISIONING_SUCCESS 2

--- a/test/tests/functional/pbs_acct_log_trunc.py
+++ b/test/tests/functional/pbs_acct_log_trunc.py
@@ -1,0 +1,147 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestAcctlogTrunc(TestFunctional):
+    """
+    Test that the resources_used information doesn't get truncated
+    in accounting log records
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        a = {'type': 'string', 'flag': 'h'}
+        self.server.manager(MGR_CMD_CREATE, RSC, a, id='foo_str')
+
+    def test_long_resource_end(self):
+        """
+        Test to see if a very long string resource is neither truncated
+        in the job's resources_used attr or the accounting log at job end
+        """
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'job_history_enable': 'True'})
+
+        # Create a very long string - the truncation was 2048 characters
+        # 4096 is plenty big to show it
+        hstr = ""
+        for i in range(4096):
+            hstr += "1"
+
+        hook_body = "import pbs\n"
+        hook_body += "e = pbs.event()\n"
+        hook_body += "hstr=\'" + hstr + "\'\n"
+        hook_body += "e.job.resources_used[\"foo_str\"] = hstr\n"
+
+        a = {'event': 'execjob_epilogue', 'enabled': 'True'}
+        self.server.create_import_hook("ep", a, hook_body)
+
+        J = Job()
+        J.set_attributes({ATTR_m: 'e'})
+        J.set_sleep_time(1)
+        jid = self.server.submit(J)
+
+        # Make sure the resources_used value hasn't been truncated
+        self.server.expect(JOB, {'job_state': 'F'}, id=jid, extend='x')
+        self.server.expect(
+            JOB, {'resources_used.foo_str': hstr}, extend='x', max_attempts=1)
+
+        # Make sure the accounting log hasn't been truncated
+        log_match = 'resources_used.foo_str=' + hstr
+        m = self.server.accounting_match(
+            "E;%s;.*%s.*" % (jid, log_match), regexp=True)
+        self.assertTrue(m)
+
+        # Make sure the server log hasn't been truncated
+        log_match = 'resources_used.foo_str=' + hstr
+        m = self.server.log_match("%s;.*%s.*" % (jid, log_match), regexp=True)
+        self.assertTrue(m)
+
+        # Make sure emails are not truncated
+        mailfile = os.environ['MAIL']
+        if not os.path.isfile(mailfile):
+            self.logger.info("Mail file does not exist or mail is not setup.\
+                     Hence this step would be skipped. Please check manually.")
+            return 1
+        mailpass = 0
+        for x in range(1, 5):
+            fo = open(mailfile, 'r')
+            maillog = fo.readlines()[-10:]
+            fo.close()
+            if (log_match in str(maillog)):
+                self.logger.info("Message found in " + mailfile)
+                mailpass = 1
+                break
+
+        self.assertTrue(mailpass, "Message not found in " + mailfile)
+
+    def test_long_resource_reque(self):
+        """
+        Test to see if a very long string value is truncated
+        in the 'R' requeue accounting record
+        """
+
+        # Create a very long string - the truncation was 2048 characters
+        # 4096 is plenty big to show it
+        hstr = ""
+        for i in range(4096):
+            hstr += "1"
+
+        hook_body = "import pbs\n"
+        hook_body += "e = pbs.event()\n"
+        hook_body += "hstr=\'" + hstr + "\'\n"
+        hook_body += "e.job.resources_used[\"foo_str\"] = hstr\n"
+
+        a = {'event': 'execjob_prologue', 'enabled': 'True'}
+        self.server.create_import_hook("pr", a, hook_body)
+
+        J = Job()
+        jid = self.server.submit(J)
+        self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+
+        self.server.rerunjob(jid)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+
+        # Make sure the accounting log hasn't been truncated
+        acctlog_match = 'resources_used.foo_str=' + hstr
+        m = self.server.accounting_match(
+            "R;%s;.*%s.*" % (jid, acctlog_match), regexp=True)
+        self.assertTrue(m)


### PR DESCRIPTION
Issue: resources_used info in emails/acct log gets truncated

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-502](https://pbspro.atlassian.net/browse/PP-502)**

#### Problem description
* Resources_used info in emails/acct log can be truncated
#### Cause / Analysis
* The server collects up all of the resources_used information and puts it into a buffer of size RESC_USED_BUF_SIZE(2048 bytes). If we have more than RESC_USED_BUF_SIZE, we truncate the entire resources_used string. The same code is used to create the resources_used string for both the accounting log and the mail (qsub -m option).

#### Solution description
* Replace static buffers with dynamic buffers. The buffers are grown through the use of pbs_strcat().

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
