### PR TITLE
PP-721: Error observed when post analysis data is saved in PTL test execution that has failed tests

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_data.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_data.py
@@ -162,6 +162,7 @@ class PTLTestData(Plugin):
         pbs_diag = os.path.join(svr.pbs_conf['PBS_EXEC'],
                                 'unsupported', 'pbs_diag')
         cmd = [pbs_diag, '-f', '-d', '2']
+        cmd += ['-u', self.du.get_current_user()]
         if len(svr.jobs) > 0:
             cmd += ['-j', ','.join(svr.jobs.keys())]
         ret = self.du.run_cmd(svr_host, cmd, sudo=True, level=logging.DEBUG2)


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-721](https://pbspro.atlassian.net/browse/PP-721)**

#### Problem description
* -u argument is missing while calling pbs_diag in saving post analysis data

#### Cause / Analysis
* -u argument is required to collect pbs_dtj information if you have jobs in systems, without -u argument pbs_diag will skip collecting pbs_dtj information for specified jobs

#### Solution description
* added -u while calling pbs_diag in post data saving

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
