### PR TITLE
PP-652: only first queuejob hook is processed

### DIFF
--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -3857,7 +3857,7 @@ process_hooks(struct batch_request *preq, char *hook_msg, size_t msg_len,
 		}
 		rc = server_process_hooks(preq->rq_type, preq->rq_user, preq->rq_host, phook,
 					  hook_event, pjob, &req_ptr, hook_msg, msg_len, pyinter_func, &num_run);
-		if ((rc == 0) || (rc == 1))
+		if ((rc == 0) || (rc == -1))
 			return (rc);
 	}
 
@@ -3889,7 +3889,7 @@ process_hooks(struct batch_request *preq, char *hook_msg, size_t msg_len,
  * @param[out]	num_run	    - reference of an integer which is incremented when
  *			      hook runs successfully.
  * @return	int
- * @retval	1 means all the executed hooks have agreed to accept the request
+ * @retval	1 means the executed hook has agreed to accept the request
  * @retval 	0 means at least one hook was encountered to have rejected the
  request.
  * @retval	2 means no hook script executed (special case).


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-652](https://pbspro.atlassian.net/browse/PP-652)**

#### Problem description
* only first of each type of server hook is processed

#### Cause / Analysis
* hook_func.c:server_process_hooks() process only one hook of type. This means you can not call return(rc) after first hook is accepted. phook_next may be waiting to be processed. The return 1 means only one hook is accepted not all of one type. 0 means the hook have been rejected, lets call return(rc).

#### Solution description
* Remove the call of return(rc) if the server_process_hooks() is 1. All hooks of the one type will proceed. If all the hooks are accepted, the return value of hook_func.c:process_hooks() will be 1.
 
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
