### PR TITLE
PP-839: PTL framework should not execute dynamically generated script as SUDO

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13525,6 +13525,7 @@ class PBSInitServices(object):
                        sched, comm or all
         :type daemon: str
         """
+        init_cmd = ['sudo']
         if daemon is not None and daemon != 'all':
             conf = self.du.parse_pbs_config(hostname, conf_file)
             dconf = {
@@ -13545,15 +13546,14 @@ class PBSInitServices(object):
             os.close(fd)
             self.du.set_pbs_config(hostname, fin=conf_file, fout=fn,
                                    confs=dconf)
-            init_cmd = ['PBS_CONF_FILE=' + fn]
+            init_cmd += ['PBS_CONF_FILE=' + fn]
             _as = True
         else:
             fn = None
             if (conf_file is not None) and (conf_file != self.dflt_conf_file):
-                init_cmd = ['PBS_CONF_FILE=' + conf_file]
+                init_cmd += ['PBS_CONF_FILE=' + conf_file]
                 _as = True
             else:
-                init_cmd = []
                 _as = False
             conf = self.du.parse_pbs_config(hostname, conf_file)
         if (init_script is None) or (not init_script.startswith('/')):
@@ -13579,7 +13579,7 @@ class PBSInitServices(object):
             msg += ' using ' + conf_file
         msg += ' init_cmd=%s' % (str(init_cmd))
         self.logger.info(msg)
-        ret = self.du.run_cmd(hostname, init_cmd, sudo=True, as_script=_as,
+        ret = self.du.run_cmd(hostname, init_cmd, as_script=_as,
                               logerr=False)
         if ret['rc'] != 0:
             raise PbsInitServicesError(rc=ret['rc'], rv=False,


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-839](https://pbspro.atlassian.net/browse/PP-839)**

#### Problem description
* PTL framework should not execute dynamically generated script as SUDO

#### Cause / Analysis
* PTL runs dynamically generated files as SUDO . One of the instance is to start/stop/restart PBS daemon it creates a file and run it as SUDO when PTL invoked as normal user. 

#### Solution description
* PTL framework need to embed the sudo call inside script to run allowed commands

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x ] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
