### PR TITLE
PP-790: qmgr output has inconsistent whitespaces

### DIFF
--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -2211,25 +2211,29 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 				}
 			}
 			else  {
+				indent_len = 4;
 				if (otype == MGR_OBJ_RSC) {
 					if ((attr != NULL) && (strcmp(attr->name, "type") == 0)) {
 						struct resc_type_map *rtm = find_resc_type_map_by_typev(atoi(attr->value));
 						if (rtm) {
-							printf("\ttype = %s\n", rtm->rtm_rname);
+							printf("%*s", indent_len, " ");
+							printf("type = %s\n", rtm->rtm_rname);
 						}
-					}
-					else if ((attr != NULL) && (strcmp(attr->name, "flag") == 0)) {
+					} else if ((attr != NULL) && (strcmp(attr->name, "flag") == 0)) {
 						char *rfm = find_resc_flag_map(atoi(attr->value));
 						if ((rfm != NULL)  && (strcmp(rfm, "") != 0)) {
-							printf("\tflag = %s\n", rfm);
+							printf("%*s", indent_len, " ");
+							printf("flag = %s\n", rfm);
 						}
 					}
 					attr = attr->next;
 					continue;
 				}
 
-				if (attr->name != NULL)
-					printf("\t%s", attr->name);
+				if (attr->name != NULL) {
+					printf("%*s", indent_len, " ");
+					printf("%s", attr->name);
+				}
 
 				if (attr->resource != NULL)
 					printf(".%s", attr->resource);
@@ -2240,8 +2244,7 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 					if (attr->resource!=NULL)
 						l += strlen(attr->resource)+1;
 
-					l += 3;
-					indent_len = l;
+					l += 3; /* length of " = " */
 					printf(" = ");
 					c = attr->value;
 					e = c;
@@ -2255,9 +2258,8 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 						*e = '\0';
 						l += strlen(c) + 1;
 
-						if (!first && (l >= 80)) {
-							printf("\n%*s", indent_len, " ");
-							l = strlen(c) + indent_len;
+						if (!first && (l >= 80)) { /* line extension */
+							printf("\n\t");
 							while (White(*c))
 								c++;
 						}

--- a/test/tests/functional/pbs_qmgr.py
+++ b/test/tests/functional/pbs_qmgr.py
@@ -1,0 +1,126 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+import os
+
+from tests.functional import *
+from ptl.lib.pbs_ifl_mock import *
+
+
+class TestQmgr(TestFunctional):
+    """
+    Test suite for PBSPro's qmgr command
+    """
+
+    def __check_whitespace_prefix(self, line):
+        """
+        Check whether the whitespace prefix for the line specified is correct
+
+        :param line: the line to check
+        :type line: String
+        """
+        if line is None:
+            return
+
+        if line[0] == " ":
+            # Spaces are the prefix for new attribute lines
+            # Make sure that this is a new attribute line
+            self.assertTrue("=" in line)
+        elif line[0] == "\t":
+            # Tabs are prefix for line extensions
+            # Make sure that this is a line extension
+            self.assertTrue("=" not in line)
+
+    def test_listcmd_whitespaces(self):
+        """
+        Check that the prefix for new attributes listed out by qmgr list
+        are spaces and that for line extensions is a tab
+        """
+        fd, fn = self.du.mkstemp()
+        node_prefix = "vn"
+        nodename = node_prefix + "[0]"
+        vndef_file = None
+        try:
+            # Check 1: New attributes are prefixed with spaces and not tabs
+            # Execute qmgr -c 'list sched' and store output in a temp file
+            if self.du.is_localhost(self.server.hostname) is True:
+                qmgr_cmd = ["qmgr", "-c", "list sched"]
+            else:
+                qmgr_cmd = ["qmgr", "-c", "\'list sched\'"]
+            with os.fdopen(fd, "w+") as tempfd:
+                ret = self.du.run_cmd(self.server.hostname, qmgr_cmd,
+                                      stdout=tempfd)
+
+                self.assertTrue(ret['rc'] == 0)
+                for line in tempfd:
+                    self.__check_whitespace_prefix(line)
+
+            # Check 2: line extensions are prefixed with tabs and not spaces
+            # Create a random long, comma separated string
+            blah = "blah"
+            long_string = ""
+            for i in range(49):
+                long_string += blah + ","
+            long_string += blah
+            # Create a new vnode
+            attrs = {ATTR_rescavail + ".ncpus": 2}
+            self.server.create_vnodes(node_prefix, attrs, 1, self.mom)
+            # Set 'comment' attribute to the long string we created above
+            attrs = {ATTR_comment: long_string}
+            self.server.manager(MGR_CMD_SET, VNODE, attrs, nodename)
+            # Execute "qmgr 'list node vn[0]'"
+            # The comment attribute should generate a line extension
+            if self.du.is_localhost(self.server.hostname) is True:
+                qmgr_cmd = ["qmgr", "-c", "list node " + nodename]
+            else:
+                qmgr_cmd = ["qmgr", "-c", "\'list node " + nodename + "\'"]
+            with open(fn, "w+") as tempfd:
+                ret = self.du.run_cmd(self.server.hostname, qmgr_cmd,
+                                      stdout=tempfd)
+                self.assertTrue(ret['rc'] == 0)
+                for line in tempfd:
+                    self.__check_whitespace_prefix(line)
+
+        finally:
+            # Cleanup
+            # Remove the temporary file
+            os.remove(fn)
+            # Delete the vnode created
+            if vndef_file is not None:
+                self.mom.delete_vnodes()
+                self.server.manager(MGR_CMD_DELETE, VNODE, id=nodename)


### PR DESCRIPTION
#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-790](https://pbspro.atlassian.net/browse/PP-790)**
* **[EDD](https://pbspro.atlassian.net/wiki/display/PD/PP-790%3A+qmgr+output+has+inconsistent+whitespaces)**
* **[Forum Discussion](http://community.pbspro.org/t/pp-790-qmgr-output-has-inconsistent-whitespaces/566)**


#### Problem description
* qmgr output has inconsistent whitespaces

#### Cause / Analysis
* For all commands (qstat, pbsnodes etc.), the code uses spaces (" ") as prefix for new attributes, but for qmgr it uses tabs. Similarly, for line extensions in qmgr, it uses spaces as prefix while the other commands use tabs. This ticket was basically intended to make qmgr's output consistent with other commands.

#### Solution description
* Modified the code inside display() to add 4 spaces as prefix for new attributes and tabs as prefix for line extensions, which is what qstat and pbsnodes use.
* Also added a new test suite TestQmgr and added a PTL test to check for whitespace consistency.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
