### PR TITLE
PP-1034: Scheduler uses uninitialized memory. PP-1035: scheduler memory leak in query_resv(). PP-1037: Server crashed after requesting multi-chunk reservation with scatter.

### DIFF
--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -673,6 +673,7 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 				sinfo);
 			selectspec = create_select_from_nspec(advresv->nspec_arr);
 			advresv->execselect = parse_selspec(selectspec);
+			free(selectspec);
 		}
 		else if (!strcmp(attrp->name, ATTR_node_set))
 			advresv->node_set_str = break_comma_list(attrp->value);
@@ -749,6 +750,7 @@ new_resv_info()
 	rinfo->execvnodes_seq = NULL;
 	rinfo->count = 0;
 	rinfo->is_standing = 0;
+	rinfo->check_alternate_nodes = 0;
 	rinfo->occr_start_arr = NULL;
 
 	return rinfo;
@@ -820,6 +822,7 @@ dup_resv_info(resv_info *rinfo, server_info *sinfo)
 	nrinfo->resv_state = rinfo->resv_state;
 	nrinfo->resv_substate = rinfo->resv_substate;
 	nrinfo->is_standing = rinfo->is_standing;
+	nrinfo->check_alternate_nodes = rinfo->check_alternate_nodes;
 	nrinfo->timezone = string_dup(rinfo->timezone);
 	nrinfo->rrule = string_dup(rinfo->rrule);
 	nrinfo->resv_idx = rinfo->resv_idx;

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1108,3 +1108,23 @@ class TestPbsResvAlter(TestFunctional):
 
         self.alter_a_reservation(rid, start, end, shift, alter_e=True,
                                  whichMessage=0)
+
+    def test_large_resv_nodes_server_crash(self):
+        """
+        This test is to test whether the server crashes or not when a very
+        large resv_nodes is being recorded in the 'Y' accounting log.
+        If tested with a build without the fix, the test case will fail
+        and vice versa.
+        """
+        duration = 60
+        shift = 10
+        offset = 10
+
+        a = {'resources_available.ncpus': 4}
+        self.server.create_vnodes('vnode', a, num=256, mom=self.mom,
+                                  usenatvnode=True)
+
+        rid, start, end = self.submit_and_confirm_reservation(
+            offset, duration, select="256:ncpus=4")
+
+        self.alter_a_reservation(rid, start, end, shift, alter_s=True)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1034](https://pbspro.atlassian.net/browse/PP-1034)**
* **[PP-1035](https://pbspro.atlassian.net/browse/PP-1035)**
* **[PP-1037](https://pbspro.atlassian.net/browse/PP-1037)**
#### Problem description
* PP-1034: Scheduler uses uninitialized memory.
* PP-1035: scheduler memory leak in query_resv() 
* PP-1037: Server crashed after requesting multi-chunk reservation with scatter 
#### Cause / Analysis
* PP-1034 - check_alternate_nodes was not initialized in new_resv_info()
* PP-1035 - selectspec was not free()ed in query_resv()
* PP-1037 - While recording the 'Y' record when a reservation is confirmed, the possibility that the nodes assigned to the reservation can be a big string was not considered.

#### Solution description
* PP-1034 - initialized check_alternate_nodes in new_resv_info().
* PP-1035 - selectspec is now free()ed in query_resv().
* PP-1037 - use dynamically allocated buffer if required.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
