### PR TITLE
PP-699: Calls to memmove() should cast third argument need as size_t, not int

### DIFF
--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -3472,7 +3472,7 @@ get_request(char **request)
 				lp++;
 			if (!EOL(*lp)) {
 				i = strlen(lp);
-				memmove(rp, lp, i); /* By using memmove() we avoid strcpy's overlapping buffer issue. */
+				memmove(rp, lp, (size_t)i); /* By using memmove() we avoid strcpy's overlapping buffer issue. */
 				empty = FALSE;	    /* Note: memmove() doesn't Null terminate; so we take care of this by */
 			}			    /* nullifying 'line', at the end of this function, by setting line[i] to '\0'. */
 			else  {

--- a/src/lib/Libattr/attr_fn_acl.c
+++ b/src/lib/Libattr/attr_fn_acl.c
@@ -495,7 +495,7 @@ set_allacl(struct attribute *attr, struct attribute *new, enum batch_op op, int 
 						nsize = strlen(pas->as_string[i]) + 1;
 						pc = pas->as_string[i] + nsize;
 						need = pas->as_next - pc;
-						(void)memmove(pas->as_string[i], pc, (int)need);
+						(void)memmove(pas->as_string[i], pc, (size_t)need);
 						pas->as_next -= nsize;
 						/* compact pointers */
 						for (++i; i < pas->as_npointers; i++)

--- a/src/lib/Libattr/attr_fn_arst.c
+++ b/src/lib/Libattr/attr_fn_arst.c
@@ -493,7 +493,7 @@ set_arst(struct attribute *attr, struct attribute *new, enum batch_op op)
 						nsize = strlen(pas->as_string[i]) + 1;
 						pc = pas->as_string[i] + nsize;
 						need = pas->as_next - pc;
-						(void)memmove(pas->as_string[i], pc, (int)need);
+						(void)memmove(pas->as_string[i], pc, (size_t)need);
 						pas->as_next -= nsize;
 						/* compact pointers */
 						for (++i; i < pas->as_npointers; i++)

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -2016,7 +2016,7 @@ add_pkts(phy_conn_t *conn)
 		count++;
 		/* coalesce before next packet to maintain alignment */
 		avl_len = avl_len - pkt_len;
-		memmove(conn->scratch.data, conn->scratch.data + pkt_len, avl_len); /* area OVERLAP - use memmove */
+		memmove(conn->scratch.data, conn->scratch.data + pkt_len, (size_t)avl_len); /* area OVERLAP - use memmove */
 		conn->scratch.pos = conn->scratch.data + avl_len;
 	}
 

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -2006,7 +2006,7 @@ req_jobscript(struct batch_request *preq)
 	pj->ji_script = temp;
 	memmove(pj->ji_script + pj->ji_qs.ji_un.ji_newt.ji_scriptsz,
 		preq->rq_ind.rq_jobfile.rq_data,
-		preq->rq_ind.rq_jobfile.rq_size);
+		(size_t)preq->rq_ind.rq_jobfile.rq_size);
 #endif
 	pj->ji_qs.ji_un.ji_newt.ji_scriptsz += preq->rq_ind.rq_jobfile.rq_size;
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-699](https://pbspro.atlassian.net/browse/PP-699)**

#### Problem description
* Parameters to memmove() had third argument as int

#### Solution description
* Changed to size_t

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
