### PR TITLE
PP-842: Scheduler doesn't detect old user/group limits when creating …

### DIFF
--- a/src/scheduler/limits.c
+++ b/src/scheduler/limits.c
@@ -599,10 +599,10 @@ convert_oldlim_to_new(const struct attrl *a)
 
 	for (i = 0; i < sizeof(old2new)/sizeof(old2new[0]); i++)
 		if (!strcmp(a->name, old2new[i].lim_attr))
-			return old2new[i].lim_attr;
+			return old2new[i].lim_param;
 	for (i = 0; i < sizeof(old2new_soft)/sizeof(old2new_soft[0]); i++)
 		if (!strcmp(a->name, old2new_soft[i].lim_attr))
-			return old2new_soft[i].lim_attr;
+			return old2new_soft[i].lim_param;
 
 	return NULL;
 }


### PR DESCRIPTION
…equiv classes

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-842](https://pbspro.atlassian.net/browse/PP-842)**

#### Problem description
* When creating job equivalence classes, the scheduler only differentiates jobs by user/group if there are user/group limits.  This is not happening for old style limits (e.g., max_user_res).  The end result is that jobs of different users and groups end up in the same equivalence class.  One the first job in the class can't run, the rest are not considered.  Since there are multiple users and groups in the same class, once one user/group hits their limit, the entire class is marked can not run.

#### Cause / Analysis
* I wrote a new function to determine if there are user or group limits set called convert_oldlim_to_new().  It uses an existing structure that is used to convert old style limits to new.  I returned the wrong element from the structure.  Instead of returning the new limit value, I returned the old limit name.
#### Solution description
* Return the correct element from the structure.
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
