### PR TITLE
PP-966: Scheduler confirms resv on stale/down nodes and resv stays co…

### DIFF
--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -258,6 +258,7 @@ extern "C" {
 #define PBSE_STDG_RESV_OCCR_CONFLICT 15179 /* cannot change start time of a non-empty reservation */
 
 #define PBSE_SOFTWT_STF		     15180 /* soft_walltime is incompatible with STF jobs */
+#define PBSE_BAD_NODE_STATE	     15181 /* node is in the wrong state for the operation */
 
 /*
  ** 	Resource monitor specific

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -411,6 +411,7 @@ char *msg_stdg_resv_occr_conflict = "Requested time(s) will interfere with a lat
 char *msg_alps_switch_err = "Switching ALPS reservation failed";
 
 char *msg_softwt_stf = "soft_walltime is not supported with Shrink to Fit jobs";
+char *msg_bad_node_state = "Node is in the wrong state for operation";
 
 /*
  * The following table connects error numbers with text
@@ -587,6 +588,7 @@ struct pbs_err_to_txt pbs_err_to_txt[] = {
 	{PBSE_STDG_RESV_OCCR_CONFLICT, &msg_stdg_resv_occr_conflict},
 	{PBSE_ALPS_SWITCH_ERR, &msg_alps_switch_err},
 	{PBSE_SOFTWT_STF, &msg_softwt_stf},
+	{PBSE_BAD_NODE_STATE, &msg_bad_node_state},
 	{ 0, (char **)0 }		/* MUST be the last entry */
 };
 

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -292,7 +292,8 @@ enum sort_type
 enum resv_conf {
 	RESV_CONFIRM_FAIL = -1,
 	RESV_CONFIRM_VOID ,
-	RESV_CONFIRM_SUCCESS
+	RESV_CONFIRM_SUCCESS,
+	RESV_CONFIRM_RETRY
 };
 
 /* job substate meaning suspended by scheduler */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -659,12 +659,18 @@ scheduling_cycle(int sd, char *jobid)
 
 	/* don't confirm reservations if we're handling a qrun request */
 	if (jobid == NULL) {
-		if (check_new_reservations(policy, sd, sinfo->resvs, sinfo)) {
+		int rc;
+		rc = check_new_reservations(policy, sd, sinfo->resvs, sinfo);
+		if (rc) {
 			/* Check if there are new reservations.  If there are, we can't go any
 			 * further in the scheduling cycle since we don't have the up to date
 			 * information about the newly confirmed reservations
 			 */
 			end_cycle_tasks(sinfo);
+			/* Problem occurred confirming reservation, retry cycle */
+			if (rc < 0)
+				return -1;
+
 			return 0;
 		}
 	}

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1678,15 +1678,9 @@ update_node_on_end(node_info *ninfo, resource_resv *resresv, char *job_state)
 		remove_resresv_from_array(ninfo->run_resvs_arr, resresv);
 	}
 
-	/* Since we are removing work from a node, it'll free up some cpus.  This
-	 * means it'll go from exclusive or shared to free.  If the node is busy
-	 * removing work will not make it leave the busy state until the loadave
-	 * has lowered.  This will take time.
-	 */
-	if (!ninfo->is_busy) {
-		set_node_info_state(ninfo, ND_free);
-	}
-	else if (is_excl(resresv->place_spec, ninfo->sharing)) {
+	if (ninfo->is_job_busy)
+		remove_node_state(ninfo, ND_jobbusy);
+	if (is_excl(resresv->place_spec, ninfo->sharing)) {
 		if (resresv->is_resv) {
 			if (ninfo->svr_node != NULL)
 				remove_node_state(ninfo->svr_node, ND_resv_exclusive);

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7061,6 +7061,12 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				return (PBSE_UNKNODE);
 			}
 
+			if (pnode->nd_state & (INUSE_DOWN | INUSE_STALE)) {
+				free(phowl);
+				free(execvncopy);
+				return (PBSE_BAD_NODE_STATE);
+			}
+
 			if (pjob != NULL) { /* only for jobs do we warn if a mom */
 				/* hook has not been sent */
 				for (i=0; i<pnode->nd_nummoms; ++i) {

--- a/test/tests/functional/pbs_conf_resv_stale_vnode.py
+++ b/test/tests/functional/pbs_conf_resv_stale_vnode.py
@@ -1,0 +1,120 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestResvStaleVnode(TestFunctional):
+    """
+    Test that the scheduler won't confirm a reservation on stale vnode and
+    make sure reservations that have nodes that have gone stale get degreaded
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        # Create 3 vnodes named different things in different vnodedef files
+        # This allows us to delete a vnodedef file and make that node stale
+        self.mom.add_config(conf={'$vnodedef_additive': 'False'})
+        a = {'resources_available.ncpus': 1, 'priority': 100}
+        self.server.create_vnodes('foo', a, 1, fname='nat', restart=False,
+                                  mom=self.mom, usenatvnode=True, expect=False)
+        a['priority'] = 10
+        self.server.create_vnodes('vn', a, 1, fname='fname1', delall=False,
+                                  restart=False, additive=True, mom=self.mom,
+                                  expect=False)
+        a['priority'] = 1
+        self.server.create_vnodes('vnode', a, 1, fname='fname2', delall=False,
+                                  additive=True, mom=self.mom, expect=False)
+
+        self.scheduler.set_sched_config({'node_sort_key': 'sort_priority'})
+
+    def test_conf_resv_stale_vnode(self):
+        """
+        Test that the scheduler won't confirm a reservation on a stale node.
+        """
+        # Ensure the hostsets aren't used by associating a node to a queue
+        a = {'queue_type': 'Execution', 'enabled': 'True', 'started': 'True'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
+        self.server.manager(MGR_CMD_SET, NODE, {'queue': 'workq2'},
+                            id=self.mom.shortname)
+
+        # Submit a job that will run on our stale vnode
+        a = {'Resource_List.select': '1:vnode=vn[0]',
+             'Resource_List.walltime': 3600}
+        J = Job(TEST_USER, attrs=a)
+        jid = self.server.submit(J)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+
+        self.mom.delete_vnode_defs(vdefname='fname1')
+        self.mom.signal('-HUP')
+        self.server.expect(NODE, {'state': (MATCH_RE, 'Stale')}, id='vn[0]')
+
+        now = int(time.time())
+        a = {'reserve_start': now + 5400, 'reserve_end': now + 7200}
+        R = Reservation(TEST_USER, a)
+        rid = self.server.submit(R)
+
+        # Reservation should be confirmed on vnode[0] since vn[0] is Stale
+        a = {'resv_nodes': '(vnode[0]:ncpus=1)'}
+        a2 = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+        self.server.expect(RESV, a2, id=rid)
+
+    def test_stale_degraded(self):
+        """
+        Test that a reservation goes into the degraded state
+        when one of its vnodes go stale
+        """
+        now = int(time.time())
+        a = {'Resource_List.select': '3:ncpus=1',
+             'Resource_List.place': 'vscatter',
+             'reserve_start': now + 3600, 'reserve_end': now + 7200}
+
+        R = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(R)
+
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+
+        self.mom.delete_vnode_defs(vdefname='fname1')
+        self.mom.signal('-HUP')
+        self.server.expect(NODE, {'state': (MATCH_RE, 'Stale')}, id='vn[0]')
+
+        a = {'reserve_state': (MATCH_RE, 'RESV_DEGRADED|10')}
+        self.server.expect(RESV, a, id=rid)


### PR DESCRIPTION
…nfirmed

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-966](https://pbspro.atlassian.net/browse/PP-966)**

#### Problem description
* Reservations can be confirmed on stale nodes.

#### Cause / Analysis
* If the scheduler tells the server to confirm a reservation on a stale vnode, it will do so.  The reservation is not marked degraded.  This can happen in one of two ways.  First, the scheduler incorrectly will mark a stale node free in its simulation when it simulates an end event.  If it does so, it will reuse it later.  Second, if a node goes stale after the scheduler queries its world, it can use the stale node.
#### Solution description
* The fix is threefold.  First, if the scheduler simulates an end event for a job or reservation on a stale vnode, leave the vnode as stale.  Do not mark it free.  Second, if the scheduler tries to confirm a job on a stale or down node, reject the confirmation request.  Lastly, if the confirmation request is rejected, restart the cycle to try again.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
