### PR TITLE
PP-890, PP-893: get_log_files() & Scheduler.cycles() are broken

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -11514,8 +11514,13 @@ class Scheduler(PBSService):
             self.logger.error('error loading ptl.utils.pbs_logutils')
             return None
 
+        if start is not None or end is not None:
+            analyze_path = os.path.dirname(self.logfile)
+        else:
+            analyze_path = self.logfile
+
         sl = PBSSchedulerLog()
-        sl.analyze(self.logfile, start, end, self.hostname)
+        sl.analyze(analyze_path, start, end, self.hostname)
         cycles = sl.cycles
         if cycles is None or len(cycles) == 0:
             return []

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -513,7 +513,7 @@ class PBSLogUtils(object):
         :type path: str
         :param start: Start time for the log file
         :param end: End time for the log file
-        :returns: list of files or None if 'path' is not found
+        :returns: list of log file(s) found or an empty list
         """
         paths = []
         if self.du.isdir(hostname, path, sudo=sudo):
@@ -533,6 +533,8 @@ class PBSLogUtils(object):
                         if d1 > d2:
                             continue
                 paths.append(f)
+        elif self.du.isfile(hostname, path, sudo=sudo):
+            paths = [path]
 
         return paths
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-890](https://pbspro.atlassian.net/browse/PP-890)**
* **[PP-893](https://pbspro.atlassian.net/browse/PP-893)**

#### Problem description
* PP-890: PTL scheduler.cycles not returning expected outcome
* PP-893: PTL : pbs_loganalyzer failing to read logs if filename is given as input

#### Cause / Analysis
* PP-758 changed the behavior of PBSLogUtils.get_log_files() to return an empty list [] if the 'path' given was not found. This was an oversight on my part, I didn't realize that the function is intended to handle file & directory paths and not just directory paths. Although the previous implementation would just return the path being sent as input even if that path was bogus.
* Scheduler.cycles() was also kind of broken. It would always pass 'Scheduler.logfile' as the 'path' argument to PBSLogUtils.analyze(), which meant that 'start' and 'end' would have no meaning and the function would always return cycles for only one log file (Scheduler.logfile)

#### Solution description
* Fixed PBSLogUtils.get_log_files() to handle the case where a file is input as 'path'.
* Fixed Scheduler.cycles() to set 'path' to sched_logs if either 'start' or 'end' are set when calling PBSLogUtils.analyze()

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [X] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
