### PR TITLE
PP-844: Make resource_release_list and resources_released attribute visible to operator/manager only

### DIFF
--- a/src/lib/Libattr/master_job_attr_def.xml
+++ b/src/lib/Libattr/master_job_attr_def.xml
@@ -2601,7 +2601,7 @@
       <member_at_free>free_str</member_at_free>
       <member_at_action>NULL_FUNC</member_at_action>
       <member_at_flags>
-         <both>READ_ONLY | ATR_DFLAG_SvWR | ATR_DFLAG_ALTRUN</both>
+         <both> PRIV_READ | ATR_DFLAG_SvWR | ATR_DFLAG_ALTRUN</both>
       </member_at_flags>
       <member_at_type>
          <both>ATR_TYPE_STR</both>
@@ -2624,7 +2624,7 @@
       <member_at_free>free_resc</member_at_free>
       <member_at_action>action_resc_job</member_at_action>
       <member_at_flags>
-         <both>ATR_DFLAG_MGRD | ATR_DFLAG_OPRD</both>
+         <both> PRIV_READ </both>
       </member_at_flags>
       <member_at_type>
          <both>ATR_TYPE_RESC</both>

--- a/test/tests/functional/pbs_release_limited_res_suspend.py
+++ b/test/tests/functional/pbs_release_limited_res_suspend.py
@@ -49,7 +49,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
     def setUp(self):
         TestFunctional.setUp(self)
         # Set default resources available on the default mom
-        a = {ATTR_rescavail+'.ncpus': 4, ATTR_rescavail+'.mem': '2gb'}
+        a = {ATTR_rescavail + '.ncpus': 4, ATTR_rescavail + '.mem': '2gb'}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         # Create an express queue
         b = {ATTR_qtype: 'Execution', ATTR_enable: 'True',
@@ -68,14 +68,14 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select': '1:ncpus=4:mem=512mb'})
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
         # Submit a high priority job
         j2 = Job(TEST_USER)
         j2.set_attributes(
-            {ATTR_l+'.select': '1:ncpus=2:mem=512mb',
+            {ATTR_l + '.select': '1:ncpus=2:mem=512mb',
              ATTR_q: 'expressq'})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
@@ -105,7 +105,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select': '1:ncpus=4:mem=512mb'})
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
@@ -138,14 +138,14 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select': '1:ncpus=4:mem=512mb'})
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
         # Submit a high priority job
         j2 = Job(TEST_USER)
         j2.set_attributes(
-            {ATTR_l+'.select': '1:ncpus=2:mem=256mb',
+            {ATTR_l + '.select': '1:ncpus=2:mem=256mb',
              ATTR_q: 'expressq'})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
@@ -186,14 +186,14 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select': '1:ncpus=4:mem=512mb'})
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
         # Submit a high priority job
         j2 = Job(TEST_USER)
         j2.set_attributes(
-            {ATTR_l+'.select': '1:ncpus=2:mem=512mb',
+            {ATTR_l + '.select': '1:ncpus=2:mem=512mb',
              ATTR_q: 'expressq'})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
@@ -227,7 +227,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select':
+        j1.set_attributes({ATTR_l + '.select':
                            '1:ncpus=8:mem=512mb+1:ncpus=6:mem=256mb'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
@@ -235,7 +235,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         # Submit a high priority job
         j2 = Job(TEST_USER)
         j2.set_attributes(
-            {ATTR_l+'.select': '1:ncpus=8:mem=256mb',
+            {ATTR_l + '.select': '1:ncpus=8:mem=256mb',
              ATTR_q: 'expressq'})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
@@ -260,7 +260,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select': '1:ncpus=4:mem=512mb',
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb',
                            ATTR_J: '1-3'})
         jid1 = self.server.submit(j1)
         subjobs = self.server.status(JOB, id=jid1, extend='t')
@@ -270,7 +270,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         # Submit a high priority job
         j2 = Job(TEST_USER)
         j2.set_attributes(
-            {ATTR_l+'.select': '1:ncpus=2:mem=512mb',
+            {ATTR_l + '.select': '1:ncpus=2:mem=512mb',
              ATTR_q: 'expressq'})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
@@ -295,7 +295,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select': '1:ncpus=4:mem=512mb',
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb',
                            ATTR_J: '1-3'})
         jid1 = self.server.submit(j1)
         subjobs = self.server.status(JOB, id=jid1, extend='t')
@@ -305,7 +305,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         # Submit a high priority job
         j2 = Job(TEST_USER)
         j2.set_attributes(
-            {ATTR_l+'.select': '1:ncpus=2:mem=256mb',
+            {ATTR_l + '.select': '1:ncpus=2:mem=256mb',
              ATTR_q: 'expressq'})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
@@ -331,14 +331,14 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select': '1:ncpus=4:mem=512mb'})
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
         # Submit a high priority job
         j2 = Job(TEST_USER)
         j2.set_attributes(
-            {ATTR_l+'.select': '1:ncpus=2:mem=256mb',
+            {ATTR_l + '.select': '1:ncpus=2:mem=256mb',
              ATTR_q: 'expressq'})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
@@ -373,7 +373,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select':
+        j1.set_attributes({ATTR_l + '.select':
                            '1:ncpus=8:mem=512mb+1:ncpus=6:mem=256mb'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
@@ -381,7 +381,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         # Submit a high priority job
         j2 = Job(TEST_USER)
         j2.set_attributes(
-            {ATTR_l+'.select': '1:ncpus=8:mem=256mb',
+            {ATTR_l + '.select': '1:ncpus=8:mem=256mb',
              ATTR_q: 'expressq'})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
@@ -406,7 +406,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select': '1:ncpus=4:mem=512mb'})
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
@@ -452,14 +452,14 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         """
         # Submit a low priority job
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select': '1:ncpus=4:mem=512mb'})
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
         # Submit a high priority job
         j2 = Job(TEST_USER)
         j2.set_attributes(
-            {ATTR_l+'.select': '1:ncpus=2:mem=256mb',
+            {ATTR_l + '.select': '1:ncpus=2:mem=256mb',
              ATTR_q: 'expressq'})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
@@ -540,9 +540,9 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.manager(MGR_CMD_SET, QUEUE, a, id="workq")
 
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.ncpus': '4',
-                           ATTR_l+'.foo': '30',
-                           ATTR_l+'.bar': '40'})
+        j1.set_attributes({ATTR_l + '.ncpus': '4',
+                           ATTR_l + '.foo': '30',
+                           ATTR_l + '.bar': '40'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
@@ -586,9 +586,9 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.ncpus': '4',
-                           ATTR_l+'.foo': '30',
-                           ATTR_l+'.bar': '40'})
+        j1.set_attributes({ATTR_l + '.ncpus': '4',
+                           ATTR_l + '.foo': '30',
+                           ATTR_l + '.bar': '40'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
@@ -633,9 +633,9 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
 
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.ncpus': '4',
-                           ATTR_l+'.foo': '30',
-                           ATTR_l+'.bar': '40'})
+        j1.set_attributes({ATTR_l + '.ncpus': '4',
+                           ATTR_l + '.foo': '30',
+                           ATTR_l + '.bar': '40'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
@@ -666,7 +666,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.ncpus': '4'})
+        j1.set_attributes({ATTR_l + '.ncpus': '4'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
@@ -703,9 +703,9 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.create_vnodes("vnode2", vn_attrs, 1,
                                   self.mom, additive=True, fname="vnodedef2")
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select':
+        j1.set_attributes({ATTR_l + '.select':
                            '1:ncpus=2+1:ncpus=6',
-                           ATTR_l+'.place': 'vscatter'})
+                           ATTR_l + '.place': 'vscatter'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
@@ -733,15 +733,15 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         j1 = Job(TEST_USER)
-        j1.set_attributes({ATTR_l+'.select': '1:ncpus=1',
-                           ATTR_l+'.place': 'excl'})
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=1',
+                           ATTR_l + '.place': 'excl'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 
         # Submit a high priority job
         j2 = Job(TEST_USER)
         j2.set_attributes(
-            {ATTR_l+'.select': '1:ncpus=2',
+            {ATTR_l + '.select': '1:ncpus=2',
              ATTR_q: 'expressq'})
         jid2 = self.server.submit(j2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
@@ -756,3 +756,30 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         # resume job
         self.server.deljob(jid2, wait=True)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+    def test_normal_user_unable_to_see_res_released(self):
+        """
+        Check if normal user (non-operator, non-manager) has privileges to see
+        resources_released and resource_released_list attribute in job status
+        """
+        # Set mem in restrict_res_to_release_on_suspend server attribute
+        a = {ATTR_restrict_res_to_release_on_suspend: 'mem'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        j1 = Job(TEST_USER)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb'})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+        # suspend job
+        self.server.sigjob(jobid=jid1, signal="suspend")
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+
+        # stat the job as a normal user
+        attrs = self.server.status(JOB, id=jid1, runas=TEST_USER)
+        self.assertFalse("resources_released" in attrs,
+                         "Normal user can see resources_released "
+                         "which is not expected")
+
+        self.assertFalse("resource_released_list.mem" in attrs,
+                         "Normal user can see resources_released_list "
+                         "which is not expected")


### PR DESCRIPTION
…ys it should be

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-844](https://pbspro.atlassian.net/browse/PP-844)**

#### Problem description
resources_released_list attribute isn't visible to the user and design say it should be. 

#### Cause / Analysis
Actually none of the resource_released attributes needs to be visible to normal user. since the attribute which specifies what all resources to be released on suspension is settable only by admins, it does not help users to view what all were actually released.

#### Solution description
Made the resources_released and resource_released_list viewable only to operator/manager privilege user.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
