### PR TITLE
PP-360: make libpbs depend on libcrypto and libpthread

### DIFF
--- a/src/lib/Libpbs/Makefile.am
+++ b/src/lib/Libpbs/Makefile.am
@@ -47,6 +47,10 @@ libpbs_la_CPPFLAGS = -I$(top_srcdir)/src/include
 #
 libpbs_la_LDFLAGS = -version-info 0:0:0
 
+libpbs_la_LIBADD= \
+	-lcrypto \
+	-lpthread
+
 libpbs_la_SOURCES = \
 	../Libattr/attr_fn_arst.c \
 	../Libattr/attr_fn_b.c \


### PR DESCRIPTION
so third party apps (such as Open MPI) can link with -lpbs
without having to manually add extra libraries

#### Issue-ID

* **[PP-360](https://pbspro.atlassian.net/browse/PP-360)**

#### Problem description
libpbs does not depend on libcrypto nor libpthread, so it is required to manually link with these libraries in order to use libpbs.
for example, a simple program such as
```c
#include <tm.h>

int main (int argc, char *argv[])
{
    struct tm_roots *roots;
    void * info;

    return tm_init (info, roots);
}
```
can only be linked with ```-lpbs -lcrypto -lpthread``` instead of only ```-lpbs```

#### Cause / Analysis
libpbs is not instructed to depend on libcrypto nor libpthread

#### Solution description
update ```src/lib/Libpbs/Makefile.am``` to explicitly depend on libcrypto and libpthread

#### Checklist:
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
