### PR TITLE
PP-1016, PP-1043: choose components of pbs to launch in docker container using env variables

### DIFF
--- a/docker/centos7/Dockerfile.build
+++ b/docker/centos7/Dockerfile.build
@@ -10,7 +10,10 @@ RUN git clone https://github.com/pbspro/pbspro.git /src/pbspro && \
 FROM centos:7
 LABEL maintainer="mliu@altair.com"
 LABEL description="PBS Professional Open Source"
-# copy rpm from builder
+# copy rpm and entrypoint script from builder
 COPY --from=builder /root/rpmbuild/RPMS/x86_64/pbspro-server-*.rpm .
+COPY --from=builder /src/pbspro/docker/centos7/entrypoint.sh /
 # install pbspro
 RUN yum install -y pbspro-server-*.rpm
+# run entrypoint script
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/docker/centos7/entrypoint.sh
+++ b/docker/centos7/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+pbs_conf_file=/etc/pbs.conf
+mom_conf_file=/var/spool/pbs/mom_priv/config
+hostname=$(hostname)
+
+# replace hostname in pbs.conf and mom_priv/config
+sed -i "s/PBS_SERVER=.*/PBS_SERVER=$hostname/" $pbs_conf_file
+sed -i "s/\$clienthost .*/\$clienthost $hostname/" $mom_conf_file
+
+# start PBS Pro
+/etc/init.d/pbs start
+
+# create default non-root user
+adduser pbsuser && su - pbsuser
+
+exec "$@"

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -831,9 +831,15 @@ pre_start_pbs()
 }
 
 : main code
-conf=${PBS_CONF_FILE:-/etc/pbs.conf}
+# save env variables in a temp file
+env_save="/tmp/$$_`date +'%s'`_env_save"
+declare -x > "${env_save}"
 
+conf=${PBS_CONF_FILE:-/etc/pbs.conf}
 [ -r "${conf}" ] && . "${conf}"
+
+# re-apply saved env variables
+. "${env_save}"
 
 if [ -z "${PBS_EXEC}" ] ; then
     echo "PBS_EXEC is undefined." >&2

--- a/test/tests/functional/pbs_init_script.py
+++ b/test/tests/functional/pbs_init_script.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestPbsInitScript(TestFunctional):
+    """
+    Testing PBS Pro init script
+    """
+    def test_env_vars_precede_pbs_conf_file(self):
+        """
+        Test PBS_START environment variables overrides values in pbs.conf file
+        """
+        self.du.run_cmd(cmd=['/etc/init.d/pbs', 'stop'])
+
+        conf = {'PBS_START_SERVER': '1', 'PBS_START_SCHED': '1',
+                'PBS_START_COMM': '1', 'PBS_START_MOM': '0'}
+        self.du.set_pbs_config(confs=conf)
+
+        env = {'PBS_START_SERVER': '0', 'PBS_START_SCHED': '0',
+               'PBS_START_COMM': '0', 'PBS_START_MOM': '1'}
+
+        rc = self.du.run_cmd(cmd=['/etc/init.d/pbs', 'start'], env=env)
+        output = rc['out']
+
+        self.assertFalse("PBS server" in output)
+        self.assertFalse("PBS sched" in output)
+        self.assertFalse("PBS comm" in output)
+        self.assertTrue("PBS mom" in output)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1016](https://pbspro.atlassian.net/browse/PP-1016)**
* **[PP-1043](https://pbspro.atlassian.net/browse/PP-1043)**

#### Description
This PR adds the functionality to start different components of PBS automatically when launching a docker container by using environment variables. For example, if a user want to start the mom, he/she can use `docker run -e PBS_START_MOM=1`.

* Fixed the bug that init script sources the `pbs.conf` file and overrides the `START` environment variables
* Added `entrypoint.sh` to modify the `PBS_SERVER` variable in `pbs.conf` and `$clienthost` in `mom_priv/config` to docker container's hostname, and then start pbs

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__