### PR TITLE
PP-781: Pass appropriate output directory to pbs_diag while saving post analysis data in PTL

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_data.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_data.py
@@ -40,6 +40,7 @@ import sys
 import socket
 import logging
 import signal
+import pwd
 import re
 from nose.util import isclass
 from nose.plugins.base import Plugin
@@ -161,8 +162,10 @@ class PTLTestData(Plugin):
             return
         pbs_diag = os.path.join(svr.pbs_conf['PBS_EXEC'],
                                 'unsupported', 'pbs_diag')
+        cur_user = self.du.get_current_user()
         cmd = [pbs_diag, '-f', '-d', '2']
-        cmd += ['-u', self.du.get_current_user()]
+        cmd += ['-u', cur_user]
+        cmd += ['-o', pwd.getpwnam(cur_user).pw_dir]
         if len(svr.jobs) > 0:
             cmd += ['-j', ','.join(svr.jobs.keys())]
         ret = self.du.run_cmd(svr_host, cmd, sudo=True, level=logging.DEBUG2)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-781](https://pbspro.atlassian.net/browse/PP-781)**

#### Problem description
* PTL fails to save post analysis data when /root is not accessible by user who invoked pbs_benchpress 

#### Cause / Analysis
* pbs_diag's default directory for saving data is /root which is only accessible by root user only

#### Solution description
* Make use of -o argument in pbs_diag to pass home directory of user who invoked pbs_benchpress for saving data instead of /root

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
