### PR TITLE
PP-649: qdel not working with seq_num.server

### DIFF
--- a/src/lib/Libcmds/get_server.c
+++ b/src/lib/Libcmds/get_server.c
@@ -171,6 +171,7 @@ get_server(char *job_id_in, char *job_id_out, char *server_out)
 		strcat(job_id_out, parent_server);
 #endif /* localmod 086 */
 
+		strcpy(server_out, parent_server);
 		free(parent_server);
 		return 0;
 	}

--- a/test/tests/functional/pbs_qdel_with_server_tagged_in_jobid.py
+++ b/test/tests/functional/pbs_qdel_with_server_tagged_in_jobid.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestDeleteJobUsingServerTaggedInJobId(PBSTestSuite):
+    """
+    This test suite contains tests for qdel where it is connecting to server
+    specified in jobid instead of PBS_SERVER from pbs.conf.
+    """
+
+    def setUp(self):
+        """
+        Set PBS_SERVER to not-a-server in pbs.conf
+        """
+        PBSTestSuite.setUp(self)
+        self.du.set_pbs_config(confs={'PBS_SERVER': 'not-a-server'})
+
+    def test_qdel_with_server_tagged_in_jobid(self):
+        """
+        Test to make sure that qdel uses server tagged in jobid instead of
+        the PBS_SERVER conf setting
+        """
+        j = Job(TEST_USER)
+        j.set_attributes({ATTR_q: 'workq@' + self.server.hostname})
+        jid = self.server.submit(j)
+        try:
+            self.server.delete(jid)
+        except PbsDeleteError as e:
+            self.assertFalse(
+                'Unknown Host' in e.msg[0],
+                "Error message is not expected as server name is \
+tagged in the jobid")
+
+    def tearDown(self):
+        self.du.set_pbs_config(confs={'PBS_SERVER': self.server.hostname})
+        PBSTestSuite.tearDown(self)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-649](https://pbspro.atlassian.net/browse/PP-649)**

#### Problem description
* qdel is not working with server tagged in the job id.

#### Cause / Analysis
* qdel is always speaking to PBS_SERVER defined in the /etc/pbs.conf file instead of the server tagged in the job id as get_server() function was not returning the server name parsed from the job id.

#### Solution description
* get_server() function is returning server_name parsed from the job id.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
