### PR TITLE
PP-84: Scheduler crashing, race condition

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1065,8 +1065,13 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 		}
 		else if (!strcmp(attrp->name, ATTR_l)) { /* resources requested*/
 			resreq = find_alloc_resource_req_by_str(resresv->resreq, attrp->resource);
-			if (resreq != NULL)
-				set_resource_req(resreq, attrp->value);
+			if (resreq == NULL) {
+				free_resource_resv(resresv);
+				return NULL;
+			}
+
+			set_resource_req(resreq, attrp->value);
+
 			if (resresv->resreq == NULL)
 				resresv->resreq = resreq;
 			if (!strcmp(attrp->resource, "place")) {

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -186,6 +186,7 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 		free_schd_error(err);
 		return NULL;
 	}
+	resresv_arr[0] = NULL;
 	sinfo->num_resvs = num_resv;
 
 	cur_resv = resvs;
@@ -532,11 +533,10 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 				continue;
 			}
 		}
-		resresv_arr[idx] = resresv;
-		idx++;
+		resresv_arr[idx++] = resresv;
+		resresv_arr[idx] = NULL;
 		cur_resv = cur_resv->next;
 	}
-	resresv_arr[idx] = NULL;
 
 	pbs_statfree(resvs);
 	free_schd_error(err);
@@ -639,8 +639,12 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 		}
 		else if (!strcmp(attrp->name, ATTR_l)) { /* resources requested*/
 			resreq = find_alloc_resource_req_by_str(advresv->resreq, attrp->resource);
-			if (resreq != NULL)
-				set_resource_req(resreq, attrp->value);
+			if (resreq == NULL) {
+				free_resource_resv(advresv);
+				return NULL;
+			}
+
+			set_resource_req(resreq, attrp->value);
 
 			if (!strcmp(resreq->name, "place"))
 				advresv->place_spec = parse_placespec(attrp->value);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-84](https://pbspro.atlassian.net/browse/PP-84)**

#### Problem description
* Scheduler crashing while querying reservation if custom resource is added (race condition)

#### Cause / Analysis
* Bhroam had already debugged this, it happens because of a race condition where a custom resource is added after the scheduler has already queried resources for the cycle AND before it has queried jobs & reservations, this means that if there are reservations submitted in this tiny window which request this new resource. Then, when the scheduler queries these reservations inside 'query_resv()', 'find_alloc_resource_req_by_str()' returns NULL for the resource that the scheduler doesn't know about, but we go ahead and try to dereference it in the next line, which causes the crash.

#### Solution description
* We now bail if we find a resource inside a reservation/job which is not recognized.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
