### PR TITLE
PP-665: On Cray X-series, accelerator_memory is not set when vnode_per_numa_node is false (or unset)

### DIFF
--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -3430,10 +3430,17 @@ inventory_to_vnodes(basil_response_t *brp)
 									"@%s_%ld_0",
 									mpphost, node->node_id);
 							}
-							if (vn_addvnr(nv, vname, attr,
-								utilBuffer, 0,
-								0, NULL) == -1)
-								goto bad_vnl;
+							/* Avoid calling vn_addvnr() repeatedly
+							 * when creating only one vnode per 
+							 * compute node.
+							 */
+							if ((seg->ordinal == 0) ||
+							     vnode_per_numa_node) {
+								if (vn_addvnr(nv, vname, attr,
+									utilBuffer, 0,
+									0, NULL) == -1)
+									goto bad_vnl;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
PP-665: On Cray X-series, accelerator_memory is not set when vnode_per_numa_node is false (or unset).
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-665](https://pbspro.atlassian.net/browse/PP-665)**

#### Problem description
* When mom_priv/config vnode_per_numa_node is unset (this is the default, and is equivalent to being set to False) and there is an accelerator on a Cray compute node, then the resources_available.accelerator_memory is not being set on the vnode that PBS creates.

#### Cause / Analysis
* This was because vn_addvnr() was mistakenly being called repeatedly when creating only one vnode per compute node.

#### Solution description
* Added code to only call vn_addvnr() for the first numa node (which will end up being the only vnode that PBS creates when vnode_per_numa_node is unset/False) or call vn_addvnr() when vnode_per_numa_node is true.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__