### PR TITLE
PP-587: One MoM reports the compute node info to server

### DIFF
--- a/src/include/avltree.h
+++ b/src/include/avltree.h
@@ -94,6 +94,17 @@ extern int	avl_next_key(AVL_IX_REC *pe, AVL_IX_DESC *pix);
 extern int	avl_prev_key(AVL_IX_REC *pe, AVL_IX_DESC *pix);
 extern int	avl_find_exact(AVL_IX_REC *pe, AVL_IX_DESC *pix);
 
+/* Added by Altair */
+int tree_add_del(AVL_IX_DESC *root, void *key, void *data, int op);
+void *find_tree(AVL_IX_DESC *root, void *key);
+AVL_IX_DESC *create_tree(int dups, int keylen);
+AVL_IX_REC *avlkey_create(AVL_IX_DESC *tree, void *key);
+
+/* Operation types for addition/deletion from AVL tree */
+#define TREE_OP_ADD	0
+#define TREE_OP_DEL	1
+
+
 #ifdef  __cplusplus
 }
 #endif

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -377,7 +377,7 @@ extern void  scan_for_terminated(void);
 extern int   setwinsize(int);
 extern void  set_termcc(int);
 extern int   conn_qsub(char *host, long port);
-extern void  state_to_server(void);
+extern void  state_to_server(int);
 extern int   send_hook_vnl(void *vnl);
 extern int hook_requests_to_server(pbs_list_head *);
 extern void  set_job_toexited(char *);
@@ -411,6 +411,10 @@ extern int pbs_pclose(FILE *);
 
 /* max length of the error message generated due to database issues */
 #define PBS_MAX_DB_ERR  500
+
+/* Defines for state_to_server */
+#define UPDATE_VNODES 0
+#define UPDATE_MOM_ONLY 1
 #ifdef	__cplusplus
 }
 #endif

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -117,6 +117,7 @@ typedef unsigned long pbs_net_t;        /* for holding host addresses */
 #define IS_HOOK_ACTION_ACK      27 /* acknowledge a request of the above 2    */
 #define IS_HOOK_SCHEDULER_RESTART_CYCLE  29 /* hook wish scheduler to recycle */
 #define IS_HOOK_CHECKSUMS		 30 /* mom reports about hooks seen */
+#define IS_HELLO_NO_INVENTORY	31 /* send info about the mom node only */
 
 #define IS_CMD          40
 #define IS_CMD_REPLY    41

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -334,6 +334,7 @@ extern "C" {
 #define ATTR_NODE_LicenseInfo	"license_info"
 #define ATTR_NODE_TopologyInfo	"topology_info"
 #define ATTR_NODE_MaintJobs	"maintenance_jobs"
+#define ATTR_NODE_VnodePool	"vnode_pool"
 
 /* Resource "attribute" names */
 #define ATTR_RESC_TYPE		"type"

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -96,7 +96,6 @@ extern void  mark_node_offline_by_mom(char *, char *);
 extern void  clear_node_offline_by_mom(char *, char *);
 extern void  mark_which_queues_have_nodes(void);
 extern void  set_sched_sock(int);
-extern int   save_nodes_db(int);
 extern void  pbs_close_stdfiles(void);
 extern int   is_job_array(char *id);
 extern char *get_index_from_jid(char *newjid);

--- a/src/lib/Libattr/master_node_attr_def.xml
+++ b/src/lib/Libattr/master_node_attr_def.xml
@@ -548,6 +548,23 @@
 	<member_at_type><SVR>ATR_TYPE_STR</SVR></member_at_type>
 	<member_at_parent>PARENT_TYPE_NODE</member_at_parent>
 	</attributes>		
+   <attributes>
+   /* ND_ATR_VnodePool */
+	<member_name><both>ATTR_NODE_VnodePool</both></member_name>   <!-- "vnode_pool" -->
+	<member_at_decode>decode_l</member_at_decode>
+	<member_at_encode>encode_l</member_at_encode>
+	<member_at_set>set_l</member_at_set>
+	<member_at_comp>comp_l</member_at_comp>
+	<member_at_free>free_null</member_at_free>
+	<member_at_action>chk_vnode_pool</member_at_action>
+	<member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
+	<member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
+	<member_at_parent>PARENT_TYPE_NODE</member_at_parent>
+	<member_verify_function>
+	<ECL>verify_datatype_long</ECL>
+	<ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+	</member_verify_function>
+   </attributes>
    <tail>
       <SVR>
 	};

--- a/src/lib/Libifl/pbsD_stathost.c
+++ b/src/lib/Libifl/pbsD_stathost.c
@@ -556,6 +556,7 @@ static struct attr_names {
 	{ ATTR_NODE_License, NULL},
 	{ ATTR_NODE_LicenseInfo, NULL},
 	{ ATTR_NODE_TopologyInfo, NULL},
+	{ ATTR_NODE_VnodePool, NULL},
 	{(char *)0, NULL }
 };
 

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -158,6 +158,7 @@ char *msg_license_bad_action = "Action not allowed with license server scheme.";
 char *msg_prov_script_notfound = "Provision hook script not found";
 char *msg_jobscript_max_size= "jobscript size exceeded the jobscript_max_size";
 char *msg_badjobscript_max_size= "jobscript max size exceeds 2GB";
+char *msg_new_inventory_mom = "Setting inventory_mom for vnode_pool %d to %s";
 /*
  * This next set of messages are returned to the client on an error.
  * They may also be logged.

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -8733,7 +8733,7 @@ _pbs_python_do_vnode_set(void)
 	 */
 	if (need_todo & WRITE_NEW_NODESFILE) {
 		/*create/delete/prop/ntype change*/
-		(void)save_nodes_db(0);
+		(void)save_nodes_db(0, NULL);
 	} else if (need_todo & WRITENODE_STATE) {  /*nodes "offline"/comment changed*/
 		write_node_state();
 	}

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -695,7 +695,7 @@ tpp_init(struct tpp_config *cnf)
 	TPP_QUE_CLEAR(&strm_action_queue);
 	TPP_QUE_CLEAR(&freed_sd_queue);
 
-	AVL_streams = tpp_create_tree(AVL_DUP_KEYS_OK, sizeof(tpp_addr_t));
+	AVL_streams = create_tree(AVL_DUP_KEYS_OK, sizeof(tpp_addr_t));
 	if (AVL_streams == NULL) {
 		tpp_log_func(LOG_CRIT, __func__, "Failed to create AVL tree for leaves");
 		return -1;
@@ -842,7 +842,7 @@ tpp_open(char *dest_host, unsigned int port)
 	 * comes to such a half open stream
 	 */
 
-	if ((pkey = tpp_avlkey_create(AVL_streams, &dest_addr))) {
+	if ((pkey = avlkey_create(AVL_streams, &dest_addr))) {
 		if (avl_find_key(pkey, AVL_streams) == AVL_IX_OK) {
 			while (1) {
 				strm = pkey->recptr;
@@ -1400,7 +1400,7 @@ alloc_stream(tpp_addr_t *src_addr, tpp_addr_t *dest_addr)
 
 	if (dest_addr) {
 		/* also add stream to the AVL_streams with the dest as key */
-		if (tpp_tree_add_del(AVL_streams, &strm->dest_addr, strm, TPP_OP_ADD) != 0) {
+		if (tree_add_del(AVL_streams, &strm->dest_addr, strm, TREE_OP_ADD) != 0) {
 			sprintf(tpp_get_logbuf(), "Failed to add strm with sd=%u to streams", strm->sd);
 			tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 			free(strm);
@@ -2576,7 +2576,7 @@ find_stream_with_dest(tpp_addr_t *dest_addr, unsigned int dest_sd, unsigned int 
 	AVL_IX_REC *pkey;
 	stream_t *strm;
 
-	pkey = tpp_avlkey_create(AVL_streams, dest_addr);
+	pkey = avlkey_create(AVL_streams, dest_addr);
 	if (pkey == NULL)
 		return NULL;
 
@@ -3661,7 +3661,7 @@ find_stream_tree_key(stream_t *strm)
 	AVL_IX_REC *pkey;
 	stream_t *t_strm;
 
-	pkey = tpp_avlkey_create(AVL_streams, &strm->dest_addr);
+	pkey = avlkey_create(AVL_streams, &strm->dest_addr);
 	if (pkey == NULL) {
 		sprintf(tpp_get_logbuf(), "Out of memory allocating avlkey for sd=%u", strm->sd);
 		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
@@ -4239,7 +4239,7 @@ leaf_pkt_handler(int tfd, void *data, int len, void *ctx)
 			/* go past the header and point to the list of addresses following it */
 			addrs = (tpp_addr_t *) (((char *) data) + sizeof(tpp_leave_pkt_hdr_t));
 			for(i = 0; i < hdr->num_addrs; i++) {
-				if ((pkey = tpp_avlkey_create(AVL_streams, &addrs[i]))) {
+				if ((pkey = avlkey_create(AVL_streams, &addrs[i]))) {
 
 					/*
 					 * An avl tree, that allows duplicates, keeps nodes with same

--- a/src/lib/Libtpp/tpp_common.h
+++ b/src/lib/Libtpp/tpp_common.h
@@ -90,10 +90,6 @@ extern "C" {
 
 #endif
 
-/* define macros for delete and add operations */
-#define	TPP_OP_ADD 0
-#define TPP_OP_DEL 1
-
 #define MAX_SEQ_NUMBER          (UINT_MAX - 10)
 #define UNINITIALIZED_INT       (MAX_SEQ_NUMBER + 1)
 #define TPP_LOGBUF_SZ        	1024
@@ -287,7 +283,6 @@ enum TPP_MSG_TYPES {
 #define TPP_CMD_WAKEUP          11
 
 #define TPP_DEF_ROUTER_PORT     17001
-#define MAX_AVLKEY_LEN          100
 #define TPP_SCRATCHSIZE         8192
 
 #define TPP_ROUTER_STATE_DISCONNECTED	0   /* Leaf not connected to router */
@@ -408,11 +403,6 @@ int tpp_ready_fds(int *sds, int len);
 void *tpp_get_user_data(int sd);
 int tpp_set_user_data(int sd, void *user_data);
 char* convert_to_ip_port(char *host_port, int port);
-
-int tpp_tree_add_del(AVL_IX_DESC *root, void *key, void *data, int op);
-void *tpp_find_tree(AVL_IX_DESC *root, void *key);
-AVL_IX_DESC *tpp_create_tree(int dups, int keylen);
-AVL_IX_REC *tpp_avlkey_create(AVL_IX_DESC *tree, void *key);
 
 int tpp_init_tls_key(void);
 tpp_tls *tpp_get_tls(void);

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -9451,7 +9451,7 @@ main(int argc, char *argv[])
 		/* can be changed in check_busy() or query_adp() */
 
 		if (internal_state_update) {
-			state_to_server();
+			state_to_server(UPDATE_VNODES);
 
 			(void)send_hook_vnl(vnlp_from_hook);
 			/* send_hook_vnl() saves 'vnlp_from_hook' internally, */

--- a/src/server/mom_info.c
+++ b/src/server/mom_info.c
@@ -378,6 +378,7 @@ create_svrmom_entry(char *hostname, unsigned int port, unsigned long *pul)
 	psvrmom->msr_jobindx = NULL;
 	psvrmom->msr_numvnds = 0;
 	psvrmom->msr_numvslots = 1;
+	psvrmom->msr_vnode_pool = 0;
 	psvrmom->msr_children =
 		(struct pbsnode **)calloc((size_t)(psvrmom->msr_numvslots),
 		sizeof(struct pbsnode *));

--- a/src/server/node_recov_db.c
+++ b/src/server/node_recov_db.c
@@ -336,6 +336,15 @@ node_save_db(struct pbsnode *pnode, int mode)
 	obj.pbs_db_obj_type = PBS_DB_NODE;
 	obj.pbs_db_un.pbs_db_node = &dbnode;
 
+	if (mode == NODE_SAVE_QUICK) {
+		/* quick save - save only the node row
+		 * no deletion, no attributes to update
+		 */
+		if (pbs_db_update_obj(conn, &obj) != 0)
+			goto db_err;
+		return (0);
+	}
+
 	if (pbs_db_begin_trx(conn, 0, 0) !=0)
 		goto db_err;
 

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2163,7 +2163,7 @@ try_db_again:
 
 	if (svr_chngNodesfile) {/*nodes created/deleted, or props changed and*/
 		/*update in req_manager failed; try again    */
-		(void)save_nodes_db(0);
+		(void)save_nodes_db(0, NULL);
 	}
 
 	/* if brought up the Secondary Scheduler, take it down */

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -522,7 +522,7 @@ void set_admin_suspend(job *pjob, int set_remove_nstate) {
 		}
 		chunk = parse_plus_spec_r(last, &last, &hasprn);
 	}
-	save_nodes_db(0);
+	save_nodes_db(0, NULL);
 	free_arst(&new);
 	free(execvncopy);
 }

--- a/src/server/svr_migrate_data.c
+++ b/src/server/svr_migrate_data.c
@@ -249,7 +249,7 @@ svr_migrate_data()
 			pbsndlist[i]->nd_modified = NODE_UPDATE_OTHERS;
 		}
 
-		if (save_nodes_db(0) != 0) {
+		if (save_nodes_db(0, NULL) != 0) {
 			log_err(errno, "svr_migrate_data", "save_nodes_db failed!");
 			return -1;
 		}
@@ -658,7 +658,7 @@ svr_migrate_data_from_fs(void)
 		}
 	}
 
-	if (save_nodes_db(0) != 0) {
+	if (save_nodes_db(0, NULL) != 0) {
 		fprintf(stderr, "Could not save nodes\n");
 		if (svr_db_conn->conn_db_err)
 			fprintf(stderr, "[%s]\n", (char*)svr_db_conn->conn_db_err);

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -243,7 +243,7 @@ svr_chk_history_conf(void)
 }
 
 int
-save_nodes_db(int flag)
+save_nodes_db(int flag, void *pmom)
 {
 	return (0);
 }
@@ -888,6 +888,12 @@ int
 set_node_topology(attribute *pattr, void *pobject, int actmode)
 {
 
+	return (PBSE_NONE);
+}
+
+int
+chk_vnode_pool(attribute *pattr, void *pobject, int actmode)
+{
 	return (PBSE_NONE);
 }
 

--- a/test/tests/functional/pbs_cray_vnode_pool.py
+++ b/test/tests/functional/pbs_cray_vnode_pool.py
@@ -1,0 +1,303 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+@tags('cray', 'configuration')
+class TestVnodePool(TestFunctional):
+
+    """
+    This test suite tests how PBS makes use of node attribute "vnode_pool"
+    It expects at least 2 moms to be specified to it while executing.
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        if len(self.moms.values()) < 2:
+            self.skipTest("Provide at least 2 moms while invoking test")
+
+        # The moms provided to the test may have unwanted vnodedef files.
+        if self.moms.values()[0].has_vnode_defs():
+            self.moms.values()[0].delete_vnode_defs()
+        if self.moms.values()[1].has_vnode_defs():
+            self.moms.values()[1].delete_vnode_defs()
+
+        # Check if vnodes exist before deleting nodes.
+        # Clean all default nodes because each test case will set up nodes.
+        try:
+            self.server.status(NODE)
+            self.server.manager(MGR_CMD_DELETE, NODE, None, "")
+        except PbsStatusError as e:
+            self.assertTrue("Server has no node list" in e.msg[0])
+
+    def test_invalid_values(self):
+        """
+        Invalid vnode_pool values shall result in errors.
+        """
+        self.momA = self.moms.values()[0]
+        self.momB = self.moms.values()[1]
+
+        self.hostA = self.momA.shortname
+        self.hostB = self.momB.shortname
+
+        attr_A = {'vnode_pool': '-1'}
+        try:
+            self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA,
+                                attrib=attr_A)
+        except PbsManagerError as e:
+            self.assertTrue("Illegal attribute or resource value" in e.msg[0])
+
+        attr_A = {'vnode_pool': '0'}
+        try:
+            self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA,
+                                attrib=attr_A)
+        except PbsManagerError as e:
+            self.assertTrue("Illegal attribute or resource value" in e.msg[0])
+
+        attr_A = {'vnode_pool': 'a'}
+        try:
+            self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA,
+                                attrib=attr_A)
+        except PbsManagerError as e:
+            self.assertTrue("Illegal attribute or resource value" in e.msg[0])
+
+    def test_two_moms_single_vnode_pool(self):
+        """
+        Same vnode_pool for two moms shall result in one mom being the
+        inventory mom and the other the non-inventory mom.
+        The inventory mom goes down (e.g. killed).
+        Compute nodes remain up even when the inventory mom is killed,
+        since another mom is reporting them.
+        Check that a new inventory mom is listed in the log.
+        Bring up killed mom.
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {"log_events": -1})
+
+        found_in_momA = 0
+        found_in_momB = 0
+        self.momA = self.moms.values()[0]
+        self.momB = self.moms.values()[1]
+        self.hostA = self.momA.shortname
+        self.hostB = self.momB.shortname
+
+        attr = {'vnode_pool': '1'}
+
+        start_time = int(time.time())
+
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA, attrib=attr)
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB, attrib=attr)
+
+        rc = self.server.log_match("Mom %s added to vnode_pool %s" %
+                                   (self.hostB, '1'), max_attempts=5,
+                                   starttime=start_time)
+        self.assertTrue(rc)
+
+        rc = self.momA.log_match(
+            "Hello (no inventory required) from server", max_attempts=9,
+            starttime=start_time)
+        if rc is None:
+            found_in_momA = 0
+        else:
+            found_in_momA = 1
+
+        rc = self.momB.log_match(
+            "Hello (no inventory required) from server", max_attempts=9,
+            starttime=start_time)
+        if rc is None:
+            found_in_momB = 0
+        else:
+            found_in_momB = 1
+
+        self.assertEqual(found_in_momA + found_in_momB,
+                         1, msg="an inventory mom not chosen correctly")
+
+        # Only one mom is inventory mom
+        if (found_in_momA == 0):
+            inv_mom = self.momA
+            noninv_mom = self.momB
+        else:
+            inv_mom = self.momB
+            noninv_mom = self.momA
+
+        self.logger.info("Inventory mom is %s." % inv_mom.shortname)
+        self.logger.info("Non-inventory mom is %s." %
+                         noninv_mom.shortname)
+
+        start_time = int(time.time())
+
+        # Kill inventory mom
+        inv_mom.signal('-KILL')
+
+        # Check that former inventory mom is down
+        rv = self.server.expect(
+            VNODE, {'state': 'down'}, id=inv_mom.shortname,
+            max_attempts=10, interval=2)
+        self.assertTrue(rv)
+
+        # Check if inventory mom changed and is listed in the server log.
+        rc = self.server.log_match(
+            "Setting inventory_mom for vnode_pool %s to %s" %
+            ('1', noninv_mom.shortname), max_attempts=5,
+            starttime=start_time)
+        self.assertTrue(rc, msg="Inventory mom %s is not in server logs" %
+                        (noninv_mom.shortname))
+        self.logger.info(
+            "Inventory mom is now %s in server logs." %
+            (noninv_mom.shortname))
+
+        # Check compute nodes are up
+        vlist = []
+        try:
+            vnl = self.server.filter(
+                VNODE, {'resources_available.vntype': 'cray_compute'})
+            vlist = vnl["resources_available.vntype=cray_compute"]
+        except Exception:
+            pass
+
+        # Loop through each compute vnode in the list and check if state = free
+        for v1 in vlist:
+            # Check that the node is in free state
+            rv = self.server.expect(
+                VNODE, {'state': 'free'}, id=v1, max_attempts=3, interval=2)
+            self.assertTrue(rv)
+
+        # Start the previous inv mom.
+        inv_mom.start()
+
+        # Check previous inventory mom is up
+        rv = self.server.expect(
+            VNODE, {'state': 'free'}, id=inv_mom.shortname,
+            max_attempts=3, interval=2)
+        self.assertTrue(rv)
+
+    def test_two_moms_different_vnode_pool(self):
+        """
+        Differing vnode_pool for two moms shall result in both moms reporting
+        inventory.
+        """
+        found_in_momA = 0
+        found_in_momB = 0
+        self.momA = self.moms.values()[0]
+        self.momB = self.moms.values()[1]
+        self.hostA = self.momA.shortname
+        self.hostB = self.momB.shortname
+
+        attr_A = {'vnode_pool': '1'}
+        attr_B = {'vnode_pool': '2'}
+
+        start_time = int(time.time())
+
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA, attrib=attr_A)
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB, attrib=attr_B)
+
+        rc = self.momA.log_match(
+            "Hello (no inventory required) from server", max_attempts=5,
+            starttime=start_time)
+        if rc is None:
+            found_in_momA = 0
+        else:
+            found_in_momA = 1
+
+        rc = self.momB.log_match(
+            "Hello (no inventory required) from server", max_attempts=5,
+            starttime=start_time)
+        if rc is None:
+            found_in_momB = 0
+        else:
+            found_in_momB = 1
+
+        self.assertTrue((found_in_momA + found_in_momB == 0),
+                        msg="Both moms must report inventory")
+
+    def test_invalid_usage(self):
+        """
+        Setting vnode_pool for an existing mom that does not have a vnode_pool
+        attribute shall not be allowable.
+        Setting vnode_pool for an existing mom having a vnode_pool attribute
+        shall not be allowable.
+        Unsetting vnode_pool for an existing mom having a vnode_pool attribute
+        shall not be allowable.
+        """
+        self.momA = self.moms.values()[0]
+        self.hostA = self.momA.shortname
+        self.logger.info("hostA is %s." % self.hostA)
+
+        start_time = int(time.time())
+
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
+
+        attr_2 = {'vnode_pool': '2'}
+        try:
+            self.server.manager(
+                MGR_CMD_SET, NODE, id=self.hostA, attrib=attr_2, expect=False)
+        except PbsManagerError as e:
+            self.assertTrue("Invalid request" in e.msg[0])
+
+        rv = self.server.log_match(
+            "Unsupported actions for vnode_pool", max_attempts=5,
+            starttime=start_time)
+        self.assertTrue(rv)
+        self.logger.info("Found correct server log message")
+
+        self.momB = self.moms.values()[1]
+        self.hostB = self.momB.shortname
+
+        attr_1 = {'vnode_pool': '1'}
+
+        start_time = int(time.time())
+
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB, attrib=attr_1)
+
+        attr_2 = {'vnode_pool': '2'}
+        try:
+            self.server.manager(MGR_CMD_SET, NODE, id=self.hostB,
+                                attrib=attr_2, expect=False)
+        except PbsManagerError as e:
+            self.assertTrue("Invalid request" in e.msg[0])
+
+        rv = self.server.log_match(
+            "Unsupported actions for vnode_pool", max_attempts=5,
+            starttime=start_time)
+        self.assertTrue(rv, msg="Found correct server log message")
+
+        try:
+            self.server.manager(MGR_CMD_UNSET, NODE, id=self.hostB,
+                                attrib='vnode_pool', expect=False)
+        except PbsManagerError as e:
+            self.assertTrue("Illegal value for node vnode_pool" in e.msg[0])


### PR DESCRIPTION
This introduces the vnode_pool attribute.
Server and mom improvements were also made.

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-587](https://pbspro.atlassian.net/browse/PP-587)**

#### Problem description
* On a Cray X*-series system, each MoM will report the same underlying set of compute nodes.  This can take up a lot of of the server's time, as well as take up communication bandwidth.

#### Cause / Analysis
* The server-MoM communication works such that the server asks each MoM to report about herself and any of vnodes she knows about.  On a Cray X*-series this is unnecessary since the MoMs are all reporting the same set of underlying compute nodes. 

#### Solution description
* Added a new attribute vnode_pool which allows the admin to specify which underlying pool of compute nodes is being reported by each mom.  Therefore all of the moms that belong to the same vnode_pool are reporting/responsible for the same set of compute nodes.  In this way the server only has to ask one mom for the compute node information, and does not have to process the same information multiple times.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__