### PR TITLE
PP-878: pbs_swigify is broken

### DIFF
--- a/test/fw/bin/pbs_swigify
+++ b/test/fw/bin/pbs_swigify
@@ -305,9 +305,11 @@ if __name__ == '__main__':
         cmd = ['gcc', '-Wall', '-Wno-unused-variable', '-fPIC', '-shared',
                '-I' + pbsinclude]
         cmd += ['-I' + pythoninc]
-        cmd += ['pbs_ifl_wrap.c', pbs_conf['PBS_EXEC'] + '/lib/libpbs.a']
-        cmd += ['-lcrypto']
+        cmd += ['pbs_ifl_wrap.c']
+        cmd += ['-L' + os.path.join(pbs_conf['PBS_EXEC'], 'lib')]
+        cmd += ['-lpbs']
         cmd += ['-o', '_pbs_ifl.so']
+        cmd += ['-lcrypto', '-lssl']
         logging.debug(du.run_cmd(targethost, cmd))
 
     libdir = os.path.dirname(ptl.lib.__file__)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-878](https://pbspro.atlassian.net/browse/PP-878)**

#### Problem description
* pbs_swigify was broken. Thus, unable to use API mode in PTL.

#### Cause / Analysis
* Problem with Linking archived library libpbs.a using -fPIC.

#### Solution description
* Generating the _pbs_ifl.so by dynamically linking the libpbs.so with -fPIC.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
