### PR TITLE
PP-682 :  pbs_comm drops new connection request for registered node

### DIFF
--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -1,36 +1,36 @@
 /*
  * Copyright (C) 1994-2016 Altair Engineering, Inc.
  * For more information, contact Altair at www.altair.com.
- *  
+ *
  * This file is part of the PBS Professional ("PBS Pro") software.
- * 
+ *
  * Open Source License Information:
- *  
+ *
  * PBS Pro is free software. You can redistribute it and/or modify it under the
- * terms of the GNU Affero General Public License as published by the Free 
- * Software Foundation, either version 3 of the License, or (at your option) any 
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
  * later version.
- *  
- * PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY 
+ *
+ * PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
- *  
- * You should have received a copy of the GNU Affero General Public License along 
+ *
+ * You should have received a copy of the GNU Affero General Public License along
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
- *  
- * Commercial License Information: 
- * 
- * The PBS Pro software is licensed under the terms of the GNU Affero General 
- * Public License agreement ("AGPL"), except where a separate commercial license 
+ *
+ * Commercial License Information:
+ *
+ * The PBS Pro software is licensed under the terms of the GNU Affero General
+ * Public License agreement ("AGPL"), except where a separate commercial license
  * agreement for PBS Pro version 14 or later has been executed in writing with Altair.
- *  
- * Altair’s dual-license business model allows companies, individuals, and 
- * organizations to create proprietary derivative works of PBS Pro and distribute 
- * them - whether embedded or bundled with other software - under a commercial 
+ *
+ * Altair’s dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of PBS Pro and distribute
+ * them - whether embedded or bundled with other software - under a commercial
  * license agreement.
- * 
- * Use of Altair’s trademarks, including but not limited to "PBS™", 
- * "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's 
+ *
+ * Use of Altair’s trademarks, including but not limited to "PBS™",
+ * "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
  * trademark licensing policies.
  *
  */
@@ -1163,12 +1163,15 @@ router_pkt_handler(int tfd, void *data, int len, void *c)
 				r = (tpp_router_t *) tpp_find_tree(AVL_routers, &connected_host);
 				if (r) {
 					if (r->conn_fd != -1) {
-						/* this router had not yet disconnected
-						 * so close this incoming connection
+						/* this router had not yet disconnected,
+						 * so close the existing connection
 						 */
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, pbs_comm %s is still connected while "
-							"another connect arrived, dropping", tfd, r->router_name);
+						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
+							 "tfd=%d, pbs_comm %s is still connected while "
+							 "another connect arrived, dropping existing connection %d",
+							 tfd, r->router_name, r->conn_fd);
 						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+						tpp_transport_close(r->conn_fd);
 						tpp_unlock(&router_lock);
 						return -1;
 					}
@@ -1277,13 +1280,15 @@ router_pkt_handler(int tfd, void *data, int len, void *c)
 					}
 
 					if (l->conn_fd != -1) {
-						/* this leaf had not yet disconnected
-						 * so close this incoming connection
+						/* this leaf had not yet disconnected,
+						 * so close the existing connection.
 						 */
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Leaf %s still connected while "
-									"another leaf connect arrived, dropping",
-									tfd, tpp_netaddr(&l->leaf_addrs[0]));
+						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ,
+							 "tfd=%d, Leaf %s still connected while "
+							 "another leaf connect arrived, dropping existing connection %d",
+							 tfd, tpp_netaddr(&l->leaf_addrs[0]), l->conn_fd);
 						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
+						tpp_transport_close(l->conn_fd);
 						tpp_unlock(&router_lock);
 						return -1;
 					}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-682](https://pbspro.atlassian.net/browse/PP-682)**

#### Problem description
* In high availability setup, "new" server leaf connection to pbs_comm keeps getting rejected because stale connection from old server is still seen
#### Cause / Analysis
* This is a TPP related bug that shows up in a IP failover situation.
In some customer site failover is configured is such a way that, when the primary machine fails, cluster manager starts the daemons on the secondary, and fails-over the IP-address along with it.

The daemon (e.g. mom) is started up on another host (by cluster manager) but has the same IP address as the primary (the IP address itself is failed over, and is the usual way cluster managers perform failover).

Since the primary machine went down abruptly, the TCP connection of the mom to the pbs_comm was not yet broken, and when a new connection comes from the restarted mom, pbs_comm keeps rejecting it. (saying the IP address is already registered).


#### Solution description
* When a connection arrives, pbs_comm checks whether the IP address is already registered (and still registered) and if so, drops the new connection.
However, now, instead of dropping the new connection, it will close the older connection such that the new connection can be accepted.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/pages/viewpage.action?pageId=51188745)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
