### PR TITLE
PP-985: PAGG ids set to non-unique session IDs

### DIFF
--- a/src/resmom/linux/mom_mach.h
+++ b/src/resmom/linux/mom_mach.h
@@ -82,13 +82,15 @@ extern "C" {
 #endif	/* CPUSET_VERSION < 4 */
 #endif	/* MOM_CPUSET */
 
-#if	MOM_CSA
+#if	MOM_CSA || MOM_ALPS
 #include <sys/types.h>
 #include <dlfcn.h>
 #include "/usr/include/job.h"
+#if	MOM_CSA
 #include <csaacct.h>
 #include <csa_api.h>
 #endif	/* MOM_CSA */
+#endif	/* MOM_CSA || MOM_ALPS */
 
 #if     MOM_BGL
 #include <rm_api.h>
@@ -129,9 +131,9 @@ struct startjob_rtn {
 	char  sj_cpuset_name[CPUSET_NAME_SIZE+1];
 #endif	/* MOM_CPUSET */
 
-#if	MOM_CSA
+#if	MOM_CSA || MOM_ALPS
 	jid_t	sj_jid;
-#endif	/* MOM_CSA */
+#endif	/* MOM_CSA or MOM_ALPS */
 
 #if	MOM_ALPS
 	long			sj_reservation;

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -5563,12 +5563,12 @@ process_hup(void)
 	cleanup();
 	initialize();
 
-#if	MOM_CSA
+#if	MOM_CSA || MOM_ALPS /* ALPS needs libjob support */
 	/*
 	 * This needs to be called after the config file is read.
 	 */
 	ck_acct_facility_present();
-#endif	/* MOM_CSA */
+#endif	/* MOM_CSA or MOM_ALPS */
 
 	if (!real_hup)		/* no need to go on */
 		return;
@@ -8705,13 +8705,13 @@ main(int argc, char *argv[])
 		return (1);
 	}
 
-#if	MOM_CSA
+#if	MOM_CSA || MOM_ALPS /* ALPS needs libjob support */
 	/*
 	 * This needs to be called after the config file is read and before MOM
 	 * forks so the exit value can be seen if there is a bad flag combination.
 	 */
 	ck_acct_facility_present();
-#endif	/* MOM_CSA */
+#endif	/* MOM_CSA or MOM_ALPS */
 
 	/* initialize the network interface */
 

--- a/test/tests/functional/pbs_cray_pagg_id.py
+++ b/test/tests/functional/pbs_cray_pagg_id.py
@@ -1,0 +1,79 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+@tags('cray')
+class TestCrayPaggIdUniqueness(TestFunctional):
+    """
+    This test suite is written to verify that the PAGG ID provided to ALPS
+    while confirming and releasing an ALPS reservation is not equal to the
+    session ID of the job.
+    This test is specific to Cray and will also not work on the Cray simulator,
+    hence, will be skipped on non-Cray systems and Cray simulator.
+    """
+    def setUp(self):
+        platform = self.du.get_platform()
+        if platform != 'cray':
+            self.skipTest("not a cray")
+        TestFunctional.setUp(self)
+
+    def test_pagg_id(self):
+        """
+        This test case submits a job, waits for it to run and then checks
+        the MoM logs to confirm that the PAGG ID provided in the ALPS
+        query is not equal to the session ID of the job.
+        """
+        j1 = Job(TEST_USER)
+        jid = self.server.submit(j1)
+
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+        self.mom.log_match("Job;%s;Started, pid" % (jid,), n=100,
+                           max_attempts=5, interval=5, regexp=True)
+
+        self.server.status(JOB, [ATTR_session], jid)
+        sess_id = j1.attributes[ATTR_session]
+
+        msg = "pagg_id =\"" + sess_id + "\""
+        try:
+            self.mom.log_match(msg, n='ALL')
+        except PtlLogMatchError:
+            self.logger.info("pagg_id is not equal to session id, test passes")
+        else:
+            self.assertFalse("pagg_id is equal to session id, test fails.")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-985](https://pbspro.atlassian.net/browse/PP-985)**

#### Problem description
* While requesting an ALPS reservation PAGG ids are being set to non-unique session IDs.

#### Cause / Analysis
* Our internal build systems while building for Cray platforms did not use the enable-csa flag for both CLE5.2 and CLE6.0.

#### Solution description
* Unique pagg-ids are generated using Cray's libjob. 
Our code is written in such a way that the code that uses libjob is conditionally compiled if enable-csa is used while building.
Starting from CLE6.0, CSA was deprecated, however, it is still supported in CLE5.2.
Our build systems will be updated to use enable-csa flag for CLE5.2 and for CLE6.0, we will conditionally compile out the CSA part and use the libjob part to generate the unique PAGG ids.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
