### PR TITLE
PP-923: qrun failing if job's formula value is below threshold

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -665,6 +665,13 @@ scheduling_cycle(int sd, char *jobid)
 		}
 	}
 
+	if (init_scheduling_cycle(policy, sd, sinfo) == 0) {
+		schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
+			sinfo->name, "init_scheduling_cycle failed.");
+		end_cycle_tasks(sinfo);
+		return 0;
+	}
+
 	/* jobid will not be NULL if we received a qrun request */
 	if (jobid != NULL) {
 		schdlog(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO,
@@ -690,13 +697,6 @@ scheduling_cycle(int sd, char *jobid)
 			rc = SCHD_ERROR;
 			sprintf(log_msg, "PBS Error: Scheduler can not find job");
 		}
-	}
-
-	if (init_scheduling_cycle(policy, sd, sinfo) == 0) {
-		schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
-			sinfo->name, "init_scheduling_cycle failed.");
-		end_cycle_tasks(sinfo);
-		return 0;
 	}
 
 	/* run loop run */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-923](https://pbspro.atlassian.net/browse/PP-923)**

#### Problem description
* qrun fails on job which is under the job_sort_formula_threshold

#### Cause / Analysis
* When fairshare was added to the formula, the location of where the threshold was checked was moved into init_scheduling_cycle().  It used to be checked in query_jobs().  If a job was under the threshold, it was marked can_not_run so we wouldn't look at it again.  After the universe is queried, we unmark the qrun job as can_not_run so it will be considered to run.  The call to init_scheduling_cycle() was after we'd unmark the qrun job.

#### Solution description
* Move the call to init_scheduling_cycle() before we unmark the qrun job.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
