### PR TITLE
PP-591: pbs_mom not coming up after switching on compute node on cpus…

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -47,6 +47,8 @@
 %define pbs_dist %{pbs_name}-%{pbs_version}.tar.gz
 %if 0%{?suse_version} >= 1210 || 0%{?rhel} >= 7 || 0%{?debian_version} >= 8
 %define have_systemd 1
+%else
+%define _unitdir /usr/lib/systemd/system
 %endif
 
 Name: %{pbs_name}
@@ -283,6 +285,10 @@ if [ `basename ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}` = %{version} ]; then
 	fi
 fi
 rm -f /etc/init.d/pbs
+%if %{defined have_systemd}
+	systemctl disable pbs
+	rm -f /usr/lib/systemd/system-preset/95-pbs.preset
+%endif
 
 %preun %{pbs_execution}
 if [ -x /sbin/chkconfig -a -x /sbin/service ]; then
@@ -313,6 +319,10 @@ if [ `basename ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}` = %{version} ]; then
 	fi
 fi
 rm -f /etc/init.d/pbs
+%if %{defined have_systemd}
+	systemctl disable pbs
+	rm -f /usr/lib/systemd/system-preset/95-pbs.preset
+%endif
 
 %preun %{pbs_client}
 if [ `basename ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}` = %{version} ]; then
@@ -348,6 +358,8 @@ echo
 %{_sysconfdir}/profile.d/pbs.sh
 %if %{defined have_systemd}
 %attr(644, root, root) %{_unitdir}/pbs.service
+%else
+%exclude %{_unitdir}/pbs.service
 %endif
 # %{_sysconfdir}/init.d/pbs
 %exclude %{pbs_prefix}/unsupported/*.pyc
@@ -363,6 +375,8 @@ echo
 %{_sysconfdir}/profile.d/pbs.sh
 %if %{defined have_systemd}
 %attr(644, root, root) %{_unitdir}/pbs.service
+%else
+%exclude %{_unitdir}/pbs.service
 %endif
 # %{_sysconfdir}/init.d/pbs
 %exclude %{pbs_prefix}/bin/printjob_svr.bin
@@ -426,7 +440,5 @@ echo
 %exclude %{pbs_prefix}/sbin/pbsfs
 %exclude %{pbs_prefix}/unsupported/*.pyc
 %exclude %{pbs_prefix}/unsupported/*.pyo
-%if %{defined have_systemd}
 %exclude %{_unitdir}/pbs.service
-%endif
 

--- a/src/cmds/scripts/pbs_postinstall.in
+++ b/src/cmds/scripts/pbs_postinstall.in
@@ -384,18 +384,21 @@ install_pbsinitd() {
 				[ -f /etc/profile.d/pbs.csh ] || cp ${PBS_EXEC}/etc/pbs.csh /etc/profile.d
 				[ -f /etc/profile.d/pbs.sh ] || cp ${PBS_EXEC}/etc/pbs.sh /etc/profile.d
 			fi
-			if [[ 1 == `pidof systemd` ]]; then
-				unitfilepath="/usr/lib/systemd/system/"
-				[ -f $unitfilepath/pbs.service ] || cp ${PBS_EXEC}/libexec/pbs.service $unitfilepath
-				chmod 644 $unitfilepath/pbs.service
-				eval "sed -i 's;\(^[[:space:]]*SourcePath=\)[^[:space:]]*;\1${PBS_EXEC}/libexec/pbs_init.d;' \"$unitfilepath/pbs.service\""
-				eval "sed -i 's;\(^[[:space:]]*ExecStart=\)[^[:space:]]*;\1${PBS_EXEC}/libexec/pbs_init.d start;' \"$unitfilepath/pbs.service\""
-				eval "sed -i 's;\(^[[:space:]]*ExecStop=\)[^[:space:]]*;\1${PBS_EXEC}/libexec/pbs_init.d stop;' \"$unitfilepath/pbs.service\""
-				if [ -x /bin/systemctl ] ; then
-					/bin/systemctl daemon-reload && /bin/systemctl enable pbs
-					[ $? != 0 ] && echo "Failed to register PBS Pro as a service in systemd"
+
+			pbs_unitfile="/usr/lib/systemd/system/pbs.service"
+			if [ -f "${pbs_unitfile}" ]; then
+				presetdir="/usr/lib/systemd/system-preset"
+				eval "sed -i 's;\(^[[:space:]]*SourcePath=\)[^[:space:]]*;\1${PBS_EXEC}/libexec/pbs_init.d;' \"$pbs_unitfile\""
+				eval "sed -i 's;\(^[[:space:]]*ExecStart=\)[^[:space:]]*;\1${PBS_EXEC}/libexec/pbs_init.d;' \"$pbs_unitfile\""
+				eval "sed -i 's;\(^[[:space:]]*ExecStop=\)[^[:space:]]*;\1${PBS_EXEC}/libexec/pbs_init.d;' \"$pbs_unitfile\""
+				if command -v systemctl >/dev/null 2>&1; then
+					systemctl daemon-reload && systemctl enable pbs
+					if [ $? != 0 -a -d "${presetdir}" ]; then
+						echo "*** Creating preset file ${presetdir}/95-pbs.preset"
+						echo "enable pbs.service" > "${presetdir}/95-pbs.preset"
+					fi
 				else
-					echo "Systemctl binary is not available in standard location; Failed to register PBS Pro as a service"
+					echo "*** Systemctl binary is not available; Failed to register PBS Pro as a service"
 				fi
 			fi
 			;;


### PR DESCRIPTION
…et machines

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-591](https://pbspro.atlassian.net/browse/PP-591)**

#### Problem description
* pbs_mom not coming up after switching on compute node on cpuset machines

#### Cause / Analysis
* systemctl preset will disable services which does not have a preset file(In fedora)

#### Solution description
* Introduced a preset file.
* Updated condition for checking the presence of systemd
* Updated sed which modifies unit file
* Excluded unit file in pbspro.spec in systems which will not support systemd in order to avoid packaging error. 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
