### PR TITLE
PP-828: preempted jobs can cause other jobs in their same equiv class…

### DIFF
--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -734,6 +734,7 @@ is_ok_to_run(status *policy, int pbs_sd, server_info *sinfo,
 
 	if(resresv->is_job && sinfo->equiv_classes != NULL &&
 	   !(flags & (IGNORE_EQUIV_CLASS|RETURN_ALL_ERR)) &&
+	   resresv->ec_index != UNSPECIFIED &&
 	   sinfo->equiv_classes[resresv->ec_index]->can_not_run) {
 		copy_schd_error(err, sinfo->equiv_classes[resresv->ec_index]->err);
 		return NULL;


### PR DESCRIPTION
… to not run

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-828](https://pbspro.atlassian.net/browse/PP-828)**

#### Problem description
* When jobs are suspended, they need to be placed back on the same nodes they are running on.  This wasn't being taken into account, so they were placed into job equivalence classes with other jobs of the same select spec.  In subsequent cycles, if the suspended job couldn't run, the entire class of queued jobs would be ignored.

#### Cause / Analysis
* The scheduler generates a special select spec for suspended jobs called an execselect.  This new select will be used to place the job back on the same nodes it was originally running on.  Since the suspended job uses a different select spec than its normal select spec, it was no longer similar to other jobs with its normal select spec.

#### Solution description
* The scheduler generates this special select for all jobs with an exec_vnode.  This includes running, suspended, and checkpointed jobs.  Other than running jobs, we put all jobs with an execspelect into their own equivalence class.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
