### PR TITLE
PP-843: pbsnode reports mem in b(bytes) instead of kb for cray login node.

### DIFF
--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -4065,7 +4065,7 @@ inventory_to_vnodes(basil_response_t *brp)
 	if (vn_addvnr(nv, mom_short_name, attr, utilBuffer, 0, 0, NULL) == -1)
 		goto bad_vnl;
 	attr = "resources_available.mem";
-	snprintf(utilBuffer, sizeof(utilBuffer), "%lu", totalmem);
+	snprintf(utilBuffer, sizeof(utilBuffer), "%lukb", totalmem);
 	/* already exists so don't define type */
 	if (vn_addvnr(nv, mom_short_name, attr, utilBuffer, 0, 0, NULL) == -1)
 		goto bad_vnl;

--- a/test/tests/functional/pbs_apbasil_inventory.py
+++ b/test/tests/functional/pbs_apbasil_inventory.py
@@ -224,3 +224,30 @@ type=\"ENGINE\"/>" % (self.basil_version[0])
                 # Compare xml vnode with pbs node.
                 print "Validating vnode:%s" % (vnode['vnode'])
                 self.comp_node(vnode)
+
+    def test_cray_login_node_memory_unit(self):
+        """
+        This test validates that cray mom node resources value remain
+        unchanged before and after adding $alps_client in mom config.
+        """
+        mom_id = self.mom.shortname
+        try:
+            cray_login_node = self.server.status(NODE, id=mom_id)[0]
+            self.mom.unset_mom_config('$alps_client', False)
+            self.reset_nodes(mom_id)
+            pbs_node = self.server.status(NODE, id=mom_id)[0]
+
+        except PbsStatusError:
+            self.assertFalse(True,
+                             "Mom node %s doesn't exist on pbs server"
+                             % (mom_id))
+
+        for rsc, val in pbs_node.iteritems():
+            self.assertTrue(rsc in cray_login_node,
+                            ("%s\t: login node has no rsc %s") %
+                            (mom_id, rsc))
+            rval = cray_login_node[rsc]
+            self.assertEqual(rval, val,
+                             ("%s\t: pbs node has %s=%s but login "
+                              "node has %s=%s") %
+                             (mom_id, rsc, val, rsc, rval))


### PR DESCRIPTION
#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-843](https://pbspro.atlassian.net/browse/PP-843)**

#### Problem description
* pbsnodes -av output shows resources_available.mem in bytes instead of kilobytes for
cray_login node

#### Cause / Analysis
* While creating inventory vnodes, cray_login node is re-initialise. Hence while setting memory resource
no unit was specified and pbs by default took the value to be in bytes instead of kilobytes
#### Solution description
* Specify the unit while setting the memory resource.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
