### PR TITLE
PP-728: Fixed upper case in some dependency library names

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -23,8 +23,8 @@ How to install PBS Pro using the configure script.
 
   For Debian systems you should run the following command as root:
 
-    sudo apt-get install gcc make libtool libhwloc-dev libX11-dev \
-      libXt-dev libedit-dev libical-dev ncurses-dev perl \
+    sudo apt-get install gcc make libtool libhwloc-dev libx11-dev \
+      libxt-dev libedit-dev libical-dev ncurses-dev perl \
       postgresql-server-dev-all python-dev tcl-dev tk-dev swig \
       libexpat-dev libssl-dev libxext-dev libxft-dev autoconf \
       automake


### PR DESCRIPTION
Changed  libX11-dev and libXt-dev to libx11-dev and libxt-dev

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-728](https://pbspro.atlassian.net/browse/PP-728)**

#### Problem description
Locate step 1 for Debian systems. Copy this long command and run it on a Debian system
```
sudo apt-get install gcc make libtool libhwloc-dev libx11-dev 
libxt-dev libedit-dev libical-dev ncurses-dev perl 
postgresql-server-dev-all python-dev tcl-dev tk-dev swig 
libexpat-dev libssl-dev libxext-dev libxft-dev autoconf 
automake
```
apt-get will tell you that it cannot find package libx11-dev and libXt-dev because the letter 'X' should be lowercase.

#### Cause / Analysis
* apt-get is case sensitive. The letter 'X' in these two filenames should be lowercase.

#### Solution description
* Changed uppercase letter 'X' to lowercase 'x'.
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
