### PR TITLE
PP-954: Skip test if multiple MoMs (specifically 3 in this case) are …

### DIFF
--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -65,9 +65,9 @@ class TestPbsAccumulateRescUsed(TestFunctional):
         TestFunctional.setUp(self)
         self.logger.info("len moms = %d" % (len(self.moms)))
         if len(self.moms) != 3:
-            self.logger.error('test requires 3 MoMs as input, ' +
-                              '  use -p moms=<mom1>:<mom2>:<mom3>')
-            self.assertEqual(len(self.moms), 3)
+            usage_string = 'test requires 3 MoMs as input, ' + \
+                           'use -p moms=<mom1>:<mom2>:<mom3>'
+            self.skip_test(usage_string)
 
         # PBSTestSuite returns the moms passed in as parameters as dictionary
         # of hostname and MoM object


### PR DESCRIPTION
Skip test if expected number of MoMs are not provided

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-954](https://pbspro.atlassian.net/browse/PP-954)**

#### Problem description
* The test "pbs_accumulate_resc_used" fails when expected number of MoMs are not provided.

#### Cause / Analysis
* The test checks if the number of MoMs provided is equal to the expected value (3 currently) by a assertion check. This causes the test to fail when there is a mismatch.

#### Solution description
* The test is now skipped using skip_test() method when the expected number of MoMs is not provided. Assertion check is removed.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__