### PR TITLE
PP-1066: PTL's is_cray() call fails to detect cray build

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -3892,7 +3892,7 @@ class PBSService(PBSObject):
                    tracejob
         :param n: One of 'ALL' of the number of lines to
                   process/display, defaults to 50.
-        :type n: int
+        :type n: str or int
         :param tail: if True, parse log from the end to the start,
                      otherwise parse from the start to the end.
                      Defaults to True.
@@ -3992,7 +3992,7 @@ class PBSService(PBSObject):
         :type id: str
         :param n: 'ALL' or the number of lines to search through,
                   defaults to 50
-        :type n: int
+        :type n: str or int
         :param tail: If true (default), starts from the end of
                      the file
         :type tail: bool
@@ -4049,7 +4049,7 @@ class PBSService(PBSObject):
             max_attempts = 60
         if interval is None:
             interval = 0.5
-        if starttime is None:
+        if starttime is None and n != 'ALL':
             starttime = self.ctime
         rv = (None, None)
         attempt = 1
@@ -4113,7 +4113,7 @@ class PBSService(PBSObject):
         :type id: str
         :param n: 'ALL' or the number of lines to search through,
                   defaults to 50
-        :type n: int
+        :type n: str or int
         :param tail: If true (default), starts from the end of
                      the file
         :type tail: bool
@@ -4176,7 +4176,7 @@ class PBSService(PBSObject):
         :type id: str
         :param n: 'ALL' or the number of lines to search through,
                   defaults to 50
-        :type n: int
+        :type n: str or int
         :param tail: If true (default), starts from the end of
                      the file
         :type tail: bool
@@ -4449,7 +4449,7 @@ class Comm(PBSService):
         :type id: str
         :param n: 'ALL' or the number of lines to search through,
                   defaults to 50
-        :type n: int
+        :type n: str or int
         :param tail: If true (default), starts from the end of
                      the file
         :type tail: bool
@@ -4979,7 +4979,7 @@ class Server(PBSService):
         :type id: str
         :param n: 'ALL' or the number of lines to search through,
                   defaults to 50
-        :type n: int
+        :type n: str or int
         :param tail: If true (default), starts from the end of
                      the file
         :type tail: bool
@@ -10548,7 +10548,7 @@ class Scheduler(PBSService):
         :type id: str
         :param n: 'ALL' or the number of lines to search through,
                   defaults to 50
-        :type n: int
+        :type n: str or int
         :param tail: If true (default), starts from the end of
                      the file
         :type tail: bool
@@ -12511,7 +12511,7 @@ class MoM(PBSService):
         :type id: str
         :param n: 'ALL' or the number of lines to search through,
                   defaults to 50
-        :type n: int
+        :type n: str or int
         :param tail: If true (default), starts from the end of
                      the file
         :type tail: bool
@@ -12691,7 +12691,7 @@ class MoM(PBSService):
         Returns True if the version of PBS used was built for Cray platforms
         """
         try:
-            self.log_match("alps_client", tail=False, max_attempts=1)
+            self.log_match("alps_client", n='ALL', tail=False, max_attempts=1)
         except PtlLogMatchError:
             return False
         else:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1066](https://pbspro.atlassian.net/browse/PP-1066)**

#### Problem description
* PTL's is_cray() call fails to detect cray build

#### Cause / Analysis
* Recently there is was change in starttime argument in all *_match methods in PTL, as per that change is user doesn't provide starttime then it will be default to test case start time (aka Server.ctime), means while calling any *_match method it will search message logged after test case execution started. But in is_cray() we want to look at start of log file where PBS logs basic information about PBS daemon like what is in config file etc... since due to recent change in starttime argument is_cray() was not able to find 'alps_client' message in log file which is logged when mom is started.

#### Solution description
* Modified call to log_match in is_cray() to look for all log lines in respective day's log file and modified _log_match method to not to add default starttime when log lines = 'ALL' because starttime doesn't make sense when user want to look into all lines of log file.
* Also fixed some argument type for log line, previously it was only int but as per design it should be str or int.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
