### PR TITLE
PP-834: fixed releasing queue/server level resource on suspension

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -8026,6 +8026,7 @@ int update_resources_rel(job *pjob, attribute *attrib, enum batch_op op)
 	struct key_value_pair *pkvp;
 	resource_def *prdef;
 	resource *presc;
+	resource *presc_sq;
 	attribute tmpattr;
 
 	if (attrib == NULL || pjob == NULL)
@@ -8040,7 +8041,7 @@ int update_resources_rel(job *pjob, attribute *attrib, enum batch_op op)
 				prdef = find_resc_def(svr_resc_def, pkvp[j].kv_keyw, svr_resc_size);
 				if (prdef == NULL)
 					return 1;
-				if (prdef -> rs_flags & ATR_DFLAG_RASSN) {
+				if (prdef->rs_flags & (ATR_DFLAG_RASSN | ATR_DFLAG_ANASSN | ATR_DFLAG_FNASSN)) {
 					presc = add_resource_entry(&pjob->ji_wattr[(int) JOB_ATR_resc_released_list], prdef);
 					if (presc == NULL)
 						return 1;
@@ -8055,6 +8056,30 @@ int update_resources_rel(job *pjob, attribute *attrib, enum batch_op op)
 		} else
 			return 1;
 	}
+	/* Now iterate through all of the job resources that are present on at
+	 * queue/server level and add them to resource_release_list.
+	 */
+	presc_sq = (resource *) GET_NEXT(pjob->ji_wattr[(int) JOB_ATR_resource].at_val.at_list);
+	for (;presc_sq != NULL; presc_sq = (resource *)GET_NEXT(presc_sq->rs_link)) {
+		prdef = presc_sq->rs_defin;
+		/* make sure it is a server/queue level consumable resource and not
+		 * set in resource_released_list already
+		 */
+		if ((prdef->rs_flags & ATR_DFLAG_RASSN) &&
+			(find_resc_entry(&pjob->ji_wattr[(int) JOB_ATR_resc_released_list], prdef) == NULL)) {
+			for (j = 0; j < server.sv_attr[(int)SVR_ATR_restrict_res_to_release_on_suspend].at_val.at_arst->as_usedptr; j++) {
+				if (strcmp(server.sv_attr[(int)SVR_ATR_restrict_res_to_release_on_suspend].at_val.at_arst->as_string[j],
+				    prdef->rs_name) == 0) {
+					presc = add_resource_entry(&pjob->ji_wattr[(int) JOB_ATR_resc_released_list], prdef);
+					if (presc == NULL)
+						return 1;
+					prdef->rs_set(&presc->rs_value, &presc_sq->rs_value, op);
+					break;
+				}
+			}
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-834](https://pbspro.atlassian.net/browse/PP-834)**

#### Problem description
Changes made for [PP-734](https://pbspro.atlassian.net/browse/PP-734) did not take into consideration the resources that might get released only on server/queue (resources with flag 'q'). It resulted into these resources not being free (after suspension) even when they were part of restrict_resource_to_release_on_suspend.

#### Cause / Analysis
resource_released_list was based off of resources_released which is made by looking at exec_vnode. This wasn't the right way to do it. It should have looked at other job's resources which are consumable but not a node level resource.

#### Solution description
Changed the way resources_released_list is being populated.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
