### PR TITLE
PP-622: PTL returns trancated Variable_List if it has newline

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1209,9 +1209,7 @@ class BatchUtils(object):
     pbsobjattrval_re = re.compile(r"""
                             [\s]*(?P<attribute>[\w\d\.-]+)
                             [\s]*=[\s]*
-                            (?P<value>.*)
-                            [\s]*""",
-                                  re.VERBOSE)
+                            (?P<value>[\s\S]*)""", re.VERBOSE)
     dt_re = '(?P<dt_from>\d\d/\d\d/\d\d\d\d \d\d:\d\d)' + \
             '[\s]+' + \
             '(?P<dt_to>\d\d/\d\d/\d\d\d\d \d\d:\d\d)'
@@ -5897,16 +5895,32 @@ class Server(PBSService):
             else:
                 as_script = False
 
+            if obj_type in (JOB, SERVER, QUEUE, NODE, VNODE):
+                #PBS status(which includes qstat) delimiter is \n with 4
+                #spaces and delimiter between records is \n\n
+                split_lines, record_d, attr_d = False, '\n\n', '\n    '
+            else:
+                split_lines = True
+
             ret = self.du.run_cmd(tgt, pcmd, runas=runas, as_script=as_script,
-                                  level=logging.INFOCLI, logerr=logerr)
+                                  level=logging.INFOCLI, logerr=logerr,
+                                  split_lines=split_lines)
             o = ret['out']
             if ret['err'] != ['']:
                 self.last_error = ret['err']
             self.last_rc = ret['rc']
             if ret['rc'] != 0:
                 raise PbsStatusError(rc=ret['rc'], rv=[], msg=self.geterrmsg())
+            mergelines = True
+            if not split_lines:
+                o = o.replace(record_d, attr_d).split(attr_d)
+                #removing whitespace characters between attribute values
+                #added by PBS
+                o = [line.replace('\n\t', '') for line in o]
+                mergelines = False
 
-            bsl = self.utils.convert_to_dictlist(o, attrib, mergelines=True)
+            bsl = self.utils.convert_to_dictlist(o, attrib,
+                                                 mergelines=mergelines)
 
         # 7- Stat with impersonation over PBS IFL swig-wrapped API
         elif runas is not None:

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -700,7 +700,7 @@ class DshUtils(object):
     def run_cmd(self, hosts=None, cmd=None, sudo=False, stdin=None,
                 stdout=PIPE, stderr=PIPE, input=None, cwd=None, env=None,
                 runas=None, logerr=True, as_script=False, wait_on_script=True,
-                level=logging.INFOCLI2):
+                level=logging.INFOCLI2, split_lines=True):
         """
         Run a command on a host or list of hosts.
 
@@ -870,7 +870,7 @@ class DshUtils(object):
 
             # handle the case where stdout is not a PIPE
             if o is not None:
-                ret['out'] = o.splitlines()
+                ret['out'] = split_lines and o.splitlines() or o
             else:
                 ret['out'] = []
             # Some output can be very verbose, for example listing many lines


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-622](https://pbspro.atlassian.net/browse/PP-622)**

#### Problem description
* PTL returns truncated Variable_List if a variable has newline character

#### Cause / Analysis
* In PTL, the run_cmd function used splitlines() (delimiter is newline-\n) to split the output. So if any variable contains newline, its end up with truncated output of Variable_List.

#### Solution description
* Solution for this issue, is to use the correct delimiter for the status requests. So introduced new argument for the run_cmd method split_lines(default to True), and call it with split_lines=False when the call is for the status of JOB, QUEUE, SERVER and NODE, by that it will give string output without splitting and then split it accordingly(using delimiter newline with 4 spaces-\n    ).

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
