### PR TITLE
PP-998: fix incorrect job array comment on subjob rejection

### DIFF
--- a/test/tests/functional/pbs_job_array_comment.py
+++ b/test/tests/functional/pbs_job_array_comment.py
@@ -1,0 +1,96 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestJobArrayComment(TestFunctional):
+    """
+    Testing job array comment is accurate
+    """
+
+    def test_job_array_comment(self):
+        """
+        Testing job array comment is correct when one or more sub jobs
+        are rejected by mom
+        """
+        attr = {'resources_available.ncpus': 10}
+        self.server.manager(MGR_CMD_SET, NODE, attr)
+        attr = {'job_history_enable': 'true'}
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
+        # create a mom hook that rejects and deletes subjob 0, 5, and 7
+        hook_name = "reject_subjob"
+        hook_body = (
+            "import pbs\n"
+            "import re\n"
+            "e = pbs.event()\n"
+            "jid = str(e.job.id)\n"
+            "if re.match(r'[0-9]*\[[057]\]', jid):\n"
+            "    e.job.delete()\n"
+            "    e.reject()\n"
+            "else:\n"
+            "    e.accept()\n"
+        )
+        attr = {'event': 'execjob_begin', 'enabled': 'True'}
+        self.server.create_import_hook(hook_name, attr, hook_body)
+
+        test_job_array = Job(TEST_USER, attrs={
+            ATTR_J: '0-9',
+            'Resource_List.select': 'ncpus=1'
+        })
+        test_job_array.set_sleep_time(1)
+        jid = self.server.submit(test_job_array)
+        attr = {
+            ATTR_state: 'B',
+            ATTR_comment: (MATCH_RE, 'Job Array Began at .*')
+        }
+        self.server.expect(JOB, attr, id=jid, attrop=PTL_AND)
+        self.server.expect(JOB, {ATTR_comment: 'Subjob failed'},
+                           id=create_subjob_id(jid, 0), extend='x')
+        self.server.expect(JOB, {ATTR_comment: 'Subjob failed'},
+                           id=create_subjob_id(jid, 5), extend='x')
+        self.server.expect(JOB, {ATTR_comment: 'Subjob failed'},
+                           id=create_subjob_id(jid, 7), extend='x')
+
+
+def create_subjob_id(job_array_id, subjob_index):
+    """
+    insert subjob index into the square brackets of job array id
+    """
+    idx = job_array_id.find('[]')
+    return job_array_id[:idx+1] + str(subjob_index) + job_array_id[idx+1:]


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-998](https://pbspro.atlassian.net/browse/PP-998)**

#### Problem description
The job array comment is set to `"Not Running: PBS Error: Execution server rejected request"` when one or more sub jobs are rejected by mom. Job array comment should not change after it moves to state 'B'.

#### Cause / Analysis
In `req_runjob()` function `PBSE_MOMREJECT` message is set on the parent job array's comment if the job is a job array regardless of the state it is in.

#### Solution description
Add a conditional that checks for `State != Begin`

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__