### PR TITLE
PP-588: Python hooks resc_used accumulation: could not load json or i…

### DIFF
--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -7973,13 +7973,12 @@ main(int argc, char *argv[])
 #endif /* _POSIX_MEMLOCK */
 	mom_hook_input_t	hook_input;
 	char			path_hooks_rescdef[MAXPATHLEN+1];
-
-#ifdef WIN32
-
 #ifdef PYTHON
 	PyObject		*path;
 	char			buf[MAXPATHLEN];
 #endif
+
+#ifdef WIN32
 	_fcloseall(); 	/* Close any inherited extra files, leaving stdin-err open */
 #else
 	/* Close any inherited extra files, leaving stdin-err open */
@@ -9157,14 +9156,33 @@ main(int argc, char *argv[])
 	Py_FrozenFlag = 1;
 	Py_Initialize();
 
-#ifdef WIN32
 	path = PySys_GetObject("path");
+#ifdef WIN32
 	snprintf(buf, sizeof(buf), "%s/python/Lib", pbs_conf.pbs_exec_path);
 
 	PyList_Append(path, PyString_FromString(buf));
 
-	PySys_SetObject("path", path);
+#else
+	/* list of possible paths to Python modules (mom imports json) */
+	snprintf(buf, sizeof(buf), "%s/python/lib/python2.7", pbs_conf.pbs_exec_path);
+	PyList_Append(path, PyString_FromString(buf));
+
+	snprintf(buf, sizeof(buf), "%s/python/lib/python2.7/lib-dynload", pbs_conf.pbs_exec_path);
+	PyList_Append(path, PyString_FromString(buf));
+
+	snprintf(buf, sizeof(buf), "/usr/lib/python/python2.7");
+	PyList_Append(path, PyString_FromString(buf));
+
+	snprintf(buf, sizeof(buf), "/usr/lib/python/python2.7/lib-dynload");
+	PyList_Append(path, PyString_FromString(buf));
+
+	snprintf(buf, sizeof(buf), "/usr/lib64/python/python2.7");
+	PyList_Append(path, PyString_FromString(buf));
+
+	snprintf(buf, sizeof(buf), "/usr/lib64/python/python2.7/lib-dynload");
+	PyList_Append(path, PyString_FromString(buf));
 #endif
+	PySys_SetObject("path", path);
 #endif
 
 #ifndef	WIN32

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -4842,8 +4842,14 @@ req_copy_hookfile(struct batch_request *preq) /* ptr to the decoded request   */
 			free_str_array(new_resources);
 			free_str_array(prev_resources);
 
-			path_rescdef = (char *)namebuf;
-			if (setup_resc(1) != 0) {
+			/* Call setup_resc() only if received
+			 * resourcedef file is the one for path_rescdef,
+ 			 * which is set up at mom startup and used when
+			 * HUP-ed.
+			 */
+			if ((path_rescdef != NULL) &&
+				(strcmp(path_rescdef, namebuf) == 0) &&
+							(setup_resc(1) != 0)) {
 				/* log_buffer set in setup_resc */
 				log_err(-1, "setup_resc",
 					"warning: failed to setup resourcedef");


### PR DESCRIPTION
…nvalid resource name upon HUP

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-588](https://pbspro.atlassian.net/browse/PP-588)**

#### Problem description
When running the PTL test pbs_accumulate_resc_used.py for RFE PP-409 (allow mom hooks to accumulate resources_used values for resources beside cput, cpupercent, and mem), tests fail as mom complains about:

failed to import json

Also, there's noise in the mom_logs about:

12/09/2016 17:16:07;0004;pbs_mom;Svr;pbs_mom;invalid character in resource name "localnode=pbs.get_local_nodename()"
12/09/2016 17:16:07;0004;pbs_mom;Svr;pbs_mom;invalid character in resource name "e.vnode_list[localnode].resources_available['foo_i']"
12/09/2016 17:16:07;0004;pbs_mom;Svr;pbs_mom;invalid character in resource name "e.vnode_list[localnode].resources_available['foo_f']"
12/09/2016 17:16:07;0004;pbs_mom;Svr;pbs_mom;invalid character in resource name "e.vnode_list[localnode].resources_available['foo_str']"

#### Cause / Analysis
Problem was due to pbs_mom not having the correct PATH for Python to resolve "import json" calls.
The issue with "invalid character in resource name" was due to the path to resourcedef getting incorrectly reset causing setup_resc() to read the wrong file.
#### Solution description
Much like what was done in the scheduler code in order to resolve importing math module, at the time Py_Iniitialize() is called in mom_main.c, the PATH variable must be updated to include python2.7 elements from possible paths: <PBS_EXEC>/python/lib/python2.7, /usr/lib/python/python2.7, /usr/lib64/python/python2.7.
Also in src/resmom/requests.c, after calling setup_resc() with a temporary value to path_rescdef, ensure that its original value is restored.
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
This would not require any new PTL test as the PP-409 test file, pbs_accumulate_resc_used.py will suffice, The tests were failing due to "could not import json" and "invalid resource name".
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
