### PR TITLE
PP-516: Additional tests for direct write and remove files

### DIFF
--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -44,26 +44,165 @@ class TestQsub_direct_write(TestFunctional):
     validate qsub direct write option.
     """
 
+    def setUp(self):
+        """
+        Default setup and variable declaration
+        """
+        TestFunctional.setUp(self)
+        self.msg = "Job is sleeping for 10 secs as job should  be running"
+        self.msg += " at the time we check for directly written files"
+
     def test_direct_write_when_job_succeeds(self):
         """
         submit a sleep job and make sure that the std_files
-        are getting directly written directly to the mapped
-        directory when direct_files option is used.
+        are getting directly written to the mapped directory
+        when direct_files option is used.
         """
-        j = Job(TEST_USER)
-        j.set_attributes({ATTR_k: 'doe'})
+        j = Job(TEST_USER, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
-        sub_dir = DshUtils().mkdtemp(uid=TEST_USER.uid)
-        mapping_dir = DshUtils().mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})
         self.mom.restart()
         jid = self.server.submit(j, submit_dir=sub_dir)
-        self.server.log_match(jid + ";Job Run at", max_attempts=10)
+        self.logger.info(self.msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         file_count = len([name for name in os.listdir(
             mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
         self.assertEqual(2, file_count)
+        self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
+
+    def test_direct_write_output_file(self):
+        """
+        submit a sleep job and make sure that the output file
+        are getting directly written to the mapped directory
+        when direct_files option is used with o option.
+        """
+        j = Job(TEST_USER, attrs={ATTR_k: 'do'})
+        j.set_sleep_time(10)
+        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        self.mom.add_config(
+            {'$usecp': self.server.hostname + ':' + sub_dir
+             + ' ' + mapping_dir})
+        self.mom.restart()
+        jid = self.server.submit(j, submit_dir=sub_dir)
+        self.logger.info(self.msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        for name in os.listdir(mapping_dir):
+            p = re.search('STDIN.e*', name)
+            if p:
+                self.logger.info('Match found: ' + p.group())
+            else:
+                self.assertTrue(False)
+        file_count = len([name for name in os.listdir(
+            mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
+        self.assertEqual(1, file_count)
+        self.server.expect(JOB, {ATTR_k: 'do'}, id=jid)
+
+    def test_direct_write_error_file(self):
+        """
+        submit a sleep job and make sure that the error file
+        are getting directly written to the mapped directory
+        when direct_files option is used with e option.
+        """
+        j = Job(TEST_USER, attrs={ATTR_k: 'de'})
+        j.set_sleep_time(10)
+        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        self.mom.add_config(
+            {'$usecp': self.server.hostname + ':' + sub_dir
+             + ' ' + mapping_dir})
+        self.mom.restart()
+        jid = self.server.submit(j, submit_dir=sub_dir)
+        self.logger.info(self.msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        for name in os.listdir(mapping_dir):
+            p = re.search('STDIN.e*', name)
+            if p:
+                self.logger.info('Match found: ' + p.group())
+            else:
+                self.assertTrue(False)
+        file_count = len([name for name in os.listdir(
+            mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
+        self.assertEqual(1, file_count)
+        self.server.expect(JOB, {ATTR_k: 'de'}, id=jid)
+
+    def test_direct_write_error_custom_path(self):
+        """
+        submit a sleep job and make sure that the files
+        are getting directly written to the custom path
+        provided in -e and -o option even when -doe is set.
+        """
+        tmp_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        err_file = os.path.join(tmp_dir, 'error_file')
+        out_file = os.path.join(tmp_dir, 'output_file')
+        a = {ATTR_e: err_file, ATTR_o: out_file, ATTR_k: 'doe'}
+        j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(10)
+        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        self.mom.add_config(
+            {'$usecp': self.server.hostname + ':' + sub_dir
+             + ' ' + mapping_dir})
+        self.mom.restart()
+        jid = self.server.submit(j, submit_dir=sub_dir)
+        self.logger.info(self.msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        file_count = len([name for name in os.listdir(
+            tmp_dir) if os.path.isfile(os.path.join(tmp_dir, name))])
+        self.assertEqual(2, file_count)
+        self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
+
+    def test_direct_write_error_custom_dir(self):
+        """
+        submit a sleep job and make sure that the files
+        are getting directly written to the custom dir
+        provided in -e and -o option even when -doe is set.
+        """
+        tmp_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        a = {ATTR_e: tmp_dir, ATTR_o: tmp_dir, ATTR_k: 'doe'}
+        j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(10)
+        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        self.mom.add_config(
+            {'$usecp': self.server.hostname + ':' + sub_dir
+             + ' ' + mapping_dir})
+        self.mom.restart()
+        jid = self.server.submit(j, submit_dir=sub_dir)
+        self.logger.info(self.msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        file_count = len([name for name in os.listdir(
+            tmp_dir) if os.path.isfile(os.path.join(tmp_dir, name))])
+        self.assertEqual(2, file_count)
+        self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
+
+    def test_direct_write_default_qsub_arguments(self):
+        """
+        submit a sleep job and make sure that the std_files
+        are getting directly written to the mapped directory
+        when default_qsub_arguments is set to -kdoe.
+        """
+        j = Job(TEST_USER)
+        j.set_sleep_time(10)
+        self.server.manager(MGR_CMD_SET, SERVER, {
+                            'default_qsub_arguments': '-kdoe'})
+        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        self.mom.add_config(
+            {'$usecp': self.server.hostname + ':' + sub_dir
+             + ' ' + mapping_dir})
+        self.mom.restart()
+        jid = self.server.submit(j, submit_dir=sub_dir)
+        self.logger.info(self.msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        file_count = len([name for name in os.listdir(
+            mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
+        self.assertEqual(2, file_count)
+        self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
     def test_direct_write_without_config_entry(self):
         """
@@ -72,12 +211,12 @@ class TestQsub_direct_write(TestFunctional):
         accessible from mom and direct_files option is used
         but submission directory is not mapped in mom config file.
         """
-        j = Job(TEST_USER)
-        j.set_attributes({ATTR_k: 'doe'})
+        j = Job(TEST_USER, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
-        sub_dir = DshUtils().mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
         jid = self.server.submit(j, submit_dir=sub_dir)
-        self.server.log_match(jid + ";Job Run at", max_attempts=10)
+        self.logger.info(self.msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         file_count = len([name for name in os.listdir(
             sub_dir) if os.path.isfile(os.path.join(sub_dir, name))])
         self.assertEqual(2, file_count)
@@ -106,3 +245,49 @@ class TestQsub_direct_write(TestFunctional):
                                    id=jid)
         except PbsAlterError as e:
             print str(e)
+
+    def test_qalter_direct_write_error(self):
+        """
+        submit a job and after it starts running alter
+        the job with -koed and check whether expected
+        error message appears
+        """
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        attribs = {ATTR_k: 'oed'}
+        self.server.expect(JOB, {'job_state': 'R'})
+        try:
+            self.server.alterjob(jid, attribs)
+        except PbsAlterError as e:
+            self.assertTrue(
+                'Cannot modify attribute while job running  Keep_Files'
+                in e.msg[0])
+
+    def test_direct_write_qrerun(self):
+        """
+        submit a sleep job and make sure that the std_files
+        are written and when a job is rerun error message
+        in logged in mom_log that it is skipping directly
+        written/absent spool file as files are already
+        present on first run of the job.
+        """
+        self.mom.add_config({'$logevent': '0xffffffff'})
+        j = Job(TEST_USER, attrs={ATTR_k: 'doe'})
+        j.set_sleep_time(10)
+        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        self.mom.add_config(
+            {'$usecp': self.server.hostname + ':' + sub_dir
+             + ' ' + mapping_dir})
+        self.mom.restart()
+        jid = self.server.submit(j, submit_dir=sub_dir)
+        self.logger.info(self.msg)
+        self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.rerunjob(jid)
+        self.mom.log_match(
+            "stage_file;Skipping directly written/absent spool file",
+            max_attempts=10, interval=5)
+        file_count = len([name for name in os.listdir(
+            mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
+        self.assertEqual(2, file_count)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-516](https://pbspro.atlassian.net/browse/PP-516)**

#### Solution description
Additional tests for direct write and remove files

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
