### PR TITLE
PP-590: Jobs may have resources_used.xxx = 0 when job has restarted d…

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -552,6 +552,7 @@ struct job {
 	struct ajtrkhd *ji_ajtrk;	/* ArrayJob: index tracking table */
 	int		ji_subjindx;	/* subjob:   its index into the table */
 	struct jbdscrd *ji_discard;	/* see discard_job() */
+	int		ji_jdcd_waiting;/* set if waiting on a mom for a response to discard job request */
 	char	       *ji_acctrec;	/* holder for accounting info */
 	char	       *ji_clterrmsg;	/* error message to return to client */
 

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -427,9 +427,16 @@ update_ajob_status_using_cmd(job *pjob, int cmd)
 		}
 	}
 
-	/* now append resources used */
 
-	encode_used(pjob, &rused.ru_attr);
+	/* if cmd is IS_RESCUSED_FROM_HOOK, send resources_used info
+	 * to the server if coming from mother superior of job.
+	 */
+	if ((cmd != IS_RESCUSED_FROM_HOOK) ||
+		((pjob->ji_qs.ji_svrflags & JOB_SVFLG_HERE) != 0)) {
+		/* now append resources used */
+
+		encode_used(pjob, &rused.ru_attr);
+	}
 
 	/* now send info to server via rpp */
 

--- a/test/tests/functional/pbs_two_mom_hooks_resources_used.py
+++ b/test/tests/functional/pbs_two_mom_hooks_resources_used.py
@@ -1,0 +1,149 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestAcctlogRescUsedWithTwoMomHooks(TestFunctional):
+    """
+    This test suite tests the accounting logs to have non-zero resources_used
+    in the scenario where we have execjob_begin and execjob_end hooks.
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        hook_body = "import time\n"
+        a = {'event': 'execjob_begin', 'enabled': 'True'}
+        rv = self.server.create_import_hook("test", a, hook_body)
+        self.assertTrue(rv)
+
+        a = {'event': 'execjob_end', 'enabled': 'True'}
+        rv = self.server.create_import_hook("test", a, hook_body)
+        self.assertTrue(rv)
+
+        a = {ATTR_nodefailrq: 5}
+        rc = self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.assertEqual(rc, 0)
+
+        a = {'job_history_enable': 'True'}
+        rc = self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.assertEqual(rc, 0)
+
+        self.momA = self.moms.values()[0]
+        self.momB = self.moms.values()[1]
+        self.momA.delete_vnode_defs()
+        self.momB.delete_vnode_defs()
+
+        self.hostA = self.momA.shortname
+        self.hostB = self.momB.shortname
+
+        rc = self.server.manager(MGR_CMD_DELETE, NODE, None, "")
+        self.assertEqual(rc, 0)
+
+        rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
+        self.assertEqual(rc, 0)
+
+        rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
+        self.assertEqual(rc, 0)
+
+    def test_Rrecord(self):
+        """
+        This test case runs a job on two nodes. Kills the mom process on
+        MS, waits for the job to be requeued and tests for the
+        resources_used value to be present in the 'R' record.
+        """
+
+        test = []
+        test += ['#PBS -N NodeFailRequeueTest\n']
+        test += ['echo Starting test at `date`\n']
+        test += ['sleep 20\n']
+
+        select = "vnode=" + self.hostA + "+vnode=" + self.hostB
+        j1 = Job(TEST_USER, attrs={
+            'Resource_List.select': select})
+        j1.create_script(body=test)
+        jid1 = self.server.submit(j1)
+
+        # Wait for the job to start running.
+        self.server.expect(JOB, {ATTR_substate: '42'}, jid1)
+        # Kill the MoM process on the MS.
+        self.momA.signal('-KILL')
+        # Wait for the job to be requeued.
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
+
+        # Check for resources_used value in the 'R' record.
+        msg = '.*R;' + str(jid1) + '.*resources_used.ncpus=2.*'
+        m = self.server.accounting_match(
+            msg, tail=True, regexp=True)
+        self.assertNotEqual(m, None)
+
+    def test_Erecord(self):
+        """
+        This test case runs a job on two nodes. Waits for the job to complete.
+        After that, tests for the E record to have non-zero values in
+        resources_used.
+        """
+
+        test = []
+        test += ['#PBS -N JobEndTest\n']
+        test += ['#PBS -lselect=2:ncpus=1 -lplace=scatter\n']
+        test += ['echo Starting test at `date`\n']
+        test += ['sleep 1\n']
+
+        j1 = Job(TEST_USER)
+        j1.create_script(body=test)
+        jid1 = self.server.submit(j1)
+
+        # Wait for the job to start running.
+        self.server.expect(JOB, {ATTR_substate: '42'}, jid1)
+
+        # Wait for the job to finish running.
+        self.server.expect(JOB, {'job_state': 'F'}, id=jid1, extend='x')
+
+        # Check for the E record to NOT have zero walltime.
+        msg = '.*E;' + str(jid1) + '.*resources_used.walltime=\"00:00:00.*'
+        m = self.server.accounting_match(
+            msg, tail=True, regexp=True)
+        self.assertEqual(m, None)
+
+        # Check for the E record to have non-zero ncpus.
+        msg = '.*E;' + str(jid1) + '.*resources_used.ncpus=2.*'
+        m = self.server.accounting_match(
+            msg, tail=True, regexp=True)
+        self.assertNotEqual(m, None)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-590](https://pbspro.atlassian.net/browse/PP-590)**

#### Problem description
* Jobs may have resources_used.xxx = 0 when job has restarted due to node_fail_requeue if there are execjob_begin and execjob_end hooks in use.

#### Cause / Analysis
* The resources_used information is zeroed out when there are two hooks and the resources_used information from the hook of sister MoM is sent which overwrites information in account_jobend().
* However, the sister MoM should not be sending the resources_used information from its hook. This change is added through this pull request (changes in catch_child.c)
* On a node_fail_requeue, in post_discard_job() if we haven't got the reply from MoM for discard job request, there are chances that account_jobend() won't be called at all and the resources_used information will be free()'ed in node_down_requeue() after discard_job() returns.

#### Solution description
* Sister MoM will not send resources_used information directly to the server if that is coming from the hook.
* We should not clear the resources_used information until reply for discard job request has come from all the MoMs that were sent this request.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
…ue to node_fail_requeue if there are execjob_begin and execjob_end hooks in use