### PR TITLE
PP-788: If a user's primary group is not the same as their user name …

### DIFF
--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -3030,7 +3030,11 @@ req_resvSub(struct batch_request *preq)
 		server.sv_attr[(int)SRV_ATR_acl_ResvGroup_enable].at_val.at_long) {
 
 		if (acl_check(&server.sv_attr[(int)SRV_ATR_acl_ResvGroups],
+#ifdef WIN32
 			presv->ri_wattr[RESV_ATR_egroup].at_val.at_str,
+#else
+			presv->ri_wattr[RESV_ATR_euser].at_val.at_str,
+#endif
 			ACL_Group) == 0) {
 
 			resv_purge(presv);


### PR DESCRIPTION
…then they are not able to submit reservations when acl_resv_group_enable is set to true

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-788](https://pbspro.atlassian.net/browse/PP-788)**

#### Problem description
* If a user's primary group is not the same as their user name then they are not able to submit reservations when acl_resv_group_enable is set to true.


#### Cause / Analysis
* I have added gacl_match() in #227 and I forgot to consider acl_resv_groups. The problem is that gacl_match() receives RESV_ATR_egroup instead of RESV_ATR_euser if it checks SRV_ATR_acl_ResvGroups on linux now. gacl_match() fails on getpwnam(egroup). Of course, there is no record of the group in passwd. The record is found for egroup == euser. The gacl_match() works like this: It takes euser and list all groups of the user and it compares the list with 'master'. If match is found, the 0 is returned. The 'master' is a record of acl_resv_groups. All records from acl_resv_groups are checked. This problem is not on Windows because there is no implementation of [PP-618](https://pbspro.atlassian.net/browse/PP-618) yet.

#### Solution description
* We need to pass RESV_ATR_euser instead of RESV_ATR_egroup to the acl_check on linux.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
