### PR TITLE
PP-1061: Preemption does not happen when a job is qrun

### DIFF
--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -388,6 +388,28 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, {'job_state': 'S'}, id=jid)
 
     @skipOnCpuSet
+    def test_preemption_qrun(self):
+        """
+        Test that qrun will preempt other jobs
+        """
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'resources_available.ncpus': 1},
+                            id=self.mom.shortname)
+        J1 = Job(TEST_USER)
+        jid1 = self.server.submit(J1)
+
+        J2 = Job(TEST_USER)
+        jid2 = self.server.submit(J2)
+
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid2)
+
+        self.server.runjob(jobid=jid2)
+
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+
+    @skipOnCpuSet
     def test_fairshare(self):
         """
         Test for fairshare


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1061](https://pbspro.atlassian.net/browse/PP-1061)**

#### Problem description
* qrun does not preempt other jobs

#### Cause / Analysis
* The call to init_scheduling_cycle was moved above the code that set sinfo->qrun_job.  The problem is that init_scheduling_cycle() calls set_preempt_priority().  That depends on sinfo->qrun_job being set.  Since it wasn't set, the qrun job wasn't getting the preemption priority it needed to preempt other jobs.
#### Solution description
* Part of the code that handles the qrun job still is needed after the call to init_scheduling_cycle().  I split it in two.  I set sinfo->qrun_job beforehand and I process it afterwards.  This way sinfo->qrun_job is set for set_preempt_prio() to correctly function.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
