### PR TITLE
PP-617:PP-788: Test for acl_groups and acl_resv_groups considers only primary group

### DIFF
--- a/test/tests/functional/pbs_acl_groups.py
+++ b/test/tests/functional/pbs_acl_groups.py
@@ -1,0 +1,85 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class Test_acl_groups(TestFunctional):
+    """
+    Test to check acl_groups and acl_resv_groups considers secondary group
+    """
+
+    def test_acl_grp_queue(self):
+        """
+        Set acl_groups on a queue and submit a job with a user
+        for whom the set group is a secondary group
+        """
+        a = {'queue_type': 'execution', 'started': 't', 'enabled': 't',
+             'acl_group_enable': 't', 'acl_groups': TSTGRP1}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
+        a = {'queue': 'workq2'}
+        j = Job(TEST_USER1, attrs=a)
+        # If 'Unauthorized Request' is found in error message the test would
+        # fail as user was not able to submit job as a secondary group member
+        try:
+            jid = self.server.submit(j)
+        except PbsSubmitError as e:
+            self.assertFalse('Unauthorized Request' in e.msg[0])
+
+    def test_acl_resv_groups(self):
+        """
+        Set acl_resv_groups on server and submit a reservation
+        from a user for whom the set group is a secondary group
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {
+                            'acl_resv_group_enable': 'true'})
+        self.server.manager(MGR_CMD_SET, SERVER, {'acl_resv_groups': TSTGRP1})
+        # If 'Requestor's group not authorized' is found in error message the
+        # test would fail as user was not able to submit reservation
+        # as a secondary group member
+        try:
+            r = Reservation(TEST_USER1)
+            rstart = int(time.time()) + 10
+            rend = int(time.time()) + 360
+            a = {'reserve_start': rstart,
+                 'reserve_end': rend}
+            r.set_attributes(a)
+            rid = self.server.submit(r)
+        except PbsSubmitError as e:
+            self.assertFalse(
+                'Requestor\'s group not authorized' in e.msg[0])


### PR DESCRIPTION
PP-617: acl_groups on queue considers only primary group
PP-788: If a user's primary group is not the same as their user name then they are not able to submit reservations when acl_resv_group_enable is set to true

Tests for acl_groups and acl_resv_groups considers only primary groups and jobs were not able to submit from secondary groups

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-617](https://pbspro.atlassian.net/browse/PP-617)**
* **[PP-788](https://pbspro.atlassian.net/browse/PP-788)**
#### Problem description
Added tests for PP-617 and PP-788

#### Solution description
* Tests for submitting jobs as a secondary group on queue and reservation queue and submitting reservation as a secondary queue

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
