### PR TITLE
PP-730: log_err messages do not appear in syslog if PBS_LOCALLOG is n…

### DIFF
--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -694,8 +694,20 @@ log_err(int errnum, const char *routine, const char *text)
 	if (log_opened == 0) {
 		(void)log_open("/dev/console", log_directory);
 
-		if (log_opened < 1)
+		if (log_opened < 1) {
+#if SYSLOG
+			char slogbuf[LOG_BUF_SIZE] = {0};
+			if (syslogopen != 0) {
+				snprintf(slogbuf, LOG_BUF_SIZE,
+					"%s;%s;%s\n",
+					class_names[PBS_EVENTCLASS_SERVER],
+					msg_daemonname,
+					buf);
+				syslog(LOG_ERR, "%s", slogbuf);
+			}
+#endif  /* SYSLOG */
 			return;
+		}
 	}
 
 	if (isatty(2))
@@ -772,9 +784,20 @@ log_joberr(int errnum, const char *routine, const char *text, const char *pjid)
 	if (log_opened == 0) {
 		(void)log_open("/dev/console", log_directory);
 
-		if (log_opened < 1)
+		if (log_opened < 1) {
+#if SYSLOG
+			char slogbuf[LOG_BUF_SIZE] = {0};
+			if (syslogopen != 0) {
+				snprintf(slogbuf, LOG_BUF_SIZE,
+					"%s;%s;%s\n",
+					class_names[PBS_EVENTCLASS_JOB],
+					msg_daemonname,
+					buf);
+				syslog(LOG_ERR, "%s", slogbuf);
+			}
+#endif  /* SYSLOG */
 			return;
-
+		}
 	}
 	if (isatty(2))
 		(void)fprintf(stderr, "%s: %s\n", msg_daemonname, buf);


### PR DESCRIPTION
…ot set and PBS_SYSLOG is set to 1 in pbs.conf

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-730](https://pbspro.atlassian.net/browse/PP-730)**

#### Problem description
* logic to write logs to the system log is under log_record(). However, log_err() checks if the local log is opened for logging or not. If not, it does not call log_record() and returns.

#### Cause / Analysis
* Analysis is in the problem description above.

#### Solution description
* before returning from log_err(), check if logging to system log is enabled, if yes, record the log.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
