### PR TITLE
PP-656: only last hook of same kind can modify Resource_List

### DIFF
--- a/src/include/hook_func.h
+++ b/src/include/hook_func.h
@@ -125,7 +125,7 @@ extern void req_stat_hook(struct batch_request *);
 extern int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 				int hook_event, job *pjob, hook_input_param_t *req_ptr,
 				char *hook_msg, int msg_len, void (*pyinter_func)(void),
-				int *num_run);
+				int *num_run, int *event_initialized);
 extern int process_hooks(struct batch_request *, char *, size_t, void (*)(void));
 extern int recreate_request(struct batch_request *);
 

--- a/test/tests/functional/pbs_one_event_multiple_hooks.py
+++ b/test/tests/functional/pbs_one_event_multiple_hooks.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under a
+# commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class Test_single_event_multiple_hooks(TestFunctional):
+    """
+    Test if changes made to pbs objects by multiple hooks of same
+    event type takes effect or not.
+    """
+    hook_string = """
+import pbs
+e = pbs.event()
+e.job.Resource_List["%s"]=%s
+%s
+"""
+
+    def create_hook_scr(self, accept, resource, value):
+        """
+        function to create a hook script.
+        It accepts 3 arguments
+        - accept	If set to true, then hook will accept else reject
+        - resource	Resource whose value we want to change
+        - value		New value to be assigned
+        """
+        hook_action = "e.accept()"
+        if not accept:
+            hook_action = "e.reject()"
+        final_hook = self.hook_string % (resource, value, hook_action)
+        return final_hook
+
+    def test_two_queuejob_hooks(self):
+        """
+        Submit two queue job hooks. One of the hook modifies resource ncpus
+        and other hook modifies walltime. Check the result of modification.
+        """
+        hook_name = "h1"
+        scr = self.create_hook_scr(True, "ncpus", "int(5)")
+        attrs = {'event': "queuejob", 'order': '1'}
+        rv = self.server.create_import_hook(
+            hook_name,
+            attrs,
+            scr,
+            overwrite=True)
+        self.assertTrue(rv)
+
+        hook_name = "h2"
+        scr = self.create_hook_scr(True, "walltime", "600")
+        attrs = {'event': "queuejob", 'order': '2'}
+        rv = self.server.create_import_hook(
+            hook_name,
+            attrs,
+            scr,
+            overwrite=True)
+        self.assertTrue(rv)
+        a = {'Resource_List.ncpus': 1,
+             'Resource_List.walltime': 10}
+        j = Job(TEST_USER)
+        j.set_attributes(a)
+        j.set_sleep_time("10")
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {
+            'Resource_List.ncpus': 5,
+            'Resource_List.walltime': '00:10:00'},
+            offset=2, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-656](https://pbspro.atlassian.net/browse/PP-656)**

#### Problem description
If there are multiple hooks of same event type then only last hook that runs for that event can modify PBS objects.
All modifications made by all other hooks for the same event are ignored.

#### Cause / Analysis
This is happening because we initialize hook event object every time we run a hook. We should be doing it only when we encounter an event and all hooks for that event should work on the same event object.

#### Solution description
made changes in hook_func.c to not initialize event object every time before running the hook.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
