### PR TITLE
PP-512: Memory leak in server when writing 'E' accounting record

### DIFF
--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -142,7 +142,7 @@ force_reque(job *pjob)
 	rel_resc(pjob);
 
 	/* note in accounting file */
-	account_jobend(pjob, (char *)0, PBS_ACCT_RERUN);
+	account_jobend(pjob, pjob->ji_acctrec, PBS_ACCT_RERUN);
 
 	/* if a subjob,  we set substate to RERUN3 to cause trktbl entry */
 	/* to be reset to Qeued, and then blow away the job struct       */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-512](https://pbspro.atlassian.net/browse/PP-512)**

#### Problem description
* Memory leak in server when writing 'E' accounting record
#### Cause / Analysis
* There is some incorrect logic that causes the server to fall into a if() statement when it shouldn't.  The if() statement recalculated and allocated (and leaked) the resources_used string for the accounting logs on an 'E' record incorrectly.

#### Solution description
* Instead of using the complex logic the original if() statement used, I split it into two if()'s.  It makes the code cleaner and makes it clearer what is going on. 
The change to req_rerun.c fixes an inconsistency with how account_jobend() is called.  Everywhere else (except for job arrays) it's called with pjob->ji_acctrec.  It's called with NULL here.  This would cause the new fix to incorrectly not fall into the if() and resources_used info wouldn't be printed in the accounting log.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
