### PR TITLE
PP-863: scheduler won't run jobs in the same equiv class if there is …

### DIFF
--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1506,8 +1506,6 @@ check_nodes(status *policy, resource_resv *resresv, node_info **ninfo_arr,
 	nspec **nspec_arr = NULL;
 	selspec *spec = NULL;
 	place *pl = NULL;
-	place place_spec;
-
 	int rc;
 
 	if (resresv == NULL || ninfo_arr == NULL || err == NULL) {

--- a/src/scheduler/fairshare.c
+++ b/src/scheduler/fairshare.c
@@ -895,7 +895,7 @@ read_usage_v1(FILE *fp, group_info *root)
 int
 read_usage_v2(FILE *fp, int flags, group_info *root)
 {
-	struct group_node_usage_v2 grp = {0};
+	struct group_node_usage_v2 grp;
 	group_info *ginfo;
 	struct group_path *gpath;
 

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1389,9 +1389,6 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 	/* used for resresv array */
 	resource_resv *array = NULL;		/* used to hold array ptr */
 
-	struct batch_status *bs;		/* used for rescspec res assignment */
-	struct attrl *attrp;			/* used for rescspec res assignment */
-	resource_req *req;
 	unsigned int eval_flags = NO_FLAGS;	/* flags to pass to eval_selspec() */
 	timed_event *te;			/* used to create timed events */
 	resource_resv *rr;
@@ -1504,6 +1501,10 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 		if (ns != NULL) {
 #ifdef RESC_SPEC /* Hack to make rescspec work with new select code */
 			if (rr->is_job && rr->job->rspec != NULL && ns[0] != NULL) {
+				struct batch_status *bs;		/* used for rescspec res assignment */
+				struct attrl *attrp;			/* used for rescspec res assignment */
+				resource_req *req;
+
 				bs = rescspec_get_assignments(rr->job->rspec);
 				if (bs != NULL) {
 					attrp = bs->attribs;

--- a/src/scheduler/limits.c
+++ b/src/scheduler/limits.c
@@ -3186,7 +3186,6 @@ static int
 lim_callback(void *ctx, enum lim_keytypes kt, char *param, char *namestring,
 	char *res, char *val)
 {
-	static char	id[] = "lim_callback";
 	char		*key = (char *) NULL;
 	char		*v = (char *) NULL;
 
@@ -3918,7 +3917,6 @@ static int
 check_queue_max_project_run(server_info *si, queue_info *qi, resource_resv *rr,
 	limcounts *sc, limcounts *qc, schd_error *err)
 {
-	static char	id[] = "check_queue_max_project_run";
 	char		*key;
 	char		*project;
 	int		used;

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -265,6 +265,9 @@ new_schd_error(void);
 schd_error *
 dup_schd_error(schd_error *oerr);
 
+/* like copy constructor but don't dup error structure */
+void copy_schd_error(schd_error *err, schd_error *oerr);
+
 /* does a shallow copy err = oerr safely moving all argument data to err */
 void
 move_schd_error(schd_error *err, schd_error *oerr);

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1649,7 +1649,6 @@ void
 update_node_on_end(node_info *ninfo, resource_resv *resresv, char *job_state)
 {
 	resource_req *resreq = NULL;
-	resource_req *ncpus = NULL;
 	schd_resource *res = NULL;
 	counts *cts;
 	nspec *ns;		/* nspec from resresv for this node */
@@ -4585,7 +4584,6 @@ create_node_array_from_nspec(nspec **nspec_arr)
 node_info **
 reorder_nodes(node_info **nodes, resource_resv *resresv)
 {
-	static char id[] = "reorder_nodes";
 	static node_info **node_array = NULL;
 	static int node_array_size = 0;
 	node_info **nptr;

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1541,8 +1541,6 @@ update_server_on_run(status *policy, server_info *sinfo,
 	counts *cts;			/* used in updating project/group/user counts */
 	int num_unassoc;		/* number of unassociated nodes */
 	counts *allcts;			/* used in updating counts for all jobs */
-	int i;
-	resource_req *used;		/* resources used by suspended job */
 
 	if (sinfo == NULL || resresv == NULL)
 		return;


### PR DESCRIPTION
…a suspended job in the list, but isn't the first job

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-863](https://pbspro.atlassian.net/browse/PP-863)**

#### Problem description
* Suspended jobs need to be resumed on the same nodes they were run on.  Suspended jobs are being added into the same equivalence class they were in when they were queued.  Suspended jobs are considered to run first.  If the nodes that the suspended was run on are not available, it will mark the entire class as can not run.  The queued jobs in that class can run anywhere, but now they're in a class that can't run.

#### Cause / Analysis
* This is the second half of this bug fix.  The two halves have to do the query order of the jobs.  Equivalence classes are created in job query order.  The first job in the class creates it and other jobs are added to it.  The original fix only caught the problem if the suspended job came first.  This fix handles the case if the suspended job is a subsequent job.

#### Solution description
* suspended jobs have a special select spec generated for them.  It's based on the original select spec and the vnodes the job is suspended on.  The original fix had logic to use the correct select spec (the special or the original) when classes were being created.  This logic needs to be used in both the code which creates a set and when it finds a set.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
