### PR TITLE
PP-742: Scheduler crashes during re-confirmation..

### DIFF
--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -502,8 +502,8 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 					resresv_ocr->resv->resv_idx = occr_idx;
 
 					/* Add the occurrence to the global array of reservations */
-					resresv_arr[idx] = resresv_ocr;
-					idx++;
+					resresv_arr[idx++] = resresv_ocr;
+					resresv_arr[idx] = NULL;
 
 					loc_time = localtime(&resresv_ocr->start);
 
@@ -531,10 +531,11 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 				free(execvnode_ptr);
 
 				continue;
+			} else {
+				resresv_arr[idx++] = resresv;
+				resresv_arr[idx] = NULL;
 			}
 		}
-		resresv_arr[idx++] = resresv;
-		resresv_arr[idx] = NULL;
 		cur_resv = cur_resv->next;
 	}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-742](https://pbspro.atlassian.net/browse/PP-742)**

#### Problem description
* Scheduler crashes during re-confirmation of a degraded standing reservation

#### Cause / Analysis
* PP-84 introduced a bug inside query_reservations(), resresv_arr[] was not being created correctly.

#### Solution description
* Fixed the code so now resresv_arr[] gets created correctly

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__