### PR TITLE
PP-1070: increment libpbs soname as the ifl call pbs_statsched has changed.

### DIFF
--- a/src/lib/Libpbs/Makefile.am
+++ b/src/lib/Libpbs/Makefile.am
@@ -45,7 +45,7 @@ libpbs_la_CPPFLAGS = -I$(top_srcdir)/src/include
 # to the following article prior to modifying the library version:
 # https://autotools.io/libtool/version.html
 #
-libpbs_la_LDFLAGS = -version-info 0:0:0
+libpbs_la_LDFLAGS = -version-info 1:0:0
 
 libpbs_la_LIBADD= \
 	-lcrypto \


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-PP-1070](https://pbspro.atlassian.net/browse/PP-PP-1070)**

#### Problem description
* The ifl call pbs_statsched was changed to support multi-sched. However, this change broke backward compatibility.

#### Cause / Analysis
* A new parameter was inserted to the prototype of pbs_statsched to support sched object name
Previous prototype of pbs_statsched() :  struct batch_status *pbs_statsched(int, struct attrl *, char *);
Current prototype of pbs_statsched()   :  struct batch_status *pbs_statsched(int, _char *_, struct attrl *, char *);
hence causing backward incompatibility.

#### Solution description
* Solution is to bump up the libpbs's  soname from 0.0.0 to 1.0.0
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
