### PR TITLE
PP-1055: Fairshare can leave data uninitialized which can crash on the next cycle

### DIFF
--- a/src/scheduler/fairshare.h
+++ b/src/scheduler/fairshare.h
@@ -125,23 +125,10 @@ int calc_fair_share_perc(group_info *root, int shares);
 void update_usage_on_run(resource_resv *resresv);
 
 /*
- *      calculate_usage_value - calcualte a value that represents the usage
- *                              information
- */
-usage_t calculate_usage_value(resource_req *resreq);
-
-
-/*
  *      decay_fairshare_tree - decay the usage information kept in the fair
  *                             share tree
  */
 void decay_fairshare_tree(group_info *root);
-
-/*
- *      extract_fairshare - extract the first job from the user with the
- *                          least percentage / usage ratio
- */
-resource_resv *extract_fairshare(resource_resv **jobs);
 
 /*
  *      write_usage - write the usage information to the usage file

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -370,34 +370,36 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 			remove(USAGE_TOUCH);
 			resort = 1;
 		}
-		if (last_running != NULL) {
+		if (last_running != NULL && sinfo->running_jobs != NULL) {
 			/* add the usage which was accumulated between the last cycle and this
 			 * one and calculate a new value
 			 */
 
-			for (i = 0; i < last_running_size; i++) {
-				user = find_alloc_ginfo(last_running[i].entity_name,
-							sinfo->fairshare->root);
+			for (i = 0; i < last_running_size ; i++) {
+				if (last_running[i].name != NULL) {
+					user = find_alloc_ginfo(last_running[i].entity_name,
+								sinfo->fairshare->root);
 
-				if (sinfo->running_jobs != NULL) {
-					for (j = 0; sinfo->running_jobs[j] != NULL &&
-						strcmp(last_running[i].name, sinfo->running_jobs[j]->name); j++)
+					if (user != NULL) {
+						for (j = 0; sinfo->running_jobs[j] != NULL &&
+						     strcmp(last_running[i].name, sinfo->running_jobs[j]->name); j++)
 							;
 
-					if (sinfo->running_jobs[j] != NULL &&
-						sinfo->running_jobs[j]->job != NULL) {
-						/* just incase the delta is negative just add 0 */
-						delta = formula_evaluate(conf.fairshare_res, sinfo->running_jobs[j], sinfo->running_jobs[j]->job->resused) -
-							formula_evaluate(conf.fairshare_res, sinfo->running_jobs[j], last_running[i].resused);
+						if (sinfo->running_jobs[j] != NULL &&
+							sinfo->running_jobs[j]->job != NULL) {
+							/* just in case the delta is negative just add 0 */
+							delta = formula_evaluate(conf.fairshare_res, sinfo->running_jobs[j], sinfo->running_jobs[j]->job->resused) -
+								formula_evaluate(conf.fairshare_res, sinfo->running_jobs[j], last_running[i].resused);
 
-						delta = IF_NEG_THEN_ZERO(delta);
+							delta = IF_NEG_THEN_ZERO(delta);
 
-						gpath = user->gpath;
-						while (gpath != NULL) {
-							gpath->ginfo->usage += delta;
-							gpath = gpath->next;
+							gpath = user->gpath;
+							while (gpath != NULL) {
+								gpath->ginfo->usage += delta;
+								gpath = gpath->next;
+							}
+							resort = 1;
 						}
-						resort = 1;
 					}
 				}
 			}

--- a/src/scheduler/prev_job_info.c
+++ b/src/scheduler/prev_job_info.c
@@ -94,22 +94,21 @@ create_prev_job_info(resource_resv **jobs, int size)
 	if (local_size == 0)
 		return NULL;
 
-	if ((new = (prev_job_info *) malloc(sizeof(prev_job_info)  * local_size)) == NULL) {
-		log_err(errno, "create_prev_job_info", "Error allocating memory");
+	if ((new = (prev_job_info *) calloc(local_size, sizeof(prev_job_info))) == NULL) {
+		log_err(errno, __func__, MEM_ERR_MSG);
 		return NULL;
 	}
 
 	for (i = 0; jobs[i] != NULL; i++) {
-		if (jobs[i]->job == NULL)
-			continue;
+		if(jobs[i]->job != NULL) {
+			new[i].name = jobs[i]->name;
+			new[i].resused = jobs[i]->job->resused;
+			new[i].entity_name = string_dup(jobs[i]->job->ginfo->name);
 
-		new[i].name = jobs[i]->name;
-		new[i].resused = jobs[i]->job->resused;
-		new[i].entity_name = string_dup(jobs[i]->job->ginfo->name);
-
-		/* so the memory is not freed at the end of the scheduling cycle */
-		jobs[i]->name = NULL;
-		jobs[i]->job->resused = NULL;
+			/* so the memory is not freed at the end of the scheduling cycle */
+			jobs[i]->name = NULL;
+			jobs[i]->job->resused = NULL;
+		}
 	}
 
 	return new;

--- a/src/scheduler/sort.h
+++ b/src/scheduler/sort.h
@@ -71,12 +71,9 @@ int cmp_placement_sets(const void *v1, const void *v2);
 int cmp_low_load(const void *v1, const void *v2);
 
 /*
- * cmp_fairshare - compare based on extract_fairshare()
- * note: extract_fairshare() returns 1 or -1 , there is no equal
- *
+ * cmp_fairshare - compare based on compare_path()
  */
 int cmp_fairshare(const void *j1, const void *j2);
-
 
 /*
  *


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1055](https://pbspro.atlassian.net/browse/PP-1055)**

#### Problem description
* Fairshare can leave data uninitialized which can crash on the next cycle

#### Cause / Analysis
The following was found during code review:
* If you pass the create_prev_job_info() function a larger size of the real array passed in, the rest of the array will contain garbage.  This will likely cause a crash on the following cycle when the array is used.
* If the resresv->job substructure is NULL, a hole filled with garbage will be left in the array.  This will likely cause a crash on the following cycle when the array is used.
* If find_alloc_group_info() which subsequently calls find_group_info() is passed a NULL name, it will pass that pointer into strcmp() and dereference it.  This will crash the scheduler.

#### Solution description
* First, use calloc() instead of malloc().  If the size passed in is larger than the original array, any leftover memory will be zeroed
* Do better detection if resresv->job is NULL.  Leave an entry that with NULL pointers.  These will be detected when the array is used on the following cycle.  It will no longer crash.
* Guard against NULL parameters in find_alloc_group_info() and find_group_info().
* Sine find_alloc_group_info() can no return NULL, check the return value for NULL and don't dereference it.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [X] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
