### PR TITLE
PP-800: qsub performance improvement opportunity: env_array_to_varlist() called unnecessarily if -v or -V are not specified, costly if environment is large

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -4927,7 +4927,9 @@ main(int argc, char **argv, char **envp)   /* qsub */
 		exit_qsub(3);
 	}
 
-	qsub_envlist = env_array_to_varlist(envp);
+	if (V_opt) {
+		qsub_envlist = env_array_to_varlist(envp);
+        }
 
 	/*
 	 * Disable backgrounding if we are inside another qsub

--- a/test/tests/performance/pbs_qsub_performance.py
+++ b/test/tests/performance/pbs_qsub_performance.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.performance import *
+
+
+class TestQsubPerformance(TestPerformance):
+    """
+    This test suite contains tests of qsub performance
+    """
+
+    def setUp(self):
+        TestPerformance.setUp(self)
+        attr = {'scheduling': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
+
+    def test_submit_large_env(self):
+        """
+        submission of 1000 jobs
+        before and after exporting variable
+        to check submission performance
+        """
+
+        start_time1 = time.time()
+        for _ in range(1000):
+            j = Job(TEST_USER)
+            self.server.submit(j)
+        end_time1 = time.time()
+
+        os.environ['VARIABLE'] = 'b' * 130000
+
+        start_time2 = time.time()
+        for _ in range(1000):
+            j1 = Job(TEST_USER)
+            self.server.submit(j1)
+        end_time2 = time.time()
+
+        sub_time1 = int(end_time1 - start_time1)
+        sub_time2 = int(end_time2 - start_time2)
+
+        self.logger.info(
+            "Submission time without env is %d and with env is %d sec"
+            % (sub_time1, sub_time2))


### PR DESCRIPTION
#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-800](https://pbspro.atlassian.net/browse/PP-800)**

#### Problem description
* qsub gets slow when the local exported environment is large, even if -v and -V are not used.

#### Cause / Analysis
* env_array_to_varlist() called unnecessarily if -v or -V are not specified, costly if environment is large

#### Solution description
* if qsub is done with -V option then only "env_array_to_varlist()" should be call. for simple job 
  submission there is no need to call this function. 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
