### PR TITLE
PP-738: Wrong test count displayed when PTL fails in setUpClass

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -115,6 +115,7 @@ class _PtlTestResult(unittest.TestResult):
         self.descriptions = descriptions
         self.errorClasses = {}
         self.config = config
+        self.success = []
         self.skipped = []
         self.timedout = []
         self.handler = TestLogCaptureHandler()
@@ -179,6 +180,7 @@ class _PtlTestResult(unittest.TestResult):
         """
         Add success to the test result
         """
+        self.success.append(test)
         unittest.TestResult.addSuccess(self, test)
         if self.showAll:
             self.logger.info('ok\n')
@@ -350,6 +352,7 @@ class _PtlTestResult(unittest.TestResult):
         fail = 0
         skip = 0
         timedout = 0
+        success = len(self.success)
         if len(self.failures) > 0:
             for failedtest in self.failures:
                 fail += 1
@@ -389,12 +392,7 @@ class _PtlTestResult(unittest.TestResult):
             _msg = 'Test suites with failures: '
             _msg += ','.join(suites)
             msg += [_msg]
-        if self.testsRun > 0:
-            runned = self.testsRun
-            success = self.testsRun - (fail + error + skip + timedout)
-        else:
-            runned = fail + error + skip + timedout
-            success = 0
+        runned = success + fail + error + skip + timedout
         _msg = 'run: ' + str(runned)
         _msg += ', succeeded: ' + str(success)
         _msg += ', failed: ' + str(fail)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-738](https://pbspro.atlassian.net/browse/PP-738)**

#### Problem description
* test failure in setUpClass leads to wrong statistics count in summary

#### Cause / Analysis
* In python unittest framework whenever test fails in setUpClass, framework doesn't increase testsRun count which leads to negative number in summary

#### Solution description
* corrected calculation of statistics count in summary by collecting success info along with error, failure, skipped and timedout infos

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
