### PR TITLE
PP-1081: Arrayjob 'E' accounting record has the 'start' value set to 0

### DIFF
--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1123,6 +1123,13 @@ complete_running(job *jobp)
 		parent = jobp->ji_parentaj;
 		if (parent->ji_qs.ji_state == JOB_STATE_QUEUED) {
 			svr_setjobstate(parent, JOB_STATE_BEGUN, JOB_SUBSTATE_BEGUN);
+
+			/* Also set the parent job's stime */
+			parent->ji_qs.ji_stime = time_now;
+			parent->ji_wattr[(int)JOB_ATR_stime].at_val.at_long = time_now;
+			parent->ji_wattr[(int)JOB_ATR_stime].at_flags |=
+			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+
 			account_jobstr(parent);
 			job_attr_def[(int) JOB_ATR_Comment].at_decode(
 					&parent->ji_wattr[(int) JOB_ATR_Comment], (char *) 0,

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestJobArray(TestFunctional):
+    """
+    Test suite for PBSPro's job array feature
+    """
+    def test_arrayjob_Erecord_startval(self):
+        """
+        Check that an arrayjob's E record's 'start' value is not set to 0
+        """
+        j = Job(TEST_USER, attrs={
+            ATTR_J: '1-2',
+            'Resource_List.select': 'ncpus=1'
+        })
+        j.set_sleep_time(1)
+
+        j_id = self.server.submit(j)
+
+        # Check for the E record for the arrayjob
+        acct_string = ";E;" + str(j_id)
+        _, record = self.server.accounting_match(acct_string, max_attempts=10,
+                                                 interval=1)
+
+        # Extract the 'start' value from the E record
+        values = record.split(";", 3)[3]
+        start_str = " start="
+        values_temp = values.split(start_str, 1)[1]
+        start_val = int(values_temp.split()[0])
+
+        # Verify that the value of 'start' isn't 0
+        self.assertNotEqual(start_val, 0,
+                            "E record value of 'start' for arrayjob is 0")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1081](https://pbspro.atlassian.net/browse/PP-1081)**

#### Problem description
* The E record of an arrayjob would have a correct 'etime' value, but the 'start' value would be set to 0:

11/15/2017 01:23:58;E;4[].pbspro;user=ravi group=wheel project=_pbs_project_default jobname=STDIN queue=workq ctime=1510709028 qtime=1510709028 etime=1510709028 *start=0* array_indices=1-2 Resource_List.ncpus=1 Resource_List.nodect=1 Resource_List.place=pack Resource_List.select=1:ncpus=1 session=0 *end=1510709038* Exit_status=0 run_count=0

#### Cause / Analysis
* The 'stime'/'start' value of an arrayjob was just not being set in the code.

#### Solution description
* Added code to set the stime/start value of an arrayjob when it goes to the "B"(begun) state

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__