### PR TITLE
PP-865: PTL doesn't unassociate nodes from queues in revert_to_defaul…

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4895,6 +4895,14 @@ class Server(PBSService):
             queues = self.status(QUEUE, level=logging.DEBUG)
             queues = [q['id'] for q in queues]
             if len(queues) > 0:
+                try:
+                    nodes = self.status(VNODE, logerr=False)
+                    for node in nodes:
+                        if 'queue' in node.keys():
+                            self.manager(MGR_CMD_UNSET, NODE, 'queue',
+                                         node['id'])
+                except:
+                    pass
                 self.manager(MGR_CMD_DELETE, QUEUE, id=queues, expect=True)
             a = {ATTR_qtype: 'Execution',
                  ATTR_enable: 'True',

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -908,9 +908,6 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  max_attempts=10, starttime=self.t)
 
-        self.server.manager(MGR_CMD_UNSET, NODE, 'queue',
-                            id='vnode[0]')
-
     def test_prime_queue(self):
         """
         Test to see if a job in a primetime queue has its queue be part of

--- a/test/tests/functional/pbs_nodes_queues.py
+++ b/test/tests/functional/pbs_nodes_queues.py
@@ -72,13 +72,6 @@ class TestNodesQueues(TestFunctional):
             a['resources_available.foo'] = 'B'
         return dict(attrib.items() + a.items())
 
-    def tearDown(self):
-        self.server.manager(MGR_CMD_UNSET, NODE, 'queue', id='vnode[0]')
-        self.server.manager(MGR_CMD_UNSET, NODE, 'queue', id='vnode[1]')
-        self.server.manager(MGR_CMD_UNSET, NODE, 'queue', id='vnode[2]')
-        self.server.manager(MGR_CMD_UNSET, NODE, 'queue', id='vnode[3]')
-        TestFunctional.tearDown(self)
-
     def test_node_queue_assoc_ignored(self):
         """
         Issue with node grouping and nodes associated with queues.  If


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-865](https://pbspro.atlassian.net/browse/PP-865)**

#### Problem description
* During Server revert to default test fails if the node is associated with the particular queue with the error ['qmgr obj=nodes_queue svr=default: Cannot delete busy object', 'qmgr: Error (15027) returned from server'] 

#### Cause / Analysis
* Inside Server's 'revert_to_defaults' during queue deletion if a queue is set on particular node then  PTL does not unassociate the node from queue before deletion.

#### Solution description
* Before deleting queues inside Server revert to default, we need to check if any queue is associated with any node and if yes then we should unset the queue before deleting it.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
