### PR TITLE
PP-806: Add a new queue attribute named "partition"

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -566,6 +566,7 @@ extern int decode_null(attribute *patr, char *name, char *rn, char *val);
 extern int set_null(attribute *patr, attribute *new, enum batch_op op);
 extern int cred_name_okay(attribute *pattr, void *pobject, int actmode);
 extern int action_resc_dflt_queue(attribute *pattr, void *pobj, int actmode);
+extern int action_queue_partition(attribute *pattr, void *pobj, int actmode);
 /* Extern functions (at_action) called  from resv_attr_def */
 extern int action_resc_resv(attribute *pattr, void *pobject, int actmode);
 extern int is_attr(int, char *, int);

--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -280,6 +280,8 @@ extern "C" {
 #define PBSE_SCHED_NO_DEL 15214		/* can not delete scheduler */
 #define PBSE_SCHED_PRIV_EXIST 15215	/* Scheduler sched_priv directory already exists */
 #define PBSE_SCHED_LOG_EXIST 15216	/* Scheduler sched_log directory already exists */
+#define PBSE_ROUTE_QUE_NO_PARTITION  15217 /*Partition can not be assigned to route queue */
+#define PBSE_CANNOT_SET_ROUTE_QUE 15218 /*Can not set queue type to route */
 
 
 /* the following structure is used to tie error number      */

--- a/src/include/queue.h
+++ b/src/include/queue.h
@@ -131,6 +131,7 @@ enum queueattr {
 	QA_ATR_Started,
 	QA_ATR_queued_jobs_threshold,
 	QA_ATR_queued_jobs_threshold_res,
+	QA_ATR_partition,
 	QA_ATR_LAST	/* WARNING: Must be the highest valued enum */
 };
 

--- a/src/lib/Libattr/master_queue_attr_def.xml
+++ b/src/lib/Libattr/master_queue_attr_def.xml
@@ -1017,6 +1017,23 @@
 	<ECL>NULL_VERIFY_VALUE_FUNC</ECL>
 	</member_verify_function>
     </attributes>
+    <attributes> 
+	/* ATTR_partition */
+	<member_name><both>ATTR_partition</both></member_name>	<!-- partition --> 
+	<member_at_decode>decode_str</member_at_decode>
+	<member_at_encode>encode_str</member_at_encode>
+	<member_at_set>set_str</member_at_set>
+	<member_at_comp>comp_str</member_at_comp>
+	<member_at_free>free_str</member_at_free>
+	<member_at_action>action_queue_partition</member_at_action>
+	<member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
+	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
+	<member_at_parent>PARENT_TYPE_QUE_ALL</member_at_parent>
+	<member_verify_function>
+	<ECL>NULL_VERIFY_DATATYPE_FUNC </ECL>
+	<ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+	</member_verify_function>
+    </attributes>
     <tail>
       <SVR>
 	};

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -400,6 +400,8 @@ char *msg_unknown_sched = "Unknown Scheduler";
 char *msg_no_del_sched = "Can not delete Scheduler";
 char *msg_sched_priv_exists = "Another Sched object also has same value for its sched_priv directory";
 char *msg_sched_logs_exists = "Another Sched object also has same value for its sched_log directory";
+char *msg_route_que_no_partition = "Can not assign a partition to route queue";
+char *msg_cannot_set_route_que = "Route queues are incompatible with the partition attribute";
 
 
 /*
@@ -568,6 +570,8 @@ struct pbs_err_to_txt pbs_err_to_txt[] = {
 	{PBSE_SCHED_NO_DEL, &msg_no_del_sched},
 	{PBSE_SCHED_PRIV_EXIST, &msg_sched_priv_exists},
 	{PBSE_SCHED_LOG_EXIST, &msg_sched_logs_exists},
+	{PBSE_ROUTE_QUE_NO_PARTITION, &msg_route_que_no_partition},
+	{PBSE_CANNOT_SET_ROUTE_QUE, &msg_cannot_set_route_que},
 	{ 0, (char **)0 }		/* MUST be the last entry */
 };
 

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -407,3 +407,28 @@ queuestart_action(attribute *pattr, void *pobject, int actmode)
 
 	return 0;
 }
+
+
+/**
+ * @brief
+ * 		action routine for the queue's "partition" attribute
+ *
+ * @param[in]	pattr	-	attribute being set
+ * @param[in]	pobj	-	Object on which attribute is being set
+ * @param[in]	actmode	-	the mode of setting, recovery or just alter
+ *
+ * @return	error code
+ * @retval	PBSE_NONE	-	Success
+ * @retval	!PBSE_NONE	-	Failure
+ *
+ */
+int
+action_queue_partition(attribute *pattr, void *pobj, int actmode)
+{
+	if (((pbs_queue *)pobj)->qu_qs.qu_type  == QTYPE_RoutePush)
+		return PBSE_ROUTE_QUE_NO_PARTITION;
+
+	return PBSE_NONE;
+}
+
+

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -162,6 +162,7 @@ extern char server_host[];
 extern char *path_hooks;
 extern 	int max_concurrent_prov;
 extern char *msg_new_inventory_mom;
+extern char *msg_cannot_set_route_que;
 
 extern int check_req_aoe_available(struct pbsnode *, char *);
 int resize_prov_table(int);
@@ -651,6 +652,11 @@ set_queue_type(attribute *pattr, void *pque, int mode)
 				(((pbs_queue *)pque)->qu_attr[(int)QE_ATR_HasNodes].at_flags & ATR_VFLAG_SET) &&
 				(((pbs_queue *)pque)->qu_attr[(int)QE_ATR_HasNodes].at_val.at_long != 0)) {
 				return (PBSE_ATTRTYPE);
+			} else {
+				if (((pbs_queue *)pque)->qu_attr[(int)QA_ATR_partition].at_flags & ATR_VFLAG_SET &&
+						(spectype == QTYPE_RoutePush)) {
+					return PBSE_CANNOT_SET_ROUTE_QUE;
+				}
 			}
 			((pbs_queue *)pque)->qu_qs.qu_type = spectype;
 			(void)free(pattr->at_val.at_str);

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -358,6 +358,12 @@ action_sched_user(attribute *pattr, void *pobj, int actmode)
 }
 
 int
+action_queue_partition(attribute *pattr, void *pobj, int actmode)
+{
+	return 0;
+}
+
+int
 set_reserve_retry_init(pattr, pobj, actmode)
 attribute *pattr;
 void      *pobj;

--- a/test/tests/interfaces/pbs_queue_partition.py
+++ b/test/tests/interfaces/pbs_queue_partition.py
@@ -1,0 +1,178 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.interfaces import *
+
+
+@tags('multisched')
+class TestQueuePartition(TestInterfaces):
+    """
+    Test suite to test partition attr for queue
+    """
+
+    def create_queue_partition(
+            self,
+            q_type="execution",
+            q_name="Q1",
+            partition="P1",
+            enable="True",
+            start="True"):
+        """
+        Common function to create queue with partition
+        :param q_type: "queue_type" attribute of queue object ,
+                    Defaults to "execution"
+        :type q_type:  str
+        :param q_name: name of the queue, Defaults to "Q1"
+        :type q_name: str
+        :param partition: "partition" attribute of queue object,
+                    Defaults to "P1"
+        :type partition: str
+        :param enable: "enabled" attribute of queue object, Defaults to "True"
+        :type enable: boolean
+        :param start: "started" attribute of queue object, Defaults to "True"
+        :type start: boolean
+        """
+        attr = {
+            'queue_type': q_type,
+            'enabled': enable,
+            'started': start,
+            'partition': partition}
+        self.server.manager(MGR_CMD_CREATE,
+                            QUEUE, attr,
+                            id=q_name, expect=True)
+
+    def test_set_unset_partition(self):
+        """
+        Test to set/unset the partition attribute of queue object
+        """
+        self.create_queue_partition()
+        self.server.manager(MGR_CMD_SET,
+                            QUEUE, {'partition': "P2"},
+                            id="Q1", expect=True)
+        # resetting the same partition value
+        self.server.manager(MGR_CMD_SET,
+                            QUEUE, {'partition': "P2"},
+                            id="Q1", expect=True)
+        self.server.manager(MGR_CMD_UNSET,
+                            QUEUE, 'partition',
+                            id="Q1", expect=True)
+
+    def test_set_partition_user_permissions(self):
+        """
+        Test to check the user permissions for set/unset the partition
+        attribute of queue
+        """
+        self.create_queue_partition()
+        msg1 = "Unauthorized Request"
+        msg2 = "checking the qmgr error message"
+        try:
+            self.server.manager(MGR_CMD_SET,
+                                QUEUE, {'partition': "P2"},
+                                id="Q1", runas=TEST_USER)
+        except PbsManagerError as e:
+            self.assertTrue(msg1 in e.msg[0], msg2)
+        try:
+            self.server.manager(MGR_CMD_UNSET,
+                                QUEUE, 'partition',
+                                id="Q1", runas=TEST_USER)
+        except PbsManagerError as e:
+            # self.assertEquals(e.rc, 15007)
+            # The above code has to be uncommented when the PTL framework
+            # bug PP-881 gets fixed
+            self.assertTrue(msg1 in e.msg[0], msg2)
+
+    def test_set_partition_to_routing_queue(self):
+        """
+        Test to check the set of partition attribute on routing queue
+        """
+        msg1 = "Can not assign a partition to route queue"
+        msg2 = "checking the qmgr error message"
+        try:
+            self.create_queue_partition(
+                q_type='route', enable='False', start='False')
+        except PbsManagerError as e:
+            # self.assertEquals(e.rc, 15217)
+            # The above code has to be uncommented when the PTL framework
+            # bug PP-881 gets fixed
+            self.assertTrue(msg1 in e.msg[0], msg2)
+        self.server.manager(
+            MGR_CMD_CREATE, QUEUE, {
+                'queue_type': 'r'}, id='Q1')
+        try:
+            self.server.manager(MGR_CMD_SET,
+                                QUEUE, {'partition': "P1"},
+                                id="Q1")
+        except PbsManagerError as e:
+            # self.assertEquals(e.rc, 15007)
+            # The above code has to be uncommented when the PTL framework
+            # bug PP-881 gets fixed
+            self.assertTrue(msg1 in e.msg[0], msg2)
+
+    def test_modify_queue_with_partition_to_routing(self):
+        """
+        Test to check the modify of execution queue to routing when
+        partition attribute is set
+        """
+        self.create_queue_partition()
+        msg1 = ("Route queues are incompatible "
+                "with the partition attribute queue_type")
+        msg2 = "checking the qmgr error message"
+        try:
+            self.server.manager(MGR_CMD_SET,
+                                QUEUE, {'queue_type': "r"},
+                                id="Q1")
+        except PbsManagerError as e:
+            # self.assertEquals(e.rc, 15218)
+            # The above code has to be uncommented when the PTL framework
+            # bug PP-881 gets fixed
+            self.assertTrue(msg1 in e.msg[0], msg2)
+
+    def test_set_partition_without_queue_type(self):
+        """
+        Test to check the set of partition attribute on queue
+        with not queue_type set
+        """
+        self.server.manager(MGR_CMD_CREATE,
+                            QUEUE, {'partition': "P1"},
+                            id="Q1", expect=True)
+        self.server.manager(MGR_CMD_SET,
+                            QUEUE, {'partition': "P2"},
+                            id="Q1", expect=True)
+        self.server.manager(MGR_CMD_SET,
+                            QUEUE, {'queue_type': "execution"},
+                            id="Q1", expect=True)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

PP-806
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-806](https://pbspro.atlassian.net/browse/PP-806)**

#### Problem description
* This is one of the tickets of the following EPIC
**[PP-337](https://pbspro.atlassian.net/browse/PP-337)** Multiple schedulers servicing the PBS cluster

This ticket addresses adding new attribute named "partition" to queue object.

#### Cause / Analysis

- Adding new queue attribute named "partition"

#### Solution description

- Adding new queue attribute named "partition"
- "partition" set on routing queues is not allowed
- Changing an execution queue's queue_type to routing when partition is already set on it should not be  allowed.


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
