### PR TITLE
PP-1017: Job ALPS reservation sometimes doesn't get cleared when preempt_order includes "C" (checkpoint)

### DIFF
--- a/src/server/req_holdjob.c
+++ b/src/server/req_holdjob.c
@@ -205,7 +205,6 @@ req_holdjob(struct batch_request *preq)
 			*hold_val = old_hold;	/* reset to the old value */
 			req_reject(rc, 0, preq);
 		} else {
-			pjob->ji_qs.ji_substate = JOB_SUBSTATE_RERUN;
 			pjob->ji_qs.ji_svrflags |=
 				JOB_SVFLG_HASRUN | JOB_SVFLG_CHKPT;
 			(void)job_save(pjob, SAVEJOB_QUICK);
@@ -410,8 +409,6 @@ post_hold(struct work_task *pwt)
 		return;
 	}
 	if (code != 0) {
-		if (code != PBSE_CKPBSY)
-			pjob->ji_qs.ji_substate = JOB_SUBSTATE_RUNNING;	/* reset it */
 		if (code != PBSE_NOSUP) {
 			/* a "real" error - log message with return error code */
 			(void)sprintf(log_buffer, msg_mombadhold, code);
@@ -424,7 +421,7 @@ post_hold(struct work_task *pwt)
 	} else if (code == 0) {
 
 		/* record that MOM has a checkpoint file */
-
+		pjob->ji_qs.ji_substate = JOB_SUBSTATE_RERUN;
 		if (preq->rq_reply.brp_auxcode)	/* chkpt can be moved */
 			pjob->ji_qs.ji_svrflags =
 				(pjob->ji_qs.ji_svrflags & ~JOB_SVFLG_CHKPT) |


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1017](https://pbspro.atlassian.net/browse/PP-1017)**

#### Problem description
On cray it has been observed that sometimes while attempting preemption, MOM ends up trying to create another ALPS reservation for the normal job.

#### Cause / Analysis
This is a timing issue where in server tries to preempt a job and by the time suspension request reaches mom the job ends. Mom then rejects the suspension request with badstate error number. This makes scheduler to try checkpointing the job and server sends checkpointing request to mom.
This reject is also rejected by mom. at the same time Obit is received by the server but the substate of the job instead of being running shows up as rerun.
This weird state/substate combination (running/rerun) makes server try to run the job again which ends up mom trying to create another ALPS reservation for a job whose previously ALPS reservation is still not deleted.

#### Solution description
Remove the code in req_holdjob.c to where we set the substate of the job to rerun. I have myself not been able to reproduce the issue, this is just by code inspection and after talking to peers that I've made this fix.


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
