### PR TITLE
PP-885: small memory leak in scheduler - equiv_class_resdef is not freed

### DIFF
--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -3283,6 +3283,8 @@ free_status(status *st)
 		free(st->resdef_to_check_noncons);
 	if (st->rel_on_susp != NULL)
 		free(st->rel_on_susp);
+	if (st->equiv_class_resdef != NULL)
+		free(st->equiv_class_resdef);
 	free(st);
 }
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-885](https://pbspro.atlassian.net/browse/PP-885)**

#### Problem description
* There is a small memory leak in the scheduler. equiv_class_resdef is not freed properly.

#### Cause / Analysis
* equiv_class_resdef is allocated on server_info.c:392 but never freed in free_status()

#### Solution description
* add equiv_class_resdef to free_status()

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
