### PR TITLE
 PP-882, PP-901, PP-908: Improvements in AppVeyor helper scripts & windows build fix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,10 +4,13 @@ pull_requests:
 configuration:
   - Release
 clone_depth: 5
-build_script:
+before_build:
   - cmd: call .appveyor\appveyor_helper.bat
+build_script:
   - cmd: call "%VS90COMNTOOLS%vsvars32.bat"
-  - cmd: msbuild /property:Configuration=Release /property:Platform=Win32 /maxcpucount:4 win_configure\pbs_windows_VS2008.sln
+  - cmd: vcbuild win_configure\pbs_windows_VS2008.sln "Release|Win32"
+after_build:
+  - cmd: call .appveyor\generate_installer.bat
 test: off
 deploy: off
 

--- a/.appveyor/appveyor_helper.bat
+++ b/.appveyor/appveyor_helper.bat
@@ -1,4 +1,39 @@
 @echo off
+REM Copyright (C) 1994-2017 Altair Engineering, Inc.
+REM For more information, contact Altair at www.altair.com.
+REM
+REM This file is part of the PBS Professional ("PBS Pro") software.
+REM
+REM Open Source License Information:
+REM
+REM PBS Pro is free software. You can redistribute it and/or modify it under the
+REM terms of the GNU Affero General Public License as published by the Free
+REM Software Foundation, either version 3 of the License, or (at your option) any
+REM later version.
+REM
+REM PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+REM WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+REM PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+REM
+REM You should have received a copy of the GNU Affero General Public License along
+REM with this program.  If not, see <http://www.gnu.org/licenses/>.
+REM
+REM Commercial License Information:
+REM
+REM The PBS Pro software is licensed under the terms of the GNU Affero General
+REM Public License agreement ("AGPL"), except where a separate commercial license
+REM agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+REM
+REM Altairs dual-license business model allows companies, individuals, and
+REM organizations to create proprietary derivative works of PBS Pro and distribute
+REM them - whether embedded or bundled with other software - under a commercial
+REM license agreement.
+REM
+REM Use of Altairs trademarks, including but not limited to "PBS",
+REM "PBS Professional", and "PBS Pro" and Altairs logos is subject to Altair's
+REM trademark licensing policies.
+
+
 
 REM this script is just helper script to build PBS deps in parallel to reduce
 REM time of building all PBS deps.
@@ -26,9 +61,12 @@ REM    end of all batch file in .appveyor directory
 
 setlocal enableDelayedExpansion
 
+cd "%~dp0\.."
+
 set /a "started=0, ended=0"
 set hasmore=1
 1>nul 2>nul del *.out *.passed
+for /f "usebackq" %%A in (`dir /b C:\__withoutspace_*dir_* 2^>nul`) do rd /Q C:\%%A
 for /f "usebackq" %%A in (`dir /on /b .appveyor ^| findstr /B /R "^build_.*\.bat$"`) do (
     if !started! lss %NUMBER_OF_PROCESSORS% (
         set /a "started+=1, next=started"
@@ -38,6 +76,8 @@ for /f "usebackq" %%A in (`dir /on /b .appveyor ^| findstr /B /R "^build_.*\.bat
     set out!next!=%%A.out
     echo !time! - %%A: started
     start /b "" "cmd /c 1>%%A.out 2>&1 .appveyor\%%A && echo > %%A.passed"
+    REM Introduce 2 sec delay to get different RANDOM value
+    1>nul 2>nul ping /n 2 ::1
 )
 set hasmore=
 
@@ -61,3 +101,4 @@ if %ended% lss %started% (
     1>nul 2>nul ping /n 5 ::1
     goto :Wait
 )
+

--- a/.appveyor/build_libedit.bat
+++ b/.appveyor/build_libedit.bat
@@ -1,3 +1,38 @@
+@echo off
+REM Copyright (C) 1994-2017 Altair Engineering, Inc.
+REM For more information, contact Altair at www.altair.com.
+REM
+REM This file is part of the PBS Professional ("PBS Pro") software.
+REM
+REM Open Source License Information:
+REM
+REM PBS Pro is free software. You can redistribute it and/or modify it under the
+REM terms of the GNU Affero General Public License as published by the Free
+REM Software Foundation, either version 3 of the License, or (at your option) any
+REM later version.
+REM
+REM PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+REM WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+REM PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+REM
+REM You should have received a copy of the GNU Affero General Public License along
+REM with this program.  If not, see <http://www.gnu.org/licenses/>.
+REM
+REM Commercial License Information:
+REM
+REM The PBS Pro software is licensed under the terms of the GNU Affero General
+REM Public License agreement ("AGPL"), except where a separate commercial license
+REM agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+REM
+REM Altair’s dual-license business model allows companies, individuals, and
+REM organizations to create proprietary derivative works of PBS Pro and distribute
+REM them - whether embedded or bundled with other software - under a commercial
+REM license agreement.
+REM
+REM Use of Altair’s trademarks, including but not limited to "PBS™",
+REM "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+REM trademark licensing policies.
+
 @echo on
 setlocal
 
@@ -5,54 +40,59 @@ call "%~dp0set_paths.bat"
 
 cd "%BUILDDIR%"
 
+if not defined LIBEDIT_VERSION (
+    echo "Please set LIBEDIT_VERSION to editline version!"
+    exit /b 1
+)
+
 if exist "%BINARIESDIR%\libedit" (
     echo "%BINARIESDIR%\libedit exist already!"
     exit /b 0
 )
 
-if not exist "%BUILDDIR%\wineditline-2.201.zip" (
-    "%CURL_BIN%" -qkL -o "%BUILDDIR%\wineditline-2.201.zip" https://sourceforge.net/projects/mingweditline/files/wineditline-2.201.zip/download
-    if not exist "%BUILDDIR%\wineditline-2.201.zip" (
+if not exist "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%.zip" (
+    "%CURL_BIN%" -qkL -o "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%.zip" https://sourceforge.net/projects/mingweditline/files/wineditline-%LIBEDIT_VERSION%.zip/download
+    if not exist "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%.zip" (
         echo "Failed to download libedit"
         exit /b 1
     )
 )
 
-2>nul rd /S /Q "%BUILDDIR%\wineditline-2.201"
-"%UNZIP_BIN%" -q "%BUILDDIR%\wineditline-2.201.zip"
+2>nul rd /S /Q "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%"
+"%UNZIP_BIN%" -q "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%.zip"
 if not %ERRORLEVEL% == 0 (
-    echo "Failed to extract %BUILDDIR%\wineditline-2.201.zip"
+    echo "Failed to extract %BUILDDIR%\wineditline-%LIBEDIT_VERSION%.zip"
     exit /b 1
 )
-if not exist "%BUILDDIR%\wineditline-2.201" (
-    echo "Could not find %BUILDDIR%\wineditline-2.201"
+if not exist "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%" (
+    echo "Could not find %BUILDDIR%\wineditline-%LIBEDIT_VERSION%"
     exit /b 1
 )
 
-2>nul rd /S /Q "%BUILDDIR%\wineditline-2.201\build"
-2>nul rd /S /Q "%BUILDDIR%\wineditline-2.201\bin32"
-2>nul rd /S /Q "%BUILDDIR%\wineditline-2.201\lib32"
-2>nul rd /S /Q "%BUILDDIR%\wineditline-2.201\include"
-mkdir "%BUILDDIR%\wineditline-2.201\build"
+2>nul rd /S /Q "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%\build"
+2>nul rd /S /Q "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%\bin32"
+2>nul rd /S /Q "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%\lib32"
+2>nul rd /S /Q "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%\include"
+mkdir "%BUILDDIR%\wineditline-%LIBEDIT_VERSION%\build"
 
-"%MSYSDIR%\bin\bash" --login -i -c "cd $BUILDDIR_M/wineditline-2.201/build && $CMAKE_BIN -DLIB_SUFFIX=32 -G \"MSYS Makefiles\" .."
+"%MSYSDIR%\bin\bash" --login -i -c "cd \"$BUILDDIR_M/wineditline-$LIBEDIT_VERSION/build\" && $CMAKE_BIN -DLIB_SUFFIX=32 -G \"MSYS Makefiles\" .."
 if not %ERRORLEVEL% == 0 (
     echo "Failed to generate makefiles for libedit"
     exit /b 1
 )
-"%MSYSDIR%\bin\bash" --login -i -c "cd $BUILDDIR_M/wineditline-2.201/build && make"
+"%MSYSDIR%\bin\bash" --login -i -c "cd \"$BUILDDIR_M/wineditline-$LIBEDIT_VERSION/build\" && make"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to compile libedit"
     exit /b 1
 )
-"%MSYSDIR%\bin\bash" --login -i -c "cd $BUILDDIR_M/wineditline-2.201/build && make install"
+"%MSYSDIR%\bin\bash" --login -i -c "cd \"$BUILDDIR_M/wineditline-$LIBEDIT_VERSION/build\" && make install"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to install libedit"
     exit /b 1
 )
-"%MSYSDIR%\bin\bash" --login -i -c "mkdir -p $BINARIESDIR_M/libedit && cd $BUILDDIR_M/wineditline-2.201/ && cp -rfv bin32 include lib32 $BINARIESDIR_M/libedit/"
+"%MSYSDIR%\bin\bash" --login -i -c "mkdir -p \"$BINARIESDIR_M/libedit\" && cd \"$BUILDDIR_M/wineditline-$LIBEDIT_VERSION/\" && cp -rfv bin32 include lib32 \"$BINARIESDIR_M/libedit/\""
 if not %ERRORLEVEL% == 0 (
-    echo "Failed to copy bin32, include and lib32 from %BUILDDIR%\wineditline-2.201 to %BINARIESDIR%\libedit"
+    echo "Failed to copy bin32, include and lib32 from %BUILDDIR%\wineditline-%LIBEDIT_VERSION% to %BINARIESDIR%\libedit"
     exit /b 1
 )
 

--- a/.appveyor/build_pgsql.bat
+++ b/.appveyor/build_pgsql.bat
@@ -1,3 +1,38 @@
+@echo off
+REM Copyright (C) 1994-2017 Altair Engineering, Inc.
+REM For more information, contact Altair at www.altair.com.
+REM
+REM This file is part of the PBS Professional ("PBS Pro") software.
+REM
+REM Open Source License Information:
+REM
+REM PBS Pro is free software. You can redistribute it and/or modify it under the
+REM terms of the GNU Affero General Public License as published by the Free
+REM Software Foundation, either version 3 of the License, or (at your option) any
+REM later version.
+REM
+REM PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+REM WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+REM PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+REM
+REM You should have received a copy of the GNU Affero General Public License along
+REM with this program.  If not, see <http://www.gnu.org/licenses/>.
+REM
+REM Commercial License Information:
+REM
+REM The PBS Pro software is licensed under the terms of the GNU Affero General
+REM Public License agreement ("AGPL"), except where a separate commercial license
+REM agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+REM
+REM Altair’s dual-license business model allows companies, individuals, and
+REM organizations to create proprietary derivative works of PBS Pro and distribute
+REM them - whether embedded or bundled with other software - under a commercial
+REM license agreement.
+REM
+REM Use of Altair’s trademarks, including but not limited to "PBS™",
+REM "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+REM trademark licensing policies.
+
 @echo on
 setlocal
 
@@ -5,39 +40,44 @@ call "%~dp0set_paths.bat"
 
 cd "%BUILDDIR%"
 
+if not defined PGSQL_VERSION (
+    echo "Please set PGSQL_VERSION to PostgreSQL version!"
+    exit /b 1
+)
+
 if exist "%BINARIESDIR%\pgsql" (
     echo "%BINARIESDIR%\pgsql exist already!"
     exit /b 0
 )
 
-if not exist "%BUILDDIR%\postgresql-9.6.3.tar.bz2" (
-    "%CURL_BIN%" -qkL -o "%BUILDDIR%\postgresql-9.6.3.tar.bz2" https://ftp.postgresql.org/pub/source/v9.6.3/postgresql-9.6.3.tar.bz2
-    if not exist "%BUILDDIR%\postgresql-9.6.3.tar.bz2" (
+if not exist "%BUILDDIR%\postgresql-%PGSQL_VERSION%.tar.bz2" (
+    "%CURL_BIN%" -qkL -o "%BUILDDIR%\postgresql-%PGSQL_VERSION%.tar.bz2" https://ftp.postgresql.org/pub/source/v%PGSQL_VERSION%/postgresql-%PGSQL_VERSION%.tar.bz2
+    if not exist "%BUILDDIR%\postgresql-%PGSQL_VERSION%.tar.bz2" (
         echo "Failed to download postgresql"
         exit /b 1
     )
 )
 
-2>nul rd /S /Q "%BUILDDIR%\postgresql-9.6.3"
-"%MSYSDIR%\bin\bash" --login -i -c "cd $BUILDDIR_M/ && tar -xf postgresql-9.6.3.tar.bz2"
+2>nul rd /S /Q "%BUILDDIR%\postgresql-%PGSQL_VERSION%"
+"%MSYSDIR%\bin\bash" --login -i -c "cd \"$BUILDDIR_M/\" && tar -xf postgresql-%PGSQL_VERSION%.tar.bz2"
 if not %ERRORLEVEL% == 0 (
-    echo "Failed to extract %BUILDDIR%\postgresql-9.6.3.tar.bz2"
+    echo "Failed to extract %BUILDDIR%\postgresql-%PGSQL_VERSION%.tar.bz2"
     exit /b 1
 )
-if not exist "%BUILDDIR%\postgresql-9.6.3" (
-    echo "Could not find %BUILDDIR%\postgresql-9.6.3"
+if not exist "%BUILDDIR%\postgresql-%PGSQL_VERSION%" (
+    echo "Could not find %BUILDDIR%\postgresql-%PGSQL_VERSION%"
     exit /b 1
 )
-if not exist "%BUILDDIR%\postgresql-9.6.3\src\tools\msvc" (
-    echo "Could not find %BUILDDIR%\postgresql-9.6.3\src\tools\msvc"
+if not exist "%BUILDDIR%\postgresql-%PGSQL_VERSION%\src\tools\msvc" (
+    echo "Could not find %BUILDDIR%\postgresql-%PGSQL_VERSION%\src\tools\msvc"
     exit /b 1
 )
 
 call "%VS90COMNTOOLS%\vsvars32.bat"
 
-cd "%BUILDDIR%\postgresql-9.6.3\src\tools\msvc"
+cd "%BUILDDIR%\postgresql-%PGSQL_VERSION%\src\tools\msvc"
 
-call "%BUILDDIR%\postgresql-9.6.3\src\tools\msvc\build.bat"
+call "%BUILDDIR%\postgresql-%PGSQL_VERSION%\src\tools\msvc\build.bat"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to compile pgsql"
     exit /b 1
@@ -45,7 +85,7 @@ if not %ERRORLEVEL% == 0 (
 
 REM This is for Perl to find ./inc/Module/Install.pm, see header of http://cpansearch.perl.org/src/AUDREYT/Module-Install-0.64/lib/Module/Install.pm
 set PERL5LIB=.
-call "%BUILDDIR%\postgresql-9.6.3\src\tools\msvc\install.bat" "%BINARIESDIR%\pgsql"
+call "%BUILDDIR%\postgresql-%PGSQL_VERSION%\src\tools\msvc\install.bat" "%BINARIESDIR%\pgsql"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to install pgsql"
     exit /b 1

--- a/.appveyor/build_python.bat
+++ b/.appveyor/build_python.bat
@@ -1,3 +1,38 @@
+@echo off
+REM Copyright (C) 1994-2017 Altair Engineering, Inc.
+REM For more information, contact Altair at www.altair.com.
+REM
+REM This file is part of the PBS Professional ("PBS Pro") software.
+REM
+REM Open Source License Information:
+REM
+REM PBS Pro is free software. You can redistribute it and/or modify it under the
+REM terms of the GNU Affero General Public License as published by the Free
+REM Software Foundation, either version 3 of the License, or (at your option) any
+REM later version.
+REM
+REM PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+REM WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+REM PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+REM
+REM You should have received a copy of the GNU Affero General Public License along
+REM with this program.  If not, see <http://www.gnu.org/licenses/>.
+REM
+REM Commercial License Information:
+REM
+REM The PBS Pro software is licensed under the terms of the GNU Affero General
+REM Public License agreement ("AGPL"), except where a separate commercial license
+REM agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+REM
+REM Altair’s dual-license business model allows companies, individuals, and
+REM organizations to create proprietary derivative works of PBS Pro and distribute
+REM them - whether embedded or bundled with other software - under a commercial
+REM license agreement.
+REM
+REM Use of Altair’s trademarks, including but not limited to "PBS™",
+REM "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+REM trademark licensing policies.
+
 @echo on
 setlocal
 
@@ -5,32 +40,37 @@ call "%~dp0set_paths.bat"
 
 cd "%BUILDDIR%"
 
-if exist "%BINARIESDIR%\python" (
-    echo "%BINARIESDIR%\python exist already!"
-    exit /b 0
+if not defined PYTHON_VERSION (
+    echo "Please set PYTHON_VERSION to Python version!"
+    exit /b 1
 )
 
-if not exist "%BUILDDIR%\cpython-2.7.13.zip" (
-    "%CURL_BIN%" -qkL -o "%BUILDDIR%\cpython-2.7.13.zip" https://github.com/python/cpython/archive/v2.7.13.zip
-    if not exist "%BUILDDIR%\cpython-2.7.13.zip" (
+if exist "%BINARIESDIR%\python" (
+    echo "%BINARIESDIR%\python exist already!"
+    goto :BuildPython64bit
+)
+
+if not exist "%BUILDDIR%\cpython-%PYTHON_VERSION%.zip" (
+    "%CURL_BIN%" -qkL -o "%BUILDDIR%\cpython-%PYTHON_VERSION%.zip" https://github.com/python/cpython/archive/v%PYTHON_VERSION%.zip
+    if not exist "%BUILDDIR%\cpython-%PYTHON_VERSION%.zip" (
         echo "Failed to download python"
         exit /b 1
     )
 )
-2>nul rd /S /Q "%BUILDDIR%\cpython-2.7.13"
-"%UNZIP_BIN%" -q "%BUILDDIR%\cpython-2.7.13.zip"
-cd "%BUILDDIR%\cpython-2.7.13"
+2>nul rd /S /Q "%BUILDDIR%\cpython-%PYTHON_VERSION%"
+"%UNZIP_BIN%" -q "%BUILDDIR%\cpython-%PYTHON_VERSION%.zip"
+cd "%BUILDDIR%\cpython-%PYTHON_VERSION%"
 
 REM Restore externals directory if python_externals.tar.gz exists
 if exist "%BUILDDIR%\python_externals.tar.gz" (
-    if not exist "%BUILDDIR%\cpython-2.7.13\externals" (
-        "%MSYSDIR%\bin\bash" --login -i -c "cd $BUILDDIR_M/cpython-2.7.13 && tar -xf $BUILDDIR_M/python_externals.tar.gz"
+    if not exist "%BUILDDIR%\cpython-%PYTHON_VERSION%\externals" (
+        "%MSYSDIR%\bin\bash" --login -i -c "cd \"$BUILDDIR_M/cpython-$PYTHON_VERSION\" && tar -xf \"$BUILDDIR_M/python_externals.tar.gz\""
     )
 )
 
-call "%BUILDDIR%\cpython-2.7.13\PCbuild\env.bat" x86
+call "%BUILDDIR%\cpython-%PYTHON_VERSION%\PCbuild\env.bat" x86
 
-call "%BUILDDIR%\cpython-2.7.13\PC\VS9.0\build.bat" -e
+call "%BUILDDIR%\cpython-%PYTHON_VERSION%\PC\VS9.0\build.bat" -e
 if not %ERRORLEVEL% == 0 (
     echo "Failed to compile Python 32bit"
     exit /b 1
@@ -45,44 +85,44 @@ if not exist "%BUILDDIR%\cabarc.exe" (
             exit /b 1
         )
     )
-    2>nul rd /S /Q "%BUILDDIR%\cpython-2.7.13\cabarc_temp"
-    mkdir "%BUILDDIR%\cpython-2.7.13\cabarc_temp"
-    "%BUILDDIR%\supporttools.exe" /C /T:"%BUILDDIR%\cpython-2.7.13\cabarc_temp"
-    expand "%BUILDDIR%\cpython-2.7.13\cabarc_temp\support.cab" -F:cabarc.exe "%BUILDDIR%"
+    2>nul rd /S /Q "%BUILDDIR%\cpython-%PYTHON_VERSION%\cabarc_temp"
+    mkdir "%BUILDDIR%\cpython-%PYTHON_VERSION%\cabarc_temp"
+    "%BUILDDIR%\supporttools.exe" /C /T:"%BUILDDIR%\cpython-%PYTHON_VERSION%\cabarc_temp"
+    expand "%BUILDDIR%\cpython-%PYTHON_VERSION%\cabarc_temp\support.cab" -F:cabarc.exe "%BUILDDIR%"
 )
 set PATH=%BUILDDIR%;%PATH%
 
 REM Workaround for python2713.chm
-mkdir "%BUILDDIR%\cpython-2.7.13\Doc\build\htmlhelp"
-echo "dummy chm file to make msi.py happy" > "%BUILDDIR%\cpython-2.7.13\Doc\build\htmlhelp\python2713.chm"
+mkdir "%BUILDDIR%\cpython-%PYTHON_VERSION%\Doc\build\htmlhelp"
+echo "dummy chm file to make msi.py happy" > "%BUILDDIR%\cpython-%PYTHON_VERSION%\Doc\build\htmlhelp\python%PYTHON_VERSION:.=%.chm"
 
 cd PC
-nmake /f "%BUILDDIR%\cpython-2.7.13\PC\icons.mak"
+nmake /f "%BUILDDIR%\cpython-%PYTHON_VERSION%\PC\icons.mak"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to build icons for Python 32bit"
     exit /b 1
 )
 
-cd "%BUILDDIR%\cpython-2.7.13\Tools\msi"
+cd "%BUILDDIR%\cpython-%PYTHON_VERSION%\Tools\msi"
 set PCBUILD=PC\VS9.0
 set SNAPSHOT=0
-"%BUILDDIR%\cpython-2.7.13\%PCBUILD%\python.exe" -m ensurepip -U --default-pip
+"%BUILDDIR%\cpython-%PYTHON_VERSION%\%PCBUILD%\python.exe" -m ensurepip -U --default-pip
 if not %ERRORLEVEL% == 0 (
     echo "Failed to run ensurepip for Python 32bit"
     exit /b 1
 )
-"%BUILDDIR%\cpython-2.7.13\%PCBUILD%\python.exe" -m pip install pypiwin32
+"%BUILDDIR%\cpython-%PYTHON_VERSION%\%PCBUILD%\python.exe" -m pip install pypiwin32
 if not %ERRORLEVEL% == 0 (
     echo "Failed to install pypiwin32 for Python 32bit"
     exit /b 1
 )
-"%BUILDDIR%\cpython-2.7.13\%PCBUILD%\python.exe" msi.py
-if not exist "%BUILDDIR%\cpython-2.7.13\Tools\msi\python-2.7.13150.msi" (
+"%BUILDDIR%\cpython-%PYTHON_VERSION%\%PCBUILD%\python.exe" msi.py
+if not exist "%BUILDDIR%\cpython-%PYTHON_VERSION%\Tools\msi\python-%PYTHON_VERSION%150.msi" (
     echo "Failed to generate msi Python 32bit"
     exit /b 1
 )
 
-start /wait msiexec /qn /a "%BUILDDIR%\cpython-2.7.13\Tools\msi\python-2.7.13150.msi" TARGETDIR="%BINARIESDIR%\python"
+start /wait msiexec /qn /a "%BUILDDIR%\cpython-%PYTHON_VERSION%\Tools\msi\python-%PYTHON_VERSION%150.msi" TARGETDIR="%BINARIESDIR%\python"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract msi Python 32bit to %BINARIESDIR%\python"
     exit /b 1
@@ -112,6 +152,7 @@ if not %ERRORLEVEL% == 0 (
 )
 
 
+:BuildPython64bit
 REM Start of build for Python 64 bit
 cd "%BUILDDIR%"
 
@@ -120,84 +161,103 @@ if exist "%BINARIESDIR%\python_x64" (
     exit /b 0
 )
 
-2>nul rd /S /Q "%BUILDDIR%\cpython-2.7.13"
-"%UNZIP_BIN%" -q "%BUILDDIR%\cpython-2.7.13.zip"
-cd "%BUILDDIR%\cpython-2.7.13"
+if not exist "%BUILDDIR%\cpython-%PYTHON_VERSION%.zip" (
+    "%CURL_BIN%" -qkL -o "%BUILDDIR%\cpython-%PYTHON_VERSION%.zip" https://github.com/python/cpython/archive/v%PYTHON_VERSION%.zip
+    if not exist "%BUILDDIR%\cpython-%PYTHON_VERSION%.zip" (
+        echo "Failed to download python"
+        exit /b 1
+    )
+)
+2>nul rd /S /Q "%BUILDDIR%\cpython-%PYTHON_VERSION%"
+"%UNZIP_BIN%" -q "%BUILDDIR%\cpython-%PYTHON_VERSION%.zip"
+cd "%BUILDDIR%\cpython-%PYTHON_VERSION%"
 
 REM Restore externals directory if python_externals.tar.gz exists
 if exist "%BUILDDIR%\python_externals.tar.gz" (
-    if not exist "%BUILDDIR%\cpython-2.7.13\externals" (
-        "%MSYSDIR%\bin\bash" --login -i -c "cd $BUILDDIR_M/cpython-2.7.13 && tar -xf $BUILDDIR_M/python_externals.tar.gz"
+    if not exist "%BUILDDIR%\cpython-%PYTHON_VERSION%\externals" (
+        "%MSYSDIR%\bin\bash" --login -i -c "cd \"$BUILDDIR_M/cpython-$PYTHON_VERSION\" && tar -xf \"$BUILDDIR_M/python_externals.tar.gz\""
     )
 ) else (
-	call "%BUILDDIR%\cpython-2.7.13\PCbuild\get_externals.bat"
+    call "%BUILDDIR%\cpython-%PYTHON_VERSION%\PCbuild\get_externals.bat"
 )
 
 REM workaround to openssl build fail
-del "%BUILDDIR%\cpython-2.7.13\externals\openssl-1.0.2j\ms\nt64.mak"
+del "%BUILDDIR%\cpython-%PYTHON_VERSION%\externals\openssl-1.0.2j\ms\nt64.mak"
 
-if not exist "%VS90COMNTOOLS%..\..\VC\bin\amd64\vcvarsamd64.bat" (
-	if not exist "%ProgramFiles%\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" (
-		echo "Could not find x64 build tools for Visual Studio"
-		exit /b 1
-	)
-    call "%VS90COMNTOOLS%vsvars32.bat"
-    call "%ProgramFiles%\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
+if exist "%VS90COMNTOOLS%..\..\VC\bin\amd64\vcvarsamd64.bat" (
+    call "%VS90COMNTOOLS%..\..\VC\bin\amd64\vcvarsamd64.bat"
+) else if exist "%VS90COMNTOOLS%..\..\VC\bin\vcvarsx86_amd64.bat" (
+    call "%VS90COMNTOOLS%..\..\VC\bin\vcvarsx86_amd64.bat"
 ) else (
-	call "%VS90COMNTOOLS%..\..\VC\bin\amd64\vcvarsamd64.bat"
+    echo "Could not find x64 build tools for Visual Studio"
+    exit /b 1
 )
 
-call "%BUILDDIR%\cpython-2.7.13\PC\VS9.0\build.bat" -e -p x64
+call "%BUILDDIR%\cpython-%PYTHON_VERSION%\PC\VS9.0\build.bat" -e -p x64
 if not %ERRORLEVEL% == 0 (
     echo "Failed to compile Python 64bit"
     exit /b 1
 )
 
+REM Workaround for cabarc.exe, required by msi.py
+if not exist "%BUILDDIR%\cabarc.exe" (
+    if not exist "%BUILDDIR%\supporttools.exe" (
+        "%CURL_BIN%" -qkL -o "%BUILDDIR%\supporttools.exe" http://download.microsoft.com/download/d/3/8/d38066aa-4e37-4ae8-bce3-a4ce662b2024/WindowsXP-KB838079-SupportTools-ENU.exe
+        if not exist "%BUILDDIR%\supporttools.exe" (
+            echo "Failed to download supporttools.exe"
+            exit /b 1
+        )
+    )
+    2>nul rd /S /Q "%BUILDDIR%\cpython-%PYTHON_VERSION%\cabarc_temp"
+    mkdir "%BUILDDIR%\cpython-%PYTHON_VERSION%\cabarc_temp"
+    "%BUILDDIR%\supporttools.exe" /C /T:"%BUILDDIR%\cpython-%PYTHON_VERSION%\cabarc_temp"
+    expand "%BUILDDIR%\cpython-%PYTHON_VERSION%\cabarc_temp\support.cab" -F:cabarc.exe "%BUILDDIR%"
+)
+set PATH=%BUILDDIR%;%PATH%
+
 REM Workaround for python2713.chm
-mkdir "%BUILDDIR%\cpython-2.7.13\Doc\build\htmlhelp"
-echo "dummy chm file to make msi.py happy" > "%BUILDDIR%\cpython-2.7.13\Doc\build\htmlhelp\python2713.chm"
+mkdir "%BUILDDIR%\cpython-%PYTHON_VERSION%\Doc\build\htmlhelp"
+echo "dummy chm file to make msi.py happy" > "%BUILDDIR%\cpython-%PYTHON_VERSION%\Doc\build\htmlhelp\python%PYTHON_VERSION:.=%.chm"
 
 cd PC
 REM we need 32bit compiler as python icons does not compile in 64bit
 call "%VS90COMNTOOLS%vsvars32.bat"
-nmake /f "%BUILDDIR%\cpython-2.7.13\PC\icons.mak"
+nmake /f "%BUILDDIR%\cpython-%PYTHON_VERSION%\PC\icons.mak"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to build icons for Python 64bit"
     exit /b 1
 )
 
 REM Restore back 64 bit compiler
-if not exist "%VS90COMNTOOLS%..\..\VC\bin\amd64\vcvarsamd64.bat" (
-	if not exist "%ProgramFiles%\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" (
-		echo "Could not find x64 build tools for Visual Studio"
-		exit /b 1
-	)
-    call "%VS90COMNTOOLS%vsvars32.bat"
-    call "%ProgramFiles%\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
+if exist "%VS90COMNTOOLS%..\..\VC\bin\amd64\vcvarsamd64.bat" (
+    call "%VS90COMNTOOLS%..\..\VC\bin\amd64\vcvarsamd64.bat"
+) else if exist "%VS90COMNTOOLS%..\..\VC\bin\vcvarsx86_amd64.bat" (
+    call "%VS90COMNTOOLS%..\..\VC\bin\vcvarsx86_amd64.bat"
 ) else (
-	call "%VS90COMNTOOLS%..\..\VC\bin\amd64\vcvarsamd64.bat"
+    echo "Could not find x64 build tools for Visual Studio"
+    exit /b 1
 )
 
-cd "%BUILDDIR%\cpython-2.7.13\Tools\msi"
+cd "%BUILDDIR%\cpython-%PYTHON_VERSION%\Tools\msi"
 set PCBUILD=PC\VS9.0\amd64
 set SNAPSHOT=0
-"%BUILDDIR%\cpython-2.7.13\%PCBUILD%\python.exe" -m ensurepip -U --default-pip
+"%BUILDDIR%\cpython-%PYTHON_VERSION%\%PCBUILD%\python.exe" -m ensurepip -U --default-pip
 if not %ERRORLEVEL% == 0 (
     echo "Failed to run ensurepip for Python 64bit"
     exit /b 1
 )
-"%BUILDDIR%\cpython-2.7.13\%PCBUILD%\python.exe" -m pip install pypiwin32
+"%BUILDDIR%\cpython-%PYTHON_VERSION%\%PCBUILD%\python.exe" -m pip install pypiwin32
 if not %ERRORLEVEL% == 0 (
     echo "Failed to install pypiwin32 for Python 64bit"
     exit /b 1
 )
-"%BUILDDIR%\cpython-2.7.13\%PCBUILD%\python.exe" msi.py
-if not exist "%BUILDDIR%\cpython-2.7.13\Tools\msi\python-2.7.13150.amd64.msi" (
+"%BUILDDIR%\cpython-%PYTHON_VERSION%\%PCBUILD%\python.exe" msi.py
+if not exist "%BUILDDIR%\cpython-%PYTHON_VERSION%\Tools\msi\python-%PYTHON_VERSION%150.amd64.msi" (
     echo "Failed to generate msi Python 64bit"
     exit /b 1
 )
 
-start /wait msiexec /qn /a "%BUILDDIR%\cpython-2.7.13\Tools\msi\python-2.7.13150.amd64.msi" TARGETDIR="%BINARIESDIR%\python_x64"
+start /wait msiexec /qn /a "%BUILDDIR%\cpython-%PYTHON_VERSION%\Tools\msi\python-%PYTHON_VERSION%150.amd64.msi" TARGETDIR="%BINARIESDIR%\python_x64"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract msi Python 64bit to %BINARIESDIR%\python_x64"
     exit /b 1

--- a/.appveyor/build_ssl.bat
+++ b/.appveyor/build_ssl.bat
@@ -1,3 +1,38 @@
+@echo off
+REM Copyright (C) 1994-2017 Altair Engineering, Inc.
+REM For more information, contact Altair at www.altair.com.
+REM
+REM This file is part of the PBS Professional ("PBS Pro") software.
+REM
+REM Open Source License Information:
+REM
+REM PBS Pro is free software. You can redistribute it and/or modify it under the
+REM terms of the GNU Affero General Public License as published by the Free
+REM Software Foundation, either version 3 of the License, or (at your option) any
+REM later version.
+REM
+REM PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+REM WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+REM PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+REM
+REM You should have received a copy of the GNU Affero General Public License along
+REM with this program.  If not, see <http://www.gnu.org/licenses/>.
+REM
+REM Commercial License Information:
+REM
+REM The PBS Pro software is licensed under the terms of the GNU Affero General
+REM Public License agreement ("AGPL"), except where a separate commercial license
+REM agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+REM
+REM Altair’s dual-license business model allows companies, individuals, and
+REM organizations to create proprietary derivative works of PBS Pro and distribute
+REM them - whether embedded or bundled with other software - under a commercial
+REM license agreement.
+REM
+REM Use of Altair’s trademarks, including but not limited to "PBS™",
+REM "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+REM trademark licensing policies.
+
 @echo on
 setlocal
 
@@ -5,50 +40,72 @@ call "%~dp0set_paths.bat"
 
 cd "%BUILDDIR%"
 
+if not defined OPENSSL_VERSION (
+    echo "Please set OPENSSL_VERSION to OpenSSL version!"
+    exit /b 1
+)
+
 if exist "%BINARIESDIR%\openssl" (
     echo "%BINARIESDIR%\openssl exist already!"
     exit /b 0
 )
 
-if not exist "%BUILDDIR%\OpenSSL_1_1_0f.zip" (
-    "%CURL_BIN%" -qkL -o "%BUILDDIR%\OpenSSL_1_1_0f.zip" https://github.com/openssl/openssl/archive/OpenSSL_1_1_0f.zip
-    if not exist "%BUILDDIR%\OpenSSL_1_1_0f.zip" (
+if not exist "%BUILDDIR%\OpenSSL_%OPENSSL_VERSION%.zip" (
+    "%CURL_BIN%" -qkL -o "%BUILDDIR%\OpenSSL_%OPENSSL_VERSION%.zip" https://github.com/openssl/openssl/archive/OpenSSL_%OPENSSL_VERSION%.zip
+    if not exist "%BUILDDIR%\OpenSSL_%OPENSSL_VERSION%.zip" (
         echo "Failed to download openssl"
         exit /b 1
     )
 )
 
-2>nul rd /S /Q "%BUILDDIR%\openssl-OpenSSL_1_1_0f"
-"%UNZIP_BIN%" -q "%BUILDDIR%\OpenSSL_1_1_0f.zip"
+2>nul rd /S /Q "%BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"
+"%UNZIP_BIN%" -q "%BUILDDIR%\OpenSSL_%OPENSSL_VERSION%.zip"
 if not %ERRORLEVEL% == 0 (
-    echo "Failed to extract %BUILDDIR%\openssl-OpenSSL_1_1_0f"
+    echo "Failed to extract %BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"
     exit /b 1
 )
-if not exist "%BUILDDIR%\openssl-OpenSSL_1_1_0f" (
-    echo "Could not find %BUILDDIR%\openssl-OpenSSL_1_1_0f"
+if not exist "%BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%" (
+    echo "Could not find %BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"
     exit /b 1
 )
 
-2>nul rd /S /Q "%BUILDDIR%\openssl-OpenSSL_1_1_0f\build"
-mkdir "%BUILDDIR%\openssl-OpenSSL_1_1_0f\build"
-cd "%BUILDDIR%\openssl-OpenSSL_1_1_0f\build"
+cd "%BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"
 
 call "%VS90COMNTOOLS%vsvars32.bat
 
-"%PERL_BIN%" ..\Configure --prefix="%BINARIESDIR%\openssl" VC-WIN32 no-asm no-shared
+"%PERL_BIN%" "%BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%\Configure" --prefix="%BINARIESDIR%\openssl" VC-WIN32 no-asm no-shared
 if not %ERRORLEVEL% == 0 (
     echo "Failed to generate makefiles for openssl"
     exit /b 1
 )
-nmake
-if not %ERRORLEVEL% == 0 (
-    echo "Failed to compile openssl"
-    exit /b 1
+
+if exist "%BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%\ms\do_nt.bat" (
+    call "%BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%\ms\do_nt.bat"
+    nmake -f "%BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%\ms\nt.mak"
+    if not %ERRORLEVEL% == 0 (
+        echo "Failed to compile openssl"
+        exit /b 1
+    )
+) else (
+    nmake
+    if not %ERRORLEVEL% == 0 (
+        echo "Failed to compile openssl"
+        exit /b 1
+    )
 )
-nmake install
-if not %ERRORLEVEL% == 0 (
-    echo "Failed to install openssl"
-    exit /b 1
+
+if exist "%BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%\ms\do_nt.bat" (
+    nmake -f "%BUILDDIR%\openssl-OpenSSL_%OPENSSL_VERSION%\ms\nt.mak" install
+    if not %ERRORLEVEL% == 0 (
+        echo "Failed to install openssl"
+        exit /b 1
+    )
+) else (
+    nmake install
+    if not %ERRORLEVEL% == 0 (
+        echo "Failed to install openssl"
+        exit /b 1
+    )
 )
 
 exit /b 0

--- a/.appveyor/build_swig.bat
+++ b/.appveyor/build_swig.bat
@@ -1,9 +1,49 @@
+@echo off
+REM Copyright (C) 1994-2017 Altair Engineering, Inc.
+REM For more information, contact Altair at www.altair.com.
+REM
+REM This file is part of the PBS Professional ("PBS Pro") software.
+REM
+REM Open Source License Information:
+REM
+REM PBS Pro is free software. You can redistribute it and/or modify it under the
+REM terms of the GNU Affero General Public License as published by the Free
+REM Software Foundation, either version 3 of the License, or (at your option) any
+REM later version.
+REM
+REM PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+REM WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+REM PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+REM
+REM You should have received a copy of the GNU Affero General Public License along
+REM with this program.  If not, see <http://www.gnu.org/licenses/>.
+REM
+REM Commercial License Information:
+REM
+REM The PBS Pro software is licensed under the terms of the GNU Affero General
+REM Public License agreement ("AGPL"), except where a separate commercial license
+REM agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+REM
+REM Altair’s dual-license business model allows companies, individuals, and
+REM organizations to create proprietary derivative works of PBS Pro and distribute
+REM them - whether embedded or bundled with other software - under a commercial
+REM license agreement.
+REM
+REM Use of Altair’s trademarks, including but not limited to "PBS™",
+REM "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+REM trademark licensing policies.
+
 @echo on
 setlocal
 
 call "%~dp0set_paths.bat"
 
 cd "%BUILDDIR%"
+
+if not defined SWIG_VERSION (
+    echo "Please set SWIG_VERSION to Swig version!"
+    exit /b 1
+)
 
 if exist "%BINARIESDIR%\swig" (
     echo "%BINARIESDIR%\swig exist already!"
@@ -12,7 +52,7 @@ if exist "%BINARIESDIR%\swig" (
 
 if exist "%BINARIESDIR%\python\python.exe" (
     echo "Found Python installation at %BINARIESDIR%\python, using it to add Python support in swig"
-    set PYTHON_INSTALL_DIR=%BINARIESDIR_M%/python/python.exe
+    set PYTHON_INSTALL_DIR="%BINARIESDIR_M%/python/python.exe"
 ) else if exist "C:\Python27\python.exe" (
     echo "Found Python installation at C:\Python27, using it to add Python support in swig"
     set PYTHON_INSTALL_DIR=/c/Python27/python.exe
@@ -21,9 +61,9 @@ if exist "%BINARIESDIR%\python\python.exe" (
     exit /b 1
 )
 
-if not exist "%BUILDDIR%\swig-rel-3.0.12.zip" (
-    "%CURL_BIN%" -qkL -o "%BUILDDIR%\swig-rel-3.0.12.zip" https://github.com/swig/swig/archive/rel-3.0.12.zip
-    if not exist "%BUILDDIR%\swig-rel-3.0.12.zip" (
+if not exist "%BUILDDIR%\swig-rel-%SWIG_VERSION%.zip" (
+    "%CURL_BIN%" -qkL -o "%BUILDDIR%\swig-rel-%SWIG_VERSION%.zip" https://github.com/swig/swig/archive/rel-%SWIG_VERSION%.zip
+    if not exist "%BUILDDIR%\swig-rel-%SWIG_VERSION%.zip" (
         echo "Failed to download swig"
         exit /b 1
     )
@@ -53,40 +93,40 @@ if not exist "%BUILDDIR%\cccl-cccl-1.0\cccl" (
     exit /b 1
 )
 
-2>nul rd /S /Q "%BUILDDIR%\swig-rel-3.0.12"
-"%UNZIP_BIN%" -q "%BUILDDIR%\swig-rel-3.0.12.zip"
+2>nul rd /S /Q "%BUILDDIR%\swig-rel-%SWIG_VERSION%"
+"%UNZIP_BIN%" -q "%BUILDDIR%\swig-rel-%SWIG_VERSION%.zip"
 if not %ERRORLEVEL% == 0 (
-    echo "Failed to extract %BUILDDIR%\swig-rel-3.0.12.zip"
+    echo "Failed to extract %BUILDDIR%\swig-rel-%SWIG_VERSION%.zip"
     exit /b 1
 )
-if not exist "%BUILDDIR%\swig-rel-3.0.12" (
-    echo "Could not find %BUILDDIR%\swig-rel-3.0.12"
+if not exist "%BUILDDIR%\swig-rel-%SWIG_VERSION%" (
+    echo "Could not find %BUILDDIR%\swig-rel-%SWIG_VERSION%"
     exit /b 1
 )
 
 call "%VS90COMNTOOLS%\vsvars32.bat
 
-"%MSYSDIR%\bin\bash" --login -i -c "cp -f $BUILDDIR_M/cccl-cccl-1.0/cccl /usr/bin/cccl && chmod +x /usr/bin/cccl"
+"%MSYSDIR%\bin\bash" --login -i -c "cp -f \"$BUILDDIR_M/cccl-cccl-1.0/cccl\" /usr/bin/cccl && chmod +x /usr/bin/cccl"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to copy cccl from %BUILDDIR%\cccl-cccl-1.0\cccl to /usr/bin/cccl in MSYS bash"
     exit /b 1
 )
-"%MSYSDIR%\bin\bash" --login -i -c "cd $BUILDDIR_M/swig-rel-3.0.12 && ./autogen.sh"
+"%MSYSDIR%\bin\bash" --login -i -c "cd \"$BUILDDIR_M/swig-rel-$SWIG_VERSION\" && ./autogen.sh"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to generate configure for swig"
     exit /b 1
 )
-"%MSYSDIR%\bin\bash" --login -i -c "cd $BUILDDIR_M/swig-rel-3.0.12 && ./configure CC=cccl CXX=cccl CFLAGS='-O2' CXXFLAGS='-O2' LDFLAGS='--cccl-link /LTCG' --prefix=$BINARIESDIR_M/swig --without-alllang --with-python=$PYTHON_INSTALL_DIR --disable-dependency-tracking --disable-ccache --without-pcre"
+"%MSYSDIR%\bin\bash" --login -i -c "cd \"$BUILDDIR_M/swig-rel-$SWIG_VERSION\" && ./configure CC=cccl CXX=cccl CFLAGS='-O2' CXXFLAGS='-O2' LDFLAGS='--cccl-link /LTCG' --prefix=\"$BINARIESDIR_M/swig\" --without-alllang --with-python=\"$PYTHON_INSTALL_DIR\" --disable-dependency-tracking --disable-ccache --without-pcre"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to generate makefiles for swig"
     exit /b 1
 )
-"%MSYSDIR%\bin\bash" --login -i -c "cd $BUILDDIR_M/swig-rel-3.0.12 && make"
+"%MSYSDIR%\bin\bash" --login -i -c "cd \"$BUILDDIR_M/swig-rel-$SWIG_VERSION\" && make"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to compile swig"
     exit /b 1
 )
-"%MSYSDIR%\bin\bash" --login -i -c "cd $BUILDDIR_M/swig-rel-3.0.12 && make install"
+"%MSYSDIR%\bin\bash" --login -i -c "cd \"$BUILDDIR_M/swig-rel-$SWIG_VERSION\" && make install"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to install swig"
     exit /b 1

--- a/.appveyor/build_tcltk.bat
+++ b/.appveyor/build_tcltk.bat
@@ -1,3 +1,38 @@
+@echo off
+REM Copyright (C) 1994-2017 Altair Engineering, Inc.
+REM For more information, contact Altair at www.altair.com.
+REM
+REM This file is part of the PBS Professional ("PBS Pro") software.
+REM
+REM Open Source License Information:
+REM
+REM PBS Pro is free software. You can redistribute it and/or modify it under the
+REM terms of the GNU Affero General Public License as published by the Free
+REM Software Foundation, either version 3 of the License, or (at your option) any
+REM later version.
+REM
+REM PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+REM WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+REM PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+REM
+REM You should have received a copy of the GNU Affero General Public License along
+REM with this program.  If not, see <http://www.gnu.org/licenses/>.
+REM
+REM Commercial License Information:
+REM
+REM The PBS Pro software is licensed under the terms of the GNU Affero General
+REM Public License agreement ("AGPL"), except where a separate commercial license
+REM agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+REM
+REM Altair’s dual-license business model allows companies, individuals, and
+REM organizations to create proprietary derivative works of PBS Pro and distribute
+REM them - whether embedded or bundled with other software - under a commercial
+REM license agreement.
+REM
+REM Use of Altair’s trademarks, including but not limited to "PBS™",
+REM "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+REM trademark licensing policies.
+
 @echo on
 setlocal
 
@@ -5,82 +40,90 @@ call "%~dp0set_paths.bat"
 
 cd "%BUILDDIR%"
 
+if not defined TCL_VERSION (
+    echo "Please set TCL_VERSION to Tcl version!"
+    exit /b 1
+)
+if not defined TK_VERSION (
+    echo "Please set TK_VERSION to Tk version!"
+    exit /b 1
+)
+
 if exist "%BINARIESDIR%\tcltk" (
     echo "%BINARIESDIR%\tcltk exist already!"
     exit /b 0
 )
 
-if not exist "%BUILDDIR%\tcl866-src.zip" (
-    "%CURL_BIN%" -qkL -o "%BUILDDIR%\tcl866-src.zip" ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl866-src.zip
-    if not exist "%BUILDDIR%\tcl866-src.zip" (
+if not exist "%BUILDDIR%\tcl%TCL_VERSION:.=%-src.zip" (
+    "%CURL_BIN%" -qkL -o "%BUILDDIR%\tcl%TCL_VERSION:.=%-src.zip" https://sourceforge.net/projects/tcl/files/Tcl/%TCL_VERSION%/tcl%TCL_VERSION:.=%-src.zip/download
+    if not exist "%BUILDDIR%\tcl%TCL_VERSION:.=%-src.zip" (
         echo "Failed to download tcl"
         exit /b 1
     )
 )
-if not exist "%BUILDDIR%\tk866-src.zip" (
-    "%CURL_BIN%" -qkL -o "%BUILDDIR%\tk866-src.zip" ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tk866-src.zip
-    if not exist "%BUILDDIR%\tk866-src.zip" (
+if not exist "%BUILDDIR%\tk%TK_VERSION:.=%-src.zip" (
+    "%CURL_BIN%" -qkL -o "%BUILDDIR%\tk%TK_VERSION:.=%-src.zip" https://sourceforge.net/projects/tcl/files/Tcl/%TK_VERSION%/tk%TK_VERSION:.=%-src.zip/download
+    if not exist "%BUILDDIR%\tk%TK_VERSION:.=%-src.zip" (
         echo "Failed to download tk"
         exit /b 1
     )
 )
 
-2>nul rd /S /Q "%BUILDDIR%\tcl8.6.6"
-"%UNZIP_BIN%" -q "%BUILDDIR%\tcl866-src.zip"
+2>nul rd /S /Q "%BUILDDIR%\tcl%TCL_VERSION%"
+"%UNZIP_BIN%" -q "%BUILDDIR%\tcl%TCL_VERSION:.=%-src.zip"
 if not %ERRORLEVEL% == 0 (
-    echo "Failed to extract %BUILDDIR%\tcl866-src.zip"
+    echo "Failed to extract %BUILDDIR%\tcl%TCL_VERSION:.=%-src.zip"
     exit /b 1
 )
-if not exist "%BUILDDIR%\tcl8.6.6" (
-    echo "Could not find %BUILDDIR%\tcl8.6.6"
+if not exist "%BUILDDIR%\tcl%TCL_VERSION%" (
+    echo "Could not find %BUILDDIR%\tcl%TCL_VERSION%"
     exit /b 1
 )
-if not exist "%BUILDDIR%\tcl8.6.6\win" (
-    echo "Could not find %BUILDDIR%\tcl8.6.6\win"
+if not exist "%BUILDDIR%\tcl%TCL_VERSION%\win" (
+    echo "Could not find %BUILDDIR%\tcl%TCL_VERSION%\win"
     exit /b 1
 )
 
-2>nul rd /S /Q "%BUILDDIR%\tk8.6.6"
-"%UNZIP_BIN%" -q "%BUILDDIR%\tk866-src.zip"
+2>nul rd /S /Q "%BUILDDIR%\tk%TK_VERSION%"
+"%UNZIP_BIN%" -q "%BUILDDIR%\tk%TK_VERSION:.=%-src.zip"
 if not %ERRORLEVEL% == 0 (
-    echo "Failed to extract %BUILDDIR%\tk866-src.zip"
+    echo "Failed to extract %BUILDDIR%\tk%TK_VERSION:.=%-src.zip"
     exit /b 1
 )
-if not exist "%BUILDDIR%\tk8.6.6" (
-    echo "Could not find %BUILDDIR%\tk8.6.6"
+if not exist "%BUILDDIR%\tk%TK_VERSION%" (
+    echo "Could not find %BUILDDIR%\tk%TK_VERSION%"
     exit /b 1
 )
-if not exist "%BUILDDIR%\tk8.6.6\win" (
-    echo "Could not find %BUILDDIR%\tk8.6.6\win"
+if not exist "%BUILDDIR%\tk%TK_VERSION%\win" (
+    echo "Could not find %BUILDDIR%\tk%TK_VERSION%\win"
     exit /b 1
 )
 
 call "%VS90COMNTOOLS%vsvars32.bat"
 
-cd  "%BUILDDIR%\tcl8.6.6\win"
-nmake /f "%BUILDDIR%\tcl8.6.6\win\makefile.vc"
+cd  "%BUILDDIR%\tcl%TCL_VERSION%\win"
+nmake /f "%BUILDDIR%\tcl%TCL_VERSION%\win\makefile.vc"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to compile tcl"
     exit /b 1
 )
-nmake /f "%BUILDDIR%\tcl8.6.6\win\makefile.vc" install INSTALLDIR="%BINARIESDIR%\tcltk"
+nmake /f "%BUILDDIR%\tcl%TCL_VERSION%\win\makefile.vc" install INSTALLDIR="%BINARIESDIR%\tcltk"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to install tcl"
     exit /b 1
 )
 
-cd "%BUILDDIR%\tk8.6.6\win"
-set TCLDIR=%BUILDDIR%\tcl8.6.6
-nmake /f "%BUILDDIR%\tk8.6.6\win\makefile.vc"
+cd "%BUILDDIR%\tk%TK_VERSION%\win"
+set TCLDIR=%BUILDDIR%\tcl%TCL_VERSION%
+nmake /f "%BUILDDIR%\tk%TK_VERSION%\win\makefile.vc"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to compile tk"
     exit /b 1
 )
-nmake /f "%BUILDDIR%\tk8.6.6\win\makefile.vc" install INSTALLDIR="%BINARIESDIR%\tcltk"
+nmake /f "%BUILDDIR%\tk%TK_VERSION%\win\makefile.vc" install INSTALLDIR="%BINARIESDIR%\tcltk"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to install tk"
     exit /b 1
 )
 
 exit /b 0
-

--- a/.appveyor/set_paths.bat
+++ b/.appveyor/set_paths.bat
@@ -1,18 +1,126 @@
+@echo off
+REM Copyright (C) 1994-2017 Altair Engineering, Inc.
+REM For more information, contact Altair at www.altair.com.
+REM
+REM This file is part of the PBS Professional ("PBS Pro") software.
+REM
+REM Open Source License Information:
+REM
+REM PBS Pro is free software. You can redistribute it and/or modify it under the
+REM terms of the GNU Affero General Public License as published by the Free
+REM Software Foundation, either version 3 of the License, or (at your option) any
+REM later version.
+REM
+REM PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+REM WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+REM PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+REM
+REM You should have received a copy of the GNU Affero General Public License along
+REM with this program.  If not, see <http://www.gnu.org/licenses/>.
+REM
+REM Commercial License Information:
+REM
+REM The PBS Pro software is licensed under the terms of the GNU Affero General
+REM Public License agreement ("AGPL"), except where a separate commercial license
+REM agreement for PBS Pro version 14 or later has been executed in writing with Altair.
+REM
+REM Altair’s dual-license business model allows companies, individuals, and
+REM organizations to create proprietary derivative works of PBS Pro and distribute
+REM them - whether embedded or bundled with other software - under a commercial
+REM license agreement.
+REM
+REM Use of Altair’s trademarks, including but not limited to "PBS™",
+REM "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+REM trademark licensing policies.
+
 @echo on
-set old_dir="%CD%"
-cd %~dp0..\..
-set SVN_BIN=svn
-set CURL_BIN=curl
-set UNZIP_BIN=unzip
-set MSYSDIR=C:\MinGW\msys\1.0
-set PERL_BIN=perl
-set CMAKE_BIN=cmake
+set __OLD_DIR="%CD%"
+cd "%~dp0..\.."
+
+REM SVN is used by Python internally, to download it's dependencies
+if not defined SVN_BIN (
+    set SVN_BIN=svn
+)
+if not defined CURL_BIN (
+    set CURL_BIN=curl
+)
+if not defined UNZIP_BIN (
+    set UNZIP_BIN=unzip
+)
+if not defined MSYSDIR (
+    set MSYSDIR=C:\MinGW\msys\1.0
+)
+if not defined PERL_BIN (
+    set PERL_BIN=perl
+)
+if not defined CMAKE_BIN (
+    set CMAKE_BIN=cmake
+)
+if not defined __BUILDDIR (
+    set __BUILDDIR=%CD%\windows-work
+)
+if not defined __BINARIESDIR (
+    set __BINARIESDIR=%CD%\binaries
+)
+set __RANDOM_VAL=%RANDOM::=_%
+set __RANDOM_VAL-%RANDOM_VAL:.=%
+set __BUILDJUNCTION=%__BUILDDIR:~0,2%\__withoutspace_builddir_%__RANDOM_VAL%
+set __BINARIESJUNCTION=%__BINARIESDIR:~0,2%\__withoutspace_binariesdir_%__RANDOM_VAL%
+if not exist "%__BUILDDIR%" (
+    mkdir "%__BUILDDIR%"
+)
+if not "%__BUILDDIR: =%"=="%__BUILDDIR%" (
+    mklink /J %__BUILDJUNCTION% "%__BUILDDIR%"
+    if not %ERRORLEVEL% == 0 (
+        echo "Could not create junction to %__BUILDJUNCTION% to %__BUILDDIR% which contains space"
+        exit 1
+    )
+    cd %__BUILDJUNCTION%
+) else (
+    cd %__BUILDDIR%
+)
 set BUILDDIR=%CD%
-set BINARIESDIR=%BUILDDIR%\binaries
-cd "%BUILDDIR%"
 for /F "usebackq tokens=*" %%i in (`""%MSYSDIR%\bin\bash.exe" -c "pwd""`) do set BUILDDIR_M=%%i
-2>nul mkdir "%BINARIESDIR%"
-cd "%BINARIESDIR%"
+cd "%~dp0..\.."
+if not exist "%__BINARIESDIR%" (
+    mkdir "%__BINARIESDIR%"
+)
+if not "%__BINARIESDIR: =%"=="%__BINARIESDIR%" (
+    mklink /J %__BINARIESJUNCTION% "%__BINARIESDIR%"
+    if not %ERRORLEVEL% == 0 (
+        echo "Could not create junction to %__BINARIESJUNCTION% to %__BINARIESDIR% which contains space"
+        exit 1
+    )
+    cd %__BINARIESJUNCTION%
+) else (
+    cd %__BINARIESDIR%
+)
+set BINARIESDIR=%CD%
 for /F "usebackq tokens=*" %%i in (`""%MSYSDIR%\bin\bash.exe" -c "pwd""`) do set BINARIESDIR_M=%%i
-cd %old_dir%
-set old_dir=
+
+if not defined LIBEDIT_VERSION (
+    set LIBEDIT_VERSION=2.201
+)
+if not defined LIBICAL_VERSION (
+    set LIBICAL_VERSION=1.0.1
+)
+if not defined PGSQL_VERSION (
+    set PGSQL_VERSION=9.6.3
+)
+if not defined PYTHON_VERSION (
+    set PYTHON_VERSION=2.7.13
+)
+if not defined OPENSSL_VERSION (
+    set OPENSSL_VERSION=1_1_0f
+)
+if not defined SWIG_VERSION (
+    set SWIG_VERSION=3.0.12
+)
+if not defined TCL_VERSION (
+    set TCL_VERSION=8.6.6
+)
+if not defined TK_VERSION (
+    set TK_VERSION=8.6.6
+)
+
+cd %__OLD_DIR%

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -599,7 +599,7 @@ DECLDIR struct batch_status *pbs_statque(int, char *, struct attrl *, char *);
 
 DECLDIR struct batch_status *pbs_statserver(int, struct attrl *, char *);
 
-DECLDIR struct batch_status *pbs_statsched(int, struct attrl *, char *);
+DECLDIR struct batch_status *pbs_statsched(int, char *, struct attrl *, char *);
 
 DECLDIR struct batch_status *pbs_stathost(int, char *, struct attrl *, char *);
 

--- a/win_configure/pbs_windows_VS2008.sln
+++ b/win_configure/pbs_windows_VS2008.sln
@@ -11,6 +11,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Libpbs", "projects.VS2008\L
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Liblog", "projects.VS2008\Liblog.vcproj", "{1CE3EDF8-7001-4756-A85B-DF7D0BFF4C52}"
+	ProjectSection(ProjectDependencies) = postProject
+		{0B889879-456F-4F8E-A15E-3C0A7BBF3B25} = {0B889879-456F-4F8E-A15E-3C0A7BBF3B25}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Libsite", "projects.VS2008\Libsite.vcproj", "{4D4DCDE5-C580-44AA-81A9-BAD24437C188}"
 EndProject


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-882](https://pbspro.atlassian.net/browse/PP-882)**
* **[PP-901](https://pbspro.atlassian.net/browse/PP-901)**
* **[PP-908](https://pbspro.atlassian.net/browse/PP-908)**

#### Problem description
* PP-882: Windows build fails
* PP-901: Make PBS deps build scripts version independent
* PP-908: Generate MSI installer using Wix tools in AppVeyor

#### Cause / Analysis
* PP-882: Windows build fails
   1. No pbs_version.h found while compiling liblog
       Reason: Missing dependency on liblog project for include as include is the one who generates pbs_version.h from pbs_version.h.in in it's Pre-build event using gen_pbs_version.bat script
   2. Change in pbs_statsched IFL API
       Reason: in pbs_ifl.h we have mentioned all IFL API at two place, one is under ifdef _USRDLL and another one is in else part of ifdef. And newly changed pbs_statsched API is not updated under ifdef _USRDLL which leads to fail to compile Libpbsaif saying argument mismatch
   3. Use of msbuild command instead vcbuild (main culprit)
       Reason:
       - As per our current windows project configuration, using msbuild if any of dependency of project is built once will not be build again, due to this AppVeyor is not able to catch 2 problem mentioned above
       - As per our current windows project configuration, and the order in which all projects are builds, somehow include projects gets build first and then liblog so liblog gets pbs_version.h in right place, due to this AppVeyor is not able to catch 1 problem mentioned above
* PP-901: Make PBS deps build scripts version independent
   - This is improvements to AppVeyor helper scripts
* PP-908: Generate MSI installer using Wix tools in AppVeyor
  - This is improvements (or adding new capability) to AppVeyor helper scripts


#### Solution description
* PP-882: Windows build fails
   1. No pbs_version.h found while compiling liblog
       - Made liblog project dependent on include project
   2. Change in pbs_statsched IFL API
       - Updated pbs_ifl.h as per API changes
   3. Use of msbuild command instead vcbuild (main culprit)
       - Replaced msbuild command with vcbuild command
* PP-901: Make PBS deps build scripts version independent
   - Changed all AppVeyor helper scripts to take version value from environment variable if present
* PP-908: Generate MSI installer using Wix tools in AppVeyor
   - Added scripts and command to generate MSI using Wix tools in AppVeyor

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
