### PR TITLE
PP-871: OpenSSL 1.1.0 compatibility

### DIFF
--- a/src/lib/Libutil/pbs_aes_encrypt.c
+++ b/src/lib/Libutil/pbs_aes_encrypt.c
@@ -37,32 +37,17 @@ pbs_encrypt_data(char *uncrypted, int *credtype, size_t len, char **crypted, siz
         char *cblk;
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-        EVP_CIPHER_CTX ctx;
-
-        EVP_CIPHER_CTX_init(&ctx);
-
-        if (EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, (const unsigned char *) pbs_aes_key, (const unsigned char *) pbs_aes_iv) == 0)
-                return -1;
-
-        plen = len + EVP_CIPHER_CTX_block_size(&ctx) + 1;
-        cblk = malloc(plen);
-        if (!cblk)
-                return -1;
-
-        if (EVP_EncryptUpdate(&ctx, cblk, &plen, uncrypted, len) == 0)
-                return -1;
-
-        if (EVP_EncryptFinal_ex(&ctx, cblk + plen, &len2) == 0)
-                return -1;
-
-        EVP_CIPHER_CTX_cleanup(&ctx);
+#define CIPHER_CONTEXT_INIT(v) EVP_CIPHER_CTX_init(v)
+#define CIPHER_CONTEXT_CLEAN(v) EVP_CIPHER_CTX_cleanup(v)
+        EVP_CIPHER_CTX real_ctx;
+        EVP_CIPHER_CTX *ctx = &real_ctx;
 #else
-        EVP_CIPHER_CTX *ctx;
+#define CIPHER_CONTEXT_INIT(v) v = EVP_CIPHER_CTX_new(); if (!v) return -1;
+#define CIPHER_CONTEXT_CLEAN(v) EVP_CIPHER_CTX_free(v)
+        EVP_CIPHER_CTX *ctx = NULL;
+#endif
 
-        ctx = EVP_CIPHER_CTX_new();
-
-        if (ctx == NULL)
-                return -1;
+        CIPHER_CONTEXT_INIT(ctx);
 
         if (EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, (const unsigned char *) pbs_aes_key, (const unsigned char *) pbs_aes_iv) == 0)
                 return -1;
@@ -78,8 +63,8 @@ pbs_encrypt_data(char *uncrypted, int *credtype, size_t len, char **crypted, siz
         if (EVP_EncryptFinal_ex(ctx, cblk + plen, &len2) == 0)
                 return -1;
 
-        EVP_CIPHER_CTX_free(ctx);
-#endif
+        CIPHER_CONTEXT_CLEAN(ctx);
+
         *crypted = cblk;
         *outlen = plen + len2;
         *credtype = PBS_CREDTYPE_AES;
@@ -119,31 +104,17 @@ pbs_decrypt_data(char *crypted, int credtype, size_t len, char **uncrypted, size
         int plen, len2 = 0;
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-        EVP_CIPHER_CTX ctx;
-
-        EVP_CIPHER_CTX_init(&ctx);
-
-        if (EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, (const unsigned char *) pbs_aes_key, (const unsigned char *) pbs_aes_iv) == 0)
-                return -1;
-
-        cblk = malloc(len + EVP_CIPHER_CTX_block_size(&ctx) + 1);
-        if (!cblk)
-                return -1;
-
-        if (EVP_DecryptUpdate(&ctx, cblk, &plen, crypted, len) == 0)
-                return -1;
-
-        if (EVP_DecryptFinal_ex(&ctx, cblk + plen, &len2) == 0)
-                return -1;
-
-        EVP_CIPHER_CTX_cleanup(&ctx);
+#define CIPHER_CONTEXT_INIT(v) EVP_CIPHER_CTX_init(v)
+#define CIPHER_CONTEXT_CLEAN(v) EVP_CIPHER_CTX_cleanup(v)
+        EVP_CIPHER_CTX real_ctx;
+        EVP_CIPHER_CTX *ctx = &real_ctx;
 #else
-        EVP_CIPHER_CTX *ctx;
+#define CIPHER_CONTEXT_INIT(v) v = EVP_CIPHER_CTX_new(); if (!v) return -1;
+#define CIPHER_CONTEXT_CLEAN(v) EVP_CIPHER_CTX_free(v)
+        EVP_CIPHER_CTX *ctx = NULL;
+#endif
 
-        ctx = EVP_CIPHER_CTX_new();
-
-        if (ctx == NULL)
-                return -1;
+        CIPHER_CONTEXT_INIT(ctx);
 
         if (EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, (const unsigned char *) pbs_aes_key, (const unsigned char *) pbs_aes_iv) == 0)
                 return -1;
@@ -158,8 +129,8 @@ pbs_decrypt_data(char *crypted, int credtype, size_t len, char **uncrypted, size
         if (EVP_DecryptFinal_ex(ctx, cblk + plen, &len2) == 0)
                 return -1;
 
-        EVP_CIPHER_CTX_free(ctx);
-#endif
+        CIPHER_CONTEXT_CLEAN(ctx);
+
         *uncrypted = cblk;
         *outlen = plen + len2;
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-871](https://pbspro.atlassian.net/browse/PP-871)**

#### Problem description
* PBS Pro cannot be compiled on Debian 9 due to incompatibility with openssl 1.1.0

#### Cause / Analysis
* OpenSSL 1.1.0 makes some structures opaque. Some objects can not be allocated directly. See this **[page](https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes)** (or man EVP_DecryptInit_ex)

#### Solution description
* We need to define the ctx as a pointer in pbs_aes_encrypt.c. The pointer points to the object allocated with EVP_CIPHER_CTX_new and the object is freed with EVP_CIPHER_CTX_free. Backward compatibility is ensured with the OPENSSL_VERSION_NUMBER macro.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
