### PR TITLE
PP-970: mom file descriptor leak on resourcedef update when mom hooks present

### DIFF
--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -4554,6 +4554,7 @@ get_resources_from_file(char *path)
 	resources = malloc((numlines+1)*sizeof(char *));
 	if (resources == NULL) {
 		log_err(PBSEVENT_SYSTEM, __func__, MALLOC_ERR_MSG);
+		fclose(fp);
 		return NULL;
 	}
 
@@ -4564,12 +4565,14 @@ get_resources_from_file(char *path)
 			if (resources[i] == NULL) {
 				log_err(PBSEVENT_SYSTEM, __func__, MALLOC_ERR_MSG);
 				free_str_array(resources);
+				fclose(fp);
 				return NULL;
 			}
 			i++;
 		}
 	}
 	resources[i] = NULL;
+	fclose(fp);
 
 	return resources;
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-970](https://pbspro.atlassian.net/browse/PP-970)**

#### Problem description
* There's a file descriptor leak in get_resources_from_file(). It opens the resourcedef file, but it doesn't appear to close it.

#### Solution description
* Do fclose before exiting the function.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
