### PR TITLE
PP-693, PP-704: qstat -Bf is incorrectly called for every vnode during a PTL test run; Few test cases in PTL test suite "SmokeTest" refer to server instead of mom object

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -589,7 +589,11 @@ class PBSTestSuite(unittest.TestCase):
                 n = name + '@' + objconf
             else:
                 n = name
-            objs[n] = func(name, pbsconf_file=objconf)
+            if getattr(cls, "server", None) is not None:
+                objs[n] = func(name, pbsconf_file=objconf,
+                               server=cls.server.hostname)
+            else:
+                objs[n] = func(name, pbsconf_file=objconf)
             if objs[n] is None:
                 _msg = 'Failed %s(%s, %s)' % (func.__name__, name, objconf)
                 raise setUpClassError(_msg)
@@ -696,7 +700,7 @@ class PBSTestSuite(unittest.TestCase):
         return server
 
     @classmethod
-    def init_comm(cls, hostname, pbsconf_file=None):
+    def init_comm(cls, hostname, pbsconf_file=None, server=None):
         """
         Initialize a Comm instance associated to the given hostname.
 
@@ -707,11 +711,18 @@ class PBSTestSuite(unittest.TestCase):
         :param pbsconf_file: Optional path to an alternate pbs config file
         :type pbsconf_file: str or None
         :returns: The instantiated Comm upon success and None on failure.
+        :param server: The server name associated to the Comm
+        :type server: str
+        Return the instantiated Comm upon success and None on failure.
         """
-        return Comm(hostname, pbsconf_file=pbsconf_file)
+        try:
+            server = cls.servers[server]
+        except:
+            server = None
+        return Comm(hostname, pbsconf_file=pbsconf_file, server=server)
 
     @classmethod
-    def init_scheduler(cls, server, pbsconf_file=None):
+    def init_scheduler(cls, hostname, pbsconf_file=None, server=None):
         """
         Initialize a Scheduler instance associated to the given server.
         This method must be called after ``init_server``
@@ -720,13 +731,16 @@ class PBSTestSuite(unittest.TestCase):
         :type server: str
         :param pbsconf_file: Optional path to an alternate config file
         :type pbsconf_file: str or None
+        :param hostname: The host on which Sched is running
+        :type hostname: str
         :returns: The instantiated scheduler upon success and None on failure
         """
         try:
             server = cls.servers[server]
         except:
             server = None
-        return Scheduler(server=server, pbsconf_file=pbsconf_file)
+        return Scheduler(hostname=hostname, server=server,
+                         pbsconf_file=pbsconf_file)
 
     @classmethod
     def init_mom(cls, hostname, pbsconf_file=None, server=None):

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -233,7 +233,7 @@ class SmokeTest(PBSTestSuite):
         a = {'resources_available.ncpus': 20, 'sharing': 'force_excl'}
         momstr = self.mom.create_vnode_def('testnode', a, 10)
         self.mom.insert_vnode_def(momstr)
-        self.server.manager(MGR_CMD_CREATE, NODE, None, self.server.hostname)
+        self.server.manager(MGR_CMD_CREATE, NODE, None, self.mom.hostname)
         a = {'resources_available.ncpus=20': 10}
         self.server.expect(VNODE, a, count=True, interval=5)
 
@@ -688,11 +688,11 @@ class SmokeTest(PBSTestSuite):
         jid = self.server.submit(j)
         a = {'job_state': 'R', 'substate': 42}
         self.server.expect(JOB, a, id=jid)
-        printjob = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
+        printjob = os.path.join(self.mom.pbs_conf['PBS_EXEC'], 'bin',
                                 'printjob')
-        jbfile = os.path.join(self.server.pbs_conf['PBS_HOME'], 'mom_priv',
+        jbfile = os.path.join(self.mom.pbs_conf['PBS_HOME'], 'mom_priv',
                               'jobs', jid + '.JB')
-        ret = self.du.run_cmd(self.server.hostname, cmd=[printjob, jbfile],
+        ret = self.du.run_cmd(self.mom.hostname, cmd=[printjob, jbfile],
                               sudo=True)
         self.assertEqual(ret['rc'], 0)
 
@@ -946,13 +946,13 @@ class SmokeTest(PBSTestSuite):
         <ppid> in Suspended state else return False
         """
         state = 'T'
-        rv = self.pu.get_proc_state(self.server.shortname, ppid)
+        rv = self.pu.get_proc_state(self.mom.shortname, ppid)
         if rv != state:
             return False
-        childlist = self.pu.get_proc_children(self.server.shortname,
+        childlist = self.pu.get_proc_children(self.mom.shortname,
                                               ppid)
         for child in childlist:
-            rv = self.pu.get_proc_state(self.server.shortname, child)
+            rv = self.pu.get_proc_state(self.mom.shortname, child)
             if rv != state:
                 return False
         return True
@@ -983,7 +983,7 @@ class SmokeTest(PBSTestSuite):
             a = {'resources_available.ncpus': 3}
         else:
             a = {'resources_available.ncpus': 1}
-        self.server.create_vnodes(self.server.shortname, a, 1,
+        self.server.create_vnodes('vn', a, 1,
                                   mom=self.mom)
         if isWithPreemt:
             self.do_preempt_config()


### PR DESCRIPTION
…test run

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-693](https://pbspro.atlassian.net/browse/PP-693)**

#### Problem description
* qstat -Bf is incorrectly called for every vnode during a PTL test run

#### Cause / Analysis
* vnode name was taken as server name and hence queried for server status

#### Solution description
* proper server name was passed for the status query, normalized other daemon object init definitions
* updated appropriate mom object names in smoke test cases which were server names that do not work when mom and server are run on different hosts

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
