### PR TITLE
PP-211: Scheduler dumps core for suspended jobs..

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1460,13 +1460,16 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 		return 0;
 
 	for (i = 0; susp_jobs[i] != NULL; i++) {
-		for (j = 0; susp_jobs[i]->ninfo_arr[j] != NULL; j++) {
-			/* resresv -> ninfo_arr is merely a new list with pointers to server nodes.
-			 * resresv -> resv -> resv_nodes is a new list with pointers to resv nodes
-			 */
-			node = find_node_info(ninfo_arr, susp_jobs[i]->ninfo_arr[j]->name);
-			if (node != NULL)
-				node->num_susp_jobs++;
+		if (susp_jobs[i]->ninfo_arr != NULL) {
+			for (j = 0; susp_jobs[i]->ninfo_arr[j] != NULL; j++) {
+				/* resresv -> ninfo_arr is merely a new list with pointers to server nodes.
+				 * resresv -> resv -> resv_nodes is a new list with pointers to resv nodes
+				 */
+				node = find_node_info(ninfo_arr,
+						susp_jobs[i]->ninfo_arr[j]->name);
+				if (node != NULL)
+					node->num_susp_jobs++;
+			}
 		}
 	}
 	free(susp_jobs);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-211](https://pbspro.atlassian.net/browse/PP-211)**

#### Problem description
* Scheduler dumps core for suspended job, when sched cycle is kicked, if requested vnode by job has been deleted

#### Cause / Analysis
* Inside 'collect_jobs_on_nodes()', line 1463, we were dereferencing 'ninfo_arr' for suspended jobs, which would be NULL if the node on which a suspended job was running got deleted.

#### Solution description
* Added a check for NULL, now we will only dereference 'ninfo_arr' if it is not NULL.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
