### PR TITLE
PP-921: qsub can crash based on -v value

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -465,22 +465,37 @@ comma_token(char *str)
 char *
 expand_varlist(char *varlist)
 {
-	char  *v_value1 = NULL;
-	char *v_value2 = NULL;
-	char *vn = NULL;
-	char *vv = NULL;
-	char *p1, *p2, *p;
-	char *ev;
-	int  v_value1_sz=0;
+	char	*v_value1 = NULL;
+	char	*v_value2 = NULL;
+	char	*vn = NULL;
+	char	*vv = NULL;
+	char	*p1, *p2, *p;
+	char	*ev;
+	int	v_value1_sz=0;
+	char	*pc;
+	int	special_char_cnt = 0;
+	int	len = 0;
 
+	/*
+	 * count special characters as they are escaped with '\' in copy_env_value function
+	 * so that this is useful while calculating the accurate size of the destination string.
+	 * Also calculating the length of the string.
+	 */
+	pc = varlist;
+	for (; *pc; pc++) {
+		if ((*pc == '"') || (*pc == '\'') || (*pc == ',') || (*pc == '\\'))
+			special_char_cnt++;
+		len++;
+	}
+
+	v_value1_sz = len +  special_char_cnt + 1;
 	/* final copy */
-	v_value1 = strdup(varlist);
+	v_value1 = malloc(v_value1_sz);
 	if (v_value1 == NULL) {
 		fprintf(stderr, "qsub: out of memory\n");
 		return NULL;
 	}
-	v_value1_sz=strlen(v_value1)+1;
-	v_value1[0] = '\0'; /* initialize */
+	v_value1[0] = '\0';
 
 	/* working copy */
 	v_value2 = strdup(varlist);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-921](https://pbspro.atlassian.net/browse/PP-921)**

#### Problem description
qsub is getting crashed when submitting with the following parameters i.e. while using -v option to pass an environment variable which has special characters like '\' to the job script.

1. qsub -v 'P=\aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' <job script>

2. qsub -v 'PAS_INCLUDE_FILE_MAPPING=C:\Viswanath\Demo\Optistruct Includes\7\includes\Body_Only_Structure_Bulk_data.fem=Body_Only_Structure_Bulk_data.fem@@DELIM@@C:\Viswanath\Demo\Optistruct Includes\7\includes\Frame_renumber_bulk.fem=Frame_renumber_bulk.fem'

#### Cause / Analysis
expand_varlist() internally calls copy_env_value() which copies an environment variable to a specified location. The size of the destination string that is passed to copy_env_value() is pre-allocated in the caller of this function itself. But there is a probability that copy_env_value() escapes certain special characters like comma,single quote,backslash etc each of which with an additional character backslash('\\') if the input indeed contains special characters due to which this function goes beyond its actual size of the string and hence the crash.

#### Solution description
Code changes are made to expand_valist() itself so as to keep in mind that special characters are escaped with an additional backslash and allocated the memory accordingly to the string that is passed to the function copy_env_value()

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
