### PR TITLE
PP-964: Wrong use of BASIL string size used in snprintf

### DIFF
--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -1436,7 +1436,7 @@ inventory_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				return;
 			}
 			snprintf(&inv->mpp_host[0],
-				BASIL_STRING_SHORT, "%s", *vp);
+				BASIL_STRING_LONG, "%s", *vp);
 		} else {
 			parse_err_unrecognized_attr(d, *np);
 			return;
@@ -2643,7 +2643,7 @@ label_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 				parse_err_multiple_attrs(d, *np);
 				return;
 			}
-			snprintf(label->name, BASIL_STRING_SHORT, "%s", *vp);
+			snprintf(label->name, BASIL_STRING_MEDIUM, "%s", *vp);
 		} else if (strcmp(BASIL_ATR_TYPE, *np) == 0) {
 			if (label->type) {
 				parse_err_multiple_attrs(d, *np);
@@ -3165,42 +3165,42 @@ reservation_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 					parse_err_multiple_attrs(d, *np);
 					return;
 				}
-			snprintf(rsvn->user_name, BASIL_STRING_SHORT,
+			snprintf(rsvn->user_name, BASIL_STRING_MEDIUM,
 					"%s", *vp);
 			} else if (strcmp(BASIL_ATR_ACCOUNT_NAME, *np) == 0) {
 				if (*rsvn->account_name != '\0') {
 					parse_err_multiple_attrs(d, *np);
 					return;
 				}
-			snprintf(rsvn->account_name, BASIL_STRING_SHORT,
+			snprintf(rsvn->account_name, BASIL_STRING_MEDIUM,
 					"%s", *vp);
 			} else if (strcmp(BASIL_ATR_TIME_STAMP, *np) == 0) {
 				if (*rsvn->time_stamp != '\0') {
 					parse_err_multiple_attrs(d, *np);
 					return;
 				}
-			snprintf(rsvn->time_stamp, BASIL_STRING_SHORT,
+			snprintf(rsvn->time_stamp, BASIL_STRING_MEDIUM,
 					"%s", *vp);
 			} else if (strcmp(BASIL_ATR_BATCH_ID, *np) == 0) {
 				if (*rsvn->batch_id != '\0') {
 					parse_err_multiple_attrs(d, *np);
 					return;
 				}
-			snprintf(rsvn->batch_id, BASIL_STRING_SHORT,
+			snprintf(rsvn->batch_id, BASIL_STRING_LONG,
 					"%s", *vp);
 			} else if (strcmp(BASIL_ATR_RSVN_MODE, *np) == 0) {
 				if (*rsvn->rsvn_mode != '\0') {
 					parse_err_multiple_attrs(d, *np);
 					return;
 				}
-			snprintf(rsvn->rsvn_mode, BASIL_STRING_SHORT,
+			snprintf(rsvn->rsvn_mode, BASIL_STRING_MEDIUM,
 					"%s", *vp);
 			} else if (strcmp(BASIL_ATR_GPC_MODE, *np) == 0) {
 				if (*rsvn->gpc_mode != '\0') {
 					parse_err_multiple_attrs(d, *np);
 					return;
 				}
-			snprintf(rsvn->gpc_mode, BASIL_STRING_SHORT,
+			snprintf(rsvn->gpc_mode, BASIL_STRING_MEDIUM,
 					"%s", *vp);
 			} else {
 				parse_err_unrecognized_attr(d, *np);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-964](https://pbspro.atlassian.net/browse/PP-964)**

#### Problem description
During code inspection it was found that in alps.c we do not use the right buffer length while copying data received from ALPS to our internal structures. 
#### Cause / Analysis
Wrong buffer length being used
#### Solution description
Use the right buffer length.

#### NOTE
This fix can not be verified because it was found during code inspection and no static analysis tool can catch it because the length being used was less than the buffer size which isn't a crime :)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
