### PR TITLE
PP-729: Failover after power loss on primary makes secondary try to c…

### DIFF
--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -407,9 +407,7 @@ case "$1" in
 	status)
 		check_status
 		ret=$?
-		if [ "$2" != "PBS" ]; then
-			echo "$msg"
-		fi
+		echo "$msg"
 		exit ${ret}
 		;;
 

--- a/src/lib/Libdb/db_postgres_common.c
+++ b/src/lib/Libdb/db_postgres_common.c
@@ -609,13 +609,17 @@ pbs_dataservice_control(char *cmd, char **errmsg)
  * @retval      -1  - Error in routine
  * @retval       0  - Data service running on local host
  * @retval       1  - Data service not running
- * @retval	 2  - Data service running on another host
+ * @retval       2  - Data service running on another host
  *
  */
 int
 pbs_status_db(char **errmsg)
 {
-	return (pbs_dataservice_control(PBS_DB_CONTROL_STATUS, errmsg));
+    int rc = pbs_dataservice_control(PBS_DB_CONTROL_STATUS, errmsg);
+    if (!(rc == 0 || rc == 1 || rc == 2))
+        rc = -1;
+
+    return rc;
 }
 
 /**


### PR DESCRIPTION
…onnect to data service on primary -- never gives up

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-729](https://pbspro.atlassian.net/browse/PP-729)**

#### Problem description
* Failover after power loss on primary makes secondary try to connect to data service on primary -- never gives up.

#### Cause / Analysis
* During failover, the secondary does indeed decide to take over. But when it does, it calls get_db_connect_information to decide where the data service starts. That in turn calls pbs_dataservice status PBS, which calls pbs_ds_monitor. Since the pbs_dblock file is still there, it then determines that the primary data service is probably running, and the secondary ends up trying to connect to the primary data service (which is obviously not there).

#### Solution description
* db_postgres_common.c: to return -1 instead of 126/127 when pbs_dataservice status fails to acquire lock.
* pbsd_main.c: in try_connect_database to mark DB down to fix the main problem.
* Many additional logs added.
* pbs_dataservice allowed check_status to return the detailed error message even in case of being called from PBS.
* Identifying whether the lock is held by primary or local host.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/spaces/PD/pages/63766571/PP-35+PP-729+PBS+Failover+-+STONITH)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

CC: @dilip-krishnan 
