### PR TITLE
PP-785, PP-778: PTL should use same version as PBS & Bump up PBS version to 17

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -51,8 +51,8 @@ How to install PBS Pro using the configure script.
 3. Open a terminal as a normal (non-root) user, unpack the PBS Pro
   tarball, and cd to the package directory.
 
-    tar -xpvf pbspro-14.0.1.tar.gz
-    cd pbspro-14.0.1
+    tar -xpvf pbspro-17.1.0.tar.gz
+    cd pbspro-17.1.0
 
 4. Generate the configure script and Makefiles. (See note 1 below)
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@
 #
 
 AC_PREREQ([2.63])
-AC_INIT([pbspro], [14.0.1], [pbssupport@altair.com])
+AC_INIT([pbspro], [17.1.0], [pbssupport@altair.com])
 AC_CONFIG_HEADERS([src/include/pbs_config.h])
 AC_CONFIG_SRCDIR([src/cmds/qmgr.c])
 AC_CONFIG_AUX_DIR([buildutils])
@@ -321,6 +321,8 @@ AC_CONFIG_FILES([
 	doc/Makefile
 	test/Makefile
 	test/fw/Makefile
+	test/fw/setup.py
+	test/fw/ptl/__init__.py
 	src/Makefile
 	src/cmds/Makefile
 	src/cmds/mpiexec

--- a/pbspro.spec
+++ b/pbspro.spec
@@ -39,7 +39,7 @@
 %define pbs_client client
 %define pbs_execution execution
 %define pbs_server server
-%define pbs_version 14.0.1
+%define pbs_version 17.1.0
 %define pbs_release 0
 %define pbs_prefix /opt/pbs
 %define pbs_home /var/spool/pbs

--- a/test/fw/ptl/__init__.py.in
+++ b/test/fw/ptl/__init__.py.in
@@ -36,4 +36,4 @@
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
 
-__version__ = '1.0.0'
+__version__ = '@PBS_VERSION@'

--- a/test/fw/setup.py.in
+++ b/test/fw/setup.py.in
@@ -52,12 +52,12 @@ def get_scripts():
 
 setup(
     name='PbsTestLab',
-    version='1.0.0',
+    version='@PBS_VERSION@',
     author='Vincent Matossian',
-    author_email='pbspro@groups.io',
+    author_email='pbspro@discoursemail.com',
     packages=find_packages(),
     scripts=get_scripts(),
-    url='http://www.pbspro.com',
+    url='http://pbspro.org/',
     license='AGPLv3 with exceptions',
     description='PBS Pro Testing and Benchmarking Framework',
     long_description=open(os.path.abspath('./doc/intro.rst')).read(),


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-785](https://pbspro.atlassian.net/browse/PP-785)**
* **[PP-778](https://pbspro.atlassian.net/browse/PP-778)**

#### Problem description
* PP-785: PTL has different version than PBS
* PP-778: pbspro repo uses old version

#### Cause / Analysis
* PP-785: Currently PTL has its own versioning scheme but PTL is part of PBS so it should use same version as PBS
* PP-778: None

#### Solution description
* PP-785: Use same version as PBS for PTL
* PP-778: Bump up PBS version to 17.1.0

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
