### PR TITLE
PP-785: PTL should use same version as PBS

### DIFF
--- a/test/fw/ptl/__init__.py
+++ b/test/fw/ptl/__init__.py
@@ -36,4 +36,4 @@
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
 
-__version__ = '1.0.0'
+__version__ = '14.0.1'

--- a/test/fw/setup.py
+++ b/test/fw/setup.py
@@ -52,7 +52,7 @@ def get_scripts():
 
 setup(
     name='PbsTestLab',
-    version='1.0.0',
+    version='14.0.1',
     author='Vincent Matossian',
     author_email='pbspro@groups.io',
     packages=find_packages(),


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-785](https://pbspro.atlassian.net/browse/PP-785)**

#### Problem description
* PTL has different version than PBS, but PTL should have same version as PBS

#### Cause / Analysis
* PTL has it's own versioning scheme than PBS, that's why it has different version 

#### Solution description
* Change PTL version to same as PBS

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
