### PR TITLE
PP-780: mom execjob_begin hook alarms when running a large multi-node…

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -94,6 +94,7 @@ extern void log_close(int close_msg);
 extern void log_err(int err, const char *func, const char *text);
 extern void log_joberr(int err, const char *func, const char *text, const char *pjid);
 extern void log_event(int type, int objclass, int severity, const char *objname, const char *text);
+extern int will_log_event(int type);
 extern void log_suspect_file(const char *func, const char *text, const char *file, struct stat *sb);
 extern int  log_open(char *name, char *directory);
 extern int  log_open_main(char *name, char *directory, int silent);

--- a/src/lib/Liblog/log_event.c
+++ b/src/lib/Liblog/log_event.c
@@ -76,6 +76,27 @@ long	    *log_event_mask = &log_event_lvl_priv;
 
 /**
  * @brief
+ * 	Checks whether or not the given event type is being recorded into
+ *	log file.
+ *
+ * @param[in] eventtype - event type
+ *
+ * @return int
+ *	1 - if the given event type gets logged,
+ *	0 - otherwise, it's not recorded.
+ *
+ */
+int
+will_log_event(int eventtype)
+{
+	if (((eventtype & PBSEVENT_FORCE) != 0) ||
+	    ((*log_event_mask & eventtype) != 0))
+		return (1);
+
+	return (0);
+}
+/**
+ * @brief
  * 	log_event - log a server event to the log file
  *
  *	Checks to see if the event type is being recorded.  If they are,
@@ -97,9 +118,6 @@ long	    *log_event_mask = &log_event_lvl_priv;
 void
 log_event(int eventtype, int objclass, int sev, const char *objname, const char *text)
 {
-	if (((eventtype & PBSEVENT_FORCE) == 0) &&
-		((*log_event_mask & eventtype) == 0))
-		return;		/* not logging this type of event */
-	else
+	if (will_log_event(eventtype))
 		log_record(eventtype, objclass, sev, objname, text);
 }

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -328,11 +328,29 @@ typedef struct server_vnodes_t {
 } server_vnodes_t;
 static	server_vnodes_t server_vnodes;
 
+/**
+ * @brief
+ * 	This is a function that logs the contents of the list
+ *	headed by 'phead'.
+ *
+ * @param[in] head_str - some string that gets printed spearheading the list.
+ * @param[in] phead - header of the list to be printed.
+ *
+ * @return	void
+ *
+ */
 void
 print_svrattrl_list(char *head_str, pbs_list_head *phead)
 {
 	svrattrl *plist = NULL;
 	int i;
+
+	if ((head_str == NULL) || (phead == NULL)) {
+		return;
+	}
+
+	if (!will_log_event(PBSEVENT_DEBUG3))
+		return;
 
 	plist = (svrattrl *)GET_NEXT(*phead);
 	i = 0;
@@ -3083,9 +3101,6 @@ pbs_python_populate_svrattrl_from_python_class(PyObject *py_instance,
 		name_str_dup = NULL;
 
 	} /* for loop */
-
-	print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>",
-		svrattrl_list);
 	rc = 0;
 svrattrl_exit:
 	Py_CLEAR(py_attr_dict);
@@ -5831,6 +5846,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 				&((struct rq_queuejob *)(req_params->rq_job))->rq_attr, NULL, 0) == -1) {
 				return -1;
 			}
+			print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>",  &((struct rq_queuejob *)(req_params->rq_job))->rq_attr);
 			break;
 		case HOOK_EVENT_EXECJOB_LAUNCH:
 			py_progname = _pbs_python_event_get_param(PY_EVENT_PARAM_PROGNAME);
@@ -5900,6 +5916,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 					"Failed to populate request structure!");
 				return -1;
 			}
+			print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>", &((struct rq_queuejob *)(req_params->rq_job))->rq_attr);
 			/* fall through here */
 		case HOOK_EVENT_EXECHOST_PERIODIC:
 		case HOOK_EVENT_EXECHOST_STARTUP:
@@ -5975,6 +5992,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 				}
 				free(key_str);
 			}
+			print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>", (pbs_list_head *)(req_params->vns_list));
 			Py_CLEAR(py_attr_keys);
 
 			if (hook_event == HOOK_EVENT_EXECHOST_PERIODIC) {
@@ -6095,6 +6113,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 					}
 				}
 				Py_CLEAR(py_attr_keys);
+				print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>", (pbs_list_head *)(req_params->jobs_list));
 			}
 
 			break;
@@ -6110,6 +6129,8 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 				&((struct rq_queuejob *)(req_params->rq_job))->rq_attr, NULL, 0) == -1) {
 				return -1;
 			}
+
+			print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>", &((struct rq_queuejob *)(req_params->rq_job))->rq_attr);
 			break;
 		case HOOK_EVENT_MODIFYJOB:
 
@@ -6150,6 +6171,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 				&((struct rq_manage *)(req_params->rq_manage))->rq_attr, NULL, 0) == -1) {
 				return -1;
 			}
+			print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>", &((struct rq_manage *)(req_params->rq_manage))->rq_attr);
 			break;
 		case HOOK_EVENT_MOVEJOB:
 

--- a/test/tests/functional/pbs_hook_alarm_large_multinode_job.py
+++ b/test/tests/functional/pbs_hook_alarm_large_multinode_job.py
@@ -1,0 +1,202 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestPbsHookAlarmLargeMultinodeJob(TestFunctional):
+
+    """
+    This test suite contains hooks test to verify that a large
+    multi-node job does not slow down hook execution and cause an alarm.
+    """
+
+    @timeout(400)
+    def setUp(self):
+
+        TestFunctional.setUp(self)
+
+        a = {'resources_available.mem': '1gb',
+             'resources_available.ncpus': '1'}
+        self.server.create_vnodes(self.mom.shortname, a, 5000, self.mom)
+
+    def test_begin_hook(self):
+        """
+        Create an execjob_begin hook, import a hook content with a small
+        alarm value, and test it against a large multi-node job.
+        """
+        hook_name = "testhook"
+        hook_event = "execjob_begin"
+        hook_body = """
+import pbs
+e=pbs.event()
+pbs.logmsg(pbs.LOG_DEBUG, "executing begin hook %s" % (e.hook_name,))
+"""
+        a = {'event': hook_event, 'enabled': 'True',
+             'alarm': '15'}
+        self.server.create_import_hook(hook_name, a, hook_body)
+
+        j = Job(TEST_USER)
+        a = {'Resource_List.select': '5000:ncpus=1:mem=1gb',
+             'Resource_List.walltime': 10}
+
+        j.set_attributes(a)
+
+        jid = self.server.submit(j)
+
+        self.server.expect(JOB, {'job_state': 'R'},
+                           jid, max_attempts=15, interval=2)
+        self.mom.log_match(
+            "pbs_python;executing begin hook %s" % (hook_name,), n=100,
+            max_attempts=5, interval=5, regexp=True)
+
+        self.mom.log_match(
+            "Job;%s;alarm call while running %s hook" % (jid, hook_event),
+            n=100, max_attempts=5, interval=5, regexp=True, existence=False)
+
+        self.mom.log_match("Job;%s;Started, pid" % (jid,), n=100,
+                           max_attempts=5, interval=5, regexp=True)
+
+    def test_prolo_hook(self):
+        """
+        Create an execjob_prologue hook, import a hook content with a
+        small alarm value, and test it against a large multi-node job.
+        """
+        hook_name = "testhook"
+        hook_event = "execjob_prologue"
+        hook_body = """
+import pbs
+e=pbs.event()
+pbs.logmsg(pbs.LOG_DEBUG, "executing prologue hook %s" % (e.hook_name,))
+"""
+        a = {'event': hook_event, 'enabled': 'True',
+             'alarm': '15'}
+        self.server.create_import_hook(hook_name, a, hook_body)
+
+        j = Job(TEST_USER)
+        a = {'Resource_List.select': '5000:ncpus=1:mem=1gb',
+             'Resource_List.walltime': 10}
+
+        j.set_attributes(a)
+
+        jid = self.server.submit(j)
+
+        self.server.expect(JOB, {'job_state': 'R'},
+                           jid, max_attempts=15, interval=2)
+
+        self.mom.log_match(
+            "pbs_python;executing prologue hook %s" % (hook_name,), n=100,
+            max_attempts=5, interval=5, regexp=True)
+
+        self.mom.log_match(
+            "Job;%s;alarm call while running %s hook" % (jid, hook_event),
+            n=100, max_attempts=5, interval=5, regexp=True, existence=False)
+
+    def test_epi_hook(self):
+        """
+        Create an execjob_epilogue hook, import a hook content with a small
+        alarm value, and test it against a large multi-node job.
+        """
+        hook_name = "testhook"
+        hook_event = "execjob_epilogue"
+        hook_body = """
+import pbs
+e=pbs.event()
+pbs.logmsg(pbs.LOG_DEBUG, "executing epilogue hook %s" % (e.hook_name,))
+"""
+        a = {'event': hook_event, 'enabled': 'True',
+             'alarm': '15'}
+        self.server.create_import_hook(hook_name, a, hook_body)
+
+        j = Job(TEST_USER)
+        a = {'Resource_List.select': '5000:ncpus=1:mem=1gb',
+             'Resource_List.walltime': 10}
+
+        j.set_attributes(a)
+
+        jid = self.server.submit(j)
+
+        self.server.expect(JOB, {'job_state': 'R'},
+                           jid, max_attempts=15, interval=2)
+        self.mom.log_match(
+            "pbs_python;executing epilogue hook %s" % (hook_name,), n=100,
+            max_attempts=5, interval=5, regexp=True)
+
+        self.mom.log_match(
+            "Job;%s;alarm call while running %s hook" % (jid, hook_event),
+            n=100, max_attempts=5, interval=5, regexp=True, existence=False)
+
+        self.mom.log_match("Job;%s;Obit sent" % (jid,), n=100,
+                           max_attempts=5, interval=5, regexp=True)
+
+    def test_end_hook(self):
+        """
+        Create an execjob_end hook, import a hook content with a small
+        alarm value, and test it against a large multi-node job.
+        """
+        hook_name = "testhook"
+        hook_event = "execjob_end"
+        hook_body = """
+import pbs
+e=pbs.event()
+pbs.logmsg(pbs.LOG_DEBUG, "executing end hook %s" % (e.hook_name,))
+"""
+        a = {'event': hook_event, 'enabled': 'True',
+             'alarm': '15'}
+        self.server.create_import_hook(hook_name, a, hook_body)
+
+        j = Job(TEST_USER)
+        a = {'Resource_List.select': '5000:ncpus=1:mem=1gb',
+             'Resource_List.walltime': 10}
+
+        j.set_attributes(a)
+
+        jid = self.server.submit(j)
+
+        self.server.expect(JOB, {'job_state': 'R'},
+                           jid, max_attempts=15, interval=2)
+        self.mom.log_match(
+            "pbs_python;executing end hook %s" % (hook_name,), n=100,
+            max_attempts=5, interval=5, regexp=True)
+
+        self.mom.log_match(
+            "Job;%s;alarm call while running %s hook" % (jid, hook_event),
+            n=100, max_attempts=5, interval=5, regexp=True, existence=False)
+
+        self.mom.log_match("Job;%s;Obit sent" % (jid,), n=100,
+                           max_attempts=5, interval=5, regexp=True)


### PR DESCRIPTION
 mom execjob_begin hook alarms when running a large multi-node job

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-780](https://pbspro.atlassian.net/browse/PP-780)**

#### Problem description
With hook alarm set to a small value (i.e. < 30 seconds), a large, multinode job, ex requesting 5000 vnodes, does not go into run state as the job takes a long time executing an execjob_begin hook,which results in an exception raised due to an alarm call. Same thing can also happen under execjob_prologue, execjob_epilogue, and execjob_end hooks.
#### Cause / Analysis
 the slowdown is due to pbs_python's attempt to log redundant vnode_list data, whether or not, PBSEVENT_DEBUG3 is in the log event mask. The functionality of vnode_list is still intact. The data is logged via print_svrattrl_list() as called by pbs_populate_svrattrl_from_python_class() for each vnode in pbs.event().vnode_list[]. Unfortunately, with the introduction of vnode_list, print_svrattrl_list() could be called in an incremental way, which is happening here, seeing the not so final vnodes data. 

#### Solution description
Fix is to call print_svrattrl_list() at the appropriate time when we have all the data in final form. Also, inside print_svrattrl_list(), only proceed exscuting the loops code if log_event_mask contains PBSEVENT_DEBUG3, since that is the mask that will cause info to be printed to the daemon log.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
