### PR TITLE
PP-747: Modify the sched object to have additional options to configu…

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -565,6 +565,8 @@ extern int action_sched_priv(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_log(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_user(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_port(attribute *pattr, void *pobj, int actmode);
+extern int action_sched_host(attribute *pattr, void *pobj, int actmode);
+extern int action_sched_partition(attribute *pattr, void *pobj, int actmode);
 /* Extern functions from queue_attr_def */
 extern int decode_null(attribute *patr, char *name, char *rn, char *val);
 extern int set_null(attribute *patr, attribute *new, enum batch_op op);

--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -293,7 +293,8 @@ extern "C" {
 #define PBSE_PARTITION_NOT_IN_QUE 15220  /* Partition does not belong to the queue */
 #define PBSE_INVALID_PARTITION_QUE 15221 /* Invalid partition to the queue */
 #define PBSE_ALPS_SWITCH_ERR 15222	/* ALPS failed to do the suspend/resume */
-
+#define PBSE_OP_NOT_PERMITTED 15223 	/* Operation not permitted on default scheduler */
+#define PBSE_PART_ALREADY_USED 15224 	/* Partition already used */
 
 /* the following structure is used to tie error number      */
 /* with text to be returned to a client, see svr_messages.c */

--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -293,8 +293,8 @@ extern "C" {
 #define PBSE_PARTITION_NOT_IN_QUE 15220  /* Partition does not belong to the queue */
 #define PBSE_INVALID_PARTITION_QUE 15221 /* Invalid partition to the queue */
 #define PBSE_ALPS_SWITCH_ERR 15222	/* ALPS failed to do the suspend/resume */
-#define PBSE_OP_NOT_PERMITTED 15223 	/* Operation not permitted on default scheduler */
-#define PBSE_PART_ALREADY_USED 15224 	/* Partition already used */
+#define PBSE_SCHED_OP_NOT_PERMITTED 15223 /* Operation not permitted on default scheduler */
+#define PBSE_SCHED_PARTITION_ALREADY_EXISTS 15224 /* Partition already exists */
 
 /* the following structure is used to tie error number      */
 /* with text to be returned to a client, see svr_messages.c */

--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -99,8 +99,7 @@ extern pbs_sched *dflt_scheduler;
 extern	pbs_list_head	svr_allscheds;
 extern void set_scheduler_flag(int flag, pbs_sched *psched);
 extern int find_assoc_sched_jid(char *jid, pbs_sched **target_sched);
-extern int find_assoc_sched_pj(job *pj, pbs_sched **target_sched);
-extern int find_assoc_sched_pq(pbs_queue *pq, pbs_sched **target_sched);
+extern int find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched);
 extern pbs_sched *find_sched_from_sock(int sock);
 
 #ifdef	__cplusplus

--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -42,12 +42,15 @@ extern "C" {
 #endif
 
 #include "attribute.h"
+#include "sched_cmds.h"
+#include "net_connect.h"
+#include "job.h"
+#include "reservation.h"
+#include "queue.h"
+#include "resource.h"
+
 #define PBS_SCHED_CYCLE_LEN_DEFAULT 1200
 
-/* scheduler-attribute values (state) */
-#define SC_DOWN		"down"
-#define SC_IDLE			"idle"
-#define SC_SCHEDULING	"scheduling"
 #define SC_STATUS_LEN 	10
 
 /*attributes for the server's sched object*/
@@ -79,7 +82,13 @@ extern attribute_def sched_attr_def[];
 
 typedef struct pbs_sched {
 	pbs_list_link	sc_link;		/* forward/backward links */
-
+	int scheduler_sock;
+	int scheduler_sock2;
+	int svr_do_schedule;
+	int svr_do_sched_high;
+	pbs_net_t pbs_scheduler_addr;
+	unsigned int pbs_scheduler_port;
+	time_t sch_next_schedule;		/* when to next run scheduler cycle */
 	char sc_name[PBS_MAXSCHEDNAME];
 	/* sched object's attributes  */
 	attribute sch_attr[SCHED_ATR_LAST];
@@ -88,6 +97,11 @@ typedef struct pbs_sched {
 
 extern pbs_sched *dflt_scheduler;
 extern	pbs_list_head	svr_allscheds;
+extern void set_scheduler_flag(int flag, pbs_sched *psched);
+extern int find_assoc_sched_jid(char *jid, pbs_sched **target_sched);
+extern int find_assoc_sched_pj(job *pj, pbs_sched **target_sched);
+extern int find_assoc_sched_pq(pbs_queue *pq, pbs_sched **target_sched);
+extern pbs_sched *find_sched_from_sock(int sock);
 
 #ifdef	__cplusplus
 }

--- a/src/include/pbs_share.h
+++ b/src/include/pbs_share.h
@@ -91,3 +91,12 @@
 
 /* Default scheduler name */
 #define PBS_DFLT_SCHED_NAME "default"
+#define SC_DAEMON "scheduler"
+
+/* scheduler-attribute values (state) */
+#define SC_DOWN	"down"
+#define SC_IDLE "idle"
+#define SC_SCHEDULING "scheduling"
+
+#define MAX_INT_LEN 10
+

--- a/src/include/sched_cmds.h
+++ b/src/include/sched_cmds.h
@@ -55,6 +55,7 @@
 #define SCH_SCHEDULE_ETE_ON 15		/* eligible_time_enable is turned ON */
 #define SCH_SCHEDULE_RESV_RECONFIRM 16		/* Reconfirm a reservation */
 #define SCH_SCHEDULE_RESTART_CYCLE 17		/* Restart a scheduling cycle */
+#define SCH_ATTRS_CONFIGURE 18
 
 
 extern int schedule(int cmd, int sd, char *runjid);

--- a/src/include/sched_cmds.h
+++ b/src/include/sched_cmds.h
@@ -56,5 +56,6 @@
 #define SCH_SCHEDULE_RESV_RECONFIRM 16		/* Reconfirm a reservation */
 #define SCH_SCHEDULE_RESTART_CYCLE 17		/* Restart a scheduling cycle */
 
+
 extern int schedule(int cmd, int sd, char *runjid);
-extern void set_scheduler_flag(int);
+

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -47,6 +47,7 @@ extern "C" {
 #include "pbs_db.h"
 #include "reservation.h"
 #include "resource.h"
+#include "pbs_sched.h"
 
 /* Protocol types when connecting to another server (eg mom) */
 #define PROT_INVALID	-1
@@ -56,7 +57,7 @@ extern "C" {
 extern int   check_num_cpus(void);
 extern int   chk_hold_priv(long hold, int priv);
 extern void  close_client(int sfds);
-extern int   contact_sched(int, char *jobid);
+extern int   contact_sched(int, char *jobid, pbs_net_t pbs_scheduler_addr, unsigned int pbs_scheduler_port);
 extern void  count_node_cpus(void);
 extern int   ctcpus(char *buf, int *hascpp);
 extern void  get_jobowner(char *from, char *to);
@@ -75,8 +76,8 @@ extern void  process_dis_request(int);
 extern int   save_flush(void);
 extern void  save_setup(int);
 extern int   save_struct(char *, unsigned int);
-extern int   schedule_jobs(void);
-extern int   schedule_high(void);
+extern int   schedule_jobs(pbs_sched *);
+extern int   schedule_high(pbs_sched *);
 extern void  shutdown_nodes(void);
 extern char *site_map_user(char *, char *);
 extern char *site_map_resvuser(char *, char *);
@@ -95,7 +96,7 @@ extern void  mark_node_down(char *, char *);
 extern void  mark_node_offline_by_mom(char *, char *);
 extern void  clear_node_offline_by_mom(char *, char *);
 extern void  mark_which_queues_have_nodes(void);
-extern void  set_sched_sock(int);
+extern void  set_sched_sock(int, pbs_sched *);
 extern void  pbs_close_stdfiles(void);
 extern int   is_job_array(char *id);
 extern char *get_index_from_jid(char *newjid);
@@ -273,6 +274,7 @@ extern int   chk_characteristic(struct pbsnode *pnode, int *pneed_todo);
 extern int   is_valid_str_resource(attribute *pattr, void *pobject, int actmode);
 extern int   setup_arrayjob_attrs(attribute *, void *, int);
 extern int   deflt_chunk_action(attribute *pattr, void *pobj, int mode);
+extern int   action_svr_iteration(attribute *pattr, void *pobj, int mode);
 extern void  update_node_rassn(attribute *, enum batch_op);
 extern int   cvt_nodespec_to_select(char *, char **, size_t *, attribute *);
 extern int is_valid_resource(attribute *pattr, void *pobject, int actmode);

--- a/src/lib/Libattr/master_sched_attr_def.xml
+++ b/src/lib/Libattr/master_sched_attr_def.xml
@@ -97,8 +97,8 @@
 	<member_at_set>set_str</member_at_set>
 	<member_at_comp>comp_str</member_at_comp>
 	<member_at_free>free_str</member_at_free>
-	<member_at_action>NULL_FUNC</member_at_action>
-	<member_at_flags><both>ATR_DFLAG_OPRD | ATR_DFLAG_MGRD | ATR_DFLAG_SvWR</both></member_at_flags>
+	<member_at_action>action_sched_host</member_at_action>
+	<member_at_flags><both>READ_ONLY | ATR_DFLAG_SSET</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
 	<member_verify_function>
@@ -114,7 +114,7 @@
 	<member_at_comp>comp_str</member_at_comp>
 	<member_at_free>free_str</member_at_free>
 	<member_at_action>NULL_FUNC</member_at_action>
-	<member_at_flags><both>ATR_DFLAG_OPRD | ATR_DFLAG_MGRD | ATR_DFLAG_SvWR</both></member_at_flags>
+	<member_at_flags><both>ATR_DFLAG_OPRD | ATR_DFLAG_MGRD | ATR_DFLAG_MGWR | ATR_DFLAG_SvWR</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
 	<member_verify_function>
@@ -258,7 +258,7 @@
         <member_at_comp>comp_l</member_at_comp>
         <member_at_free>free_null</member_at_free>
         <member_at_action>action_sched_port</member_at_action>
-        <member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
+        <member_at_flags><both>READ_ONLY | ATR_DFLAG_SSET</both></member_at_flags>
         <member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
         <member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
         <member_verify_function>
@@ -270,10 +270,10 @@
 	<member_name><both>ATTR_partition</both></member_name>		<!-- "partition" -->
 	<member_at_decode>decode_arst</member_at_decode>
 	<member_at_encode>encode_arst</member_at_encode>
-	<member_at_set>set_arst</member_at_set>
+	<member_at_set>set_arst_uniq</member_at_set>
 	<member_at_comp>comp_arst</member_at_comp>
 	<member_at_free>free_arst</member_at_free>
-	<member_at_action>NULL_FUNC</member_at_action>
+	<member_at_action>action_sched_partition</member_at_action>
 	<member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_ARST</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
@@ -386,7 +386,7 @@
 	<member_at_comp>comp_str</member_at_comp>
 	<member_at_free>free_str</member_at_free>
 	<member_at_action>NULL_FUNC</member_at_action>
-	<member_at_flags><both>READ_ONLY</both></member_at_flags>
+	<member_at_flags><both>NO_USER_SET | ATR_DFLAG_NOSAVM</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
 	<member_verify_function>

--- a/src/lib/Libattr/master_sched_attr_def.xml
+++ b/src/lib/Libattr/master_sched_attr_def.xml
@@ -98,7 +98,7 @@
 	<member_at_comp>comp_str</member_at_comp>
 	<member_at_free>free_str</member_at_free>
 	<member_at_action>action_sched_host</member_at_action>
-	<member_at_flags><both>READ_ONLY | ATR_DFLAG_SSET</both></member_at_flags>
+	<member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
 	<member_verify_function>
@@ -258,7 +258,7 @@
         <member_at_comp>comp_l</member_at_comp>
         <member_at_free>free_null</member_at_free>
         <member_at_action>action_sched_port</member_at_action>
-        <member_at_flags><both>READ_ONLY | ATR_DFLAG_SSET</both></member_at_flags>
+        <member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
         <member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
         <member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
         <member_verify_function>
@@ -386,7 +386,7 @@
 	<member_at_comp>comp_str</member_at_comp>
 	<member_at_free>free_str</member_at_free>
 	<member_at_action>NULL_FUNC</member_at_action>
-	<member_at_flags><both>NO_USER_SET | ATR_DFLAG_NOSAVM</both></member_at_flags>
+	<member_at_flags><both>READ_ONLY | ATR_DFLAG_SSET</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
 	<member_verify_function>

--- a/src/lib/Libattr/master_svr_attr_def.xml
+++ b/src/lib/Libattr/master_svr_attr_def.xml
@@ -882,7 +882,7 @@
 	<member_at_set>set_l</member_at_set>
 	<member_at_comp>comp_l</member_at_comp>
 	<member_at_free>free_null</member_at_free>
-	<member_at_action>NULL_FUNC</member_at_action>
+	<member_at_action>action_svr_iteration</member_at_action>
 	<member_at_flags><both>NO_USER_SET</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SERVER</member_at_parent>

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -405,8 +405,8 @@ char *msg_cannot_set_route_que = "Route queues are incompatible with the partiti
 char *msg_queue_not_in_partition = "Queue %s is not part of partition for node";
 char *msg_partition_not_in_queue = "Partition %s is not part of queue for node";
 char *msg_invalid_partion_in_queue = "Invalid partition in queue";
-char *msg_op_not_permitted = "Operation is not permitted on default scheduler";
-char *msg_part_already_used = "Partition is already associated with other scheduler";
+char *msg_sched_op_not_permitted = "Operation is not permitted on default scheduler";
+char *msg_sched_part_already_used = "Partition is already associated with other scheduler";
 
 char *msg_resv_not_empty = "Reservation not empty";
 char *msg_stdg_resv_occr_conflict = "Requested time(s) will interfere with a later occurrence";
@@ -591,8 +591,8 @@ struct pbs_err_to_txt pbs_err_to_txt[] = {
 	{PBSE_ALPS_SWITCH_ERR, &msg_alps_switch_err},
 	{PBSE_SOFTWT_STF, &msg_softwt_stf},
 	{PBSE_BAD_NODE_STATE, &msg_bad_node_state},
-	{PBSE_OP_NOT_PERMITTED, &msg_op_not_permitted},
-	{PBSE_PART_ALREADY_USED, &msg_part_already_used},
+	{PBSE_SCHED_OP_NOT_PERMITTED, &msg_sched_op_not_permitted},
+	{PBSE_SCHED_PARTITION_ALREADY_EXISTS, &msg_sched_part_already_used},
 	{ 0, (char **)0 }		/* MUST be the last entry */
 };
 

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -405,6 +405,8 @@ char *msg_cannot_set_route_que = "Route queues are incompatible with the partiti
 char *msg_queue_not_in_partition = "Queue %s is not part of partition for node";
 char *msg_partition_not_in_queue = "Partition %s is not part of queue for node";
 char *msg_invalid_partion_in_queue = "Invalid partition in queue";
+char *msg_op_not_permitted = "Operation is not permitted on default scheduler";
+char *msg_part_already_used = "Partition is already associated with other scheduler";
 
 char *msg_resv_not_empty = "Reservation not empty";
 char *msg_stdg_resv_occr_conflict = "Requested time(s) will interfere with a later occurrence";
@@ -589,6 +591,8 @@ struct pbs_err_to_txt pbs_err_to_txt[] = {
 	{PBSE_ALPS_SWITCH_ERR, &msg_alps_switch_err},
 	{PBSE_SOFTWT_STF, &msg_softwt_stf},
 	{PBSE_BAD_NODE_STATE, &msg_bad_node_state},
+	{PBSE_OP_NOT_PERMITTED, &msg_op_not_permitted},
+	{PBSE_PART_ALREADY_USED, &msg_part_already_used},
 	{ 0, (char **)0 }		/* MUST be the last entry */
 };
 

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -150,18 +150,6 @@ enum update_accruetype_mode
 
 #define PREEMPT_NONE 1
 
-#define COPY_ATTR_VALUE(DEST, SRC) \
-	{ \
-		int len = 0;\
-		if (DEST) { \
-			free(DEST); \
-		} \
-		len = strlen(SRC);\
-		DEST = (char*)malloc(len + 1); \
-		strncpy(DEST, attr->value, len); \
-		DEST[len] = '\0';\
-	}
-
 /* resource comparison flag values */
 enum resval_cmpflag
 {

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -150,6 +150,18 @@ enum update_accruetype_mode
 
 #define PREEMPT_NONE 1
 
+#define COPY_ATTR_VALUE(DEST, SRC) \
+	{ \
+		int len = 0;\
+		if (DEST) { \
+			free(DEST); \
+		} \
+		len = strlen(SRC);\
+		DEST = (char*)malloc(len + 1); \
+		strncpy(DEST, attr->value, len); \
+		DEST[len] = '\0';\
+	}
+
 /* resource comparison flag values */
 enum resval_cmpflag
 {

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -413,6 +413,7 @@ struct queue_info
 	int num_parts;		/* number of node partitions(node_group_key) */
 	int num_topjobs;	/* current number of top jobs in this queue */
 	int backfill_depth;	/* total allowable topjobs in this queue*/
+	char *partition;	/* partition to which queue belongs to */
 };
 
 struct job_info
@@ -603,6 +604,7 @@ struct node_info
 	node_info *svr_node;		/* ptr to svr's node if we're a resv node */
 	node_partition *hostset;      /* other vnodes on on the same host */
 	node_scratch nscr;            /* scratch space local to node search code */
+	char *partition;	      /*  partition to which node belongs to */
 };
 
 struct resv_info

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2436,12 +2436,8 @@ sched_settings_frm_svr(struct batch_status *status)
 	char *tmp_priv_dir = NULL;
 	char *tmp_log_dir = NULL;
 	char *tmp_partitions = NULL;
-	int c;
-	int lockfds;
 	struct	attropl	*attribs, *patt;
 	struct batch_status *ss = NULL;
-	int	err;
-	int priv_dir_update_fail = 0;
 	extern char *partitions;
 
 	attr = status->attribs;
@@ -2462,10 +2458,13 @@ sched_settings_frm_svr(struct batch_status *status)
 	}
 
 	if (!dflt_sched) {
+		int err;
+		int priv_dir_update_fail = 0;
 		if ((log_dir != NULL) && strcmp(log_dir, tmp_log_dir) != 0) {
 			(void)snprintf(path_log,  MAXPATHLEN, tmp_log_dir);
 			log_close(1);
 			if (log_open(logfile, path_log) == -1) {
+				struct attropl *patt;
 				/* update the sched_log attribute with its previous value only */
 				attribs = (struct  attropl *)calloc(1, sizeof(struct attropl));
 				if (attribs == NULL) {
@@ -2505,6 +2504,7 @@ sched_settings_frm_svr(struct batch_status *status)
 		} else
 			log_dir = tmp_log_dir;
 		if ((priv_dir != NULL) && strcmp(priv_dir, tmp_priv_dir) != 0) {
+			int c;
 			(void)snprintf(log_buffer,  LOG_BUF_SIZE, tmp_priv_dir);
 			#if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
 				c  = chk_file_sec(log_buffer, 1, 0, S_IWGRP|S_IWOTH, 1);
@@ -2523,6 +2523,7 @@ sched_settings_frm_svr(struct batch_status *status)
 					log_err(-1, __func__, log_buffer);
 					priv_dir_update_fail = 1;
 				} else {
+					int lockfds;
 					(void)unlink("sched.lock");
 					lockfds = open("sched.lock", O_CREAT|O_WRONLY, 0644);
 					if (lockfds < 0) {

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2433,7 +2433,6 @@ sched_settings_frm_svr(struct batch_status *status)
 				patt->value = "0";
 				patt->next = NULL;
 
-				patt->next = NULL;
 				err = pbs_manager(connector,
 					MGR_CMD_SET, MGR_OBJ_SCHED,
 					sc_name, attribs, NULL);

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -81,6 +81,9 @@
 #include <sched_cmds.h>
 #include <time.h>
 #include <log.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include "data_types.h"
 #include "fifo.h"
 #include "queue_info.h"
@@ -108,6 +111,7 @@
 #include "pbs_share.h"
 #include "pbs_internal.h"
 #include "limits_if.h"
+#include "pbs_version.h"
 
 
 #ifdef NAS
@@ -118,12 +122,39 @@
 static prev_job_info *last_running = NULL;
 static int last_running_size = 0;
 
+char	scheduler_name[PBS_MAXHOSTNAME+1] = "Me";  /*arbitrary string*/
+char	sc_name[PBS_MAXSCHEDNAME];
+char	*log_dir = NULL;
+char	*priv_dir = NULL;
+char	*partitions = NULL;
+int	sched_port = -1;
+char	*logfile = (char *)0;
+#ifdef WIN32
+char	path_log[_MAX_PATH];
+#else
+char	path_log[_POSIX_PATH_MAX];
+#endif
+int	dflt_sched = 0;
+
 #ifdef WIN32
 extern void win_toolong(void);
 #endif
 
 extern int	second_connection;
 extern int	get_sched_cmd_noblk(int sock, int *val, char **jobid);
+extern void     update_svr_sched_state(char *state);
+
+#define COPY_ATTR_VALUE(DEST, SRC) \
+	{ \
+		int len = 0;\
+		if (DEST) { \
+			free(DEST); \
+		} \
+		len = strlen(SRC);\
+		DEST = (char*)malloc(len + 1); \
+		strncpy(DEST, attr->value, len); \
+		DEST[len] = '\0';\
+	}
 
 /**
  * @brief
@@ -520,6 +551,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 int
 schedule(int cmd, int sd, char *runjobid)
 {
+	update_svr_sched_state(SC_SCHEDULING);
 	switch (cmd) {
 		case SCH_ERROR:
 		case SCH_SCHEDULE_NULL:
@@ -554,17 +586,31 @@ schedule(int cmd, int sd, char *runjobid)
 			reset_global_resource_ptrs();
 			free(conf.prime_sort);
 			free(conf.non_prime_sort);
-			if(schedinit() != 0)
+			/*
+			 * This is required since there is a probability that scheduler's configuration has been changed at
+			 * server through qmgr.
+			 */
+			if (update_svr_schedobj(connector, 0, 0)) {
+				sprintf(log_buffer, "update_svr_schedobj failed");
+				log_err(-1, __func__, log_buffer);
+				return 1;
+			}
+			if(schedinit() != 0) {
+				update_svr_sched_state(SC_IDLE);
 				return 0;
+			}
 			break;
 		case SCH_QUIT:
 #ifdef PYTHON
 			Py_Finalize();
 #endif
+			update_svr_sched_state(SC_DOWN);
 			return 1;		/* have the scheduler exit nicely */
 		default:
+			update_svr_sched_state(SC_IDLE);
 			return 0;
 	}
+	update_svr_sched_state(SC_IDLE);
 	return 0;
 }
 
@@ -612,6 +658,7 @@ intermediate_schedule(int sd, char *jobid)
 	}
 	while (ret == -1);
 
+	update_svr_sched_state(SC_IDLE);
 	return 0;
 }
 
@@ -2327,3 +2374,306 @@ next_job(status *policy, server_info *sinfo, int flag)
 	}
 	return rjob;
 }
+
+/**
+ * @brief
+ *	Updates the scheduler state to the server.
+ *
+ * @param[in] state - status to be updated.
+ *
+ * @par Side Effects:
+ *	None
+ *
+ *
+ */
+void
+update_svr_sched_state(char *state)
+{
+
+	struct	attropl	*attribs, *patt;
+	if (connector < 0)
+		return;
+
+	attribs = (struct  attropl *)calloc(1, sizeof(struct attropl));
+	if (attribs == NULL) {
+		sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
+		log_err(-1, __func__, log_buffer);
+		return;
+	}
+	patt = attribs;
+
+	/* Scheduler State*/
+	patt->name = ATTR_sched_state;
+	patt->value = state;
+	patt->next = NULL;
+
+	pbs_manager(connector,
+			MGR_CMD_SET,
+			MGR_OBJ_SCHED,
+			sc_name,
+			attribs,
+			NULL);
+	free(attribs);
+}
+
+/**
+ * @brief
+ *	Helper function used to copy the attribute values from batch_status to the corresponding
+ *	scheduler global variables which hold its priv_dir, log_dir and partitions
+ *
+ * @param[in] status - populated batch_status after stating this scheduler from server
+ *
+ *
+ * @par Side Effects:
+ *	None
+ *
+ *
+ */
+static void
+sched_settings_frm_svr(struct batch_status *status)
+{
+	struct attrl *attr;
+	char *tmp_priv_dir = NULL;
+	char *tmp_log_dir = NULL;
+	char *tmp_partitions = NULL;
+	int c;
+	int lockfds;
+	struct	attropl	*attribs, *patt;
+	struct batch_status *ss = NULL;
+	int	err;
+	int priv_dir_update_fail = 0;
+	extern char *partitions;
+
+	attr = status->attribs;
+	/*
+	 * resetting the following before fetching from batch_status.
+	 */
+	while (attr != NULL) {
+		if (attr->name != NULL && attr->value != NULL) {
+			if (!strcmp(attr->name, ATTR_sched_priv)) {
+				COPY_ATTR_VALUE(tmp_priv_dir, attr->value);
+			} else if (!strcmp(attr->name, ATTR_sched_log)) {
+				COPY_ATTR_VALUE(tmp_log_dir, attr->value);
+			} else if (!strcmp(attr->name, ATTR_partition)) {
+				COPY_ATTR_VALUE(tmp_partitions, attr->value);
+			}
+		}
+		attr = attr->next;
+	}
+
+	if (!dflt_sched) {
+		if ((log_dir != NULL) && strcmp(log_dir, tmp_log_dir) != 0) {
+			(void)snprintf(path_log,  MAXPATHLEN, tmp_log_dir);
+			log_close(1);
+			if (log_open(logfile, path_log) == -1) {
+				/* update the sched_log attribute with its previous value only */
+				attribs = (struct  attropl *)calloc(1, sizeof(struct attropl));
+				if (attribs == NULL) {
+					sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
+					log_err(-1, __func__, log_buffer);
+					return;
+				}
+				patt = attribs;
+				patt->name = ATTR_sched_log;
+				patt->value = log_dir;
+				patt->next = NULL;
+				err = pbs_manager(connector,
+					MGR_CMD_SET, MGR_OBJ_SCHED,
+					sc_name, attribs, NULL);
+				free(attribs);
+				if (err) {
+					sprintf(log_buffer, "Failed to update log_dir value %s at the server", log_dir);
+					log_err(-1, __func__, log_buffer);
+				}
+				/* switch back to the existing logs directory */
+				(void)snprintf(path_log,  MAXPATHLEN, log_dir);
+				if (log_open(logfile, path_log)) {
+					sprintf(log_buffer, "Failed to open the log file in dir %s", log_dir);
+					log_err(-1, __func__, log_buffer);
+					return;
+				}
+				sprintf(log_buffer, "%s: logfile could not be opened under directory %s", logfile, tmp_log_dir);
+				sprintf(log_buffer, "switching back to previous directory %s", log_dir);
+				log_err(-1, __func__, log_buffer);
+			} else {
+				free(log_dir);
+				log_dir = tmp_log_dir;
+				sprintf(log_buffer, "scheduler log directory is changed to %s", log_dir);
+				schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_INFO,
+						"reconfigure", log_buffer);
+			}
+		} else
+			log_dir = tmp_log_dir;
+		if ((priv_dir != NULL) && strcmp(priv_dir, tmp_priv_dir) != 0) {
+			(void)snprintf(log_buffer,  LOG_BUF_SIZE, tmp_priv_dir);
+			#if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
+				c  = chk_file_sec(log_buffer, 1, 0, S_IWGRP|S_IWOTH, 1);
+				c |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, S_IWGRP|S_IWOTH, 0);
+				if (c != 0) {
+					sprintf(log_buffer, "PBS failed validation checks for directory %s", tmp_priv_dir);
+					sprintf(log_buffer, "switching back to previous directory %s", priv_dir);
+					log_err(-1, __func__, log_buffer);
+					priv_dir_update_fail = 1;
+				}
+			#endif  /* not DEBUG and not NO_SECURITY_CHECK */
+			if (c == 0) {
+				if (chdir(log_buffer) == -1) {
+					sprintf(log_buffer, "PBS failed validation checks for directory %s", tmp_priv_dir);
+					sprintf(log_buffer, "switching back to previous directory %s", priv_dir);
+					log_err(-1, __func__, log_buffer);
+					priv_dir_update_fail = 1;
+				} else {
+					(void)unlink("sched.lock");
+					lockfds = open("sched.lock", O_CREAT|O_WRONLY, 0644);
+					if (lockfds < 0) {
+						sprintf(log_buffer, "PBS failed validation checks for directory %s", tmp_priv_dir);
+						sprintf(log_buffer, "switching back to previous directory %s", priv_dir);
+						log_err(-1, __func__, log_buffer);
+						priv_dir_update_fail = 1;
+						/*
+						 *  change back to the previous sched_priv directory
+						 */
+						chdir(priv_dir);
+					} else {
+						/* write schedulers pid into lockfile */
+						#ifdef WIN32
+							lseek(lockfds, (off_t)0, SEEK_SET);
+						#else
+							(void)ftruncate(lockfds, (off_t)0);
+						#endif
+							(void)sprintf(log_buffer, "%d\n", getpid());
+						(void)write(lockfds, log_buffer, strlen(log_buffer));
+						free(priv_dir);
+						priv_dir = tmp_priv_dir;
+						sprintf(log_buffer, "scheduler priv directory has changed to %s", priv_dir);
+						schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_INFO,
+								"reconfigure", log_buffer);
+					}
+				}
+			}
+		} else
+			priv_dir = tmp_priv_dir;
+
+		if (priv_dir_update_fail) {
+			/* update the sched_log attribute with its previous value only */
+			attribs = (struct  attropl *)calloc(1, sizeof(struct attropl));
+			if (attribs == NULL) {
+				sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
+				log_err(-1, __func__, log_buffer);
+				return;
+			}
+			patt = attribs;
+			patt->name = ATTR_sched_priv;
+			patt->value = priv_dir;
+			patt->next = NULL;
+			err = pbs_manager(connector,
+				MGR_CMD_SET, MGR_OBJ_SCHED,
+				sc_name, attribs, NULL);
+			free(attribs);
+			if (err) {
+				sprintf(log_buffer, "Failed in updating priv_dir value %s to the server", priv_dir);
+				log_err(-1, __func__, log_buffer);
+			}
+		}
+		if ((partitions != NULL) && strcmp(partitions, tmp_partitions) != 0) {
+			free(partitions);
+			partitions = tmp_partitions;
+		} else
+			partitions = tmp_partitions;
+	}
+
+}
+
+/**
+ * @brief
+ *	Updates a set of attribute values of scheduler to the server and also does a status of this scheduler
+ *	on server and fetches the updates of its attributes.
+ *
+ * @param[in] connector - socket descriptor to server
+ * @param[in] cmd     - scheduler command
+ * @param[in] alarm_time  - value to be updated for scheduler cycle length.
+ *
+ *
+ * @retval Error code
+ * @return -1 - Failure
+ * @return  0 - Success
+ *
+ * @par Side Effects:
+ *	None
+ *
+ *
+ */
+int
+update_svr_schedobj(int connector, int cmd, int alarm_time)
+{
+	char timestr[128];
+	char port_str[MAX_INT_LEN];
+	static	int svr_knows_me = 0;
+	int	err;
+	struct	attropl	*attribs, *patt;
+	struct batch_status *ss = NULL;
+
+	/* This command is only sent on restart of the server */
+	if (cmd != 0 && cmd == SCH_SCHEDULE_FIRST)
+		svr_knows_me = 0;
+
+	if (cmd !=0 && svr_knows_me || cmd == SCH_ERROR || connector < 0)
+		return 0;
+
+	/* Stat the scheduler to get details of sched */
+	ss = pbs_statsched(connector, sc_name, NULL, NULL);
+	if (ss == NULL) {
+		sprintf(log_buffer, "Unable to retrieve the scheduler attributes from server");
+		log_err(-1, __func__, log_buffer);
+		return 1;
+	}
+	sched_settings_frm_svr(ss);
+
+	if (!dflt_sched && (partitions == NULL)) {
+		sprintf(log_buffer, "Scheduler does not contain a partition. shutting down");
+		log_err(-1, __func__, log_buffer);
+		return 1;
+	}
+
+	pbs_statfree(ss);
+
+	/* update the sched with new values */
+	attribs = (struct  attropl *)calloc(4, sizeof(struct attropl));
+	if (attribs == NULL) {
+		sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
+		log_err(-1, __func__, log_buffer);
+		return 1;
+	}
+	patt = attribs;
+	patt->name = ATTR_SchedHost;
+	patt->value = scheduler_name;
+	patt->next = patt + 1;
+	patt++;
+	patt->name = ATTR_sched_port;
+	snprintf(port_str, MAX_INT_LEN, "%d", sched_port);
+	patt->value = port_str;
+	patt->next = patt + 1;
+	patt++;
+	patt->name = ATTR_version;
+	patt->value = pbs_version;
+	if (alarm_time) {
+		patt->next = patt + 1;
+		patt++;
+		patt->name = ATTR_sched_cycle_len;
+		snprintf(timestr, sizeof(timestr), "%d", alarm_time);
+		patt->value = timestr;
+	}
+	patt->next = NULL;
+
+	err = pbs_manager(connector,
+		MGR_CMD_SET, MGR_OBJ_SCHED,
+		sc_name, attribs, NULL);
+	if (err == 0 && svr_knows_me == 0)
+		svr_knows_me = 1;
+
+	free(attribs);
+
+	return 0;
+}
+
+

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -606,11 +606,7 @@ intermediate_schedule(int sd, char *jobid)
 	 * This is required since there is a probability that scheduler's configuration has been changed at
 	 * server through qmgr.
 	 */
-	if (!update_svr_schedobj(connector, 0, 0)) {
-		sprintf(log_buffer, "update_svr_schedobj failed");
-		log_err(-1, __func__, log_buffer);
-		return 0;
-	}
+	update_svr_schedobj(connector, 0, 0);
 
 	do {
 		ret = scheduling_cycle(sd, jobid);
@@ -2357,6 +2353,46 @@ next_job(status *policy, server_info *sinfo, int flag)
 
 /**
  * @brief
+ *	Helper function used to copy the given source string to the destination string. It also
+ *	frees the destination and then allocates required memory before copying.
+ *
+ * @param[in] dest - Address of pointer to destination string
+ * @param[in] dest - pointer to source string
+ *
+ * @retval
+ * @return 0 - Failure
+ * @return  1 - Success
+ *
+ * @par Side Effects:
+ *	None
+ *
+ *
+ */
+static int
+copy_attr_value(char **dest, char *src)
+{
+	int len = 0;
+	int ret = 0;
+
+	if (*dest != NULL)
+		free(*dest);
+
+	if (src !=NULL) {
+		len = strlen(src);
+		*dest = (char*)malloc(len + 1);
+		if (*dest == NULL) {
+			log_err(errno, __func__, MEM_ERR_MSG);
+			return ret;
+		}
+		strncpy(*dest, src, len);
+		(*dest)[len] = '\0';
+		ret = 1;
+	}
+	return ret;
+}
+
+/**
+ * @brief
  *	Helper function used to copy the attribute values from batch_status to the corresponding
  *	scheduler global variables which hold its priv_dir, log_dir and partitions
  *
@@ -2391,13 +2427,17 @@ sched_settings_frm_svr(struct batch_status *status)
 	while (attr != NULL) {
 		if (attr->name != NULL && attr->value != NULL) {
 			if (!strcmp(attr->name, ATTR_sched_priv)) {
-				COPY_ATTR_VALUE(tmp_priv_dir, attr->value);
+				if (copy_attr_value(&tmp_priv_dir, attr->value) == 0)
+					return 0;
 			} else if (!strcmp(attr->name, ATTR_sched_log)) {
-				COPY_ATTR_VALUE(tmp_log_dir, attr->value);
+				if (copy_attr_value(&tmp_log_dir, attr->value) == 0)
+					return 0;
 			} else if (!strcmp(attr->name, ATTR_partition)) {
-				COPY_ATTR_VALUE(tmp_partitions, attr->value);
+				if (copy_attr_value(&tmp_partitions, attr->value) == 0)
+					return 0;
 			} else if (!strcmp(attr->name, ATTR_comment)) {
-				COPY_ATTR_VALUE(tmp_comment, attr->value);
+				if (copy_attr_value(&tmp_comment, attr->value) == 0)
+					return 0;
 			}
 		}
 		attr = attr->next;
@@ -2414,9 +2454,9 @@ sched_settings_frm_svr(struct batch_status *status)
 			log_close(1);
 			if (log_open(logfile, path_log) == -1) {
 				/* update the sched comment attribute with the reason for failure */
-				attribs = (struct  attropl *)calloc(2, sizeof(struct attropl));
+				attribs = calloc(2, sizeof(struct attropl));
 				if (attribs == NULL) {
-					sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
+					snprintf(log_buffer, sizeof(log_buffer), "can't update scheduler attribs, calloc failed");
 					log_err(errno, __func__, log_buffer);
 					free(tmp_log_dir);
 					free(tmp_priv_dir);
@@ -2438,7 +2478,7 @@ sched_settings_frm_svr(struct batch_status *status)
 					sc_name, attribs, NULL);
 				free(attribs);
 				if (err) {
-					sprintf(log_buffer, "Failed to update scheduler comment %s at the server", log_dir);
+					snprintf(log_buffer, sizeof(log_buffer), "Failed to update scheduler comment %s at the server", comment);
 					log_err(-1, __func__, log_buffer);
 				}
 				log_dir = tmp_log_dir;
@@ -2446,7 +2486,7 @@ sched_settings_frm_svr(struct batch_status *status)
 			} else {
 				if (tmp_comment != NULL)
 					clear_comment = 1;
-				sprintf(log_buffer, "scheduler log directory is changed to %s", tmp_log_dir);
+				snprintf(log_buffer, sizeof(log_buffer), "scheduler log directory is changed to %s", tmp_log_dir);
 				schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_INFO,
 						"reconfigure", log_buffer);
 				free(log_dir);
@@ -2456,20 +2496,19 @@ sched_settings_frm_svr(struct batch_status *status)
 
 		if ((priv_dir != NULL) && strcmp(priv_dir, tmp_priv_dir) != 0) {
 			int c;
-			(void)snprintf(log_buffer,  LOG_BUF_SIZE, tmp_priv_dir);
 			#if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
-				c  = chk_file_sec(log_buffer, 1, 0, S_IWGRP|S_IWOTH, 1);
+				c  = chk_file_sec(tmp_priv_dir, 1, 0, S_IWGRP|S_IWOTH, 1);
 				c |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, S_IWGRP|S_IWOTH, 0);
 				if (c != 0) {
-					sprintf(log_buffer, "PBS failed validation checks for directory %s", tmp_priv_dir);
+					snprintf(log_buffer, sizeof(log_buffer), "PBS failed validation checks for directory %s", tmp_priv_dir);
 					log_err(-1, __func__, log_buffer);
 					strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
 					priv_dir_update_fail = 1;
 				}
 			#endif  /* not DEBUG and not NO_SECURITY_CHECK */
 			if (c == 0) {
-				if (chdir(log_buffer) == -1) {
-					sprintf(log_buffer, "PBS failed validation checks for directory %s", tmp_priv_dir);
+				if (chdir(tmp_priv_dir) == -1) {
+					snprintf(log_buffer, sizeof(log_buffer), "PBS failed validation checks for directory %s", tmp_priv_dir);
 					strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
 					log_err(-1, __func__, log_buffer);
 					priv_dir_update_fail = 1;
@@ -2478,7 +2517,7 @@ sched_settings_frm_svr(struct batch_status *status)
 					(void)unlink("sched.lock");
 					lockfds = open("sched.lock", O_CREAT|O_WRONLY, 0644);
 					if (lockfds < 0) {
-						sprintf(log_buffer, "PBS failed validation checks for directory %s", tmp_priv_dir);
+						snprintf(log_buffer, sizeof(log_buffer), "PBS failed validation checks for directory %s", tmp_priv_dir);
 						strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
 						log_err(-1, __func__, log_buffer);
 						priv_dir_update_fail = 1;
@@ -2492,7 +2531,7 @@ sched_settings_frm_svr(struct batch_status *status)
 							(void)sprintf(log_buffer, "%d\n", getpid());
 						(void)write(lockfds, log_buffer, strlen(log_buffer));
 						priv_dir = tmp_priv_dir;
-						sprintf(log_buffer, "scheduler priv directory has changed to %s", tmp_priv_dir);
+						snprintf(log_buffer, sizeof(log_buffer), "scheduler priv directory has changed to %s", tmp_priv_dir);
 						schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_INFO,
 								"reconfigure", log_buffer);
 						if (tmp_comment != NULL)
@@ -2506,9 +2545,9 @@ sched_settings_frm_svr(struct batch_status *status)
 
 		if (priv_dir_update_fail) {
 			/* update the sched comment attribute with the reason for failure */
-			attribs = (struct  attropl *)calloc(2, sizeof(struct attropl));
+			attribs = calloc(2, sizeof(struct attropl));
 			if (attribs == NULL) {
-				sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
+				snprintf(log_buffer, sizeof(log_buffer), "can't update scheduler attribs, calloc failed");
 				log_err(errno, __func__, log_buffer);
 				strncpy(comment, "Unable to change the sched_priv directory", MAX_LOG_SIZE);
 				free(tmp_log_dir);
@@ -2528,12 +2567,12 @@ sched_settings_frm_svr(struct batch_status *status)
 				sc_name, attribs, NULL);
 			free(attribs);
 			if (err) {
-				sprintf(log_buffer, "Failed to update scheduler comment %s at the server", log_dir);
+				snprintf(log_buffer, sizeof(log_buffer), "Failed to update scheduler comment %s at the server", comment);
 				log_err(-1, __func__, log_buffer);
 			}
 			return 0;
 		}
-		if ((partitions != NULL) && (tmp_partitions != NULL) && strcmp(partitions, tmp_partitions) != 0) {
+		if (cstrcmp(partitions, tmp_partitions) != 0) {
 			free(partitions);
 		}
 		partitions = tmp_partitions;
@@ -2543,9 +2582,9 @@ sched_settings_frm_svr(struct batch_status *status)
 		struct attropl *patt;
 		char comment[MAX_LOG_SIZE] = {0};
 
-		attribs = (struct  attropl *)calloc(1, sizeof(struct attropl));
+		attribs = calloc(1, sizeof(struct attropl));
 		if (attribs == NULL) {
-			sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
+			snprintf(log_buffer, sizeof(log_buffer), "can't update scheduler attribs, calloc failed");
 			log_err(errno, __func__, log_buffer);
 			strncpy(comment, "Unable to clear comment", MAX_LOG_SIZE);
 			free(tmp_log_dir);
@@ -2563,7 +2602,7 @@ sched_settings_frm_svr(struct batch_status *status)
 		free(attribs);
 		free(tmp_comment);
 		if (err) {
-			sprintf(log_buffer, "Failed to update scheduler comment %s at the server", log_dir);
+			snprintf(log_buffer, sizeof(log_buffer), "Failed to update scheduler comment %s at the server", comment);
 			log_err(-1, __func__, log_buffer);
 		}
 		clear_comment = 0;
@@ -2602,7 +2641,7 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	struct batch_status *ss = NULL;
 
 	/* This command is only sent on restart of the server */
-	if (cmd != SCH_SCHEDULE_NULL && cmd == SCH_SCHEDULE_FIRST)
+	if (cmd == SCH_SCHEDULE_FIRST)
 		svr_knows_me = 0;
 
 	if (cmd != SCH_SCHEDULE_NULL && svr_knows_me || cmd == SCH_ERROR || connector < 0)
@@ -2627,7 +2666,7 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	pbs_statfree(ss);
 
 	/* update the sched with new values */
-	attribs = (struct  attropl *)calloc(4, sizeof(struct attropl));
+	attribs = calloc(4, sizeof(struct attropl));
 	if (attribs == NULL) {
 		sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
 		log_err(errno, __func__, log_buffer);

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2381,7 +2381,6 @@ sched_settings_frm_svr(struct batch_status *status)
 	struct	attropl	*attribs;
 	struct batch_status *ss = NULL;
 	static char *log_dir = NULL;
-	static char *priv_dir = NULL;
 	char *tmp_comment = NULL;
 	int clear_comment = 0;
 	extern char *partitions;
@@ -2409,6 +2408,7 @@ sched_settings_frm_svr(struct batch_status *status)
 		int priv_dir_update_fail = 0;
 		struct attropl *patt;
 		char comment[MAX_LOG_SIZE] = {0};
+		static char *priv_dir = NULL;
 		if ((log_dir != NULL) && strcmp(log_dir, tmp_log_dir) != 0) {
 			(void)snprintf(path_log,  sizeof(path_log), tmp_log_dir);
 			log_close(1);
@@ -2522,8 +2522,6 @@ sched_settings_frm_svr(struct batch_status *status)
 			patt++;
 			patt->name = ATTR_scheduling;
 			patt->value = "0";
-			patt->next = NULL;
-
 			patt->next = NULL;
 			err = pbs_manager(connector,
 				MGR_CMD_SET, MGR_OBJ_SCHED,

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -122,39 +122,12 @@
 static prev_job_info *last_running = NULL;
 static int last_running_size = 0;
 
-char	scheduler_name[PBS_MAXHOSTNAME+1] = "Me";  /*arbitrary string*/
-char	sc_name[PBS_MAXSCHEDNAME];
-char	*log_dir = NULL;
-char	*priv_dir = NULL;
-char	*partitions = NULL;
-int	sched_port = -1;
-char	*logfile = (char *)0;
-#ifdef WIN32
-char	path_log[_MAX_PATH];
-#else
-char	path_log[_POSIX_PATH_MAX];
-#endif
-int	dflt_sched = 0;
-
 #ifdef WIN32
 extern void win_toolong(void);
 #endif
 
 extern int	second_connection;
 extern int	get_sched_cmd_noblk(int sock, int *val, char **jobid);
-extern void     update_svr_sched_state(char *state);
-
-#define COPY_ATTR_VALUE(DEST, SRC) \
-	{ \
-		int len = 0;\
-		if (DEST) { \
-			free(DEST); \
-		} \
-		len = strlen(SRC);\
-		DEST = (char*)malloc(len + 1); \
-		strncpy(DEST, attr->value, len); \
-		DEST[len] = '\0';\
-	}
 
 /**
  * @brief
@@ -551,7 +524,6 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 int
 schedule(int cmd, int sd, char *runjobid)
 {
-	update_svr_sched_state(SC_SCHEDULING);
 	switch (cmd) {
 		case SCH_ERROR:
 		case SCH_SCHEDULE_NULL:
@@ -586,17 +558,19 @@ schedule(int cmd, int sd, char *runjobid)
 			reset_global_resource_ptrs();
 			free(conf.prime_sort);
 			free(conf.non_prime_sort);
+
+			if(schedinit() != 0) {
+				return 0;
+			}
+			break;
+		case SCH_ATTRS_CONFIGURE:
 			/*
 			 * This is required since there is a probability that scheduler's configuration has been changed at
 			 * server through qmgr.
 			 */
-			if (update_svr_schedobj(connector, 0, 0)) {
+			if (!update_svr_schedobj(connector, 0, 0)) {
 				sprintf(log_buffer, "update_svr_schedobj failed");
 				log_err(-1, __func__, log_buffer);
-				return 1;
-			}
-			if(schedinit() != 0) {
-				update_svr_sched_state(SC_IDLE);
 				return 0;
 			}
 			break;
@@ -604,13 +578,10 @@ schedule(int cmd, int sd, char *runjobid)
 #ifdef PYTHON
 			Py_Finalize();
 #endif
-			update_svr_sched_state(SC_DOWN);
 			return 1;		/* have the scheduler exit nicely */
 		default:
-			update_svr_sched_state(SC_IDLE);
 			return 0;
 	}
-	update_svr_sched_state(SC_IDLE);
 	return 0;
 }
 
@@ -630,6 +601,16 @@ intermediate_schedule(int sd, char *jobid)
 {
 	int ret; /* to re schedule or not */
 	int cycle_cnt = 0; /* count of cycles run */
+
+	/*
+	 * This is required since there is a probability that scheduler's configuration has been changed at
+	 * server through qmgr.
+	 */
+	if (!update_svr_schedobj(connector, 0, 0)) {
+		sprintf(log_buffer, "update_svr_schedobj failed");
+		log_err(-1, __func__, log_buffer);
+		return 0;
+	}
 
 	do {
 		ret = scheduling_cycle(sd, jobid);
@@ -658,7 +639,6 @@ intermediate_schedule(int sd, char *jobid)
 	}
 	while (ret == -1);
 
-	update_svr_sched_state(SC_IDLE);
 	return 0;
 }
 
@@ -2377,73 +2357,38 @@ next_job(status *policy, server_info *sinfo, int flag)
 
 /**
  * @brief
- *	Updates the scheduler state to the server.
- *
- * @param[in] state - status to be updated.
- *
- * @par Side Effects:
- *	None
- *
- *
- */
-void
-update_svr_sched_state(char *state)
-{
-
-	struct	attropl	*attribs, *patt;
-	if (connector < 0)
-		return;
-
-	attribs = (struct  attropl *)calloc(1, sizeof(struct attropl));
-	if (attribs == NULL) {
-		sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
-		log_err(-1, __func__, log_buffer);
-		return;
-	}
-	patt = attribs;
-
-	/* Scheduler State*/
-	patt->name = ATTR_sched_state;
-	patt->value = state;
-	patt->next = NULL;
-
-	pbs_manager(connector,
-			MGR_CMD_SET,
-			MGR_OBJ_SCHED,
-			sc_name,
-			attribs,
-			NULL);
-	free(attribs);
-}
-
-/**
- * @brief
  *	Helper function used to copy the attribute values from batch_status to the corresponding
  *	scheduler global variables which hold its priv_dir, log_dir and partitions
  *
  * @param[in] status - populated batch_status after stating this scheduler from server
  *
+ * @retval
+ * @return 0 - Failure
+ * @return  1 - Success
  *
  * @par Side Effects:
  *	None
  *
  *
  */
-static void
+static int
 sched_settings_frm_svr(struct batch_status *status)
 {
 	struct attrl *attr;
 	char *tmp_priv_dir = NULL;
 	char *tmp_log_dir = NULL;
 	char *tmp_partitions = NULL;
-	struct	attropl	*attribs, *patt;
+	struct	attropl	*attribs;
 	struct batch_status *ss = NULL;
+	static char *log_dir = NULL;
+	static char *priv_dir = NULL;
+	char *tmp_comment = NULL;
+	int clear_comment = 0;
 	extern char *partitions;
 
 	attr = status->attribs;
-	/*
-	 * resetting the following before fetching from batch_status.
-	 */
+
+	 /* resetting the following before fetching from batch_status. */
 	while (attr != NULL) {
 		if (attr->name != NULL && attr->value != NULL) {
 			if (!strcmp(attr->name, ATTR_sched_priv)) {
@@ -2452,6 +2397,8 @@ sched_settings_frm_svr(struct batch_status *status)
 				COPY_ATTR_VALUE(tmp_log_dir, attr->value);
 			} else if (!strcmp(attr->name, ATTR_partition)) {
 				COPY_ATTR_VALUE(tmp_partitions, attr->value);
+			} else if (!strcmp(attr->name, ATTR_comment)) {
+				COPY_ATTR_VALUE(tmp_comment, attr->value);
 			}
 		}
 		attr = attr->next;
@@ -2460,49 +2407,54 @@ sched_settings_frm_svr(struct batch_status *status)
 	if (!dflt_sched) {
 		int err;
 		int priv_dir_update_fail = 0;
+		struct attropl *patt;
+		char comment[MAX_LOG_SIZE] = {0};
 		if ((log_dir != NULL) && strcmp(log_dir, tmp_log_dir) != 0) {
-			(void)snprintf(path_log,  MAXPATHLEN, tmp_log_dir);
+			(void)snprintf(path_log,  sizeof(path_log), tmp_log_dir);
 			log_close(1);
 			if (log_open(logfile, path_log) == -1) {
-				struct attropl *patt;
-				/* update the sched_log attribute with its previous value only */
-				attribs = (struct  attropl *)calloc(1, sizeof(struct attropl));
+				/* update the sched comment attribute with the reason for failure */
+				attribs = (struct  attropl *)calloc(2, sizeof(struct attropl));
 				if (attribs == NULL) {
 					sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
-					log_err(-1, __func__, log_buffer);
-					return;
+					log_err(errno, __func__, log_buffer);
+					free(tmp_log_dir);
+					free(tmp_priv_dir);
+					free(tmp_partitions);
 				}
+
+				strncpy(comment, "Unable to change the sched_logs directory", MAX_LOG_SIZE -1);
 				patt = attribs;
-				patt->name = ATTR_sched_log;
-				patt->value = log_dir;
+				patt->name = ATTR_comment;
+				patt->value = comment;
+				patt->next = patt + 1;
+				patt++;
+				patt->name = ATTR_scheduling;
+				patt->value = "0";
+				patt->next = NULL;
+
 				patt->next = NULL;
 				err = pbs_manager(connector,
 					MGR_CMD_SET, MGR_OBJ_SCHED,
 					sc_name, attribs, NULL);
 				free(attribs);
 				if (err) {
-					sprintf(log_buffer, "Failed to update log_dir value %s at the server", log_dir);
+					sprintf(log_buffer, "Failed to update scheduler comment %s at the server", log_dir);
 					log_err(-1, __func__, log_buffer);
 				}
-				/* switch back to the existing logs directory */
-				(void)snprintf(path_log,  MAXPATHLEN, log_dir);
-				if (log_open(logfile, path_log)) {
-					sprintf(log_buffer, "Failed to open the log file in dir %s", log_dir);
-					log_err(-1, __func__, log_buffer);
-					return;
-				}
-				sprintf(log_buffer, "%s: logfile could not be opened under directory %s", logfile, tmp_log_dir);
-				sprintf(log_buffer, "switching back to previous directory %s", log_dir);
-				log_err(-1, __func__, log_buffer);
-			} else {
-				free(log_dir);
 				log_dir = tmp_log_dir;
-				sprintf(log_buffer, "scheduler log directory is changed to %s", log_dir);
+				return 0;
+			} else {
+				if (tmp_comment != NULL)
+					clear_comment = 1;
+				sprintf(log_buffer, "scheduler log directory is changed to %s", tmp_log_dir);
 				schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_INFO,
 						"reconfigure", log_buffer);
+				free(log_dir);
 			}
-		} else
-			log_dir = tmp_log_dir;
+		}
+		log_dir = tmp_log_dir;
+
 		if ((priv_dir != NULL) && strcmp(priv_dir, tmp_priv_dir) != 0) {
 			int c;
 			(void)snprintf(log_buffer,  LOG_BUF_SIZE, tmp_priv_dir);
@@ -2511,15 +2463,15 @@ sched_settings_frm_svr(struct batch_status *status)
 				c |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, S_IWGRP|S_IWOTH, 0);
 				if (c != 0) {
 					sprintf(log_buffer, "PBS failed validation checks for directory %s", tmp_priv_dir);
-					sprintf(log_buffer, "switching back to previous directory %s", priv_dir);
 					log_err(-1, __func__, log_buffer);
+					strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
 					priv_dir_update_fail = 1;
 				}
 			#endif  /* not DEBUG and not NO_SECURITY_CHECK */
 			if (c == 0) {
 				if (chdir(log_buffer) == -1) {
 					sprintf(log_buffer, "PBS failed validation checks for directory %s", tmp_priv_dir);
-					sprintf(log_buffer, "switching back to previous directory %s", priv_dir);
+					strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
 					log_err(-1, __func__, log_buffer);
 					priv_dir_update_fail = 1;
 				} else {
@@ -2528,13 +2480,9 @@ sched_settings_frm_svr(struct batch_status *status)
 					lockfds = open("sched.lock", O_CREAT|O_WRONLY, 0644);
 					if (lockfds < 0) {
 						sprintf(log_buffer, "PBS failed validation checks for directory %s", tmp_priv_dir);
-						sprintf(log_buffer, "switching back to previous directory %s", priv_dir);
+						strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
 						log_err(-1, __func__, log_buffer);
 						priv_dir_update_fail = 1;
-						/*
-						 *  change back to the previous sched_priv directory
-						 */
-						chdir(priv_dir);
 					} else {
 						/* write schedulers pid into lockfile */
 						#ifdef WIN32
@@ -2544,44 +2492,86 @@ sched_settings_frm_svr(struct batch_status *status)
 						#endif
 							(void)sprintf(log_buffer, "%d\n", getpid());
 						(void)write(lockfds, log_buffer, strlen(log_buffer));
-						free(priv_dir);
 						priv_dir = tmp_priv_dir;
-						sprintf(log_buffer, "scheduler priv directory has changed to %s", priv_dir);
+						sprintf(log_buffer, "scheduler priv directory has changed to %s", tmp_priv_dir);
 						schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_INFO,
 								"reconfigure", log_buffer);
+						if (tmp_comment != NULL)
+							clear_comment = 1;
+						free(priv_dir);
 					}
 				}
 			}
-		} else
-			priv_dir = tmp_priv_dir;
+		}
+		priv_dir = tmp_priv_dir;
 
 		if (priv_dir_update_fail) {
-			/* update the sched_log attribute with its previous value only */
-			attribs = (struct  attropl *)calloc(1, sizeof(struct attropl));
+			/* update the sched comment attribute with the reason for failure */
+			attribs = (struct  attropl *)calloc(2, sizeof(struct attropl));
 			if (attribs == NULL) {
 				sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
-				log_err(-1, __func__, log_buffer);
-				return;
+				log_err(errno, __func__, log_buffer);
+				strncpy(comment, "Unable to change the sched_priv directory", MAX_LOG_SIZE);
+				free(tmp_log_dir);
+				free(tmp_priv_dir);
+				free(tmp_partitions);
 			}
 			patt = attribs;
-			patt->name = ATTR_sched_priv;
-			patt->value = priv_dir;
+			patt->name = ATTR_comment;
+			patt->value = comment;
+			patt->next = patt + 1;
+			patt++;
+			patt->name = ATTR_scheduling;
+			patt->value = "0";
+			patt->next = NULL;
+
 			patt->next = NULL;
 			err = pbs_manager(connector,
 				MGR_CMD_SET, MGR_OBJ_SCHED,
 				sc_name, attribs, NULL);
 			free(attribs);
 			if (err) {
-				sprintf(log_buffer, "Failed in updating priv_dir value %s to the server", priv_dir);
+				sprintf(log_buffer, "Failed to update scheduler comment %s at the server", log_dir);
 				log_err(-1, __func__, log_buffer);
 			}
+			return 0;
 		}
-		if ((partitions != NULL) && strcmp(partitions, tmp_partitions) != 0) {
+		if ((partitions != NULL) && (tmp_partitions != NULL) && strcmp(partitions, tmp_partitions) != 0) {
 			free(partitions);
-			partitions = tmp_partitions;
-		} else
-			partitions = tmp_partitions;
+		}
+		partitions = tmp_partitions;
 	}
+	if (clear_comment) {
+		int err;
+		struct attropl *patt;
+		char comment[MAX_LOG_SIZE] = {0};
+
+		attribs = (struct  attropl *)calloc(1, sizeof(struct attropl));
+		if (attribs == NULL) {
+			sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
+			log_err(errno, __func__, log_buffer);
+			strncpy(comment, "Unable to clear comment", MAX_LOG_SIZE);
+			free(tmp_log_dir);
+			free(tmp_priv_dir);
+			free(tmp_partitions);
+		} else
+			strncpy(comment, " ", 1);
+		patt = attribs;
+		patt->name = ATTR_comment;
+		patt->value = comment;
+		patt->next = NULL;
+		err = pbs_manager(connector,
+			MGR_CMD_SET, MGR_OBJ_SCHED,
+			sc_name, attribs, NULL);
+		free(attribs);
+		free(tmp_comment);
+		if (err) {
+			sprintf(log_buffer, "Failed to update scheduler comment %s at the server", log_dir);
+			log_err(-1, __func__, log_buffer);
+		}
+		clear_comment = 0;
+	}
+	return 1;
 
 }
 
@@ -2596,8 +2586,8 @@ sched_settings_frm_svr(struct batch_status *status)
  *
  *
  * @retval Error code
- * @return -1 - Failure
- * @return  0 - Success
+ * @return 0 - Failure
+ * @return 1 - Success
  *
  * @par Side Effects:
  *	None
@@ -2615,25 +2605,26 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	struct batch_status *ss = NULL;
 
 	/* This command is only sent on restart of the server */
-	if (cmd != 0 && cmd == SCH_SCHEDULE_FIRST)
+	if (cmd != SCH_SCHEDULE_NULL && cmd == SCH_SCHEDULE_FIRST)
 		svr_knows_me = 0;
 
-	if (cmd !=0 && svr_knows_me || cmd == SCH_ERROR || connector < 0)
-		return 0;
+	if (cmd != SCH_SCHEDULE_NULL && svr_knows_me || cmd == SCH_ERROR || connector < 0)
+		return 1;
 
 	/* Stat the scheduler to get details of sched */
 	ss = pbs_statsched(connector, sc_name, NULL, NULL);
 	if (ss == NULL) {
 		sprintf(log_buffer, "Unable to retrieve the scheduler attributes from server");
 		log_err(-1, __func__, log_buffer);
-		return 1;
+		return 0;
 	}
-	sched_settings_frm_svr(ss);
+	if (!sched_settings_frm_svr(ss))
+		return 0;
 
 	if (!dflt_sched && (partitions == NULL)) {
-		sprintf(log_buffer, "Scheduler does not contain a partition. shutting down");
+		sprintf(log_buffer, "Scheduler does not contain a partition");
 		log_err(-1, __func__, log_buffer);
-		return 1;
+		return 0;
 	}
 
 	pbs_statfree(ss);
@@ -2642,12 +2633,12 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	attribs = (struct  attropl *)calloc(4, sizeof(struct attropl));
 	if (attribs == NULL) {
 		sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
-		log_err(-1, __func__, log_buffer);
-		return 1;
+		log_err(errno, __func__, log_buffer);
+		return 0;
 	}
 	patt = attribs;
 	patt->name = ATTR_SchedHost;
-	patt->value = scheduler_name;
+	patt->value = scheduler_host_name;
 	patt->next = patt + 1;
 	patt++;
 	patt->name = ATTR_sched_port;
@@ -2674,7 +2665,7 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 
 	free(attribs);
 
-	return 0;
+	return 1;
 }
 
 

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -43,12 +43,10 @@ extern "C" {
 #include  <limits.h>
 #include "data_types.h"
 int connector;
-extern char sc_name[PBS_MAXSCHEDNAME];
-extern char *log_dir;
-extern char *priv_dir;
+extern char *sc_name;
 extern int sched_port;
 extern char *partitions;
-extern char scheduler_name[PBS_MAXHOSTNAME+1];
+extern char scheduler_host_name[PBS_MAXHOSTNAME+1];
 extern char *logfile;
 extern char path_log[_POSIX_PATH_MAX];
 extern int dflt_sched;

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -40,7 +40,18 @@
 extern "C" {
 #endif
 
+#include  <limits.h>
 #include "data_types.h"
+int connector;
+extern char sc_name[PBS_MAXSCHEDNAME];
+extern char *log_dir;
+extern char *priv_dir;
+extern int sched_port;
+extern char *partitions;
+extern char scheduler_name[PBS_MAXHOSTNAME+1];
+extern char *logfile;
+extern char path_log[_POSIX_PATH_MAX];
+extern int dflt_sched;
 
 /*
  *      schedinit - initialize conf struct and parse conf files
@@ -219,6 +230,9 @@ int main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rer
  *	return success 1 or error 0
  */
 int scheduler_simulation_task(int pbs_sd, int debug);
+
+int update_svr_schedobj(int connector, int cmd, int alarm_time);
+
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -43,13 +43,6 @@ extern "C" {
 #include  <limits.h>
 #include "data_types.h"
 int connector;
-extern char *sc_name;
-extern int sched_port;
-extern char *partitions;
-extern char scheduler_host_name[PBS_MAXHOSTNAME+1];
-extern char *logfile;
-extern char path_log[_POSIX_PATH_MAX];
-extern int dflt_sched;
 
 /*
  *      schedinit - initialize conf struct and parse conf files

--- a/src/scheduler/globals.c
+++ b/src/scheduler/globals.c
@@ -40,6 +40,7 @@
 #include "globals.h"
 #include "constant.h"
 #include "sort.h"
+#include "limits.h"
 
 
 
@@ -156,3 +157,15 @@ resdef **boolres = NULL;
 
 /* AOE name used to compare nodes, free when exit cycle */
 char *cmp_aoename = NULL;
+
+char *partitions = NULL;
+char scheduler_host_name[PBS_MAXHOSTNAME+1] = "Me";  /*arbitrary string*/
+char *sc_name = NULL;
+int sched_port = -1;
+char *logfile = (char *)0;
+#ifdef WIN32
+char path_log[_MAX_PATH];
+#else
+char path_log[_POSIX_PATH_MAX];
+#endif
+int dflt_sched = 0;

--- a/src/scheduler/globals.c
+++ b/src/scheduler/globals.c
@@ -159,10 +159,10 @@ resdef **boolres = NULL;
 char *cmp_aoename = NULL;
 
 char *partitions = NULL;
-char scheduler_host_name[PBS_MAXHOSTNAME+1] = "Me";  /*arbitrary string*/
+char scheduler_host_name[PBS_MAXHOSTNAME + 1] = "Me";  /* arbitrary string */
 char *sc_name = NULL;
 int sched_port = -1;
-char *logfile = (char *)0;
+char *logfile = NULL;
 #ifdef WIN32
 char path_log[_MAX_PATH];
 #else

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -41,7 +41,7 @@ extern "C" {
 #endif
 
 #include "data_types.h"
-
+#include "limits.h"
 /* resources to check */
 extern const struct rescheck res_to_check[];
 
@@ -73,6 +73,19 @@ const struct enum_conv resind[RES_HIGH+1];
 extern resdef **allres;
 extern resdef **consres;
 extern resdef **boolres;
+
+extern char *partitions;
+extern char scheduler_host_name[PBS_MAXHOSTNAME+1];
+extern char *sc_name;
+extern int sched_port;
+extern char *logfile;
+#ifdef WIN32
+extern char path_log[_MAX_PATH];
+#else
+extern char path_log[_POSIX_PATH_MAX];
+#endif
+extern int dflt_sched;
+
 
 /**
  * @brief

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -176,9 +176,10 @@ query_nodes(int pbs_sd, server_info *sinfo)
 	char *err;				/* used with pbs_geterrmsg() */
 	int num_nodes = 0;			/* the number of nodes */
 	int i;
+	extern char *partitions;
 
 	/* get nodes from PBS server */
-	if ((nodes = pbs_statvnode(pbs_sd, NULL, NULL, NULL)) == NULL) {
+	if ((nodes = pbs_statvnode(pbs_sd, NULL, NULL, partitions)) == NULL) {
 		err = pbs_geterrmsg(pbs_sd);
 		sprintf(errbuf, "Error getting nodes: %s", err);
 		schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_NODE, LOG_INFO, "", errbuf);

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -176,10 +176,11 @@ query_nodes(int pbs_sd, server_info *sinfo)
 	char *err;				/* used with pbs_geterrmsg() */
 	int num_nodes = 0;			/* the number of nodes */
 	int i;
-	extern char *partitions;
+	int nidx;
+	char **my_partitions;
 
 	/* get nodes from PBS server */
-	if ((nodes = pbs_statvnode(pbs_sd, NULL, NULL, partitions)) == NULL) {
+	if ((nodes = pbs_statvnode(pbs_sd, NULL, NULL, NULL)) == NULL) {
 		err = pbs_geterrmsg(pbs_sd);
 		sprintf(errbuf, "Error getting nodes: %s", err);
 		schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_NODE, LOG_INFO, "", errbuf);
@@ -208,8 +209,10 @@ query_nodes(int pbs_sd, server_info *sinfo)
 	}
 #endif /* localmod 049 */
 
+	my_partitions = break_comma_list(partitions);
+
 	cur_node = nodes;
-	for (i = 0; cur_node != NULL; i++) {
+	for (i = 0, nidx=0; cur_node != NULL; i++) {
 		/* get node info from server */
 		if ((ninfo = query_node_info(cur_node, sinfo)) == NULL) {
 			pbs_statfree(nodes);
@@ -222,6 +225,32 @@ query_nodes(int pbs_sd, server_info *sinfo)
 		sinfo->nodes_by_NASrank[i] = ninfo;
 #endif /* localmod 049 */
 
+		if (dflt_sched) {
+			if (ninfo->partition != NULL) {
+				cur_node = cur_node->next;
+				continue;
+			}
+		} else {
+			if (ninfo->partition == NULL) {
+				cur_node = cur_node->next;
+				continue;
+			} else {
+				int i;
+				int in_partition = 0;
+				for (i=0; my_partitions[i] != NULL; i++) {
+					if (strcmp(ninfo->partition, my_partitions[i]) == 0) {
+						in_partition = 1;
+						break;
+					}
+				}
+				if (!in_partition) {
+					cur_node = cur_node->next;
+					continue;
+				}
+
+			}
+		}
+
 		ninfo->rank = get_sched_rank();
 
 		/* get node info from mom */
@@ -233,11 +262,11 @@ query_nodes(int pbs_sd, server_info *sinfo)
 				"Failed to talk with mom, marking node offline");
 		}
 
-		ninfo_arr[i] = ninfo;
+		ninfo_arr[nidx++] = ninfo;
 
 		cur_node = cur_node->next;
 	}
-	ninfo_arr[i] = NULL;
+	ninfo_arr[nidx] = NULL;
 
 	if (update_mom_resources(ninfo_arr) == 0) {
 		pbs_statfree(nodes);
@@ -249,7 +278,7 @@ query_nodes(int pbs_sd, server_info *sinfo)
 	site_vnode_inherit(ninfo_arr);
 #endif /* localmod 062 */
 	resolve_indirect_resources(ninfo_arr);
-	sinfo->num_nodes = num_nodes;
+	sinfo->num_nodes = nidx;
 	pbs_statfree(nodes);
 	return ninfo_arr;
 }
@@ -309,6 +338,13 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp == '\0')
 				ninfo->port = count + 1;
+		}
+		else if(!strcmp(attrp->name, ATTR_partition)) {
+			ninfo->partition = string_dup(attrp->value);
+			if (ninfo->partition == NULL) {
+				log_err(errno, "node_queue_info", MEM_ERR_MSG);
+				return NULL;
+			}
 		}
 		else if (!strcmp(attrp->name, ATTR_NODE_jobs))
 			ninfo->jobs = break_comma_list(attrp->value);
@@ -522,6 +558,7 @@ new_node_info()
 	/* localmod 049 */
 	new->NASrank = -1;
 #endif
+	new->partition = NULL;
 	return new;
 }
 
@@ -595,6 +632,10 @@ free_node_info(node_info *ninfo)
 
 		if (ninfo->nodesig != NULL)
 			free(ninfo->nodesig);
+
+		if (ninfo->partition != NULL) {
+			free(ninfo->partition);
+		}
 
 		free(ninfo);
 	}
@@ -1269,6 +1310,14 @@ dup_node_info(node_info *onode, server_info *nsinfo,
 #ifdef NAS /* localmod 049 */
 	nnode->NASrank = onode->NASrank;
 #endif /* localmod 049 */
+
+	if (nnode->partition != NULL) {
+		nnode->partition = string_dup(onode->partition);
+		if (nnode->partition == NULL) {
+			free_node_info(nnode);
+			return NULL;
+		}
+	}
 
 	return nnode;
 }

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -107,8 +107,8 @@
 #include	"libsec.h"
 #include	"pbs_ecl.h"
 #include	"pbs_share.h"
-#include "config.h"
-#include "fifo.h"
+#include	"config.h"
+#include	"fifo.h"
 
 struct		connect_handle connection[NCONNECTS];
 int		connector;
@@ -126,7 +126,7 @@ char		*configfile = NULL;	/* name of file containing
 extern char		*msg_daemonname;
 char		**glob_argv;
 char		usage[] =
-	"[-d home][-L logfile][-p file] [-S port][-R port][-n][-N][-c clientsfile]";
+	"[-d home][-L logfile][-p file][-I schedname][-S port][-R port][-n][-N][-c clientsfile]";
 struct	sockaddr_in	saddr;
 sigset_t	allsigs;
 int		pbs_rm_port;
@@ -221,8 +221,6 @@ die(int sig)
 	}
 
 	log_close(1);
-	if (connector > 0)
-		update_svr_sched_state(SC_DOWN);
 	exit(1);
 }
 
@@ -792,8 +790,8 @@ are_we_primary()
 		log_err(-1, __func__, "Unable to get my host name");
 		return -1;
 	}
-	strncpy(scheduler_name, server_host, sizeof(scheduler_name));
-	scheduler_name [ sizeof(scheduler_name) -1 ] = '\0';
+	strncpy(scheduler_host_name, server_host, sizeof(scheduler_host_name));
+	scheduler_host_name [ sizeof(scheduler_host_name) -1 ] = '\0';
 
 	/* both secondary and primary should be set or neither set */
 	if ((pbs_conf.pbs_secondary == NULL) && (pbs_conf.pbs_primary == NULL))
@@ -938,7 +936,7 @@ main(int argc, char *argv[])
 	pbs_rm_port = pbs_conf.manager_service_port;
 
 	opterr = 0;
-	while ((c = getopt(argc, argv, "lL:NS:R:d:p:c:a:n")) != EOF) {
+	while ((c = getopt(argc, argv, "lL:NS:I:R:d:p:c:a:n")) != EOF) {
 		switch (c) {
 			case 'l':
 #ifdef _POSIX_MEMLOCK
@@ -952,6 +950,9 @@ main(int argc, char *argv[])
 				break;
 			case 'N':
 				stalone = 1;
+				break;
+			case 'I':
+				sc_name = optarg;
 				break;
 			case 'S':
 				sched_port = atoi(optarg);
@@ -998,16 +999,11 @@ main(int argc, char *argv[])
 				break;
 		}
 	}
-	/* Check whether the sched name is specified in command line args
-	 * If specified then copy the sched name
-	 * */
-	if (argc > optind)
-		strncpy(sc_name, argv[optind], PBS_MAXSCHEDNAME - 1);
-	else {
-		strncpy(sc_name, PBS_DFLT_SCHED_NAME, PBS_MAXSCHEDNAME -1);
+
+	if (sc_name == NULL) {
+		sc_name = PBS_DFLT_SCHED_NAME;
 		dflt_sched = 1;
 	}
-	sc_name[PBS_MAXSCHEDNAME] = '\0';
 
 	if (errflg) {
 		fprintf(stderr, "usage: %s %s\n", argv[0], usage);
@@ -1143,33 +1139,13 @@ main(int argc, char *argv[])
 		log_err(errno, __func__, "setsockopt");
 		die(0);
 	}
-	if (dflt_sched) {
-		saddr.sin_family = AF_INET;
-		saddr.sin_port = htons(sched_port);
-		saddr.sin_addr.s_addr = INADDR_ANY;
-		if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
-			log_err(errno, __func__, "bind");
-			die(0);
-		}
-	} else {
-		int try_port;
-		for (try_port=STARTING_PORT_NUM;try_port < MAX_PORT_NUM;try_port++) {
-			/* try to bind this socket to a reserved port */
-			saddr.sin_family = AF_INET;
-			saddr.sin_addr.s_addr = INADDR_ANY;
-			saddr.sin_port = htons(try_port);
-			memset(&(saddr.sin_zero), '\0', sizeof(saddr.sin_zero));
-			if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) != -1) {
-				break;
-			}
-			if ((errno != EADDRINUSE) && (errno != EADDRNOTAVAIL))
-				break;
-		}
-		if (try_port == MAX_PORT_NUM) {
-			log_err(errno, __func__, "No free ports are available");
-			die(0);
-		}
-		sched_port = try_port;
+
+	saddr.sin_family = AF_INET;
+	saddr.sin_port = htons(sched_port);
+	saddr.sin_addr.s_addr = INADDR_ANY;
+	if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
+		log_err(errno, __func__, "bind");
+		die(0);
 	}
 
 	/*Initialize security library's internal data structures*/
@@ -1329,15 +1305,6 @@ main(int argc, char *argv[])
 	sprintf(log_buffer, "%s startup pid %ld", argv[0], (long)pid);
 	log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO, __func__, log_buffer);
 
-	/*connector = pbs_connect_noblk(NULL,10);*/
-	connector = cnt2server_extend(NULL, SC_DAEMON);
-	if (update_svr_schedobj(connector, 0, alarm_time)) {
-		sprintf(log_buffer, "update_svr_schedobj failed");
-		log_err(-1, __func__, log_buffer);
-		return -1;
-	}
-	update_svr_sched_state(SC_IDLE);
-
 	rpp_fd = -1;
 	if (pbs_conf.pbs_use_tcp == 1) {
 		char *nodename;
@@ -1419,7 +1386,6 @@ main(int argc, char *argv[])
 		if (!FD_ISSET(server_sock, &fdset))
 			continue;
 
-		pbs_disconnect(connector);
 		/* connector is set in server_connect() */
 		cmd = server_command(&runjobid);
 

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -99,7 +99,6 @@
 #include	"pbs_error.h"
 #include	"pbs_ifl.h"
 #include	"log.h"
-#include	"resmon.h"
 #include	"sched_cmds.h"
 #include	"server_limits.h"
 #include	"net_connect.h"
@@ -108,6 +107,8 @@
 #include	"libsec.h"
 #include	"pbs_ecl.h"
 #include	"pbs_share.h"
+#include "config.h"
+#include "fifo.h"
 
 struct		connect_handle connection[NCONNECTS];
 int		connector;
@@ -115,6 +116,8 @@ int		server_sock;
 int		second_connection = -1;
 
 #define		START_CLIENTS	2	/* minimum number of clients */
+#define		MAX_PORT_NUM 65535
+#define		STARTING_PORT_NUM 15050
 pbs_net_t	*okclients = NULL;	/* accept connections from */
 int		numclients = 0;		/* the number of clients */
 char		*configfile = NULL;	/* name of file containing
@@ -126,9 +129,7 @@ char		usage[] =
 	"[-d home][-L logfile][-p file] [-S port][-R port][-n][-N][-c clientsfile]";
 struct	sockaddr_in	saddr;
 sigset_t	allsigs;
-static char    *logfile = (char *)0;
-static char	path_log[_POSIX_PATH_MAX];
-int 		pbs_rm_port;
+int		pbs_rm_port;
 
 /* if we received a sigpipe, this probably means the server went away. */
 int		got_sigpipe = 0;
@@ -220,6 +221,8 @@ die(int sig)
 	}
 
 	log_close(1);
+	if (connector > 0)
+		update_svr_sched_state(SC_DOWN);
 	exit(1);
 }
 
@@ -732,56 +735,6 @@ engage_authentication(struct connect_handle *phandle)
  *
  * @return	void
  */
-static	char scheduler_name[PBS_MAXHOSTNAME+1] = "Me";  /*arbitrary string*/
-
-static void
-update_svr_schedobj(int cmd, int alarm_time)
-{
-	char timestr[128];
-
-	static	int svr_knows_me = 0;
-
-	int	err;
-	struct	attropl	*attribs, *patt;
-
-	/* This command is only sent on restart of the server */
-	if (cmd == SCH_SCHEDULE_FIRST)
-		svr_knows_me = 0;
-
-	if (svr_knows_me || cmd == SCH_ERROR || connector < 0)
-		return;
-
-	attribs = (struct  attropl *)calloc(3, sizeof(struct attropl));
-	if (attribs == NULL) {
-		sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
-		log_err(-1, __func__, log_buffer);
-		return;
-	}
-	patt = attribs;
-	patt->name = ATTR_SchedHost;
-	patt->value = scheduler_name;
-	patt->next = patt + 1;
-	patt++;
-	patt->name = ATTR_version;
-	patt->value = pbs_version;
-	if (alarm_time) {
-		patt->next = patt + 1;
-		patt++;
-		patt->name = ATTR_sched_cycle_len;
-		snprintf(timestr, sizeof(timestr), "%d", alarm_time);
-		patt->value = timestr;
-	}
-	patt->next = NULL;
-
-	err = pbs_manager(connector,
-		MGR_CMD_SET, MGR_OBJ_SCHED,
-		PBS_DFLT_SCHED_NAME, attribs, NULL);
-	if (err == 0 && svr_knows_me == 0)
-		svr_knows_me = 1;
-
-	free(attribs);
-}
-
 
 /**
  * @brief
@@ -918,8 +871,8 @@ main(int argc, char *argv[])
 	int		lockfds;
 	int		t = 1;
 	pid_t		pid;
+	int		try_port;
 	char		host[PBS_MAXHOSTNAME+1];
-	unsigned int	port;
 #ifndef DEBUG
 	char		*dbfile = "sched_out";
 #endif
@@ -981,7 +934,8 @@ main(int argc, char *argv[])
 	glob_argv = argv;
 	segv_start_time = segv_last_time = time(NULL);
 
-	port = pbs_conf.scheduler_service_port;
+
+	sched_port = pbs_conf.scheduler_service_port;
 	pbs_rm_port = pbs_conf.manager_service_port;
 
 	opterr = 0;
@@ -1001,8 +955,8 @@ main(int argc, char *argv[])
 				stalone = 1;
 				break;
 			case 'S':
-				port = atoi(optarg);
-				if (port == 0) {
+				sched_port = atoi(optarg);
+				if (sched_port == 0) {
 					fprintf(stderr,
 						"%s: illegal port\n", optarg);
 					errflg = 1;
@@ -1045,13 +999,28 @@ main(int argc, char *argv[])
 				break;
 		}
 	}
+	/* Check whether the sched name is specified in command line args
+	 * If specified then copy the sched name
+	 * */
+	if (argc > optind)
+		strncpy(sc_name, argv[optind], PBS_MAXSCHEDNAME - 1);
+	else {
+		strncpy(sc_name, PBS_DFLT_SCHED_NAME, PBS_MAXSCHEDNAME -1);
+		dflt_sched = 1;
+	}
+	sc_name[PBS_MAXSCHEDNAME] = '\0';
+
 	if (errflg) {
 		fprintf(stderr, "usage: %s %s\n", argv[0], usage);
 		fprintf(stderr, "       %s --version\n", argv[0]);
 		exit(1);
 	}
 
-	(void)sprintf(log_buffer, "%s/sched_priv", pbs_conf.pbs_home_path);
+	if (dflt_sched) {
+		(void)sprintf(log_buffer, "%s/sched_priv", pbs_conf.pbs_home_path);
+	} else {
+		(void)sprintf(log_buffer, "%s/sched_priv_%s", pbs_conf.pbs_home_path, sc_name);
+	}
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
 	c  = chk_file_sec(log_buffer, 1, 0, S_IWGRP|S_IWOTH, 1);
 	c |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, S_IWGRP|S_IWOTH, 0);
@@ -1061,7 +1030,11 @@ main(int argc, char *argv[])
 		perror("chdir");
 		exit(1);
 	}
-	(void)sprintf(path_log,   "%s/sched_logs", pbs_conf.pbs_home_path);
+	if (dflt_sched) {
+		(void)sprintf(path_log,   "%s/sched_logs", pbs_conf.pbs_home_path);
+	} else {
+		(void)sprintf(path_log,   "%s/sched_logs_%s", pbs_conf.pbs_home_path, sc_name);
+	}
 	if (log_open(logfile, path_log) == -1) {
 		fprintf(stderr, "%s: logfile could not be opened\n", argv[0]);
 		exit(1);
@@ -1171,12 +1144,32 @@ main(int argc, char *argv[])
 		log_err(errno, __func__, "setsockopt");
 		die(0);
 	}
-	saddr.sin_family = AF_INET;
-	saddr.sin_port = htons(port);
-	saddr.sin_addr.s_addr = INADDR_ANY;
-	if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
-		log_err(errno, __func__, "bind");
-		die(0);
+	if (dflt_sched) {
+		saddr.sin_family = AF_INET;
+		saddr.sin_port = htons(sched_port);
+		saddr.sin_addr.s_addr = INADDR_ANY;
+		if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
+			log_err(errno, __func__, "bind");
+			die(0);
+		}
+	} else {
+		for (try_port=STARTING_PORT_NUM;try_port < MAX_PORT_NUM;try_port++) {
+			/* try to bind this socket to a reserved port */
+			saddr.sin_family = AF_INET;
+			saddr.sin_addr.s_addr = INADDR_ANY;
+			saddr.sin_port = htons(try_port);
+			memset(&(saddr.sin_zero), '\0', sizeof(saddr.sin_zero));
+			if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) != -1) {
+				break;
+			}
+			if ((errno != EADDRINUSE) && (errno != EADDRNOTAVAIL))
+				break;
+		}
+		if (try_port == MAX_PORT_NUM) {
+			log_err(errno, __func__, "No free ports are available");
+			die(0);
+		}
+		sched_port = try_port;
 	}
 
 	/*Initialize security library's internal data structures*/
@@ -1336,6 +1329,15 @@ main(int argc, char *argv[])
 	sprintf(log_buffer, "%s startup pid %ld", argv[0], (long)pid);
 	log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO, __func__, log_buffer);
 
+	/*connector = pbs_connect_noblk(NULL,10);*/
+	connector = cnt2server_extend(NULL, SC_DAEMON);
+	if (update_svr_schedobj(connector, 0, alarm_time)) {
+		sprintf(log_buffer, "update_svr_schedobj failed");
+		log_err(-1, __func__, log_buffer);
+		return -1;
+	}
+	update_svr_sched_state(SC_IDLE);
+
 	rpp_fd = -1;
 	if (pbs_conf.pbs_use_tcp == 1) {
 		char *nodename;
@@ -1351,12 +1353,12 @@ main(int argc, char *argv[])
 		set_tpp_funcs(log_tppmsg);
 
 		if (pbs_conf.auth_method == AUTH_RESV_PORT) {
-			rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, pbs_conf.scheduler_service_port,
+			rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, sched_port,
 								pbs_conf.pbs_leaf_routers, pbs_conf.pbs_use_compression,
 								TPP_AUTH_RESV_PORT, NULL, NULL);
 		} else {
 			/* for all non-resv-port based authentication use a callback from TPP */
-			rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, pbs_conf.scheduler_service_port,
+			rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, sched_port,
 								pbs_conf.pbs_leaf_routers, pbs_conf.pbs_use_compression,
 								TPP_AUTH_EXTERNAL, get_ext_auth_data, validate_ext_auth_data);
 		}
@@ -1417,12 +1419,13 @@ main(int argc, char *argv[])
 		if (!FD_ISSET(server_sock, &fdset))
 			continue;
 
+		pbs_disconnect(connector);
 		/* connector is set in server_connect() */
 		cmd = server_command(&runjobid);
 
 		if (connector >= 0) {
 			/* update sched object attributes on server */
-			update_svr_schedobj(cmd, alarm_time);
+			update_svr_schedobj(connector, cmd, alarm_time);
 
 			if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)
 				log_err(errno, __func__, "sigprocmask(SIG_BLOCK)");
@@ -1444,9 +1447,9 @@ main(int argc, char *argv[])
 			DBPRT(("Scheduler received command %d\n", cmd));
 #endif /* localmod 031 */
 
-			if (schedule(cmd, connector, runjobid)) /* magic happens here */
+			if (schedule(cmd, connector, runjobid)) /* magic happens here */ {
 				go = 0;
-
+			}
 			if (second_connection != -1) {
 				close(second_connection);
 				second_connection = -1;

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -871,7 +871,6 @@ main(int argc, char *argv[])
 	int		lockfds;
 	int		t = 1;
 	pid_t		pid;
-	int		try_port;
 	char		host[PBS_MAXHOSTNAME+1];
 #ifndef DEBUG
 	char		*dbfile = "sched_out";
@@ -1153,6 +1152,7 @@ main(int argc, char *argv[])
 			die(0);
 		}
 	} else {
+		int try_port;
 		for (try_port=STARTING_PORT_NUM;try_port < MAX_PORT_NUM;try_port++) {
 			/* try to bind this socket to a reserved port */
 			saddr.sin_family = AF_INET;

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -109,6 +109,7 @@
 #include	"pbs_share.h"
 #include	"config.h"
 #include	"fifo.h"
+#include	"globals.h"
 
 struct		connect_handle connection[NCONNECTS];
 int		connector;
@@ -791,7 +792,7 @@ are_we_primary()
 		return -1;
 	}
 	strncpy(scheduler_host_name, server_host, sizeof(scheduler_host_name));
-	scheduler_host_name [ sizeof(scheduler_host_name) -1 ] = '\0';
+	scheduler_host_name[sizeof(scheduler_host_name) -1] = '\0';
 
 	/* both secondary and primary should be set or neither set */
 	if ((pbs_conf.pbs_secondary == NULL) && (pbs_conf.pbs_primary == NULL))

--- a/src/scheduler/pbs_sched_win.c
+++ b/src/scheduler/pbs_sched_win.c
@@ -147,7 +147,7 @@ char		*configfile = NULL;	/* name of file containing
 char		*oldpath;
 char		**glob_argv;
 char		usage[] =
-	"[-d home][-L logfile][-p file][-S port][-R port][-n][-c clientsfile]";
+	"[-d home][-L logfile][-p file][-I schedname][-S port][-R port][-n][-c clientsfile]";
 struct	sockaddr_in	saddr;
 extern char	*msg_noloopbackstopdaemon;
 #ifndef WIN32
@@ -234,8 +234,6 @@ die(int sig)
 	}
 
 	log_close(1);
-	if (connector > 0)
-		update_svr_sched_state(SC_DOWN);
 	exit(1);
 }
 
@@ -775,8 +773,8 @@ are_we_primary()
 			return -1;
 		}
 	}
-	strncpy(scheduler_name, server_host, sizeof(scheduler_name));
-	scheduler_name [ sizeof(scheduler_name) -1 ] = '\0';
+	strncpy(scheduler_host_name, server_host, sizeof(scheduler_host_name));
+	scheduler_host_name [ sizeof(scheduler_host_name) -1 ] = '\0';
 	/* both secondary and primary should be set or neither set */
 	if ((pbs_conf.pbs_secondary == NULL) && (pbs_conf.pbs_primary == NULL))
 		return 1;
@@ -1017,7 +1015,7 @@ main(int argc, char *argv[])
 #endif
 
 	opterr = 0;
-	while ((c = getopt(argc, argv, "lL:S:R:d:p:c:a:n")) != EOF) {
+	while ((c = getopt(argc, argv, "lL:S:I:R:d:p:c:a:n")) != EOF) {
 		switch (c) {
 			case 'l':
 #ifdef _POSIX_MEMLOCK
@@ -1028,6 +1026,9 @@ main(int argc, char *argv[])
 				break;
 			case 'L':
 				logfile = optarg;
+				break;
+			case 'I':
+				sc_name = optarg;
 				break;
 			case 'S':
 				sched_port = atoi(optarg);
@@ -1072,16 +1073,12 @@ main(int argc, char *argv[])
 				break;
 		}
 	}
-	/* Check whether the sched name is specified in command line args
-	 * If specified then copy the sched name
-	 * */
-	if (argc > optind)
-		strncpy(sc_name, argv[optind], PBS_MAXSCHEDNAME - 1);
-	else {
-		strncpy(sc_name, PBS_DFLT_SCHED_NAME, PBS_MAXSCHEDNAME -1);
+
+	if (sc_name == NULL) {
+		sc_name = PBS_DFLT_SCHED_NAME;
 		dflt_sched = 1;
 	}
-	sc_name[PBS_MAXSCHEDNAME] = '\0';
+
 	if (errflg) {
 #ifdef WIN32
 		usage2(argv[0]);
@@ -1270,36 +1267,16 @@ main(int argc, char *argv[])
 		die(0);
 	}
 
-	if (dflt_sched) {
-		saddr.sin_family = AF_INET;
-		saddr.sin_port = htons(sched_port);
-		saddr.sin_addr.s_addr = INADDR_ANY;
-		if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
-			errno = WSAGetLastError();
-			log_err(errno, __func__, "bind");
-			die(0);
-		}
-	} else {
-		int try_port;
-		for (try_port=STARTING_PORT_NUM;try_port < MAX_PORT_NUM;try_port++) {
-			/* try to bind this socket to a reserved port */
-			saddr.sin_family = AF_INET;
-			saddr.sin_addr.s_addr = INADDR_ANY;
-			saddr.sin_port = htons(try_port);
-			memset(&(saddr.sin_zero), '\0', sizeof(saddr.sin_zero));
-			if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) != -1) {
-				break;
-			}
-			errno = WSAGetLastError();
-			if ((errno != EADDRINUSE) && (errno != EADDRNOTAVAIL))
-				break;
-		}
-		if (try_port == MAX_PORT_NUM) {
-			log_err(errno, __func__, "No free ports are available");
-			die(0);
-		}
-		sched_port = try_port;
+
+	saddr.sin_family = AF_INET;
+	saddr.sin_port = htons(sched_port);
+	saddr.sin_addr.s_addr = INADDR_ANY;
+	if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
+		errno = WSAGetLastError();
+		log_err(errno, __func__, "bind");
+		die(0);
 	}
+
 
 	if (listen(server_sock, 5) < 0) {
 #ifdef WIN32
@@ -1471,14 +1448,6 @@ main(int argc, char *argv[])
 	sprintf(log_buffer, "%s startup pid %d", argv[0], pid);
 	log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO, id, log_buffer);
 
-	connector = cnt2server_extend(NULL, SC_DAEMON);
-	if (update_svr_schedobj(connector, 0, alarm_time)) {
-		sprintf(log_buffer, "update_svr_schedobj failed");
-		log_err(-1, __func__, log_buffer);
-		return -1;
-	}
-	update_svr_sched_state(SC_IDLE);
-
 	rpp_fd = -1;
 	if (pbs_conf.pbs_use_tcp == 1) {
 		char *nodename;
@@ -1569,7 +1538,6 @@ main(int argc, char *argv[])
 		if (!FD_ISSET(server_sock, &fdset))
 			continue;
 
-		pbs_disconnect(connector);
 		cmd = server_command(&runjobid);
 
 		/*based on cmd: send|not scheduler's PBS version to server*/

--- a/src/scheduler/pbs_sched_win.c
+++ b/src/scheduler/pbs_sched_win.c
@@ -897,7 +897,6 @@ main(int argc, char *argv[])
 #endif
 
 	char		host[PBS_MAXHOSTNAME+1];
-	int		try_port;
 
 #ifndef DEBUG
 	char		*dbfile = "sched_out";
@@ -1281,6 +1280,7 @@ main(int argc, char *argv[])
 			die(0);
 		}
 	} else {
+		int try_port;
 		for (try_port=STARTING_PORT_NUM;try_port < MAX_PORT_NUM;try_port++) {
 			/* try to bind this socket to a reserved port */
 			saddr.sin_family = AF_INET;

--- a/src/scheduler/pbs_sched_win.c
+++ b/src/scheduler/pbs_sched_win.c
@@ -118,13 +118,15 @@
 #include	"pbs_ifl.h"
 #include	"pbs_ecl.h"
 #include	"log.h"
-#include	"resmon.h"
 #include	"sched_cmds.h"
 #include	"server_limits.h"
 #include	"net_connect.h"
 #include	"rm.h"
 #include	"rpp.h"
-#include 	"pbs_internal.h"
+#include	"pbs_internal.h"
+#include	"pbs_share.h"
+#include	"config.h"
+#include	"fifo.h"
 
 
 struct		connect_handle connection[NCONNECTS];
@@ -135,6 +137,8 @@ int		second_connection = -1;
 struct tpp_config tpp_conf; /* global settings for tcp */
 
 #define		START_CLIENTS	2	/* minimum number of clients */
+#define		MAX_PORT_NUM 65535
+#define		STARTING_PORT_NUM 15050
 pbs_net_t	*okclients = NULL;	/* accept connections from */
 int		numclients = 0;		/* the number of clients */
 char		*configfile = NULL;	/* name of file containing
@@ -150,12 +154,6 @@ extern char	*msg_noloopbackstopdaemon;
 sigset_t	allsigs;
 #endif
 
-static char    *logfile = (char *)0;
-#ifdef WIN32
-static char	path_log[_MAX_PATH];
-#else
-static char	path_log[_POSIX_PATH_MAX];
-#endif
 int 		pbs_rm_port;
 int		got_sigpipe = 0;   /* needed for UNIX so we need the symbol */
 
@@ -236,6 +234,8 @@ die(int sig)
 	}
 
 	log_close(1);
+	if (connector > 0)
+		update_svr_sched_state(SC_DOWN);
 	exit(1);
 }
 
@@ -674,71 +674,6 @@ server_command(char **jid)
 }
 
 
-/**
- * @brief
- * 		update_svr_schedobj - sends scheduler attributes to pbs_server on the first
- *			 contact of the server.
- *
- * @param[in]	cmd	-	scheduling command from the server -- see sched_cmds.h
- * @param[in]	alarm	-	alarm value, set if non-zero
- *
- * @par Side-Effects: none
- *
- * @par MT-Unsafe
- *
- * @return	void
- */
-static	char scheduler_name[PBS_MAXHOSTNAME+1] = "Me";  /*arbitrary string*/
-
-static void
-update_svr_schedobj(int cmd, int alarm_time)
-{
-	static	char    id[] = "update_svr_schedobj";
-	char timestr[128];
-
-	/*same host:port with a new scheduler*/
-	static	int svr_knows_me = 0;
-
-	int	err;
-	struct	attropl	*attribs, *patt;
-
-	if (!(cmd == SCH_SCHEDULE_NULL  ||
-		cmd == SCH_SCHEDULE_FIRST ||
-		svr_knows_me == 0))
-		return;
-
-	attribs = (struct  attropl *)calloc(3, sizeof(struct attropl));
-	if (attribs == NULL) {
-		sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
-		log_err(-1, id, log_buffer);
-		return;
-	}
-	patt = attribs;
-	patt->name = ATTR_SchedHost;
-	patt->value = scheduler_name;
-	patt->next = patt + 1;
-	patt++;
-	patt->name = ATTR_version;
-	patt->value = pbs_version;
-	patt->next = NULL;
-	if (alarm_time) {
-		patt->next = patt + 1;
-		patt++;
-		patt->name = ATTR_sched_cycle_len;
-		snprintf(timestr, sizeof(timestr), "%d", alarm_time);
-		patt->value = timestr;
-		patt->next = NULL;
-	}
-
-	err = pbs_manager(connector,
-		MGR_CMD_SET, MGR_OBJ_SCHED,
-		"scheduler", attribs, NULL);
-	if (err == 0 && svr_knows_me == 0)
-		svr_knows_me = 1;
-
-	free(attribs);
-}
-
 #ifdef WIN32
 
 /**
@@ -962,7 +897,7 @@ main(int argc, char *argv[])
 #endif
 
 	char		host[PBS_MAXHOSTNAME+1];
-	unsigned int	port;
+	int		try_port;
 
 #ifndef DEBUG
 	char		*dbfile = "sched_out";
@@ -1075,7 +1010,7 @@ main(int argc, char *argv[])
 
 	glob_argv = argv;
 
-	port = pbs_conf.scheduler_service_port;
+	sched_port = pbs_conf.scheduler_service_port;
 	pbs_rm_port = pbs_conf.manager_service_port;
 
 #ifndef WIN32
@@ -1096,8 +1031,8 @@ main(int argc, char *argv[])
 				logfile = optarg;
 				break;
 			case 'S':
-				port = atoi(optarg);
-				if (port == 0) {
+				sched_port = atoi(optarg);
+				if (sched_port == 0) {
 					fprintf(stderr,
 						"%s: illegal port\n", optarg);
 					errflg = 1;
@@ -1138,6 +1073,16 @@ main(int argc, char *argv[])
 				break;
 		}
 	}
+	/* Check whether the sched name is specified in command line args
+	 * If specified then copy the sched name
+	 * */
+	if (argc > optind)
+		strncpy(sc_name, argv[optind], PBS_MAXSCHEDNAME - 1);
+	else {
+		strncpy(sc_name, PBS_DFLT_SCHED_NAME, PBS_MAXSCHEDNAME -1);
+		dflt_sched = 1;
+	}
+	sc_name[PBS_MAXSCHEDNAME] = '\0';
 	if (errflg) {
 #ifdef WIN32
 		usage2(argv[0]);
@@ -1161,8 +1106,12 @@ main(int argc, char *argv[])
 
 		exit(1);
 	}
+	if (dflt_sched) {
+		(void)sprintf(log_buffer, "%s/sched_priv", pbs_conf.pbs_home_path);
+	} else {
+		(void)sprintf(log_buffer, "%s/sched_priv_%s", pbs_conf.pbs_home_path, sc_name);
+	}
 
-	(void)sprintf(log_buffer, "%s/sched_priv", pbs_conf.pbs_home_path);
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
 #ifdef WIN32
 	/* For windows, do not check full path. Allow system to put in */
@@ -1185,8 +1134,11 @@ main(int argc, char *argv[])
 #endif
 		exit(1);
 	}
-	(void)sprintf(path_log,   "%s/sched_logs", pbs_conf.pbs_home_path);
-
+	if (dflt_sched) {
+		(void)sprintf(path_log,   "%s/sched_logs", pbs_conf.pbs_home_path);
+	} else {
+		(void)sprintf(path_log,   "%s/sched_logs_%s", pbs_conf.pbs_home_path, sc_name);
+	}
 
 	/* The following is code to reduce security risks                */
 	/* start out with standard umask, system resource limit infinite */
@@ -1318,16 +1270,37 @@ main(int argc, char *argv[])
 		log_err(errno, id, "setsockopt");
 		die(0);
 	}
-	saddr.sin_family = AF_INET;
-	saddr.sin_port = htons(port);
-	saddr.sin_addr.s_addr = INADDR_ANY;
-	if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
-#ifdef WIN32
-		errno = WSAGetLastError();
-#endif
-		log_err(errno, id, "bind");
-		die(0);
+
+	if (dflt_sched) {
+		saddr.sin_family = AF_INET;
+		saddr.sin_port = htons(sched_port);
+		saddr.sin_addr.s_addr = INADDR_ANY;
+		if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
+			errno = WSAGetLastError();
+			log_err(errno, __func__, "bind");
+			die(0);
+		}
+	} else {
+		for (try_port=STARTING_PORT_NUM;try_port < MAX_PORT_NUM;try_port++) {
+			/* try to bind this socket to a reserved port */
+			saddr.sin_family = AF_INET;
+			saddr.sin_addr.s_addr = INADDR_ANY;
+			saddr.sin_port = htons(try_port);
+			memset(&(saddr.sin_zero), '\0', sizeof(saddr.sin_zero));
+			if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) != -1) {
+				break;
+			}
+			errno = WSAGetLastError();
+			if ((errno != EADDRINUSE) && (errno != EADDRNOTAVAIL))
+				break;
+		}
+		if (try_port == MAX_PORT_NUM) {
+			log_err(errno, __func__, "No free ports are available");
+			die(0);
+		}
+		sched_port = try_port;
 	}
+
 	if (listen(server_sock, 5) < 0) {
 #ifdef WIN32
 		errno = WSAGetLastError();
@@ -1498,6 +1471,14 @@ main(int argc, char *argv[])
 	sprintf(log_buffer, "%s startup pid %d", argv[0], pid);
 	log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO, id, log_buffer);
 
+	connector = cnt2server_extend(NULL, SC_DAEMON);
+	if (update_svr_schedobj(connector, 0, alarm_time)) {
+		sprintf(log_buffer, "update_svr_schedobj failed");
+		log_err(-1, __func__, log_buffer);
+		return -1;
+	}
+	update_svr_sched_state(SC_IDLE);
+
 	rpp_fd = -1;
 	if (pbs_conf.pbs_use_tcp == 1) {
 		char *nodename;
@@ -1513,12 +1494,12 @@ main(int argc, char *argv[])
 		set_tpp_funcs(log_tppmsg);
 
 		if (pbs_conf.auth_method == AUTH_RESV_PORT) {
-		rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, pbs_conf.scheduler_service_port,
+		rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, sched_port,
 							pbs_conf.pbs_leaf_routers, pbs_conf.pbs_use_compression,
 							TPP_AUTH_RESV_PORT, NULL, NULL);
 		} else {
 			/* for all non-resv-port based authentication use a callback from TPP */
-			rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, pbs_conf.scheduler_service_port,
+			rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, sched_port,
 								pbs_conf.pbs_leaf_routers, pbs_conf.pbs_use_compression,
 								TPP_AUTH_EXTERNAL, get_ext_auth_data, validate_ext_auth_data);
 		}
@@ -1588,11 +1569,15 @@ main(int argc, char *argv[])
 		if (!FD_ISSET(server_sock, &fdset))
 			continue;
 
+		pbs_disconnect(connector);
 		cmd = server_command(&runjobid);
 
 		/*based on cmd: send|not scheduler's PBS version to server*/
-		update_svr_schedobj(cmd, alarm_time);
-
+		if (update_svr_schedobj(connector, cmd, alarm_time)) {
+			sprintf(log_buffer, "update_svr_schedobj failed");
+			log_err(-1, __func__, log_buffer);
+			return -1;
+		}
 
 #ifndef WIN32
 		if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)

--- a/src/scheduler/pbs_sched_win.c
+++ b/src/scheduler/pbs_sched_win.c
@@ -127,6 +127,7 @@
 #include	"pbs_share.h"
 #include	"config.h"
 #include	"fifo.h"
+#include	"globals.h"
 
 
 struct		connect_handle connection[NCONNECTS];
@@ -774,7 +775,7 @@ are_we_primary()
 		}
 	}
 	strncpy(scheduler_host_name, server_host, sizeof(scheduler_host_name));
-	scheduler_host_name [ sizeof(scheduler_host_name) -1 ] = '\0';
+	scheduler_host_name[sizeof(scheduler_host_name) -1] = '\0';
 	/* both secondary and primary should be set or neither set */
 	if ((pbs_conf.pbs_secondary == NULL) && (pbs_conf.pbs_primary == NULL))
 		return 1;
@@ -1541,11 +1542,7 @@ main(int argc, char *argv[])
 		cmd = server_command(&runjobid);
 
 		/*based on cmd: send|not scheduler's PBS version to server*/
-		if (update_svr_schedobj(connector, cmd, alarm_time)) {
-			sprintf(log_buffer, "update_svr_schedobj failed");
-			log_err(-1, __func__, log_buffer);
-			return -1;
-		}
+		update_svr_schedobj(connector, cmd, alarm_time);
 
 #ifndef WIN32
 		if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -85,7 +85,7 @@
 #include "node_partition.h"
 #include "limits_if.h"
 #include "pbs_internal.h"
-
+#include "fifo.h"
 
 /**
  * @brief
@@ -148,7 +148,7 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 		return NULL;
 
 	/* get queue info from PBS server */
-	if ((queues = pbs_statque(pbs_sd, NULL, NULL, NULL)) == NULL) {
+	if ((queues = pbs_statque(pbs_sd, NULL, NULL, partitions)) == NULL) {
 		errmsg = pbs_geterrmsg(pbs_sd);
 		if (errmsg == NULL)
 			errmsg = "";

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -140,6 +140,7 @@
 #include "fairshare.h"
 #include "check.h"
 #include "pbs_sched.h"
+#include "fifo.h"
 #ifdef NAS
 #include "site_code.h"
 #endif
@@ -171,7 +172,7 @@ query_server(status *pol, int pbs_sd)
 {
 	struct batch_status *server;	/* info about the server */
 	struct batch_status *sched;	/* info about the server's scheduler object */
-	struct batch_status *bs_resvs;	/* batch status of the reservations */
+	struct batch_status *bs_resvs = NULL;	/* batch status of the reservations */
 	server_info *sinfo;		/* scheduler internal form of server info */
 	queue_info **qinfo;		/* array of queues on the server */
 	counts *cts;			/* used to count running per user/grp */
@@ -244,7 +245,8 @@ query_server(status *pol, int pbs_sd)
 	 * will populate internal data structures based on this batch status
 	 * after all other data is queried
 	 */
-	bs_resvs = stat_resvs(pbs_sd);
+	if (dflt_sched)
+		bs_resvs = stat_resvs(pbs_sd);
 
 	/* get the nodes, if any - NOTE: will set sinfo -> num_nodes */
 	if ((sinfo->nodes = query_nodes(pbs_sd, sinfo)) == NULL) {

--- a/src/send_hooks_win/w32_send_hooks.c
+++ b/src/send_hooks_win/w32_send_hooks.c
@@ -134,8 +134,6 @@ long		new_log_event_mask = 0;
 int	 	server_init_type = RECOV_WARM;
 char	        server_name[PBS_MAXSERVERNAME+1]; /* host_name[:service|port] */
 int		svr_delay_entry = 0;
-int		svr_do_schedule = SCH_SCHEDULE_NULL;
-int		svr_do_sched_high = SCH_SCHEDULE_NULL;
 int		svr_total_cpus = 0;		/* total number of cpus on nodes   */
 int		have_blue_gene_nodes = 0;
 int		svr_ping_rate = SVR_DEFAULT_PING_RATE;	/* time between sets of node pings */

--- a/src/send_job_win/w32_send_job.c
+++ b/src/send_job_win/w32_send_job.c
@@ -144,8 +144,6 @@ long		new_log_event_mask = 0;
 int	 	server_init_type = RECOV_WARM;
 char	        server_name[PBS_MAXSERVERNAME+1]; /* host_name[:service|port] */
 int		svr_delay_entry = 0;
-int		svr_do_schedule = SCH_SCHEDULE_NULL;
-int		svr_do_sched_high = SCH_SCHEDULE_NULL;
 int		svr_total_cpus = 0;		/* total number of cpus on nodes   */
 int		have_blue_gene_nodes = 0;
 int		svr_ping_rate = SVR_DEFAULT_PING_RATE;	/* time between sets of node pings */

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -142,6 +142,7 @@
 #include "reservation.h"
 #include "cmds.h"
 #include "server.h"
+#include "pbs_sched.h"
 
 
 /* External functions */

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -4305,7 +4305,7 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 	*num_run += 1;
 	if (pbs_python_get_scheduler_restart_cycle_flag() == TRUE) {
 
-		set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE);
+		set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE, dflt_scheduler);
 		log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_HOOK,
 			LOG_INFO, phook->hook_name,
 			"requested for scheduler to restart cycle");

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -108,6 +108,7 @@
 #include "resv_node.h"
 #include "queue.h"
 #include "sched_cmds.h"
+#include "pbs_sched.h"
 
 #ifdef WIN32
 #include <direct.h>

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -154,7 +154,6 @@ static int  set_resvAttrs_off_jobAttrs(resc_resv*, job*);
 /* Global Data items */
 #ifndef PBS_MOM
 extern struct server   server;
-extern int scheduler_sock;
 #endif	/* PBS_MOM */
 extern char *msg_abt_err;
 extern char *path_jobs;
@@ -518,7 +517,7 @@ job_free(job *pj)
 					 * If so, then reject the request.
 					 */
 					if ((tbr->rq_orgconn != -1) &&
-						(tbr->rq_orgconn == scheduler_sock)) {
+						(find_sched_from_sock(tbr->rq_orgconn) != NULL)) {
 						tbr->rq_conn = tbr->rq_orgconn;
 						req_reject(PBSE_HISTJOBID, 0, tbr);
 					}
@@ -1686,7 +1685,7 @@ resv_purge(resc_resv *presv)
 
 	/*Release any nodes that were associated to this reservation*/
 	free_resvNodes(presv);
-	set_scheduler_flag(SCH_SCHEDULE_TERM);
+	set_scheduler_flag(SCH_SCHEDULE_TERM, dflt_scheduler);
 
 	strcpy(dbresv.ri_resvid, presv->ri_qs.ri_resvID);
 	obj.pbs_db_obj_type = PBS_DB_RESV;

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -176,7 +176,7 @@
 #include	"hook_func.h"
 #include	"sched_cmds.h"
 #include	"provision.h"
-#include "pbs_sched.h"
+#include        "pbs_sched.h"
 
 #if !defined(H_ERRNO_DECLARED) && !defined(WIN32)
 extern int h_errno;

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -176,6 +176,7 @@
 #include	"hook_func.h"
 #include	"sched_cmds.h"
 #include	"provision.h"
+#include "pbs_sched.h"
 
 #if !defined(H_ERRNO_DECLARED) && !defined(WIN32)
 extern int h_errno;
@@ -3042,10 +3043,10 @@ deallocate_job(mominfo_t *pmom, job *pjob)
 		free(new_exec_vnode);
 
 	}
-	if (find_assoc_sched_pj(pjob, &psched))
+	if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
 		set_scheduler_flag(SCH_SCHEDULE_TERM, psched);
 	else {
-		sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);
+		sprintf(log_buffer, "Unable to reach scheduler associated with partition");
 		log_err(-1, __func__, log_buffer);
 	}
 	free(freed_vnode_list);
@@ -8707,10 +8708,10 @@ free_sister_vnodes(job *pjob, char *vnodelist, char *err_msg,
 	/* increment everything found in new exec_vnode */
 	set_resc_assigned((void *)pjob, 0,  INCR);
 						
-	if (find_assoc_sched_pj(pjob, &psched))
+	if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
 		set_scheduler_flag(SCH_SCHEDULE_TERM, psched);
 	else {
-		sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);
+		sprintf(log_buffer, "Unable to reach scheduler associated with partition");
 		log_err(-1, __func__, log_buffer);
 	}
 	rc = send_job_exec_update_to_mom(pjob, err_msg, err_msg_sz,

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -713,6 +713,10 @@ pbsd_init(int type)
 			psched = (pbs_sched *) GET_NEXT(svr_allscheds);
 			while (psched != (pbs_sched *) 0) {
 				set_sched_default(psched);
+				if (psched != dflt_scheduler) {
+					psched->pbs_scheduler_port = psched->sch_attr[SCHED_ATR_sched_port].at_val.at_long;
+					psched->pbs_scheduler_addr = get_hostaddr(psched->sch_attr[SCHED_ATR_SchedHost].at_val.at_str);
+				}
 				psched = (pbs_sched *) GET_NEXT(psched->sc_link);
 			}
 		}
@@ -733,10 +737,11 @@ pbsd_init(int type)
 				printf("%s\n", log_buffer);
 				return -1;
 			}
-			svr_save_db(&server, SVR_SAVE_NEW);
-		} else {
-			svr_save_db(&server, SVR_SAVE_NEW);
 		}
+		svr_save_db(&server, SVR_SAVE_NEW);
+		dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME);
+		(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
+		set_sched_default(dflt_scheduler);
 	}
 
 	/* 4. Check License information */

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2356,7 +2356,6 @@ next_task()
 {
 
 	time_t		   tilwhen;
-	time_t		   delay;
 	pbs_sched	   *psched;
 
 	tilwhen = default_next_task();
@@ -2364,6 +2363,7 @@ next_task()
 	/* should the scheduler be run?  If so, adjust the delay time  */
 
 	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+		time_t delay;
 		if ((delay = psched->sch_next_schedule - time_now) <= 0)
 			set_scheduler_flag(SCH_SCHEDULE_TIME, psched);
 		else if (delay < tilwhen)

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -138,6 +138,7 @@
 #include "provision.h"
 #include "pbs_db.h"
 #include "pbs_sched.h"
+#include "pbs_share.h"
 
 #include <pbs_python.h>  /* for python interpreter */
 
@@ -160,11 +161,10 @@ extern int put_sched_cmd(int sock, int cmd, char *jobid);
 extern void setup_ping(int delay);
 
 /* External data items */
-extern	int		svr_chngNodesfile;
+extern	int	svr_chngNodesfile;
 extern  pbs_list_head svr_requests;
 extern char     *msg_err_malloc;
 extern int       pbs_failover_active;
-extern int	scheduler_sock, scheduler_sock2;
 
 /* Local Private Functions */
 
@@ -223,8 +223,6 @@ char	       *pbs_o_host = "PBS_O_HOST";
 pbs_net_t	pbs_mom_addr;
 unsigned int	pbs_mom_port;
 unsigned int	pbs_rm_port;
-pbs_net_t	pbs_scheduler_addr;
-unsigned int	pbs_scheduler_port;
 pbs_net_t	pbs_server_addr;
 unsigned int	pbs_server_port_dis;
 /*
@@ -271,20 +269,18 @@ char	       *pbs_server_id;
 int		reap_child_flag = 0;
 time_t		secondary_delay = 30;
 struct server	server;		/* the server structure */
-pbs_sched	*dflt_scheduler;	/* the default scheduler */
+pbs_sched	*dflt_scheduler = NULL;	/* the default scheduler */
 char	        primary_host[PBS_MAXHOSTNAME+1];   /* host_name of primary */
 int		shutdown_who;		/* see req_shutdown() */
 char	       *mom_host = server_host;
 long		new_log_event_mask = 0;
 int		server_init_type = RECOV_WARM;
 int		svr_delay_entry = 0;
-int             svr_do_schedule = SCH_SCHEDULE_NULL;
-int             svr_do_sched_high = SCH_SCHEDULE_NULL; /* high priority cmds */
 int             svr_ping_rate = SVR_DEFAULT_PING_RATE;    /* time between sets of node pings */
 int             ping_nodes_rate = SVR_DEFAULT_PING_RATE; /* time between ping nodes as determined from server_init_type */
-pbs_list_head   svr_deferred_req;
-pbs_list_head   svr_queues;            /* list of queues                   */
-pbs_list_head   svr_alljobs;           /* list of all jobs in server       */
+pbs_list_head	svr_deferred_req;
+pbs_list_head	svr_queues;            /* list of queues                   */
+pbs_list_head	svr_alljobs;           /* list of all jobs in server       */
 pbs_list_head	svr_newjobs;           /* list of incomming new jobs       */
 pbs_list_head	svr_allresvs;          /* all reservations in server */
 pbs_list_head	svr_newresvs;          /* temporary list for new resv jobs */
@@ -367,8 +363,8 @@ int tpp_network_up = 0;
 void
 net_restore_handler(void *data)
 {
-    log_tppmsg(LOG_INFO, NULL, "net restore handler called");
-    tpp_network_up = 1;
+	log_tppmsg(LOG_INFO, NULL, "net restore handler called");
+	tpp_network_up = 1;
     ping_nodes(NULL);
 }
 
@@ -907,6 +903,7 @@ main(int argc, char **argv)
 	struct batch_request	*periodic_req;
 	char			hook_msg[HOOK_MSG_SIZE];
 	int			ret;
+	pbs_sched		*psched;
 #ifndef WIN32
 	pid_t			sid = -1;
 #endif
@@ -933,6 +930,9 @@ main(int argc, char **argv)
 	int				try_db = 0;
 	int 			db_stop_counts = 0;
 	int 			db_stop_email_sent = 0;
+
+	pbs_net_t		pbs_scheduler_addr;
+	unsigned int		pbs_scheduler_port;
 
 	extern int		optind;
 	extern char		*optarg;
@@ -1907,10 +1907,10 @@ try_db_again:
 		svr_mailowner(0, 0, 1, log_buffer);
 		if (server.sv_attr[(int)SRV_ATR_scheduling].at_val.at_long) {
 			/* Scheduling is true, see if we can contact scheduler */
-			if (contact_sched(SCH_SCHEDULE_NULL, NULL) < 0) {
+			if (contact_sched(SCH_SCHEDULE_NULL, NULL, pbs_scheduler_addr, pbs_scheduler_port) < 0) {
 				/* No - try bringing up scheduler here */
 				pbs_scheduler_addr = get_hostaddr(pbs_conf.pbs_secondary);
-				if (contact_sched(SCH_SCHEDULE_NULL, NULL) < 0) {
+				if (contact_sched(SCH_SCHEDULE_NULL, NULL, pbs_scheduler_addr, pbs_scheduler_port) < 0) {
 					char **workenv;
 					char schedcmd[MAXPATHLEN+1];
 					/* save the current, "safe", environment.          */
@@ -1945,6 +1945,8 @@ try_db_again:
 		(void)set_task(WORK_Timed, time_now, primary_handshake, NULL);
 
 	}
+	dflt_scheduler->pbs_scheduler_addr = pbs_scheduler_addr;
+	dflt_scheduler->pbs_scheduler_port = pbs_scheduler_port;
 
 #ifdef WIN32
 	sprintf(log_buffer, msg_startup2, getpid(), pbs_server_port_dis,
@@ -2045,53 +2047,56 @@ try_db_again:
 				clear_exec_vnode();
 				first_run = 0;
 			}
+			for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+				/* if time or event says to run scheduler, do it */
 
-			/* if time or event says to run scheduler, do it */
+				/* if we have a high prio sched command, send it 1st */
+				if ((strcmp(psched->sch_attr[SCHED_ATR_sched_state].at_val.at_str, SC_DOWN)) &&
+					psched->svr_do_sched_high != SCH_SCHEDULE_NULL)
+					schedule_high(psched);
 
-			/* if we have a high prio sched command, send it 1st */
-			if (svr_do_sched_high != SCH_SCHEDULE_NULL)
-				schedule_high();
 
+				if (psched->svr_do_schedule == SCH_SCHEDULE_RESTART_CYCLE) {
 
-			if (svr_do_schedule == SCH_SCHEDULE_RESTART_CYCLE) {
-
-				/* send only to existing connection */
-				/* since it is for interrupting current */
-				/* cycle */
-				/* NOTE: both primary and secondary scheduler */
-				/* connect must have been setup to be valid */
-				if ((scheduler_sock2 != -1) &&
-					(scheduler_sock != -1)) {
-					if (put_sched_cmd(scheduler_sock2,
-						svr_do_schedule, NULL) == 0) {
-						log_event(PBSEVENT_DEBUG2,
+					/* send only to existing connection */
+					/* since it is for interrupting current */
+					/* cycle */
+					/* NOTE: both primary and secondary scheduler */
+					/* connect must have been setup to be valid */
+					if ((psched->scheduler_sock2 != -1) &&
+						(psched->scheduler_sock != -1)) {
+						if (put_sched_cmd(psched->scheduler_sock2,
+								psched->svr_do_schedule, NULL) == 0) {
+							log_event(PBSEVENT_DEBUG2,
+								PBS_EVENTCLASS_SERVER,
+								LOG_NOTICE, msg_daemonname,
+								"sent scheduler restart scheduling cycle request");
+						}
+					} else {
+						log_event(PBSEVENT_DEBUG3,
 							PBS_EVENTCLASS_SERVER,
 							LOG_NOTICE, msg_daemonname,
-							"sent scheduler restart scheduling cycle request");
+							"no valid secondary connection to scheduler: restart scheduling cycle request ignored");
 					}
-				} else {
-					log_event(PBSEVENT_DEBUG3,
-						PBS_EVENTCLASS_SERVER,
-						LOG_NOTICE, msg_daemonname,
-						"no valid secondary connection to scheduler: restart scheduling cycle request ignored");
+					psched->svr_do_schedule = SCH_SCHEDULE_NULL;
+				} else if (((svr_unsent_qrun_req) || ((psched->svr_do_schedule != SCH_SCHEDULE_NULL) &&
+					psched->sch_attr[(int)SCHED_ATR_scheduling].at_val.at_long))
+					&& can_schedule()) {
+					/*
+					 * If svr_unsent_qrun_req is set to one there are pending qrun
+					 * request, then do schedule_jobs irrespective of the server scheduling
+					 * state.
+					 * If svr_unsent_qrun_req is not set then do the existing checking and do
+					 * scheduling only if server scheduling is turned on.
+					 */
+
+					psched->sch_next_schedule = time_now +
+							psched->sch_attr[(int)	SCHED_ATR_schediteration].at_val.at_long;
+					if((strcmp(psched->sch_attr[SCHED_ATR_sched_state].at_val.at_str, SC_DOWN)) &&
+							(schedule_jobs(psched) == 0) && (svr_unsent_qrun_req))
+						svr_unsent_qrun_req = 0;
 				}
-				svr_do_schedule = SCH_SCHEDULE_NULL;
-			} else if (((svr_unsent_qrun_req) || ((svr_do_schedule != SCH_SCHEDULE_NULL) &&
-				server.sv_attr[(int)SRV_ATR_scheduling].at_val.at_long))
-				&& can_schedule()) {
-				/*
-				 * If svr_unsent_qrun_req is set to one there are pending qrun
-				 * request, then do schedule_jobs irrespective of the server scheduling 
-				 * state.
-				 * If svr_unsent_qrun_req is not set then do the existing checking and do 
-				 * scheduling only if server scheduling is turned on.
-				 */
-				server.sv_next_schedule = time_now + server.sv_attr[(int)SRV_ATR_scheduler_iteration].at_val.at_long;
-				if((schedule_jobs() == 0) && (svr_unsent_qrun_req))
-					svr_unsent_qrun_req = 0;
 			}
-
-
 		} else if (*state == SV_STATE_HOT) {
 
 			/* Are there HOT jobs to rerun */
@@ -2191,7 +2196,7 @@ try_db_again:
 	/* if brought up the Secondary Scheduler, take it down */
 
 	if (brought_up_alt_sched == 1)
-		(void)contact_sched(SCH_QUIT, NULL);
+		(void)contact_sched(SCH_QUIT, NULL, pbs_scheduler_addr, pbs_scheduler_port);
 
 	/* if Moms are to to down as well, tell them */
 
@@ -2352,15 +2357,18 @@ next_task()
 
 	time_t		   tilwhen;
 	time_t		   delay;
+	pbs_sched	   *psched;
 
 	tilwhen = default_next_task();
 
 	/* should the scheduler be run?  If so, adjust the delay time  */
 
-	if ((delay = server.sv_next_schedule - time_now) <= 0)
-		set_scheduler_flag(SCH_SCHEDULE_TIME);
-	else if (delay < tilwhen)
-		tilwhen = delay;
+	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+		if ((delay = psched->sch_next_schedule - time_now) <= 0)
+			set_scheduler_flag(SCH_SCHEDULE_TIME, psched);
+		else if (delay < tilwhen)
+			tilwhen = delay;
+	}
 
 	next_sync_mom_hookfiles();
 
@@ -2990,9 +2998,9 @@ try_connect_database(pbs_db_conn_t *conn)
 	if (conn->conn_state == PBS_DB_CONNECT_STATE_FAILED && failcode != PBS_DB_STILL_STARTING) {
 		db_oper_failed_times++;
 		get_db_errmsg(failcode, &db_err_msg);
-		log_set_dberr(db_err_msg, conn->conn_db_err);
+			log_set_dberr(db_err_msg, conn->conn_db_err);
 		log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_CRIT, msg_daemonname, log_buffer);
-		conn->conn_db_state = PBS_DB_DOWN; /* allow to retry to start db again */
+			conn->conn_db_state = PBS_DB_DOWN; /* allow to retry to start db again */
 	} else if (conn->conn_state == PBS_DB_CONNECT_STATE_CONNECTED) {
 		sprintf(log_buffer, "connected to PBS dataservice@%s", conn->conn_host);
 		log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE,
@@ -3109,7 +3117,7 @@ setup_db_connection(char *host, int timeout, int have_db_control)
 
 		if (db_err_msg && strlen(db_err_msg) > 0) {
 			log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_CRIT, msg_daemonname, db_err_msg);
-			fprintf(stderr, "%s\n", db_err_msg);
+		fprintf(stderr, "%s\n", db_err_msg);
 		}
 
 		if (errmsg && strlen(errmsg) > 0) {

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -109,6 +109,7 @@
 #include "dis.h"
 #include "pbs_nodes.h"
 #include "svrfunc.h"
+#include "pbs_sched.h"
 
 /* global data items */
 

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -126,7 +126,6 @@ extern char  *msg_request;
 
 extern int    is_local_root(char *, char *);
 extern void   req_stat_hook(struct batch_request *);
-extern int    scheduler_sock;
 
 /* Private functions local to this file */
 
@@ -583,8 +582,7 @@ process_request(int sfds)
 #ifndef PBS_MOM
 	/* If the request is coming on the socket we opened to the  */
 	/* scheduler,  change the "user" from "root" to "Scheduler" */
-
-	if (request->rq_conn == scheduler_sock) {
+	if (find_sched_from_sock(request->rq_conn) != NULL) {
 		strncpy(request->rq_user, PBS_SCHED_DAEMON_NAME, PBS_MAXUSER);
 		request->rq_user[PBS_MAXUSER] = '\0';
 	}

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -357,6 +357,7 @@ queuestart_action(attribute *pattr, void *pobject, int actmode)
 	long	oldtype;
 	long 	newaccruetype = -1;	/* if determining accrue type */
 	pbs_queue *pque = (pbs_queue *) pobject;
+	pbs_sched *psched;
 
 	if ((pque != NULL) && (server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long == 1)) {
 
@@ -401,8 +402,14 @@ queuestart_action(attribute *pattr, void *pobject, int actmode)
 			}
 
 			/* if scheduling = True, notify scheduler to start */
-			if (server.sv_attr[SRV_ATR_scheduling].at_val.at_long)
-				set_scheduler_flag(SCH_SCHEDULE_STARTQ);
+			if (server.sv_attr[SRV_ATR_scheduling].at_val.at_long) {
+				if (find_assoc_sched_pq(pque, &psched))
+					set_scheduler_flag(SCH_SCHEDULE_STARTQ, psched);
+				else {
+					sprintf(log_buffer, "No scheduler associated with the queue %s", pque->qu_qs.qu_name);
+					log_err(-1, __func__, log_buffer);
+				}
+			}
 		}
 	}
 

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -76,6 +76,7 @@
 #include "pbs_db.h"
 #include "pbs_nodes.h"
 #include <memory.h>
+#include "pbs_sched.h"
 
 
 /* Global Data */
@@ -403,10 +404,10 @@ queuestart_action(attribute *pattr, void *pobject, int actmode)
 
 			/* if scheduling = True, notify scheduler to start */
 			if (server.sv_attr[SRV_ATR_scheduling].at_val.at_long) {
-				if (find_assoc_sched_pq(pque, &psched))
+				if (find_assoc_sched_pque(pque, &psched))
 					set_scheduler_flag(SCH_SCHEDULE_STARTQ, psched);
 				else {
-					sprintf(log_buffer, "No scheduler associated with the queue %s", pque->qu_qs.qu_name);
+					sprintf(log_buffer, "No scheduler associated with the partition %s", pque->qu_attr[QA_ATR_partition].at_val.at_str);
 					log_err(-1, __func__, log_buffer);
 				}
 			}

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -101,6 +101,8 @@ extern time_t time_now;
 /* External functions */
 
 extern int issue_to_svr(char *, struct batch_request *, void (*func)(struct work_task *));
+extern struct batch_request *cpy_stage(struct batch_request *, job *, enum job_atr, int);
+extern resc_resv  *chk_rescResv_request(char *, struct batch_request *);
 
 /* Private Functions in this file */
 
@@ -327,6 +329,7 @@ req_deletejob(struct batch_request *preq)
 	int delhist = 0;
 	int maxindex = 0;
 	int count = 0;
+	extern job  *chk_job_request(char *, struct batch_request *, int *);
 
 	jid = preq->rq_ind.rq_delete.rq_objname;
 

--- a/src/server/req_getcred.c
+++ b/src/server/req_getcred.c
@@ -53,6 +53,7 @@
 #include "credential.h"
 #include "net_connect.h"
 #include "batch_request.h"
+#include "pbs_share.h"
 
 
 /* External Global Data Items Referenced */
@@ -85,6 +86,9 @@ req_connect(struct batch_request *preq)
 	if ( (preq->rq_extend != NULL) && \
 		(strcmp(preq->rq_extend, QSUB_DAEMON) == 0) ) {
 		conn->cn_authen |= PBS_NET_CONN_FROM_QSUB_DAEMON;
+	} else if ( (preq->rq_extend != NULL) && \
+		(strcmp(preq->rq_extend, SC_DAEMON) == 0) ) {
+		conn->cn_authen |= PBS_NET_CONN_FROM_PRIVIL;
 	}
 
 	if ((conn->cn_authen &

--- a/src/server/req_getcred.c
+++ b/src/server/req_getcred.c
@@ -83,13 +83,13 @@ req_connect(struct batch_request *preq)
 		return;
 	}
 
-	if ( (preq->rq_extend != NULL) && \
-		(strcmp(preq->rq_extend, QSUB_DAEMON) == 0) ) {
-		conn->cn_authen |= PBS_NET_CONN_FROM_QSUB_DAEMON;
-	} else if ( (preq->rq_extend != NULL) && \
-		(strcmp(preq->rq_extend, SC_DAEMON) == 0) ) {
-		conn->cn_authen |= PBS_NET_CONN_FROM_PRIVIL;
+	if (preq->rq_extend != NULL) {
+		if (strcmp(preq->rq_extend, QSUB_DAEMON) == 0)
+			conn->cn_authen |= PBS_NET_CONN_FROM_QSUB_DAEMON;
+		else if (strcmp(preq->rq_extend, SC_DAEMON) == 0)
+			conn->cn_authen |= PBS_NET_CONN_FROM_PRIVIL;
 	}
+
 
 	if ((conn->cn_authen &
 		(PBS_NET_CONN_AUTHENTICATED|PBS_NET_CONN_FROM_PRIVIL))==0) {

--- a/src/server/req_holdjob.c
+++ b/src/server/req_holdjob.c
@@ -83,6 +83,8 @@ extern char	*msg_jobholdrel;
 extern char	*msg_mombadhold;
 extern char	*msg_postmomnojob;
 extern time_t	 time_now;
+extern job  *chk_job_request(char *, struct batch_request *, int *);
+
 
 int chk_hold_priv(long val, int perm);
 

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -623,6 +623,7 @@ void
 rel_resc(job *pjob)
 {
 	conn_t *conn = NULL;
+	pbs_sched *psched;
 
 	free_nodes(pjob);
 
@@ -649,7 +650,12 @@ rel_resc(job *pjob)
 
 	/* Mark that scheduler should be called */
 
-	set_scheduler_flag(SCH_SCHEDULE_TERM);
+	if (find_assoc_sched_pj(pjob, &psched))
+		set_scheduler_flag(SCH_SCHEDULE_TERM, psched);
+	else {
+		sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);
+		log_err(-1, __func__, log_buffer);
+	}
 }
 /**
  * @brief

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -94,6 +94,7 @@
 #include "dis.h"
 #include "rpp.h"
 #include "libutil.h"
+#include "pbs_sched.h"
 
 
 /* External Global Data Items */
@@ -650,10 +651,12 @@ rel_resc(job *pjob)
 
 	/* Mark that scheduler should be called */
 
-	if (find_assoc_sched_pj(pjob, &psched))
+	if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
 		set_scheduler_flag(SCH_SCHEDULE_TERM, psched);
 	else {
-		sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);
+		pbs_queue *pq;
+		pq = find_queuebyname( pjob->ji_qs.ji_queue);
+		sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pq->qu_attr[QA_ATR_partition].at_val.at_str);
 		log_err(-1, __func__, log_buffer);
 	}
 }

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1615,8 +1615,23 @@ mgr_server_unset(struct batch_request *preq)
 		} else if (strcasecmp(plist->al_name,
 			ATTR_power_provisioning) == 0) {
 			unset_power_provisioning();
+		} else if (strcasecmp(plist->al_name,
+				ATTR_scheduling) == 0) {
+			if (dflt_scheduler) {
+				dflt_scheduler->sch_attr[SCHED_ATR_scheduling].at_val.at_long = 0;
+				dflt_scheduler->sch_attr[SCHED_ATR_scheduling].at_flags |=
+						ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+				(void)sched_save_db(dflt_scheduler, SVR_SAVE_FULL);
+			}
+		}  else if (strcasecmp(plist->al_name,
+				ATTR_schediteration) == 0) {
+			if (dflt_scheduler) {
+				dflt_scheduler->sch_attr[SCHED_ATR_schediteration].at_val.at_long = 0;
+				dflt_scheduler->sch_attr[SCHED_ATR_schediteration].at_flags |=
+						ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+				(void)sched_save_db(dflt_scheduler, SVR_SAVE_FULL);
+			}
 		}
-
 		plist = (struct svrattrl *)GET_NEXT(plist->al_link);
 	}
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
@@ -4145,7 +4160,7 @@ mgr_resource_delete(struct batch_request *preq)
 
 	restart_python_interpreter(__func__);
 	deferred_send_rescdef();
-	set_scheduler_flag(SCH_CONFIGURE);
+	set_scheduler_flag(SCH_CONFIGURE, NULL);
 
 	return;
 }
@@ -4384,7 +4399,7 @@ mgr_resource_set(struct batch_request *preq)
 
 	restart_python_interpreter(__func__);
 	deferred_send_rescdef();
-	set_scheduler_flag(SCH_CONFIGURE);
+	set_scheduler_flag(SCH_CONFIGURE, NULL);
 
 	return;
 }
@@ -4614,7 +4629,7 @@ mgr_resource_unset(struct batch_request *preq)
 
 	restart_python_interpreter(__func__);
 	deferred_send_rescdef();
-	set_scheduler_flag(SCH_CONFIGURE);
+	set_scheduler_flag(SCH_CONFIGURE, NULL);
 
 	return;
 }

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1711,15 +1711,23 @@ void
 mgr_sched_unset(struct batch_request *preq)
 {
 	int	  bad_attr = 0;
-	svrattrl *plist;
+	svrattrl *plist, *tmp_plist;
 	int	  rc;
 	pbs_sched *psched = find_scheduler(preq->rq_ind.rq_manager.rq_objname);
 	if (!psched) {
 		req_reject(PBSE_UNKSCHED, 0, preq);
 		return;
 	}
-	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 
+
+	for (tmp_plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);tmp_plist;tmp_plist = (struct svrattrl *)GET_NEXT(tmp_plist->al_link)) {
+		if (strcasecmp(tmp_plist->al_name, ATTR_sched_log) == 0 ||
+			strcasecmp(tmp_plist->al_name, ATTR_sched_priv) == 0) {
+			set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
+		}
+	}
+
+	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 	rc = mgr_unset_attr(psched->sch_attr, sched_attr_def, SCHED_ATR_LAST, plist,
 		preq->rq_perm, &bad_attr, (void *)psched, PARENT_TYPE_SCHED, INDIRECT_RES_CHECK);
 	if (rc != 0)

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1720,7 +1720,7 @@ mgr_sched_unset(struct batch_request *preq)
 	}
 
 
-	for (tmp_plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);tmp_plist;tmp_plist = (struct svrattrl *)GET_NEXT(tmp_plist->al_link)) {
+	for (tmp_plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr); tmp_plist; tmp_plist = (struct svrattrl *)GET_NEXT(tmp_plist->al_link)) {
 		if (strcasecmp(tmp_plist->al_name, ATTR_sched_log) == 0 ||
 			strcasecmp(tmp_plist->al_name, ATTR_sched_priv) == 0) {
 			set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);

--- a/src/server/req_message.c
+++ b/src/server/req_message.c
@@ -76,6 +76,9 @@ static void post_message_req(struct work_task *);
 
 extern char *msg_messagejob;
 
+extern job  *chk_job_request(char *, struct batch_request *, int *);
+
+
 
 /**
  * @brief

--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -87,7 +87,6 @@ extern int   comp_resc_lt;
 extern char *resc_in_err;
 
 static resource_def *pseldef = NULL;
-extern int scheduler_sock;
 extern int scheduler_jobs_stat;
 extern int resc_access_perm;
 extern char *msg_nostf_resv;
@@ -197,7 +196,7 @@ req_modifyjob(struct batch_request *preq)
 	}
 
 	/* allow scheduler to modify job */
-	if (preq->rq_conn != scheduler_sock) {
+	if (find_sched_from_sock(preq->rq_conn) == NULL) {
 		/* provisioning job is not allowed to be modified */
 		if ((pjob->ji_qs.ji_state == JOB_STATE_RUNNING) &&
 			(pjob->ji_qs.ji_substate == JOB_SUBSTATE_PROVISION)) {
@@ -242,7 +241,7 @@ req_modifyjob(struct batch_request *preq)
 		 * If the scheduler itself sends a modify job request,
 		 * no need to delay the job until next cycle.
 		 */
-		if ((preq->rq_conn != scheduler_sock) && (scheduler_jobs_stat) && (job_attr_def[i].at_flags & ATR_DFLAG_SCGALT))
+		if ((find_sched_from_sock(preq->rq_conn) == NULL) && (scheduler_jobs_stat) && (job_attr_def[i].at_flags & ATR_DFLAG_SCGALT))
 			add_to_am_list = 1;
 
 		/* Is the attribute modifiable in RUN state ? */
@@ -880,7 +879,7 @@ req_modifyReservation(struct batch_request *preq)
 		rc = modify_resv_attr(presv, psatl, preq->rq_perm, &bad);
 
 	if (send_to_scheduler)
-		set_scheduler_flag(SCH_SCHEDULE_RESV_RECONFIRM);
+		set_scheduler_flag(SCH_SCHEDULE_RESV_RECONFIRM, dflt_scheduler);
 
 	(void)sprintf(log_buffer, "Attempting to modify reservation");
 	if (presv->ri_alter_flags & RESV_START_TIME_MODIFIED) {

--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -70,6 +70,7 @@
 #include "hook.h"
 #include "sched_cmds.h"
 #include "pbs_internal.h"
+#include "pbs_sched.h"
 
 
 /* Global Data Items: */
@@ -94,6 +95,9 @@ extern char *msg_nostf_resv;
 int modify_resv_attr(resc_resv *presv, svrattrl *plist, int perm, int *bad);
 extern void resv_revert_alter_times(resc_resv *presv);
 extern int gen_future_reply(resc_resv *presv, long fromNow);
+extern job  *chk_job_request(char *, struct batch_request *, int *);
+extern resc_resv  *chk_rescResv_request(char *, struct batch_request *);
+
 
 
 

--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -162,6 +162,7 @@ req_modifyjob(struct batch_request *preq)
 	int		 sendmom = 0;
 	char		hook_msg[HOOK_MSG_SIZE];
 	int		mod_project = 0;
+	pbs_sched	*psched;
 
 	switch (process_hooks(preq, hook_msg, sizeof(hook_msg),
 			pbs_python_set_interrupt)) {
@@ -199,8 +200,9 @@ req_modifyjob(struct batch_request *preq)
 		return;
 	}
 
+	psched = find_sched_from_sock(preq->rq_conn);
 	/* allow scheduler to modify job */
-	if (find_sched_from_sock(preq->rq_conn) == NULL) {
+	if (psched == NULL) {
 		/* provisioning job is not allowed to be modified */
 		if ((pjob->ji_qs.ji_state == JOB_STATE_RUNNING) &&
 			(pjob->ji_qs.ji_substate == JOB_SUBSTATE_PROVISION)) {
@@ -245,7 +247,7 @@ req_modifyjob(struct batch_request *preq)
 		 * If the scheduler itself sends a modify job request,
 		 * no need to delay the job until next cycle.
 		 */
-		if ((find_sched_from_sock(preq->rq_conn) == NULL) && (scheduler_jobs_stat) && (job_attr_def[i].at_flags & ATR_DFLAG_SCGALT))
+		if ((psched == NULL) && (scheduler_jobs_stat) && (job_attr_def[i].at_flags & ATR_DFLAG_SCGALT))
 			add_to_am_list = 1;
 
 		/* Is the attribute modifiable in RUN state ? */

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -111,6 +111,7 @@
 #include "user.h"
 #include "hook.h"
 #include "pbs_internal.h"
+#include "pbs_sched.h"
 #ifndef PBS_MOM
 #include "pbs_db.h"
 #endif

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -2407,7 +2407,7 @@ req_commit(struct batch_request *preq)
 		}
 		delete_link(&presv->ri_allresvs);
 		append_link(&svr_allresvs, &presv->ri_allresvs, presv);
-		set_scheduler_flag(SCH_SCHEDULE_NEW);
+		set_scheduler_flag(SCH_SCHEDULE_NEW, dflt_scheduler);
 		Update_Resvstate_if_resv(pj);
 	}
 
@@ -3223,7 +3223,7 @@ req_resvSub(struct batch_request *preq)
 	 * is available for consideration
 	 */
 	append_link(&svr_allresvs, &presv->ri_allresvs, presv);
-	set_scheduler_flag(SCH_SCHEDULE_NEW);
+	set_scheduler_flag(SCH_SCHEDULE_NEW, dflt_scheduler);
 }
 
 

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -79,6 +79,8 @@ static void req_rerunjob2(struct batch_request *preq, job *pjob);
 extern char *msg_manager;
 extern char *msg_jobrerun;
 extern time_t time_now;
+extern job  *chk_job_request(char *, struct batch_request *, int *);
+
 
 
 /**

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -140,8 +140,6 @@ extern char *msg_init_substate;
 extern char *msg_manager;
 extern char *msg_stageinfail;
 extern char *msg_job_abort;
-extern int   scheduler_sock;
-extern int   svr_do_schedule;
 extern pbs_list_head svr_deferred_req;
 extern time_t time_now;
 extern int   svr_totnodes;	/* non-zero if using nodes */
@@ -309,6 +307,7 @@ req_runjob(struct batch_request *preq)
 	int		  x, y, z;
 	struct deferred_request *pdefr;
 	char		  hook_msg[HOOK_MSG_SIZE];
+	pbs_sched	  *psched;
 
 	if (license_expired) {
 		req_reject(PBSE_LICENSEINV, 0, preq);
@@ -332,15 +331,22 @@ req_runjob(struct batch_request *preq)
 		return;
 	}
 	
+	if (!find_assoc_sched_jid(jid, &psched)) {
+		sprintf(log_buffer, "Unable to reach scheduler associated with job %s", jid);
+		log_err(-1, __func__, log_buffer);
+		req_reject(PBSE_IVALREQ, 0, preq);
+		return;
+	}
+
 #ifndef NAS /* localmod 133 */
-	if ((scheduler_sock != -1) && was_job_alteredmoved(parent)) {
+	if ((psched->scheduler_sock != -1) && was_job_alteredmoved(parent)) {
 		int index = find_attr(sched_attr_def, ATTR_throughput_mode, SCHED_ATR_LAST);
 		/* do not blacklist altered/moved jobs when throughput_mode is enabled */
 		if ((index == -1) ||
-			((dflt_scheduler->sch_attr[index].at_flags & ATR_VFLAG_SET) &&
-			 (dflt_scheduler->sch_attr[index].at_val.at_long == 0))) {
+			((psched->sch_attr[index].at_flags & ATR_VFLAG_SET) &&
+			 (psched->sch_attr[index].at_val.at_long == 0))) {
 			req_reject(PBSE_NORUNALTEREDJOB, 0, preq);
-			set_scheduler_flag(SCH_SCHEDULE_NEW);
+			set_scheduler_flag(SCH_SCHEDULE_NEW, psched);
 			return;
 		}
 	}
@@ -424,7 +430,7 @@ req_runjob(struct batch_request *preq)
 
 		/* if runjob request is from the Scheduler, */
 		/* it must have a destination specified     */
-		if (preq->rq_conn == scheduler_sock) {
+		if (preq->rq_conn == psched->scheduler_sock) {
 			sprintf(log_buffer,
 				"runjob request from scheduler with null destination");
 			log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_JOB, LOG_INFO,
@@ -458,7 +464,8 @@ req_runjob(struct batch_request *preq)
 		/* ensure that request is removed if client connect is closed */
 		net_add_close_func(preq->rq_conn, clear_from_defr);
 
-		if (schedule_jobs() == -1) {
+		if ((strcmp(psched->sch_attr[SCHED_ATR_sched_state].at_val.at_str, SC_DOWN))
+			&&  schedule_jobs(psched) == -1) {
 			/* unable to contact the Scheduler, reject */
 			req_reject(PBSE_NOSCHEDULER, 0, preq);
 			/* unlink and free the deferred request entry */
@@ -1595,7 +1602,7 @@ post_sendmom(struct work_task *pwt)
 							}
 							if ((phook->fail_action & HOOK_FAIL_ACTION_SCHEDULER_RESTART_CYCLE) != 0) {
 
-								set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE);
+								set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE, dflt_scheduler);
 								log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_HOOK, LOG_INFO, phook->hook_name, "requested for scheduler to restart cycle");
 							}
 						}
@@ -1733,7 +1740,7 @@ where_to_runjob(struct batch_request *preq, job *pjob)
 	}
 
 	/* If the request did not come from the scheduler, update the comment. */
-	if (preq->rq_conn != scheduler_sock) {
+	if (find_sched_from_sock(preq->rq_conn) == NULL) {
 		char comment[MAXCOMMENTLEN];
 		nspec = pjob->ji_wattr[(int)JOB_ATR_exec_vnode].at_val.at_str;
 		if ((nspec != NULL) && (*nspec != '\0')) {

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -103,6 +103,7 @@
 #include "hook.h"
 #include "provision.h"
 #include "pbs_share.h"
+#include "pbs_sched.h"
 
 
 /* External Functions Called: */
@@ -143,6 +144,8 @@ extern char *msg_job_abort;
 extern pbs_list_head svr_deferred_req;
 extern time_t time_now;
 extern int   svr_totnodes;	/* non-zero if using nodes */
+extern job  *chk_job_request(char *, struct batch_request *, int *);
+
 
 /* private data */
 
@@ -464,8 +467,7 @@ req_runjob(struct batch_request *preq)
 		/* ensure that request is removed if client connect is closed */
 		net_add_close_func(preq->rq_conn, clear_from_defr);
 
-		if ((strcmp(psched->sch_attr[SCHED_ATR_sched_state].at_val.at_str, SC_DOWN))
-			&&  schedule_jobs(psched) == -1) {
+		if (schedule_jobs(psched) == -1) {
 			/* unable to contact the Scheduler, reject */
 			req_reject(PBSE_NOSCHEDULER, 0, preq);
 			/* unlink and free the deferred request entry */

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -332,6 +332,7 @@ req_selectjobs(struct batch_request *preq)
 	char		   *pstate = NULL;
 	int		    rc;
 	struct select_list *selistp;
+	pbs_sched	   *psched;
 
 	/*
 	 * if the letter T (or t) is in the extend string,  select subjobs
@@ -365,7 +366,8 @@ req_selectjobs(struct batch_request *preq)
 	 * approach to query for jobs, e.g., by issuing a single pbs_statjob()
 	 * instead of a per-queue selstat()
 	 */
-	if ((find_sched_from_sock(preq->rq_conn) != NULL) && (!scheduler_jobs_stat)) {
+	psched = find_sched_from_sock(preq->rq_conn);
+	if ((psched != NULL) && (psched == dflt_scheduler ) && (!scheduler_jobs_stat)) {
 		scheduler_jobs_stat = 1;
 	}
 

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -79,7 +79,7 @@
 #include "log.h"
 #include "pbs_nodes.h"
 #include "svrfunc.h"
-
+#include "pbs_sched.h"
 
 /* Private Data */
 

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -90,7 +90,6 @@ extern pbs_list_head svr_alljobs;
 extern time_t	 time_now;
 extern char	 statechars[];
 extern long svr_history_enable;
-extern int scheduler_sock;
 extern int scheduler_jobs_stat;
 
 /* Private Functions  */
@@ -366,7 +365,8 @@ req_selectjobs(struct batch_request *preq)
 	 * approach to query for jobs, e.g., by issuing a single pbs_statjob()
 	 * instead of a per-queue selstat()
 	 */
-	if ((scheduler_sock != -1) && (preq->rq_conn == scheduler_sock) && (!scheduler_jobs_stat)) {
+	if ((find_sched_from_sock(preq->rq_conn) != NULL) && (!scheduler_jobs_stat)) {
+		//if ((dflt_scheduler->scheduler_sock != -1) && (preq->rq_conn == dflt_scheduler->scheduler_sock) && (!scheduler_jobs_stat)) {
 		scheduler_jobs_stat = 1;
 	}
 

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -366,7 +366,6 @@ req_selectjobs(struct batch_request *preq)
 	 * instead of a per-queue selstat()
 	 */
 	if ((find_sched_from_sock(preq->rq_conn) != NULL) && (!scheduler_jobs_stat)) {
-		//if ((dflt_scheduler->scheduler_sock != -1) && (preq->rq_conn == dflt_scheduler->scheduler_sock) && (!scheduler_jobs_stat)) {
 		scheduler_jobs_stat = 1;
 	}
 

--- a/src/server/req_shutdown.c
+++ b/src/server/req_shutdown.c
@@ -266,7 +266,7 @@ req_shutdown(struct batch_request *preq)
 		(void)failover_send_shutdown(FAILOVER_SecdShutdown);
 
 	if (shutdown_who & SHUT_WHO_SCHED)
-		(void)contact_sched(SCH_QUIT, NULL);	/* tell scheduler to quit */
+		(void)contact_sched(SCH_QUIT, NULL, dflt_scheduler->pbs_scheduler_addr, dflt_scheduler->pbs_scheduler_port);	/* tell scheduler to quit */
 
 	if (shutdown_who & SHUT_WHO_SECDONLY) {
 		reply_ack(preq);

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -283,6 +283,7 @@ req_signaljob2(struct batch_request *preq, job *pjob)
 	char 		 *pnodespec;
 	int		suspend = 0;
 	int		resume = 0;
+	pbs_sched	*psched;
 
 	if ((pjob->ji_qs.ji_state != JOB_STATE_RUNNING)	||
 		((pjob->ji_qs.ji_state == JOB_STATE_RUNNING) && (pjob->ji_qs.ji_substate == JOB_SUBSTATE_PROVISION))) {
@@ -349,7 +350,12 @@ req_signaljob2(struct batch_request *preq, job *pjob)
 					/* not from scheduler, change substate so the  */
 					/* scheduler will resume the job when possible */
 					svr_setjobstate(pjob, JOB_STATE_RUNNING, JOB_SUBSTATE_SCHSUSP);
-					set_scheduler_flag(SCH_SCHEDULE_NEW);
+					if (find_assoc_sched_pj(pjob, &psched))
+						set_scheduler_flag(SCH_SCHEDULE_NEW, psched);
+					else {
+						sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);
+						log_err(-1, __func__, log_buffer);
+					}
 					reply_send(preq);
 					return;
 				}

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -69,6 +69,7 @@
 #include "pbs_nodes.h"
 #include "svrfunc.h"
 #include "sched_cmds.h"
+#include "pbs_sched.h"
 
 
 /* Private Function local to this file */
@@ -82,6 +83,8 @@ int create_resreleased (job *pjob);
 
 extern char *msg_momreject;
 extern char *msg_signal_job;
+extern job  *chk_job_request(char *, struct batch_request *, int *);
+
 
 /**
  * @brief
@@ -350,7 +353,7 @@ req_signaljob2(struct batch_request *preq, job *pjob)
 					/* not from scheduler, change substate so the  */
 					/* scheduler will resume the job when possible */
 					svr_setjobstate(pjob, JOB_STATE_RUNNING, JOB_SUBSTATE_SCHSUSP);
-					if (find_assoc_sched_pj(pjob, &psched))
+					if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
 						set_scheduler_flag(SCH_SCHEDULE_NEW, psched);
 					else {
 						sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -118,8 +118,8 @@ static int bad;
 
 /* The following private support functions are included */
 
-static int  status_que(pbs_queue *, struct batch_request *, pbs_list_head *);
-static int status_node(struct pbsnode *, struct batch_request *, pbs_list_head *);
+static int  status_que(pbs_queue *, struct batch_request *, pbs_list_head *, attribute *attr);
+static int status_node(struct pbsnode *, struct batch_request *, pbs_list_head *, attribute *attr);
 static int status_resv(resc_resv *, struct batch_request *, pbs_list_head *);
 extern pbs_sched *find_scheduler(char *sched_name);
 /**
@@ -416,6 +416,9 @@ req_stat_que(struct batch_request *preq)
 	struct batch_reply *preply;
 	int		    rc   = 0;
 	int		    type = 0;
+	int		    k;
+	int		    consider_q = 0;
+	attribute	    attr;
 
 	/*
 	 * first, validate the name of the requested object, either
@@ -442,23 +445,86 @@ req_stat_que(struct batch_request *preq)
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
 
+	memset(&attr, 0, sizeof(attr));
+	if (preq->rq_extend != NULL) {
+		rc = sched_attr_def[SCHED_ATR_partition].at_decode(&attr, ATTR_partition, NULL, preq->rq_extend);
+		if (rc) {
+			(void) reply_free(preply);
+			req_reject(rc, bad, preq);
+			return;
+		}
+	}
+
 	if (type == 0) {	/* get status of the one named queue */
-		rc = status_que(pque, preq, &preply->brp_un.brp_status);
-
+		if (preq->rq_extend != NULL) {
+			if (pque->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
+				/*search for the partition in the attr*/
+				for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
+					if ((attr.at_val.at_arst->as_string[k] != NULL)
+							&& (!strcmp(
+									pque->qu_attr[QA_ATR_partition].at_val.at_str,
+									attr.at_val.at_arst->as_string[k]))) {
+						consider_q = 1;
+						break;
+					}
+				}
+			}
+		} else {
+			if (preq->rq_conn == dflt_scheduler->scheduler_sock) {
+				if (!(pque->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET))
+					consider_q = 1;
+			} else {
+				consider_q = 1;
+			}
+		}
+		if (consider_q) {
+			rc = status_que(pque, preq, &preply->brp_un.brp_status,
+					(preq->rq_extend ? &attr : NULL));
+			consider_q = 0;
+		}
 	} else {	/* get status of queues */
-
 		pque = (pbs_queue *)GET_NEXT(svr_queues);
 		while (pque) {
-			rc = status_que(pque, preq, &preply->brp_un.brp_status);
-			if (rc != 0) {
-				if (rc == PBSE_PERM)
-					rc = 0;
-				else
-					break;
+			if (preq->rq_extend != NULL) {
+				if (pque->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
+					/*search for the partition in the attr*/
+					for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
+						if ((attr.at_val.at_arst->as_string[k] != NULL)
+								&& (!strcmp(
+										pque->qu_attr[QA_ATR_partition].at_val.at_str,
+										attr.at_val.at_arst->as_string[k]))) {
+							consider_q = 1;
+							break;
+						}
+					}
+				}
+				if (!consider_q) {
+					pque = (pbs_queue *)GET_NEXT(pque->qu_link);
+					continue;
+				}
+			} else {
+				if (preq->rq_conn == dflt_scheduler->scheduler_sock) {
+					if (!(pque->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET))
+						consider_q = 1;
+				} else {
+					consider_q = 1;
+				}
+			}
+			if (consider_q) {
+				rc = status_que(pque, preq, &preply->brp_un.brp_status,
+						(preq->rq_extend ? &attr : NULL));
+				if (rc != 0) {
+					if (rc == PBSE_PERM)
+						rc = 0;
+					else
+						break;
+				}
+				consider_q = 0;
 			}
 			pque = (pbs_queue *)GET_NEXT(pque->qu_link);
 		}
 	}
+
 	if (rc) {
 		(void)reply_free(preply);
 		req_reject(rc, bad, preq);
@@ -481,10 +547,11 @@ req_stat_que(struct batch_request *preq)
  */
 
 static int
-status_que(pbs_queue *pque, struct batch_request *preq, pbs_list_head *pstathd)
+status_que(pbs_queue *pque, struct batch_request *preq, pbs_list_head *pstathd, attribute *attr)
 {
 	struct brp_status *pstat;
 	svrattrl	  *pal;
+	int k;
 
 	if ((preq->rq_perm & ATR_DFLAG_RDACC) == 0)
 		return (PBSE_PERM);
@@ -547,6 +614,9 @@ req_stat_node(struct batch_request *preq)
 	int		    rc   = 0;
 	int		    type = 0;
 	int		    i;
+	attribute	    attr;
+	int		    consider_n = 0;
+	int		    k;
 
 	/*
 	 * first, check that the server indeed has a list of nodes
@@ -578,18 +648,83 @@ req_stat_node(struct batch_request *preq)
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
 
+	memset(&attr, 0, sizeof(attr));
+
+	if (preq->rq_extend != NULL) {
+		rc = sched_attr_def[SCHED_ATR_partition].at_decode(&attr, ATTR_partition, NULL, preq->rq_extend);
+		if (rc) {
+			(void) reply_free(preply);
+			req_reject(rc, bad, preq);
+			return;
+		}
+	}
+
 	if (type == 0) {		/*get status of the named node*/
-		rc = status_node(pnode, preq, &preply->brp_un.brp_status);
-
-	} else {			/*get status of all nodes     */
-
+		if (preq->rq_extend != NULL) {
+			if (pnode->nd_attr[ND_ATR_partition].at_flags & ATR_VFLAG_SET) {
+				/*search for the partition in the attr*/
+				for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
+					if ((attr.at_val.at_arst->as_string[k] != NULL)
+							&& (!strcmp(
+									pnode->nd_attr[ND_ATR_partition].at_val.at_str,
+									attr.at_val.at_arst->as_string[k]))) {
+						consider_n = 1;
+						break;
+					}
+				}
+			}
+		} else {
+			if (preq->rq_conn == dflt_scheduler->scheduler_sock) {
+				if (!(pnode->nd_attr[ND_ATR_partition].at_flags & ATR_VFLAG_SET))
+					consider_n = 1;
+			} else {
+				consider_n = 1;
+			}
+		}
+		if (consider_n || preq->rq_conn != dflt_scheduler->scheduler_sock) {
+			rc = status_node(pnode, preq, &preply->brp_un.brp_status,
+					(preq->rq_extend ? &attr : NULL));
+			consider_n = 0;
+		}
+	} else {
+		/*get status of all nodes     */
 		for (i=0; i<svr_totnodes; i++) {
 			pnode = pbsndlist[i];
-
-			rc = status_node(pnode, preq,
-				&preply->brp_un.brp_status);
-			if (rc)
-				break;
+			if (preq->rq_extend != NULL) {
+				if (pnode->nd_attr[ND_ATR_partition].at_flags & ATR_VFLAG_SET) {
+					/*search for the partition in the attr*/
+					for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
+						if ((attr.at_val.at_arst->as_string[k] != NULL)
+								&& (!strcmp(
+										pnode->nd_attr[ND_ATR_partition].at_val.at_str,
+										attr.at_val.at_arst->as_string[k]))) {
+							consider_n = 1;
+							break;
+						}
+					}
+				}
+				if (!consider_n) {
+					continue;
+				}
+			} else {
+				if (preq->rq_conn == dflt_scheduler->scheduler_sock) {
+					if (!(pnode->nd_attr[ND_ATR_partition].at_flags & ATR_VFLAG_SET))
+						consider_n = 1;
+				} else {
+					consider_n = 1;
+				}
+			}
+			if (consider_n || preq->rq_conn != dflt_scheduler->scheduler_sock) {
+				rc = status_node(pnode, preq, &preply->brp_un.brp_status,
+						(preq->rq_extend ? &attr : NULL));
+				if (rc != 0) {
+					if (rc == PBSE_PERM)
+						rc = 0;
+					else
+						break;
+				}
+				consider_n = 0;
+			}
 		}
 	}
 
@@ -623,12 +758,14 @@ req_stat_node(struct batch_request *preq)
  */
 
 static int
-status_node(struct pbsnode *pnode, struct batch_request *preq, pbs_list_head *pstathd)
+status_node(struct pbsnode *pnode, struct batch_request *preq, pbs_list_head *pstathd, attribute *attr)
 {
 	int		   rc = 0;
 	struct brp_status *pstat;
 	svrattrl	  *pal;
 	unsigned long		   old_nd_state = VNODE_UNAVAILABLE;
+	int k;
+	int found;
 
 	if (pnode->nd_state & INUSE_DELETED)  /*node no longer valid*/
 		return  (0);

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -118,8 +118,8 @@ static int bad;
 
 /* The following private support functions are included */
 
-static int  status_que(pbs_queue *, struct batch_request *, pbs_list_head *, attribute *attr);
-static int status_node(struct pbsnode *, struct batch_request *, pbs_list_head *, attribute *attr);
+static int status_que(pbs_queue *, struct batch_request *, pbs_list_head *);
+static int status_node(struct pbsnode *, struct batch_request *, pbs_list_head *);
 static int status_resv(resc_resv *, struct batch_request *, pbs_list_head *);
 extern pbs_sched *find_scheduler(char *sched_name);
 /**
@@ -458,12 +458,10 @@ req_stat_que(struct batch_request *preq)
 	if (type == 0) {	/* get status of the one named queue */
 		if (preq->rq_extend != NULL) {
 			if (pque->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
-				/*search for the partition in the attr*/
+				/* search for the partition in the attr */
 				for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
-					if ((attr.at_val.at_arst->as_string[k] != NULL)
-							&& (!strcmp(
-									pque->qu_attr[QA_ATR_partition].at_val.at_str,
-									attr.at_val.at_arst->as_string[k]))) {
+					if ((attr.at_val.at_arst->as_string[k] != NULL) &&
+						(!strcmp(pque->qu_attr[QA_ATR_partition].at_val.at_str, attr.at_val.at_arst->as_string[k]))) {
 						consider_q = 1;
 						break;
 					}
@@ -478,28 +476,23 @@ req_stat_que(struct batch_request *preq)
 			}
 		}
 		if (consider_q) {
-			rc = status_que(pque, preq, &preply->brp_un.brp_status,
-					(preq->rq_extend ? &attr : NULL));
+			rc = status_que(pque, preq, &preply->brp_un.brp_status);
 			consider_q = 0;
 		}
 	} else {	/* get status of queues */
-		pque = (pbs_queue *)GET_NEXT(svr_queues);
-		while (pque) {
+		for (pque = (pbs_queue *)GET_NEXT(svr_queues); pque;pque = (pbs_queue *)GET_NEXT(pque->qu_link)) {
 			if (preq->rq_extend != NULL) {
 				if (pque->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
-					/*search for the partition in the attr*/
+					/* search for the partition in the attr */
 					for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
-						if ((attr.at_val.at_arst->as_string[k] != NULL)
-								&& (!strcmp(
-										pque->qu_attr[QA_ATR_partition].at_val.at_str,
-										attr.at_val.at_arst->as_string[k]))) {
+						if ((attr.at_val.at_arst->as_string[k] != NULL) &&
+							(!strcmp(pque->qu_attr[QA_ATR_partition].at_val.at_str, attr.at_val.at_arst->as_string[k]))) {
 							consider_q = 1;
 							break;
 						}
 					}
 				}
 				if (!consider_q) {
-					pque = (pbs_queue *)GET_NEXT(pque->qu_link);
 					continue;
 				}
 			} else {
@@ -511,8 +504,7 @@ req_stat_que(struct batch_request *preq)
 				}
 			}
 			if (consider_q) {
-				rc = status_que(pque, preq, &preply->brp_un.brp_status,
-						(preq->rq_extend ? &attr : NULL));
+				rc = status_que(pque, preq, &preply->brp_un.brp_status);
 				if (rc != 0) {
 					if (rc == PBSE_PERM)
 						rc = 0;
@@ -521,7 +513,6 @@ req_stat_que(struct batch_request *preq)
 				}
 				consider_q = 0;
 			}
-			pque = (pbs_queue *)GET_NEXT(pque->qu_link);
 		}
 	}
 
@@ -538,7 +529,7 @@ req_stat_que(struct batch_request *preq)
  * 		status_que - Build the status reply for a single queue.
  *
  * @param[in,out]	pque	-	ptr to que to status
- * @param[in]	preq	-	ptr to the decoded request
+ * @param[in]		preq	-	ptr to the decoded request
  * @param[in,out]	pstathd	-	head of list to append status to
  *
  * @return	int
@@ -547,11 +538,10 @@ req_stat_que(struct batch_request *preq)
  */
 
 static int
-status_que(pbs_queue *pque, struct batch_request *preq, pbs_list_head *pstathd, attribute *attr)
+status_que(pbs_queue *pque, struct batch_request *preq, pbs_list_head *pstathd)
 {
 	struct brp_status *pstat;
 	svrattrl	  *pal;
-	int k;
 
 	if ((preq->rq_perm & ATR_DFLAG_RDACC) == 0)
 		return (PBSE_PERM);
@@ -664,10 +654,8 @@ req_stat_node(struct batch_request *preq)
 			if (pnode->nd_attr[ND_ATR_partition].at_flags & ATR_VFLAG_SET) {
 				/*search for the partition in the attr*/
 				for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
-					if ((attr.at_val.at_arst->as_string[k] != NULL)
-							&& (!strcmp(
-									pnode->nd_attr[ND_ATR_partition].at_val.at_str,
-									attr.at_val.at_arst->as_string[k]))) {
+					if ((attr.at_val.at_arst->as_string[k] != NULL) &&
+						(!strcmp(pnode->nd_attr[ND_ATR_partition].at_val.at_str, attr.at_val.at_arst->as_string[k]))) {
 						consider_n = 1;
 						break;
 					}
@@ -682,22 +670,19 @@ req_stat_node(struct batch_request *preq)
 			}
 		}
 		if (consider_n || preq->rq_conn != dflt_scheduler->scheduler_sock) {
-			rc = status_node(pnode, preq, &preply->brp_un.brp_status,
-					(preq->rq_extend ? &attr : NULL));
+			rc = status_node(pnode, preq, &preply->brp_un.brp_status);
 			consider_n = 0;
 		}
 	} else {
 		/*get status of all nodes     */
-		for (i=0; i<svr_totnodes; i++) {
+		for (i = 0; i < svr_totnodes; i++) {
 			pnode = pbsndlist[i];
 			if (preq->rq_extend != NULL) {
 				if (pnode->nd_attr[ND_ATR_partition].at_flags & ATR_VFLAG_SET) {
-					/*search for the partition in the attr*/
+					/* search for the partition in the attr */
 					for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
-						if ((attr.at_val.at_arst->as_string[k] != NULL)
-								&& (!strcmp(
-										pnode->nd_attr[ND_ATR_partition].at_val.at_str,
-										attr.at_val.at_arst->as_string[k]))) {
+						if ((attr.at_val.at_arst->as_string[k] != NULL) &&
+							(!strcmp(pnode->nd_attr[ND_ATR_partition].at_val.at_str, attr.at_val.at_arst->as_string[k]))) {
 							consider_n = 1;
 							break;
 						}
@@ -715,8 +700,7 @@ req_stat_node(struct batch_request *preq)
 				}
 			}
 			if (consider_n || preq->rq_conn != dflt_scheduler->scheduler_sock) {
-				rc = status_node(pnode, preq, &preply->brp_un.brp_status,
-						(preq->rq_extend ? &attr : NULL));
+				rc = status_node(pnode, preq, &preply->brp_un.brp_status);
 				if (rc != 0) {
 					if (rc == PBSE_PERM)
 						rc = 0;
@@ -758,13 +742,12 @@ req_stat_node(struct batch_request *preq)
  */
 
 static int
-status_node(struct pbsnode *pnode, struct batch_request *preq, pbs_list_head *pstathd, attribute *attr)
+status_node(struct pbsnode *pnode, struct batch_request *preq, pbs_list_head *pstathd)
 {
 	int		   rc = 0;
 	struct brp_status *pstat;
 	svrattrl	  *pal;
 	unsigned long		   old_nd_state = VNODE_UNAVAILABLE;
-	int k;
 	int found;
 
 	if (pnode->nd_state & INUSE_DELETED)  /*node no longer valid*/

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -416,9 +416,6 @@ req_stat_que(struct batch_request *preq)
 	struct batch_reply *preply;
 	int		    rc   = 0;
 	int		    type = 0;
-	int		    k;
-	int		    consider_q = 0;
-	attribute	    attr;
 
 	/*
 	 * first, validate the name of the requested object, either
@@ -445,77 +442,23 @@ req_stat_que(struct batch_request *preq)
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
 
-	memset(&attr, 0, sizeof(attr));
-	if (preq->rq_extend != NULL) {
-		rc = sched_attr_def[SCHED_ATR_partition].at_decode(&attr, ATTR_partition, NULL, preq->rq_extend);
-		if (rc) {
-			(void) reply_free(preply);
-			req_reject(rc, bad, preq);
-			return;
-		}
-	}
-
 	if (type == 0) {	/* get status of the one named queue */
-		if (preq->rq_extend != NULL) {
-			if (pque->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
-				/* search for the partition in the attr */
-				for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
-					if ((attr.at_val.at_arst->as_string[k] != NULL) &&
-						(!strcmp(pque->qu_attr[QA_ATR_partition].at_val.at_str, attr.at_val.at_arst->as_string[k]))) {
-						consider_q = 1;
-						break;
-					}
-				}
-			}
-		} else {
-			if (preq->rq_conn == dflt_scheduler->scheduler_sock) {
-				if (!(pque->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET))
-					consider_q = 1;
-			} else {
-				consider_q = 1;
-			}
-		}
-		if (consider_q) {
-			rc = status_que(pque, preq, &preply->brp_un.brp_status);
-			consider_q = 0;
-		}
+		rc = status_que(pque, preq, &preply->brp_un.brp_status);
+
 	} else {	/* get status of queues */
-		for (pque = (pbs_queue *)GET_NEXT(svr_queues); pque;pque = (pbs_queue *)GET_NEXT(pque->qu_link)) {
-			if (preq->rq_extend != NULL) {
-				if (pque->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
-					/* search for the partition in the attr */
-					for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
-						if ((attr.at_val.at_arst->as_string[k] != NULL) &&
-							(!strcmp(pque->qu_attr[QA_ATR_partition].at_val.at_str, attr.at_val.at_arst->as_string[k]))) {
-							consider_q = 1;
-							break;
-						}
-					}
-				}
-				if (!consider_q) {
-					continue;
-				}
-			} else {
-				if (preq->rq_conn == dflt_scheduler->scheduler_sock) {
-					if (!(pque->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET))
-						consider_q = 1;
-				} else {
-					consider_q = 1;
-				}
+
+		pque = (pbs_queue *)GET_NEXT(svr_queues);
+		while (pque) {
+			rc = status_que(pque, preq, &preply->brp_un.brp_status);
+			if (rc != 0) {
+				if (rc == PBSE_PERM)
+					rc = 0;
+				else
+					break;
 			}
-			if (consider_q) {
-				rc = status_que(pque, preq, &preply->brp_un.brp_status);
-				if (rc != 0) {
-					if (rc == PBSE_PERM)
-						rc = 0;
-					else
-						break;
-				}
-				consider_q = 0;
-			}
+			pque = (pbs_queue *)GET_NEXT(pque->qu_link);
 		}
 	}
-
 	if (rc) {
 		(void)reply_free(preply);
 		req_reject(rc, bad, preq);
@@ -604,9 +547,6 @@ req_stat_node(struct batch_request *preq)
 	int		    rc   = 0;
 	int		    type = 0;
 	int		    i;
-	attribute	    attr;
-	int		    consider_n = 0;
-	int		    k;
 
 	/*
 	 * first, check that the server indeed has a list of nodes
@@ -638,77 +578,18 @@ req_stat_node(struct batch_request *preq)
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
 
-	memset(&attr, 0, sizeof(attr));
-
-	if (preq->rq_extend != NULL) {
-		rc = sched_attr_def[SCHED_ATR_partition].at_decode(&attr, ATTR_partition, NULL, preq->rq_extend);
-		if (rc) {
-			(void) reply_free(preply);
-			req_reject(rc, bad, preq);
-			return;
-		}
-	}
-
 	if (type == 0) {		/*get status of the named node*/
-		if (preq->rq_extend != NULL) {
-			if (pnode->nd_attr[ND_ATR_partition].at_flags & ATR_VFLAG_SET) {
-				/*search for the partition in the attr*/
-				for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
-					if ((attr.at_val.at_arst->as_string[k] != NULL) &&
-						(!strcmp(pnode->nd_attr[ND_ATR_partition].at_val.at_str, attr.at_val.at_arst->as_string[k]))) {
-						consider_n = 1;
-						break;
-					}
-				}
-			}
-		} else {
-			if (preq->rq_conn == dflt_scheduler->scheduler_sock) {
-				if (!(pnode->nd_attr[ND_ATR_partition].at_flags & ATR_VFLAG_SET))
-					consider_n = 1;
-			} else {
-				consider_n = 1;
-			}
-		}
-		if (consider_n || preq->rq_conn != dflt_scheduler->scheduler_sock) {
-			rc = status_node(pnode, preq, &preply->brp_un.brp_status);
-			consider_n = 0;
-		}
-	} else {
-		/*get status of all nodes     */
-		for (i = 0; i < svr_totnodes; i++) {
+		rc = status_node(pnode, preq, &preply->brp_un.brp_status);
+
+	} else {			/*get status of all nodes     */
+
+		for (i=0; i<svr_totnodes; i++) {
 			pnode = pbsndlist[i];
-			if (preq->rq_extend != NULL) {
-				if (pnode->nd_attr[ND_ATR_partition].at_flags & ATR_VFLAG_SET) {
-					/* search for the partition in the attr */
-					for (k = 0; k < attr.at_val.at_arst->as_usedptr; k++) {
-						if ((attr.at_val.at_arst->as_string[k] != NULL) &&
-							(!strcmp(pnode->nd_attr[ND_ATR_partition].at_val.at_str, attr.at_val.at_arst->as_string[k]))) {
-							consider_n = 1;
-							break;
-						}
-					}
-				}
-				if (!consider_n) {
-					continue;
-				}
-			} else {
-				if (preq->rq_conn == dflt_scheduler->scheduler_sock) {
-					if (!(pnode->nd_attr[ND_ATR_partition].at_flags & ATR_VFLAG_SET))
-						consider_n = 1;
-				} else {
-					consider_n = 1;
-				}
-			}
-			if (consider_n || preq->rq_conn != dflt_scheduler->scheduler_sock) {
-				rc = status_node(pnode, preq, &preply->brp_un.brp_status);
-				if (rc != 0) {
-					if (rc == PBSE_PERM)
-						rc = 0;
-					else
-						break;
-				}
-				consider_n = 0;
-			}
+
+			rc = status_node(pnode, preq,
+				&preply->brp_un.brp_status);
+			if (rc)
+				break;
 		}
 	}
 
@@ -748,7 +629,6 @@ status_node(struct pbsnode *pnode, struct batch_request *preq, pbs_list_head *ps
 	struct brp_status *pstat;
 	svrattrl	  *pal;
 	unsigned long		   old_nd_state = VNODE_UNAVAILABLE;
-	int found;
 
 	if (pnode->nd_state & INUSE_DELETED)  /*node no longer valid*/
 		return  (0);

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -235,8 +235,6 @@ find_assoc_sched_pj(job *pj, pbs_sched **target_sched)
 {
 	pbs_queue *pq;
 	pbs_sched *psched;
-	attribute *part_attr;
-	int k;
 	char *q_name;
 
 	*target_sched = NULL;
@@ -247,10 +245,12 @@ find_assoc_sched_pj(job *pj, pbs_sched **target_sched)
 		return 0;
 
 	if (pq->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
+		attribute *part_attr;
 		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
 		while (psched) {
 			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
 			if (part_attr->at_flags & ATR_VFLAG_SET) {
+				int k;
 				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
 					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
 							&& (!strcmp(part_attr->at_val.at_arst->as_string[k],

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -66,6 +66,7 @@
 #include "batch_request.h"
 #include "pbs_sched.h"
 #include "queue.h"
+#include "pbs_share.h"
 
 
 /* Global Data */
@@ -174,8 +175,6 @@ find_assoc_sched_jid(char *jid, pbs_sched **target_sched)
 {
 	job *pj;
 	pbs_queue *pq;
-	attribute *part_attr;
-	int k;
 	char *q_name;
 	pbs_sched *psched;
 	int t;
@@ -190,54 +189,6 @@ find_assoc_sched_jid(char *jid, pbs_sched **target_sched)
 
 	if (pj == NULL)
 		return 0;
-
-	q_name = pj->ji_qs.ji_queue;
-	pq = find_queuebyname(q_name);
-	if (pq == NULL)
-		return 0;
-
-	if (pq->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
-		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
-		while (psched) {
-			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
-			if (part_attr->at_flags & ATR_VFLAG_SET) {
-				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
-					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
-							&& (!strcmp(part_attr->at_val.at_arst->as_string[k],
-									pq->qu_attr[QA_ATR_partition].at_val.at_str))) {
-						*target_sched = psched;
-						return 1;
-					}
-				}
-			}
-			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
-		}
-	} else {
-		*target_sched = dflt_scheduler;
-		return 1;
-	}
-	return 0;
-}
-
-/**
- * @brief
- * 		find_assoc_sched - find the corresponding scheduler which is responsible
- * 		for handling this job.
- *
- * @param[in]	jid	- job id
- * @param[out]target_sched	- pointer to the corresponding scheduler to which the job belongs to
- *
- * @retval - 1 if success
- * 	   - 0 if fail
- */
-int
-find_assoc_sched_pj(job *pj, pbs_sched **target_sched)
-{
-	pbs_queue *pq;
-	pbs_sched *psched;
-	char *q_name;
-
-	*target_sched = NULL;
 
 	q_name = pj->ji_qs.ji_queue;
 	pq = find_queuebyname(q_name);
@@ -267,7 +218,6 @@ find_assoc_sched_pj(job *pj, pbs_sched **target_sched)
 		return 1;
 	}
 	return 0;
-
 }
 
 /**
@@ -282,7 +232,7 @@ find_assoc_sched_pj(job *pj, pbs_sched **target_sched)
  * 	    - 0 if fail
  */
 int
-find_assoc_sched_pq(pbs_queue *pq, pbs_sched **target_sched)
+find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched)
 {
 	pbs_sched *psched;
 	attribute *part_attr;
@@ -294,8 +244,7 @@ find_assoc_sched_pq(pbs_queue *pq, pbs_sched **target_sched)
 		return 0;
 
 	if (pq->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
-		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
-		while (psched) {
+		for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
 			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
 			if (part_attr->at_flags & ATR_VFLAG_SET) {
 				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
@@ -307,7 +256,6 @@ find_assoc_sched_pq(pbs_queue *pq, pbs_sched **target_sched)
 					}
 				}
 			}
-			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	} else {
 		*target_sched = dflt_scheduler;
@@ -332,12 +280,10 @@ pbs_sched *
 find_sched_from_sock(int sock)
 {
 	pbs_sched *psched;
-	psched = (pbs_sched*) GET_NEXT(svr_allscheds);
-	while (psched) {
+
+	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
 		if (psched->scheduler_sock == sock || psched->scheduler_sock2 == sock)
 			return psched;
-		psched = (pbs_sched*) GET_NEXT(psched->sc_link);
-
 	}
 	return NULL;
 }
@@ -443,6 +389,10 @@ schedule_high(pbs_sched *psched)
 		psched->svr_do_sched_high = SCH_SCHEDULE_NULL;
 		return 0;
 	}
+	strncpy(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_SCHEDULING, SC_STATUS_LEN);
+	psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str[SC_STATUS_LEN] = '\0';
+	psched->sch_attr[(int) SCHED_ATR_sched_state].at_flags = ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+
 	return 1;
 }
 
@@ -515,6 +465,11 @@ schedule_jobs(pbs_sched *psched)
 				psched->scheduler_sock2 = s;
 		}
 		psched->svr_do_schedule = SCH_SCHEDULE_NULL;
+
+		strncpy(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_SCHEDULING, SC_STATUS_LEN);
+		psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str[SC_STATUS_LEN] = '\0';
+		psched->sch_attr[(int) SCHED_ATR_sched_state].at_flags = ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+
 		first_time = 0;
 
 		/* if there are more qrun requests queued up, reset cmd so */
@@ -522,7 +477,9 @@ schedule_jobs(pbs_sched *psched)
 		pdefr = GET_NEXT(svr_deferred_req);
 		while (pdefr) {
 			if (pdefr->dr_sent == 0) {
-				dflt_scheduler->svr_do_schedule = SCH_SCHEDULE_AJOB;
+				pbs_sched *target_sched;
+				if (find_assoc_sched_jid(pdefr->dr_preq->rq_ind.rq_queuejob.rq_jid, &target_sched))
+					target_sched->svr_do_schedule = SCH_SCHEDULE_AJOB;
 				break;
 			}
 			pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
@@ -531,6 +488,7 @@ schedule_jobs(pbs_sched *psched)
 		return (0);
 	} else
 		return (1);	/* scheduler was busy */
+
 }
 
 /**
@@ -557,6 +515,13 @@ scheduler_close(int sock)
 	pbs_sched *psched;
 
 	psched = find_sched_from_sock(sock);
+
+	if (psched == NULL)
+		return;
+
+	strncpy(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_IDLE, SC_STATUS_LEN);
+	psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str[SC_STATUS_LEN] = '\0';
+	psched->sch_attr[(int) SCHED_ATR_sched_state].at_flags = ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
 
 	if ((sock != -1) && (sock == psched->scheduler_sock2)) {
 		psched->scheduler_sock2 = -1;
@@ -656,10 +621,12 @@ set_scheduler_flag(int flag, pbs_sched *psched)
 
 	if (psched)
 		single_sched = 1;
-	else
+	else {
 		single_sched = 0;
+		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
+	}
 
-	for (single_sched || (psched = (pbs_sched*) GET_NEXT(svr_allscheds)); psched ;psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+	for (single_sched || psched; psched ; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
 		/* high priority commands:
 		 * Note: A) usually SCH_QUIT is sent directly and not via here
 		 *       B) if we ever add a 3rd high prio command, we can lose them

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -64,6 +64,8 @@
 #include "work_task.h"
 #include "pbs_error.h"
 #include "batch_request.h"
+#include "pbs_sched.h"
+#include "queue.h"
 
 
 /* Global Data */
@@ -72,6 +74,7 @@ extern struct server server;
 extern pbs_net_t pbs_scheduler_addr;
 extern unsigned int pbs_scheduler_port;
 extern char      server_name[];
+extern struct connection *svr_conn;
 extern int	 svr_do_schedule;
 extern int	 svr_do_sched_high;
 extern char     *msg_sched_called;
@@ -157,6 +160,190 @@ err:
 
 /**
  * @brief
+ * 		find_assoc_sched - find the corresponding scheduler which is responsible
+ * 		for handling this job.
+ *
+ * @param[in]	jid	- job id
+ * @param[out]target_sched	- pointer to the corresponding scheduler to which the job belongs to
+ *
+ * @retval - 1 if success
+ * 	   - 0 if fail
+ */
+int
+find_assoc_sched_jid(char *jid, pbs_sched **target_sched)
+{
+	job *pj;
+	pbs_queue *pq;
+	attribute *part_attr;
+	int k;
+	char *q_name;
+	pbs_sched *psched;
+	int t;
+
+	*target_sched = NULL;
+
+	t = is_job_array(jid);
+	if ((t == IS_ARRAY_NO) || (t == IS_ARRAY_ArrayJob))
+		pj = find_job(jid);		/* regular or ArrayJob itself */
+	else
+		pj = find_arrayparent(jid); /* subjob(s) */
+
+	if (pj == NULL)
+		return 0;
+
+	q_name = pj->ji_qs.ji_queue;
+	pq = find_queuebyname(q_name);
+	if (pq == NULL)
+		return 0;
+
+	if (pq->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
+		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
+		while (psched) {
+			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
+			if (part_attr->at_flags & ATR_VFLAG_SET) {
+				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
+					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
+							&& (!strcmp(part_attr->at_val.at_arst->as_string[k],
+									pq->qu_attr[QA_ATR_partition].at_val.at_str))) {
+						*target_sched = psched;
+						return 1;
+					}
+				}
+			}
+			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
+		}
+	} else {
+		*target_sched = dflt_scheduler;
+		return 1;
+	}
+	return 0;
+}
+
+/**
+ * @brief
+ * 		find_assoc_sched - find the corresponding scheduler which is responsible
+ * 		for handling this job.
+ *
+ * @param[in]	jid	- job id
+ * @param[out]target_sched	- pointer to the corresponding scheduler to which the job belongs to
+ *
+ * @retval - 1 if success
+ * 	   - 0 if fail
+ */
+int
+find_assoc_sched_pj(job *pj, pbs_sched **target_sched)
+{
+	pbs_queue *pq;
+	pbs_sched *psched;
+	attribute *part_attr;
+	int k;
+	char *q_name;
+
+	*target_sched = NULL;
+
+	q_name = pj->ji_qs.ji_queue;
+	pq = find_queuebyname(q_name);
+	if (pq == NULL)
+		return 0;
+
+	if (pq->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
+		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
+		while (psched) {
+			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
+			if (part_attr->at_flags & ATR_VFLAG_SET) {
+				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
+					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
+							&& (!strcmp(part_attr->at_val.at_arst->as_string[k],
+									pq->qu_attr[QA_ATR_partition].at_val.at_str))) {
+						*target_sched = psched;
+						return 1;
+					}
+				}
+			}
+			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
+		}
+	} else {
+		*target_sched = dflt_scheduler;
+		return 1;
+	}
+	return 0;
+
+}
+
+/**
+ * @brief
+ * 		find_assoc_sched - find the corresponding scheduler which is responsible
+ * 		for handling this job.
+ *
+ * @param[in]	jid	- job id
+ * @param[out]target_sched	- pointer to the corresponding scheduler to which the job belongs to
+ *
+  * @retval - 1 if success
+ * 	    - 0 if fail
+ */
+int
+find_assoc_sched_pq(pbs_queue *pq, pbs_sched **target_sched)
+{
+	pbs_sched *psched;
+	attribute *part_attr;
+	int k;
+	char *q_name;
+
+	*target_sched = NULL;
+	if (pq == NULL)
+		return 0;
+
+	if (pq->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
+		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
+		while (psched) {
+			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
+			if (part_attr->at_flags & ATR_VFLAG_SET) {
+				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
+					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
+							&& (!strcmp(part_attr->at_val.at_arst->as_string[k],
+									pq->qu_attr[QA_ATR_partition].at_val.at_str))) {
+						*target_sched = psched;
+						return 1;
+					}
+				}
+			}
+			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
+		}
+	} else {
+		*target_sched = dflt_scheduler;
+		return 1;
+	}
+	return 0;
+
+}
+
+
+/**
+ * @brief
+ * 		find_sched_from_sock - find the corresponding scheduler which is having
+ * 		the given socket.
+ *
+ * @param[in]	sock	- socket descriptor
+ *
+ * @retval - pointer to the corresponding pbs_sched object if success
+ * 		 -  NULL if fail
+ */
+pbs_sched *
+find_sched_from_sock(int sock)
+{
+	pbs_sched *psched;
+	psched = (pbs_sched*) GET_NEXT(svr_allscheds);
+	while (psched) {
+		if (psched->scheduler_sock == sock || psched->scheduler_sock2 == sock)
+			return psched;
+		psched = (pbs_sched*) GET_NEXT(psched->sc_link);
+
+	}
+	return NULL;
+}
+
+/**
+ * @brief
  * 		contact_sched - open connection to the scheduler and send it a command
  *		Jobid is passed if and only if the cmd is SCH_SCHEDULE_AJOB
  *
@@ -165,7 +352,7 @@ err:
  */
 
 int
-contact_sched(int cmd, char *jobid)
+contact_sched(int cmd, char *jobid, pbs_net_t pbs_scheduler_addr, unsigned int pbs_scheduler_port)
 {
 	int sock;
 	conn_t *conn;
@@ -238,18 +425,22 @@ contact_sched(int cmd, char *jobid)
  * @retval	-1	: error
  */
 int
-schedule_high()
+schedule_high(pbs_sched *psched)
 {
 	int s;
-	if (scheduler_sock == -1) {
-		if ((s = contact_sched(svr_do_sched_high, NULL)) < 0)
+
+	if (psched == NULL)
+		return -1;
+
+	if (psched->scheduler_sock == -1) {
+		if ((s = contact_sched(psched->svr_do_sched_high, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) < 0)
 			return (-1);
-		set_sched_sock(s);
-		if (scheduler_sock2 == -1) {
-			if ((s = contact_sched(SCH_SCHEDULE_NULL, NULL)) >= 0)
-				scheduler_sock2 = s;
+		set_sched_sock(s, psched);
+		if (psched->scheduler_sock2 == -1) {
+			if ((s = contact_sched(SCH_SCHEDULE_NULL, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) >= 0)
+				psched->scheduler_sock2 = s;
 		}
-		svr_do_sched_high = SCH_SCHEDULE_NULL;
+		psched->svr_do_sched_high = SCH_SCHEDULE_NULL;
 		return 0;
 	}
 	return 1;
@@ -272,7 +463,7 @@ schedule_high()
  */
 
 int
-schedule_jobs()
+schedule_jobs(pbs_sched *psched)
 {
 	int cmd;
 	int s;
@@ -280,12 +471,15 @@ schedule_jobs()
 	struct deferred_request *pdefr;
 	char  *jid = NULL;
 
+	if (psched == NULL)
+		return -1;
+
 	if (first_time)
 		cmd = SCH_SCHEDULE_FIRST;
 	else
-		cmd = svr_do_schedule;
+		cmd = psched->svr_do_schedule;
 
-	if (scheduler_sock == -1) {
+	if (psched->scheduler_sock == -1) {
 
 		/* are there any qrun requests from manager/operator */
 		/* which haven't been sent,  they take priority      */
@@ -311,16 +505,16 @@ schedule_jobs()
 			pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
 		}
 
-		if ((s = contact_sched(cmd, jid)) < 0)
+		if ((s = contact_sched(cmd, jid, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) < 0)
 			return (-1);
 		else if (pdefr != NULL)
 			pdefr->dr_sent = 1;   /* mark entry as sent to sched */
-		set_sched_sock(s);
-		if (scheduler_sock2 == -1) {
-			if ((s = contact_sched(SCH_SCHEDULE_NULL, NULL)) >= 0)
-				scheduler_sock2 = s;
+		set_sched_sock(s, psched);
+		if (psched->scheduler_sock2 == -1) {
+			if ((s = contact_sched(SCH_SCHEDULE_NULL, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) >= 0)
+				psched->scheduler_sock2 = s;
 		}
-		svr_do_schedule = SCH_SCHEDULE_NULL;
+		psched->svr_do_schedule = SCH_SCHEDULE_NULL;
 		first_time = 0;
 
 		/* if there are more qrun requests queued up, reset cmd so */
@@ -328,7 +522,7 @@ schedule_jobs()
 		pdefr = GET_NEXT(svr_deferred_req);
 		while (pdefr) {
 			if (pdefr->dr_sent == 0) {
-				svr_do_schedule = SCH_SCHEDULE_AJOB;
+				dflt_scheduler->svr_do_schedule = SCH_SCHEDULE_AJOB;
 				break;
 			}
 			pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
@@ -360,13 +554,16 @@ static void
 scheduler_close(int sock)
 {
 	struct deferred_request *pdefr;
+	pbs_sched *psched;
 
-	if ((sock != -1) && (sock == scheduler_sock2)) {
-		scheduler_sock2 = -1;
+	psched = find_sched_from_sock(sock);
+
+	if ((sock != -1) && (sock == psched->scheduler_sock2)) {
+		psched->scheduler_sock2 = -1;
 		return;	/* nothing to check if scheduler_sock2 */
 	}
 
-	set_sched_sock(-1);
+	set_sched_sock(-1, psched);
 
 	/* clear list of jobs which were altered/modified during cycle */
 	am_jobs.am_used = 0;
@@ -449,20 +646,34 @@ was_job_alteredmoved(job *pjob)
  *		certain flag values should not be overwritten
  *
  * @param[in]	flag	-	pointer to job in question.
+ * @parm[in] psched -   pointer to sched object. Then set the flag only for this object.
+ *                                     NULL. Then set the flag for all the scheduler objects.
  */
 void
-set_scheduler_flag(int flag)
+set_scheduler_flag(int flag, pbs_sched *psched)
 {
-	/* high priority commands:
-	 * Note: A) usually SCH_QUIT is sent directly and not via here
-	 *       B) if we ever add a 3rd high prio command, we can lose them
-	 */
-	if (flag == SCH_CONFIGURE || flag == SCH_QUIT) {
-		if (svr_do_sched_high == SCH_QUIT)
-			return; /* keep only SCH_QUIT */
+	int single_sched;
 
-		svr_do_sched_high = flag;
-	}
+	if (psched)
+		single_sched = 1;
 	else
-		svr_do_schedule = flag;
+		single_sched = 0;
+
+	for (single_sched || (psched = (pbs_sched*) GET_NEXT(svr_allscheds)); psched ;psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+		/* high priority commands:
+		 * Note: A) usually SCH_QUIT is sent directly and not via here
+		 *       B) if we ever add a 3rd high prio command, we can lose them
+		 */
+		if (flag == SCH_CONFIGURE || flag == SCH_QUIT) {
+			if (psched->svr_do_sched_high == SCH_QUIT)
+				return; /* keep only SCH_QUIT */
+
+			psched->svr_do_sched_high = flag;
+		}
+		else
+			psched->svr_do_schedule = flag;
+		if (single_sched)
+			break;
+	}
+
 }

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -164,10 +164,10 @@ err:
  * 		find_assoc_sched - find the corresponding scheduler which is responsible
  * 		for handling this job.
  *
- * @param[in]	jid	- job id
- * @param[out]target_sched	- pointer to the corresponding scheduler to which the job belongs to
+ * @param[in]	jid - job id
+ * @param[out]	target_sched - pointer to the corresponding scheduler to which the job belongs to
  *
- * @retval - 1 if success
+ * @retval - 1  if success
  * 	   - 0 if fail
  */
 int
@@ -197,8 +197,7 @@ find_assoc_sched_jid(char *jid, pbs_sched **target_sched)
 
 	if (pq->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
 		attribute *part_attr;
-		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
-		while (psched) {
+		for (psched = (pbs_sched *) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched *) GET_NEXT(psched->sc_link)) {
 			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
 			if (part_attr->at_flags & ATR_VFLAG_SET) {
 				int k;
@@ -211,7 +210,6 @@ find_assoc_sched_jid(char *jid, pbs_sched **target_sched)
 					}
 				}
 			}
-			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	} else {
 		*target_sched = dflt_scheduler;
@@ -236,7 +234,6 @@ find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched)
 {
 	pbs_sched *psched;
 	attribute *part_attr;
-	int k;
 	char *q_name;
 
 	*target_sched = NULL;
@@ -247,6 +244,7 @@ find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched)
 		for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
 			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
 			if (part_attr->at_flags & ATR_VFLAG_SET) {
+				int k;
 				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
 					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
 							&& (!strcmp(part_attr->at_val.at_arst->as_string[k],

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -439,9 +439,11 @@ set_sched_default(pbs_sched* psched)
 	}
 	if ((psched->sch_attr[(int) SCHED_ATR_sched_state].at_flags & ATR_VFLAG_SET) == 0) {
 		psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str = malloc(SC_STATUS_LEN + 1);
-		if (psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str == NULL)
+		if (psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str == NULL) {
+			snprintf(log_buffer, LOG_BUF_SIZE-1, "malloc failure (errno %d)", errno);
+			log_err(PBSE_SYSTEM, __func__, log_buffer);
 			return;
-		else {
+		} else {
 			if (psched != dflt_scheduler)
 				strncpy(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_DOWN, SC_STATUS_LEN);
 			else
@@ -454,9 +456,11 @@ set_sched_default(pbs_sched* psched)
 	}
 	if ((psched->sch_attr[(int) SCHED_ATR_sched_priv].at_flags & ATR_VFLAG_SET) == 0) {
 		psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str = malloc(MAXPATHLEN + 1);
-		if (psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str == NULL)
+		if (psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str == NULL) {
+			snprintf(log_buffer, LOG_BUF_SIZE-1, "malloc failure (errno %d)", errno);
+			log_err(PBSE_SYSTEM, __func__, log_buffer);
 			return;
-		else {
+		} else {
 			if (psched != dflt_scheduler)
 				(void) snprintf(psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str, MAXPATHLEN, "%s/sched_priv_%s",
 						pbs_conf.pbs_home_path, psched->sc_name);
@@ -470,9 +474,11 @@ set_sched_default(pbs_sched* psched)
 	}
 	if ((psched->sch_attr[(int) SCHED_ATR_sched_log].at_flags & ATR_VFLAG_SET) == 0) {
 		psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str = malloc(MAXPATHLEN + 1);
-		if (psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str == NULL)
+		if (psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str == NULL) {
+			snprintf(log_buffer, LOG_BUF_SIZE-1, "malloc failure (errno %d)", errno);
+			log_err(PBSE_SYSTEM, __func__, log_buffer);
 			return;
-		else {
+		} else {
 			if (psched != dflt_scheduler)
 				(void) snprintf(psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str, MAXPATHLEN, "%s/sched_logs_%s",
 						pbs_conf.pbs_home_path, psched->sc_name);
@@ -517,10 +523,8 @@ action_sched_partition(attribute *pattr, void *pobj, int actmode)
 	for (i=0; i < pattr->at_val.at_arst->as_usedptr; ++i) {
 		if (pattr->at_val.at_arst->as_string[i] == NULL)
 			continue;
-		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
-		while (psched) {
+		for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
 			if (psched == pobj) {
-				psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 				continue;
 			}
 			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
@@ -532,7 +536,6 @@ action_sched_partition(attribute *pattr, void *pobj, int actmode)
 						return PBSE_SCHED_PARTITION_ALREADY_EXISTS;
 				}
 			}
-			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
 	set_scheduler_flag(SCH_ATTRS_CONFIGURE, pin_sched);

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -440,8 +440,7 @@ set_sched_default(pbs_sched* psched)
 	if ((psched->sch_attr[(int) SCHED_ATR_sched_state].at_flags & ATR_VFLAG_SET) == 0) {
 		psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str = malloc(SC_STATUS_LEN + 1);
 		if (psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str == NULL) {
-			snprintf(log_buffer, LOG_BUF_SIZE-1, "malloc failure (errno %d)", errno);
-			log_err(PBSE_SYSTEM, __func__, log_buffer);
+			log_err(errno, __func__, "no memory");
 			return;
 		} else {
 			if (psched != dflt_scheduler)
@@ -457,8 +456,7 @@ set_sched_default(pbs_sched* psched)
 	if ((psched->sch_attr[(int) SCHED_ATR_sched_priv].at_flags & ATR_VFLAG_SET) == 0) {
 		psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str = malloc(MAXPATHLEN + 1);
 		if (psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str == NULL) {
-			snprintf(log_buffer, LOG_BUF_SIZE-1, "malloc failure (errno %d)", errno);
-			log_err(PBSE_SYSTEM, __func__, log_buffer);
+			log_err(errno, __func__, "no memory");
 			return;
 		} else {
 			if (psched != dflt_scheduler)
@@ -475,8 +473,7 @@ set_sched_default(pbs_sched* psched)
 	if ((psched->sch_attr[(int) SCHED_ATR_sched_log].at_flags & ATR_VFLAG_SET) == 0) {
 		psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str = malloc(MAXPATHLEN + 1);
 		if (psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str == NULL) {
-			snprintf(log_buffer, LOG_BUF_SIZE-1, "malloc failure (errno %d)", errno);
-			log_err(PBSE_SYSTEM, __func__, log_buffer);
+			log_err(errno, __func__, "no memory");
 			return;
 		} else {
 			if (psched != dflt_scheduler)
@@ -518,9 +515,9 @@ action_sched_partition(attribute *pattr, void *pobj, int actmode)
 	int k;
 	if (pobj == dflt_scheduler)
 		return PBSE_SCHED_OP_NOT_PERMITTED;
-	pin_sched = (pbs_sched*) pobj;
+	pin_sched = (pbs_sched *) pobj;
 
-	for (i=0; i < pattr->at_val.at_arst->as_usedptr; ++i) {
+	for (i = 0; i < pattr->at_val.at_arst->as_usedptr; ++i) {
 		if (pattr->at_val.at_arst->as_string[i] == NULL)
 			continue;
 		for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -204,7 +204,7 @@ action_sched_port(attribute *pattr, void *pobj, int actmode)
 	pbs_sched *psched;
 	psched = (pbs_sched *) pobj;
 
-	if (actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
 		if ( dflt_scheduler && psched != dflt_scheduler) {
 			psched->pbs_scheduler_port = pattr->at_val.at_long;
 		}
@@ -231,7 +231,7 @@ action_sched_host(attribute *pattr, void *pobj, int actmode)
 	pbs_sched *psched;
 	psched = (pbs_sched *) pobj;
 
-	if (actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
 		if ( dflt_scheduler && psched != dflt_scheduler)
 			psched->pbs_scheduler_addr = get_hostaddr(pattr->at_val.at_str);
 	}
@@ -259,9 +259,9 @@ action_sched_priv(attribute *pattr, void *pobj, int actmode)
 	psched = (pbs_sched *) pobj;
 
 	if (pobj == dflt_scheduler)
-		return PBSE_OP_NOT_PERMITTED;
+		return PBSE_SCHED_OP_NOT_PERMITTED;
 
-	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER) {
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
 		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
 		while (psched != (pbs_sched*) 0) {
 			if (psched->sch_attr[SCHED_ATR_sched_priv].at_flags & ATR_VFLAG_SET) {
@@ -275,7 +275,7 @@ action_sched_priv(attribute *pattr, void *pobj, int actmode)
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
-	set_scheduler_flag(SCH_CONFIGURE, psched);
+	set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
 	return PBSE_NONE;
 }
 
@@ -299,9 +299,9 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 	psched = (pbs_sched *) pobj;
 
 	if (pobj == dflt_scheduler)
-		return PBSE_OP_NOT_PERMITTED;
+		return PBSE_SCHED_OP_NOT_PERMITTED;
 
-	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER) {
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
 		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
 		while (psched != (pbs_sched*) 0) {
 			if (psched->sch_attr[SCHED_ATR_sched_log].at_flags & ATR_VFLAG_SET) {
@@ -315,7 +315,7 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
-	set_scheduler_flag(SCH_CONFIGURE, psched);
+	set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
 	return PBSE_NONE;
 }
 
@@ -511,7 +511,7 @@ action_sched_partition(attribute *pattr, void *pobj, int actmode)
 	int i;
 	int k;
 	if (pobj == dflt_scheduler)
-		return PBSE_OP_NOT_PERMITTED;
+		return PBSE_SCHED_OP_NOT_PERMITTED;
 	pin_sched = (pbs_sched*) pobj;
 
 	for (i=0; i < pattr->at_val.at_arst->as_usedptr; ++i) {
@@ -529,12 +529,12 @@ action_sched_partition(attribute *pattr, void *pobj, int actmode)
 					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
 							&& (!strcmp(pattr->at_val.at_arst->as_string[i],
 									part_attr->at_val.at_arst->as_string[k])))
-						return PBSE_PART_ALREADY_USED;
+						return PBSE_SCHED_PARTITION_ALREADY_EXISTS;
 				}
 			}
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
-	set_scheduler_flag(SCH_CONFIGURE, pin_sched);
+	set_scheduler_flag(SCH_ATTRS_CONFIGURE, pin_sched);
 	return PBSE_NONE;
 }

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -46,6 +46,7 @@
 #include <string.h>
 #include <memory.h>
 #include <pbs_config.h>
+#include "pbs_share.h"
 #include "pbs_sched.h"
 #include "log.h"
 #include "pbs_ifl.h"
@@ -83,7 +84,10 @@ sched_alloc(char *sched_name)
 	CLEAR_LINK(psched->sc_link);
 	strncpy(psched->sc_name, sched_name, PBS_MAXSCHEDNAME);
 	psched->sc_name[PBS_MAXSCHEDNAME] = '\0';
-
+	psched->svr_do_schedule = SCH_SCHEDULE_NULL;
+	psched->svr_do_sched_high = SCH_SCHEDULE_NULL;
+	psched->scheduler_sock = -1;
+	psched->scheduler_sock2 = -1;
 	append_link(&svr_allscheds, &psched->sc_link, psched);
 
 	/* set the working attributes to "unspecified" */
@@ -197,8 +201,39 @@ sched_delete(pbs_sched *psched)
 int
 action_sched_port(attribute *pattr, void *pobj, int actmode)
 {
-	if (actmode == ATR_ACTION_ALTER) {
-		/*TODO*/
+	pbs_sched *psched;
+	psched = (pbs_sched *) pobj;
+
+	if (actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
+		if ( dflt_scheduler && psched != dflt_scheduler) {
+			psched->pbs_scheduler_port = pattr->at_val.at_long;
+		}
+	}
+	return PBSE_NONE;
+}
+
+/**
+ * @brief
+ * 		action routine for the sched's "sched_host" attribute
+ *
+ * @param[in]	pattr	-	attribute being set
+ * @param[in]	pobj	-	Object on which attribute is being set
+ * @param[in]	actmode	-	the mode of setting, recovery or just alter
+ *
+ * @return	error code
+ * @retval	PBSE_NONE	-	Success
+ * @retval	!PBSE_NONE	-	Failure
+ *
+ */
+int
+action_sched_host(attribute *pattr, void *pobj, int actmode)
+{
+	pbs_sched *psched;
+	psched = (pbs_sched *) pobj;
+
+	if (actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
+		if ( dflt_scheduler && psched != dflt_scheduler)
+			psched->pbs_scheduler_addr = get_hostaddr(pattr->at_val.at_str);
 	}
 	return PBSE_NONE;
 }
@@ -220,6 +255,12 @@ int
 action_sched_priv(attribute *pattr, void *pobj, int actmode)
 {
 	pbs_sched* psched;
+
+	psched = (pbs_sched *) pobj;
+
+	if (pobj == dflt_scheduler)
+		return PBSE_OP_NOT_PERMITTED;
+
 	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER) {
 		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
 		while (psched != (pbs_sched*) 0) {
@@ -234,6 +275,7 @@ action_sched_priv(attribute *pattr, void *pobj, int actmode)
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
+	set_scheduler_flag(SCH_CONFIGURE, psched);
 	return PBSE_NONE;
 }
 
@@ -254,6 +296,11 @@ int
 action_sched_log(attribute *pattr, void *pobj, int actmode)
 {
 	pbs_sched* psched;
+	psched = (pbs_sched *) pobj;
+
+	if (pobj == dflt_scheduler)
+		return PBSE_OP_NOT_PERMITTED;
+
 	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER) {
 		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
 		while (psched != (pbs_sched*) 0) {
@@ -268,6 +315,7 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
+	set_scheduler_flag(SCH_CONFIGURE, psched);
 	return PBSE_NONE;
 }
 
@@ -287,8 +335,10 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 int
 action_sched_iteration(attribute *pattr, void *pobj, int actmode)
 {
-	if (actmode == ATR_ACTION_ALTER) {
-		/*TODO*/
+	if (pobj == dflt_scheduler) {
+			server.sv_attr[SRV_ATR_scheduler_iteration].at_val.at_long = pattr->at_val.at_long;
+			server.sv_attr[SRV_ATR_scheduler_iteration].at_flags |= ATR_VFLAG_MODCACHE;
+			svr_save_db(&server, SVR_SAVE_QUICK);
 	}
 	return PBSE_NONE;
 }
@@ -332,13 +382,28 @@ int
 poke_scheduler(attribute *pattr, void *pobj, int actmode)
 {
 	if (pobj == &server || pobj == dflt_scheduler) {
+		if (pobj == &server) {
+			/* set this attribute on main scheduler */
+			if (dflt_scheduler) {
+				dflt_scheduler->sch_attr[SCHED_ATR_scheduling].at_val.at_long = pattr->at_val.at_long;
+				dflt_scheduler->sch_attr[SCHED_ATR_scheduling].at_flags |=
+						ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+				(void)sched_save_db(dflt_scheduler, SVR_SAVE_FULL);
+			}
+		} else {
+			server.sv_attr[SRV_ATR_scheduling].at_val.at_long = pattr->at_val.at_long;
+			server.sv_attr[SRV_ATR_scheduling].at_flags |= ATR_VFLAG_MODCACHE;
+			svr_save_db(&server, SVR_SAVE_QUICK);
+		}
 		if (actmode == ATR_ACTION_ALTER) {
 			if (pattr->at_val.at_long)
-				set_scheduler_flag(SCH_SCHEDULE_CMD);
+				set_scheduler_flag(SCH_SCHEDULE_CMD, dflt_scheduler);
 		}
-		/*TODO also set this attribute on main scheduler */
 	} else {
-		/*TODO need add the code for other scheduler apart from main scheduler. */
+		if (actmode == ATR_ACTION_ALTER) {
+			if (pattr->at_val.at_long)
+				set_scheduler_flag(SCH_SCHEDULE_CMD, (pbs_sched *)pobj);
+		}
 	}
 	return PBSE_NONE;
 }
@@ -359,6 +424,19 @@ set_sched_default(pbs_sched* psched)
 		psched->sch_attr[(int) SCHED_ATR_sched_cycle_len].at_flags =
 				ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
 	}
+	if ((psched->sch_attr[(int) SCHED_ATR_schediteration].at_flags & ATR_VFLAG_SET) == 0) {
+		psched->sch_attr[(int) SCHED_ATR_schediteration].at_val.at_long = PBS_SCHEDULE_CYCLE;
+		psched->sch_attr[(int) SCHED_ATR_schediteration].at_flags =
+				ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+	}
+	if ((psched->sch_attr[(int) SCHED_ATR_scheduling].at_flags & ATR_VFLAG_SET) == 0) {
+		if (psched != dflt_scheduler)
+			psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long = 0;
+		else
+			psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long = 1;
+		psched->sch_attr[(int) SCHED_ATR_scheduling].at_flags =
+				ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+	}
 	if ((psched->sch_attr[(int) SCHED_ATR_sched_state].at_flags & ATR_VFLAG_SET) == 0) {
 		psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str = malloc(SC_STATUS_LEN + 1);
 		if (psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str == NULL)
@@ -374,5 +452,89 @@ set_sched_default(pbs_sched* psched)
 		}
 
 	}
+	if ((psched->sch_attr[(int) SCHED_ATR_sched_priv].at_flags & ATR_VFLAG_SET) == 0) {
+		psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str = malloc(MAXPATHLEN + 1);
+		if (psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str == NULL)
+			return;
+		else {
+			if (psched != dflt_scheduler)
+				(void) snprintf(psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str, MAXPATHLEN, "%s/sched_priv_%s",
+						pbs_conf.pbs_home_path, psched->sc_name);
+			else
+				(void) snprintf(psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str, MAXPATHLEN, "%s/sched_priv",
+						pbs_conf.pbs_home_path);
+			psched->sch_attr[(int) SCHED_ATR_sched_priv].at_flags =
+			ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		}
+
+	}
+	if ((psched->sch_attr[(int) SCHED_ATR_sched_log].at_flags & ATR_VFLAG_SET) == 0) {
+		psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str = malloc(MAXPATHLEN + 1);
+		if (psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str == NULL)
+			return;
+		else {
+			if (psched != dflt_scheduler)
+				(void) snprintf(psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str, MAXPATHLEN, "%s/sched_logs_%s",
+						pbs_conf.pbs_home_path, psched->sc_name);
+			else
+				(void) snprintf(psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str, MAXPATHLEN, "%s/sched_logs",
+						pbs_conf.pbs_home_path);
+			psched->sch_attr[(int) SCHED_ATR_sched_log].at_flags =
+			ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		}
+
+	}
 }
 
+
+/**
+ * @brief
+ * 		action routine for the scheduler's partition attribute
+ *
+ * @param[in]	pattr	-	pointer to attribute structure
+ * @param[in]	pobj	-	not used
+ * @param[in]	actmode	-	action mode
+ *
+ *
+ * @return	error code
+ * @retval	PBSE_NONE	-	Success
+ * @retval	!PBSE_NONE	-	Failure
+ *
+ */
+
+int
+action_sched_partition(attribute *pattr, void *pobj, int actmode)
+{
+	pbs_sched* psched;
+	pbs_sched* pin_sched;
+	attribute *part_attr;
+	int i;
+	int k;
+	if (pobj == dflt_scheduler)
+		return PBSE_OP_NOT_PERMITTED;
+	pin_sched = (pbs_sched*) pobj;
+
+	for (i=0; i < pattr->at_val.at_arst->as_usedptr; ++i) {
+		if (pattr->at_val.at_arst->as_string[i] == NULL)
+			continue;
+		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
+		while (psched) {
+			if (psched == pobj) {
+				psched = (pbs_sched*) GET_NEXT(psched->sc_link);
+				continue;
+			}
+			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
+			if (part_attr->at_flags & ATR_VFLAG_SET) {
+				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
+					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
+							&& (!strcmp(pattr->at_val.at_arst->as_string[i],
+									part_attr->at_val.at_arst->as_string[k])))
+						return PBSE_PART_ALREADY_USED;
+				}
+			}
+			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
+		}
+	}
+	set_scheduler_flag(SCH_CONFIGURE, pin_sched);
+	return PBSE_NONE;
+}

--- a/src/server/setup_resc.c
+++ b/src/server/setup_resc.c
@@ -59,6 +59,7 @@
 #include "pbs_nodes.h"
 #include <sys/file.h>
 #include "libutil.h"
+#include "pbs_sched.h"
 
 extern char *msg_daemonname;
 #ifndef PBS_MOM

--- a/src/server/setup_resc.c
+++ b/src/server/setup_resc.c
@@ -129,7 +129,7 @@ add_resource_def(char *name, int type, int perms)
 
 	}
 #ifndef PBS_MOM
-	set_scheduler_flag(SCH_CONFIGURE);
+	set_scheduler_flag(SCH_CONFIGURE, NULL);
 #endif
 
 	return 0;

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -466,7 +466,6 @@ chk_job_request(char *jobid, struct batch_request *preq, int *rc)
 		p2 = strchr(jobid, '.');
 		if (p2) 
 			*p2 = '\0';
-		/*strcat(jobid, p1);*/
 		strncat(jobid, p1, PBS_MAXSVRJOBID-1);
 	}
 

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -466,7 +466,8 @@ chk_job_request(char *jobid, struct batch_request *preq, int *rc)
 		p2 = strchr(jobid, '.');
 		if (p2) 
 			*p2 = '\0';
-		strcat(jobid, p1);
+		/*strcat(jobid, p1);*/
+		strncat(jobid, p1, PBS_MAXSVRJOBID-1);
 	}
 
 	if (svr_authorize_jobreq(preq, pjob) == -1) {

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -190,6 +190,7 @@
 #include "pbs_db.h"
 #include "libutil.h"
 #include "pbs_ecl.h"
+#include "pbs_sched.h"
 
 extern struct python_interpreter_data  svr_interp_data;
 

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -193,8 +193,6 @@
 
 extern struct python_interpreter_data  svr_interp_data;
 
-
-extern int    scheduler_sock;
 extern time_t time_now;
 extern char  *resc_in_err;
 extern char  *msg_daemonname;
@@ -314,7 +312,7 @@ encode_svrstate(attribute *pattr, pbs_list_head *phead, char *atname, char *rsna
 	if (pattr->at_val.at_long == SV_STATE_RUN) {
 		if (server.sv_attr[(int)SRV_ATR_scheduling].at_val.at_long == 0)
 			psname = svr_idle;
-		else if (scheduler_sock != -1)
+		else if (dflt_scheduler->scheduler_sock != -1)
 			psname = svr_sched;
 	}
 
@@ -801,9 +799,9 @@ set_rpp_highwater(attribute *pattr, void *pobj, int actmode)
  * @param[in]	s	-	internal socket used to communicate with the scheduler
  */
 void
-set_sched_sock(int s)
+set_sched_sock(int s, pbs_sched *psched)
 {
-	scheduler_sock = s;
+	psched->scheduler_sock = s;
 	server.sv_attr[(int)SRV_ATR_State].at_flags |= ATR_VFLAG_MODCACHE;
 }
 
@@ -925,6 +923,31 @@ ssignon_transition_okay(attribute *pattr, void *pobject, int actmode)
 
 	return (0);
 
+}
+
+/**
+ * @brief
+ * 		action_svr_iteration - the "action" routine for the server
+ *		scheduler_iteration attribute
+ * @param[in]	pattr	-	pointer to attribute structure
+ * @param[in]	pobject -	pointer to some parent object.
+ * @param[in]	actmode	-	the action to take (e.g. ATR_ACTION_ALTER)
+ *
+ * @return	int
+ * @retval	0	: success
+ * @retval	!0	: PBSE Error Code
+ */
+int
+action_svr_iteration(attribute *pattr, void *pobj, int mode)
+{
+	/* set this attribute on main scheduler */
+	if (dflt_scheduler) {
+		dflt_scheduler->sch_attr[SCHED_ATR_schediteration].at_val.at_long = pattr->at_val.at_long;
+		dflt_scheduler->sch_attr[SCHED_ATR_schediteration].at_flags |=
+				ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+		(void)sched_save_db(dflt_scheduler, SVR_SAVE_FULL);
+	}
+	return PBSE_NONE;
 }
 
 /**
@@ -1589,7 +1612,7 @@ eligibletime_action(attribute *pattr, void *pobject, int actmode)
 		/* if scheduling is true, need to run the scheduling cycle */
 		/* so that, accrue type is determined for cases */
 		if (server.sv_attr[SRV_ATR_scheduling].at_val.at_long)
-			set_scheduler_flag(SCH_SCHEDULE_ETE_ON);
+			set_scheduler_flag(SCH_SCHEDULE_ETE_ON, NULL);
 
 	}
 

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -117,6 +117,7 @@
 #include "win.h"
 #endif
 #include "job.h"
+#include "pbs_sched.h"
 #include "reservation.h"
 #include "pbs_error.h"
 #include "log.h"
@@ -501,7 +502,7 @@ svr_enquejob(job *pjob)
 
 			/* better notify the Scheduler we have a new job */
 
-			if (find_assoc_sched_pj(pjob, &psched))
+			if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
 				set_scheduler_flag(SCH_SCHEDULE_NEW, psched);
 			else {
 				sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);
@@ -512,7 +513,7 @@ svr_enquejob(job *pjob)
 
 			/* notify the Scheduler we have moved a job here */
 
-			if (find_assoc_sched_pj(pjob, &psched))
+			if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
 				set_scheduler_flag(SCH_SCHEDULE_MVLOCAL, psched);
 			else {
 				sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);
@@ -682,7 +683,7 @@ svr_setjobstate(job *pjob, int newstate, int newsubstate)
 					attribute *etime = &pjob->
 						ji_wattr[(int)JOB_ATR_etime];
 
-					if (find_assoc_sched_pj(pjob, &psched))
+					if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
 						set_scheduler_flag(SCH_SCHEDULE_NEW, psched);
 					else {
 						sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -220,6 +220,23 @@ clear_default_resc(job *pjob)
 
 /**
  * @brief
+ * 		tickle_for_reply ()
+ * 		For internally generated requests to the server we would like
+ * 		processing of the reply from the particular server subsystem
+ * 		to happen as "soon" as the server get back to its main loop -
+ * 		see server's main loop and "next_task()" and variable, "waittime".
+ * 		By placing a do nothing task on the "timed_task_list" whose time
+ * 		is now (or already passed), we can get next_task() to look at the
+ * 		"task_list_immed" tasks now rather than wait for a while
+ */
+void
+tickle_for_reply(void)
+{
+	(void)set_task(WORK_Timed, time_now + 10, 0, (void *)0);
+}
+
+/**
+ * @brief
  * 		svr_enquejob	-	Enqueue the job into specified queue.
  *
  * @param[in]	pjob	-	The job to be enqueued.
@@ -242,6 +259,7 @@ svr_enquejob(job *pjob)
 	job	       *pjcur;
 	pbs_queue      *pque;
 	int		rc;
+	pbs_sched	*psched;
 
 	/* make sure queue is still there, there exist a small window ... */
 
@@ -483,15 +501,23 @@ svr_enquejob(job *pjob)
 
 			/* better notify the Scheduler we have a new job */
 
-			set_scheduler_flag(SCH_SCHEDULE_NEW);
-
+			if (find_assoc_sched_pj(pjob, &psched))
+				set_scheduler_flag(SCH_SCHEDULE_NEW, psched);
+			else {
+				sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);
+				log_err(-1, __func__, log_buffer);
+			}
 		} else if (server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long &&
 			server.sv_attr[SRV_ATR_scheduling].at_val.at_long) {
 
 			/* notify the Scheduler we have moved a job here */
 
-			set_scheduler_flag(SCH_SCHEDULE_MVLOCAL);
-
+			if (find_assoc_sched_pj(pjob, &psched))
+				set_scheduler_flag(SCH_SCHEDULE_MVLOCAL, psched);
+			else {
+				sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);
+				log_err(-1, __func__, log_buffer);
+			}
 		}
 
 
@@ -612,6 +638,7 @@ svr_setjobstate(job *pjob, int newstate, int newsubstate)
 	int    oldstate;
 	pbs_queue *pque = pjob->ji_qhdr;
 	long newaccruetype;
+	pbs_sched *psched;
 
 	/*
 	 * If the job has already finished, then do not make any new changes
@@ -655,7 +682,13 @@ svr_setjobstate(job *pjob, int newstate, int newsubstate)
 					attribute *etime = &pjob->
 						ji_wattr[(int)JOB_ATR_etime];
 
-					set_scheduler_flag(SCH_SCHEDULE_NEW);
+					if (find_assoc_sched_pj(pjob, &psched))
+						set_scheduler_flag(SCH_SCHEDULE_NEW, psched);
+					else {
+						sprintf(log_buffer, "Unable to reach scheduler associated with job %s", pjob->ji_qs.ji_jobid);
+						log_err(-1, __func__, log_buffer);
+					}
+
 					if ((etime->at_flags & ATR_VFLAG_SET)
 						== 0) {
 						etime->at_val.at_long = time_now;
@@ -3183,7 +3216,7 @@ Time4resv(struct work_task *ptask)
 
 		resv_exclusive_handler(presv);
 
-		set_scheduler_flag(SCH_SCHEDULE_JOBRESV);
+		set_scheduler_flag(SCH_SCHEDULE_JOBRESV,dflt_scheduler);
 
 		/*notify the relevant persons that the reservation time has arrived*/
 		if(presv->ri_qs.ri_tactive == time_now){
@@ -3257,7 +3290,7 @@ Time4resv1(struct work_task *ptask)
 #endif
 
 		/* specify the scheduling command for the scheduler */
-		set_scheduler_flag(SCH_SCHEDULE_JOBRESV);
+		set_scheduler_flag(SCH_SCHEDULE_JOBRESV, dflt_scheduler);
 }
 
 
@@ -3961,7 +3994,7 @@ resv_retry_handler(struct work_task *ptask)
 		return;
 
 	/* Notify scheduler that a reservation needs to be reconfirmed */
-	set_scheduler_flag(SCH_SCHEDULE_RESV_RECONFIRM);
+	set_scheduler_flag(SCH_SCHEDULE_RESV_RECONFIRM, dflt_scheduler);
 }
 
 /**
@@ -4386,25 +4419,6 @@ handle_qmgr_reply_to_startORenable(struct work_task *pwt)
 	 *action.  We will pass on that for now.
 	 */
 }
-
-
-/**
- * @brief
- * 		tickle_for_reply ()
- * 		For internally generated requests to the server we would like
- * 		processing of the reply from the particular server subsystem
- * 		to happen as "soon" as the server get back to its main loop -
- * 		see server's main loop and "next_task()" and variable, "waittime".
- * 		By placing a do nothing task on the "timed_task_list" whose time
- * 		is now (or already passed), we can get next_task() to look at the
- * 		"task_list_immed" tasks now rather than wait for a while
- */
-void
-tickle_for_reply(void)
-{
-	(void)set_task(WORK_Timed, time_now + 10, 0, (void *)0);
-}
-
 
 
 /**

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -101,6 +101,7 @@
 #include <memory.h>
 #include "server.h"
 #include "hook.h"
+#include "pbs_sched.h"
 
 
 #define	RETRY	3	/* number of times to retry network move */

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -141,7 +141,6 @@ extern unsigned int pbs_server_port_dis;
 extern int	resc_access_perm;
 extern time_t	time_now;
 extern int svr_create_tmp_jobscript(job *pj, char *script_name);
-extern int	scheduler_sock;
 extern int	scheduler_jobs_stat;
 extern	char	*path_hooks_workdir;
 extern struct work_task *add_mom_deferred_list(int stream, mominfo_t *minfo, void (*func)(), char *msgid, void *parm1, void *parm2);
@@ -319,7 +318,7 @@ local_move(job *jobp, struct batch_request *req)
 	 * had changes resulting from the move that would impact scheduling or
 	 * placement, add job to list of jobs which cannot be run in this cycle.
 	 */
-	if ((req == NULL || (req->rq_conn != scheduler_sock)) && (scheduler_jobs_stat))
+	if ((req == NULL || (find_sched_from_sock(req->rq_conn) == NULL)) && (scheduler_jobs_stat))
 		am_jobs_add(jobp);
 
 	return 0;

--- a/src/server/svr_recov_db.c
+++ b/src/server/svr_recov_db.c
@@ -435,6 +435,9 @@ sched_recov_db(void)
 	if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0)
 		goto db_err;
 
+	if (server.sv_attr[SRV_ATR_scheduling].at_val.at_long)
+		set_scheduler_flag(SCH_SCHEDULE_ETE_ON, NULL);
+
 	return 0;
 
 db_err:

--- a/src/server/w32_svr_periodic_hook.c
+++ b/src/server/w32_svr_periodic_hook.c
@@ -138,8 +138,6 @@ long		new_log_event_mask = 0;
 int	 	server_init_type = RECOV_WARM;
 char	        server_name[PBS_MAXSERVERNAME+1]; /* host_name[:service|port] */
 int		svr_delay_entry = 0;
-int		svr_do_schedule = SCH_SCHEDULE_NULL;
-int		svr_do_sched_high = SCH_SCHEDULE_NULL;
 int		svr_total_cpus = 0;		/* total number of cpus on nodes   */
 int		have_blue_gene_nodes = 0;
 int		svr_ping_rate = SVR_DEFAULT_PING_RATE;	/* time between sets of node pings */

--- a/src/start_provision_win/w32_start_provision.c
+++ b/src/start_provision_win/w32_start_provision.c
@@ -140,8 +140,6 @@ long		new_log_event_mask = 0;
 int	 	server_init_type = RECOV_WARM;
 char	        server_name[PBS_MAXSERVERNAME+1]; /* host_name[:service|port] */
 int		svr_delay_entry = 0;
-int		svr_do_schedule = SCH_SCHEDULE_NULL;
-int		svr_do_sched_high = SCH_SCHEDULE_NULL;
 int		svr_total_cpus = 0;		/* total number of cpus on nodes   */
 int		have_blue_gene_nodes = 0;
 int		svr_ping_rate = SVR_DEFAULT_PING_RATE;	/* time between sets of node pings */

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -174,7 +174,7 @@ set_resources_min_max(attribute *old, attribute *new, enum batch_op op)
 }
 
 void
-set_scheduler_flag(int flag)
+set_scheduler_flag(int flag, pbs_sched *psched)
 {
 	return;
 }
@@ -398,6 +398,12 @@ int
 deflt_chunk_action(attribute *pattr, void *pobj, int mode)
 {
 
+	return 0;
+}
+
+int
+action_svr_iteration(attribute *pattr, void *pobj, int mode)
+{
 	return 0;
 }
 

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -96,6 +96,7 @@
 #include "libutil.h"
 #include "cmds.h"
 #include "svrfunc.h"
+#include "pbs_sched.h"
 
 #define PBS_PYTHON 1.1
 #define MAXBUF	4096

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -10923,7 +10923,8 @@ class Scheduler(PBSService):
                             SCHED,
                             id="@default")
         self.server.manager(MGR_CMD_LIST, SCHED)
-        ignore_attrs = ['id', 'pbs_version', 'sched_host', 'state']
+        ignore_attrs = ['id', 'pbs_version', 'sched_host', 'state',
+                        'sched_port']
         unsetattrs = []
         for k in self.attributes.keys():
             if k not in ignore_attrs:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -3743,7 +3743,10 @@ class PBSService(PBSObject):
         """
         priv = self._instance_to_privpath(inst)
         lock = self._instance_to_lock(inst)
-        path = os.path.join(self.pbs_conf['PBS_HOME'], priv, lock)
+        if isinstance(inst, Scheduler) and 'sched_priv' in inst.attributes:
+            path = os.path.join(inst.attributes.get('sched_priv'), lock)
+        else:
+            path = os.path.join(self.pbs_conf['PBS_HOME'], priv, lock)
         rv = self.du.cat(self.hostname, path, sudo=True, logerr=False)
         if ((rv['rc'] == 0) and (len(rv['out']) > 0)):
             self.pid = rv['out'][0].strip()
@@ -3929,10 +3932,15 @@ class PBSService(PBSObject):
                                             'server_priv', 'accounting', day)
                     sudo = True
                 else:
-                    logval = self._instance_to_logpath(logtype)
-                    if logval:
-                        filename = os.path.join(self.pbs_conf['PBS_HOME'],
-                                                logval, day)
+                    if (isinstance(self, Scheduler) and
+                            'sched_log' in self.attributes):
+                        filename = os.path.join(
+                            self.attributes.get('sched_log'), day)
+                    else:
+                        logval = self._instance_to_logpath(logtype)
+                        if logval:
+                            filename = os.path.join(self.pbs_conf['PBS_HOME'],
+                                                    logval, day)
                 if n == 'ALL':
                     if self._is_local and not sudo:
                         lines = open(filename)
@@ -6623,6 +6631,21 @@ class Server(PBSService):
                     del self.queues[i]
                 if obj_type == MGR_OBJ_RSC and i in self.resources:
                     del self.resources[i]
+                if obj_type == SCHED and i in self.schedulers.keys():
+                    del self.schedulers[i]
+
+        bs_list = []
+        if cmd == MGR_CMD_SET:
+            if rc == 0 and id is not None:
+                tbsl = copy.deepcopy(attrib)
+                tbsl['id'] = id
+                bs_list.append(tbsl)
+                self.update_attributes(obj_type, bs_list)
+
+        if cmd == MGR_CMD_CREATE or cmd == MGR_CMD_UNSET:
+            if rc == 0:
+                bsl = self.status(obj_type, attrib, id, extend)
+                self.update_attributes(obj_type, bsl)
 
         if rc != 0:
             raise PbsManagerError(rv=False, rc=rc, msg=self.geterrmsg(),
@@ -8326,7 +8349,6 @@ class Server(PBSService):
         """
         Populate objects from batch status data
         """
-
         if bs is None:
             return
 
@@ -10423,14 +10445,12 @@ class Scheduler(PBSService):
 
         self.dflt_holidays_file = os.path.join(self.pbs_conf['PBS_EXEC'],
                                                'etc', 'pbs_holidays')
-
         self.holidays_file = os.path.join(self.pbs_conf['PBS_HOME'],
                                           'sched_priv', 'holidays')
 
         self.dflt_resource_group_file = os.path.join(self.pbs_conf['PBS_EXEC'],
                                                      'etc',
                                                      'pbs_resource_group')
-
         self.resource_group_file = os.path.join(self.pbs_conf['PBS_HOME'],
                                                 'sched_priv', 'resource_group')
         self.fairshare_tree = self.query_fairshare()
@@ -10485,7 +10505,8 @@ class Scheduler(PBSService):
         """
         return super(Scheduler, self)._all_instance_pids(inst=self)
 
-    def start(self, args=None, launcher=None):
+    def start(self, sched_port=None, sched_home=None, args=None,
+              launcher=None):
         """
         Start the scheduler
 
@@ -10494,6 +10515,21 @@ class Scheduler(PBSService):
         :param launcher: Optional utility to invoke the launch of the service
         :type launcher: str or list
         """
+        if self.attributes['id'] != 'default' and sched_port is not None:
+            cmd = [os.path.join(self.pbs_conf['PBS_EXEC'],
+                                'sbin', 'pbs_sched')]
+            cmd += ['-I', self.attributes['id']]
+            cmd += ['-S', sched_port]
+            if sched_home is not None:
+                cmd += ['-d', sched_home]
+            try:
+                ret = self.du.run_cmd(self.hostname, cmd, sudo=True,
+                                      logerr=False, level=logging.INFOCLI)
+            except PbsInitServicesError as e:
+                raise PbsServiceError(rc=e.rc, rv=e.rv, msg=e.msg)
+            self.server.manager(MGR_CMD_LIST, SCHED)
+            return ret
+
         if args is not None or launcher is not None:
             return super(Scheduler, self)._start(inst=self, args=args,
                                                  launcher=launcher)
@@ -10641,13 +10677,17 @@ class Scheduler(PBSService):
             self.sched_config = {}
             self._sched_config_comments = {}
             self._config_order = []
-
+        if 'sched_priv' in self.attributes:
+            self.sched_config_file = os.path.join(
+                self.attributes.get('sched_priv'),
+                'sched_config')
         if schd_cnfg is None:
             if self.sched_config_file is not None:
                 schd_cnfg = self.sched_config_file
             else:
                 self.logger.error('no scheduler configuration file to parse')
                 return False
+
         try:
             conf_opts = self.du.cat(self.hostname, schd_cnfg,
                                     sudo=(not self.has_diag),
@@ -10789,8 +10829,12 @@ class Scheduler(PBSService):
             os.close(fd)
 
             if path is None:
-                sp = os.path.join(self.pbs_conf['PBS_HOME'], "sched_priv",
-                                  "sched_config")
+                if 'sched_priv' in self.attributes:
+                    sp = os.path.join(self.attributes.get('sched_priv'),
+                                      'sched_config')
+                else:
+                    sp = os.path.join(self.pbs_conf['PBS_HOME'],
+                                      'sched_priv', 'sched_config')
                 if self.du.is_localhost(self.hostname):
                     self.du.run_copy(self.hostname, sp, sp + '.bak', sudo=True)
                 else:
@@ -10923,8 +10967,8 @@ class Scheduler(PBSService):
                             SCHED,
                             id="@default")
         self.server.manager(MGR_CMD_LIST, SCHED)
-        ignore_attrs = ['id', 'pbs_version', 'sched_host', 'state',
-                        'sched_port']
+        ignore_attrs = ['id', 'pbs_version', 'sched_host',
+                        'state', 'sched_port']
         unsetattrs = []
         for k in self.attributes.keys():
             if k not in ignore_attrs:
@@ -10944,7 +10988,8 @@ class Scheduler(PBSService):
         if self.du.cmp(self.hostname, self.dflt_sched_config_file,
                        self.sched_config_file) != 0:
             self.du.run_copy(self.hostname, self.dflt_sched_config_file,
-                             self.sched_config_file, mode=0644, sudo=True)
+                             self.sched_config_file, mode=0644,
+                             sudo=True)
         self.signal('-HUP')
         # Revert fairshare usage
         cmd = [os.path.join(self.pbs_conf['PBS_EXEC'], 'sbin', 'pbsfs'), '-e']
@@ -10970,7 +11015,11 @@ class Scheduler(PBSService):
         """
         conf = {}
         sconf = {MGR_OBJ_SCHED: conf}
-        sched_priv = os.path.join(self.pbs_conf['PBS_HOME'], 'sched_priv')
+        if 'sched_priv' in self.attributes:
+            sched_priv = self.attributes.get('sched_priv')
+        else:
+            sched_priv = os.path.join(
+                self.pbs_conf['PBS_HOME'], 'sched_priv')
         sc = os.path.join(sched_priv, 'sched_config')
         self._save_config_file(conf, sc)
         rg = os.path.join(sched_priv, 'resource_group')
@@ -11080,7 +11129,10 @@ class Scheduler(PBSService):
                         "reverting holidays file to default")
 
         rc = None
-
+        if 'sched_priv' in self.attributes:
+            self.holidays_file = os.path.join(
+                self.attributes.get('sched_priv'),
+                'holidays')
         # Copy over the holidays file from PBS_EXEC if it exists
         if self.du.cmp(self.hostname, self.dflt_holidays_file,
                        self.holidays_file) != 0:
@@ -11111,7 +11163,10 @@ class Scheduler(PBSService):
 
         days_map = obj._days_map
         days_set = obj.days_set
-
+        if 'sched_priv' in self.attributes:
+            self.holidays_file = os.path.join(
+                self.attributes.get('sched_priv'),
+                'holidays')
         if path is None:
             path = self.holidays_file
         lines = self.du.cat(self.hostname, path, sudo=True)['out']
@@ -11622,6 +11677,10 @@ class Scheduler(PBSService):
         if obj is None:
             obj = self.holidays_obj
 
+        if 'sched_priv' in self.attributes:
+            self.holidays_file = os.path.join(
+                self.attributes.get('sched_priv'),
+                'holidays')
         if out_path is None:
             out_path = self.holidays_file
 
@@ -12031,9 +12090,12 @@ class Scheduler(PBSService):
 
         if hostname is None:
             hostname = self.hostname
-        if resource_group is None:
-            resource_group = self.resource_group_file
-
+        if 'sched_priv' in self.attributes:
+            self.resource_group_file = os.path.join(
+                self.attributes.get('sched_priv'),
+                'resource_group')
+        # if resource_group is None:
+        resource_group = self.resource_group_file
         # if has_diag is True acces to sched_priv may not require su privilege
         ret = self.du.cat(hostname, resource_group, sudo=(not self.has_diag))
         if ret['rc'] != 0:
@@ -12066,6 +12128,10 @@ class Scheduler(PBSService):
         :param nshares: The number of shares associated to the entity
         :type nshares: int
         """
+        if 'sched_priv' in self.attributes:
+            self.resource_group_file = os.path.join(
+                self.attributes.get('sched_priv'),
+                'resource_group')
         if self.resource_group is None:
             self.resource_group = self.parse_resource_group(
                 self.hostname, self.resource_group_file)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -10687,7 +10687,6 @@ class Scheduler(PBSService):
             else:
                 self.logger.error('no scheduler configuration file to parse')
                 return False
-
         try:
             conf_opts = self.du.cat(self.hostname, schd_cnfg,
                                     sudo=(not self.has_diag),
@@ -10988,8 +10987,7 @@ class Scheduler(PBSService):
         if self.du.cmp(self.hostname, self.dflt_sched_config_file,
                        self.sched_config_file) != 0:
             self.du.run_copy(self.hostname, self.dflt_sched_config_file,
-                             self.sched_config_file, mode=0644,
-                             sudo=True)
+                             self.sched_config_file, mode=0644, sudo=True)
         self.signal('-HUP')
         # Revert fairshare usage
         cmd = [os.path.join(self.pbs_conf['PBS_EXEC'], 'sbin', 'pbsfs'), '-e']

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -1,0 +1,601 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+@tags('multisched')
+class TestMultipleSchedulers(TestFunctional):
+
+    """
+    Test suite to test different scheduler interfaces
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        a = {'partition': 'P1,P4',
+             'sched_host': self.server.hostname,
+             'sched_port': '15050'}
+        self.server.manager(MGR_CMD_CREATE, SCHED,
+                            a, id="sc1")
+        self.sched_configure('sc1', '15050')
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 1,
+                             'sched_port': 15050}, id="sc1")
+        dir_path = '/var/spool/pbs/sched_dir'
+        if not os.path.exists(dir_path):
+            self.du.mkdir(path=dir_path, sudo=True)
+        a = {'partition': 'P2',
+             'sched_priv': '/var/spool/pbs/sched_dir/sched_priv_sc2',
+             'sched_log': '/var/spool/pbs/sched_dir/sched_logs_sc2',
+             'sched_host': self.server.hostname,
+             'sched_port': '15051'}
+        self.server.manager(MGR_CMD_CREATE, SCHED,
+                            a, id="sc2")
+        self.sched_configure('sc2', '15051', '/var/spool/pbs/sched_dir')
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 1,
+                             'sched_port': 15051}, id="sc2")
+        a = {'partition': 'P3',
+             'sched_host': self.server.hostname,
+             'sched_port': '15052'}
+        self.server.manager(MGR_CMD_CREATE, SCHED,
+                            a, id="sc3")
+        self.sched_configure('sc3', '15052')
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 1,
+                             'sched_port': 15052}, id="sc3")
+
+        a = {'queue_type': 'execution',
+             'started': 't',
+             'enabled': 't'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq1')
+        print self.server.queues
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq2')
+        print self.server.queues
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq3')
+        print self.server.queues
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq4')
+        p1 = {'partition': 'P1'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq1')
+        p2 = {'partition': 'P2'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p2, id='wq2')
+        p3 = {'partition': 'P3'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p3, id='wq3')
+        p4 = {'partition': 'P4'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p4, id='wq4')
+        a = {'resources_available.ncpus': 2}
+        self.server.create_vnodes('vnode', a, 5, self.mom)
+        self.server.manager(MGR_CMD_SET, NODE, p1, id='vnode[0]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, p2, id='vnode[1]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, p3, id='vnode[2]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, p4, id='vnode[3]', expect=True)
+
+    def sched_configure(self, sched_name, sched_port=None, sched_home=None):
+        pbs_home = self.server.pbs_conf['PBS_HOME']
+        if sched_home is None:
+            sched_home = pbs_home
+        sched_priv_dir = 'sched_priv_' + sched_name
+        sched_logs_dir = 'sched_logs_' + sched_name
+        if not os.path.exists(os.path.join(sched_home, sched_priv_dir)):
+            self.du.run_copy(self.server.hostname,
+                             os.path.join(pbs_home, 'sched_priv'),
+                             os.path.join(sched_home, sched_priv_dir),
+                             recursive=True)
+        if not os.path.exists(os.path.join(sched_home, sched_logs_dir)):
+            self.du.run_copy(self.server.hostname,
+                             os.path.join(pbs_home, 'sched_logs'),
+                             os.path.join(sched_home, sched_logs_dir),
+                             recursive=True)
+        self.server.schedulers[sched_name].start(sched_port, sched_home)
+
+    def check_vnodes(self, j, vnodes, jid):
+        self.server.status(JOB, 'exec_vnode', id=jid)
+        nodes = j.get_vnodes(j.exec_vnode)
+        for vnode in vnodes:
+            if vnode not in nodes:
+                self.assertFalse(True, str(vnode) +
+                                 " is not in exec_vnode list as expected")
+
+    def test_set_sched_priv(self):
+        """
+        Test sched_priv can be only set to valid paths
+        and check for appropriate comments
+        """
+        sched = self.server.schedulers['sc1']
+        if not os.path.exists('/var/sched_priv_do_not_exist'):
+            self.server.manager(MGR_CMD_SET, SCHED,
+                                {'sched_priv': '/var/sched_priv_do_not_exist'},
+                                id="sc1")
+        msg = 'PBS failed validation checks for sched_priv directory'
+        a = {'sched_priv': '/var/sched_priv_do_not_exist',
+             'comment': msg,
+             'scheduling': 'False'}
+        self.server.expect(SCHED, a, id='sc1', attrop=PTL_AND, max_attempts=10)
+        pbs_home = self.server.pbs_conf['PBS_HOME']
+        self.du.run_copy(self.server.hostname,
+                         os.path.join(pbs_home, 'sched_priv'),
+                         os.path.join(pbs_home, 'sc1_new_priv'),
+                         recursive=True)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'sched_priv': '/var/spool/pbs/sc1_new_priv'},
+                            id="sc1")
+        a = {'sched_priv': '/var/spool/pbs/sc1_new_priv'}
+        self.server.expect(SCHED, a, id='sc1', max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc1")
+        a = {'comment': ''}
+        self.server.expect(SCHED, a, id='sc1', max_attempts=10)
+        self.du.rm(path=os.path.join(pbs_home, 'sc1_new_priv'), recursive=True)
+
+    def test_set_sched_log(self):
+        """
+        Test sched_log can be only set to valid paths
+        and check for appropriate comments
+        """
+        sched = self.server.schedulers['sc1']
+        if not os.path.exists('/var/sched_log_do_not_exist'):
+            self.server.manager(MGR_CMD_SET, SCHED,
+                                {'sched_log': '/var/sched_log_do_not_exist'},
+                                id="sc1")
+        a = {'sched_log': '/var/sched_log_do_not_exist',
+             'comment': 'Unable to change the sched_logs directory',
+             'scheduling': 'False'}
+        self.server.expect(SCHED, a, id='sc1', max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc1")
+        pbs_home = self.server.pbs_conf['PBS_HOME']
+        self.du.run_copy(self.server.hostname,
+                         os.path.join(pbs_home, 'sched_logs'),
+                         os.path.join(pbs_home, 'sc1_new_logs'),
+                         recursive=True)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'sched_log': '/var/spool/pbs/sc1_new_logs'},
+                            id="sc1")
+        a = {'sched_log': '/var/spool/pbs/sc1_new_logs'}
+        self.server.expect(SCHED, a, id='sc1', max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc1")
+        a = {'comment': ''}
+        self.server.expect(SCHED, a, id='sc1', max_attempts=10)
+        self.du.rm(path=os.path.join(pbs_home, 'sc1_new_logs'), recursive=True)
+
+    def test_start_scheduler(self):
+        """
+        Test that scheduler wont start without creation from qmgr and
+        appropriate folders created and partition assigned and test
+        states of scheduler in each stage
+        """
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'partition': (DECR, 'P3')}, id="sc3")
+        # Unset sc3's partition to assign to this scheduler
+        pbs_home = self.server.pbs_conf['PBS_HOME']
+        self.server.manager(MGR_CMD_CREATE, SCHED,
+                            id="sc5")
+        a = {'sched_host': self.server.hostname,
+             'sched_port': '15055',
+             'scheduling': 'True'}
+        self.server.manager(MGR_CMD_SET, SCHED, a, id="sc5")
+        sched = self.server.schedulers['sc5']
+        # Try starting without sched_priv and sched_logs
+        ret = self.server.schedulers['sc5'].start(sched_port='15055')
+        self.server.expect(SCHED, {'state': 'down'}, id='sc5', max_attempts=10)
+        if ret['rc'] == 0:
+            self.assertTrue(False)
+        self.du.run_copy(self.server.hostname,
+                         os.path.join(pbs_home, 'sched_priv'),
+                         os.path.join(pbs_home, 'sched_priv_sc5'),
+                         recursive=True)
+        ret = self.server.schedulers['sc5'].start(sched_port='15055')
+        if ret['rc'] == 0:
+            self.assertTrue(False)
+        self.du.run_copy(self.server.hostname,
+                         os.path.join(pbs_home, 'sched_logs'),
+                         os.path.join(pbs_home, 'sched_logs_sc5'),
+                         recursive=True)
+        ret = self.server.schedulers['sc5'].start(sched_port='15055')
+        self.server.schedulers['sc5'].log_match(
+            "Scheduler does not contain a partition",
+            max_attempts=10, starttime=self.server.ctime)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'partition': 'P3'}, id="sc5")
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'Scheduling': 'True'}, id="sc5")
+        self.server.expect(SCHED, {'state': 'idle'}, id='sc5', max_attempts=10)
+        a = {'resources_available.ncpus': 100}
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[2]', expect=True)
+        for _ in xrange(100):
+            j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3'})
+            self.server.submit(j)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc5")
+        self.server.manager(MGR_CMD_LIST, SCHED, id="sc5")
+        self.assertEqual(sched.attributes['state'], 'scheduling')
+        self.du.rm(path=os.path.join(
+            pbs_home, 'sched_priv_sc5'), recursive=True)
+        self.du.rm(path=os.path.join(
+            pbs_home, 'sched_logs_sc5'), recursive=True)
+
+    def test_resource_sched_reconfigure(self):
+        """
+        Test all schedulers will reconfigure while creating,
+        setting or deleting a resource
+        """
+        t = int(time.time())
+        self.server.manager(MGR_CMD_CREATE, RSC, id='foo')
+        sched_list = self.server.schedulers.keys()
+        for name in sched_list:
+            self.server.schedulers[name].log_match(
+                "Scheduler is reconfiguring",
+                max_attempts=10, starttime=t)
+        t = int(time.time())
+        attr = {ATTR_RESC_TYPE: 'long'}
+        self.server.manager(MGR_CMD_SET, RSC, attr, id='foo')
+        for name in sched_list:
+            self.server.schedulers[name].log_match(
+                "Scheduler is reconfiguring",
+                max_attempts=10, starttime=t)
+        t = int(time.time())
+        self.server.manager(MGR_CMD_DELETE, RSC, id='foo')
+        for name in sched_list:
+            self.server.schedulers[name].log_match(
+                "Scheduler is reconfiguring",
+                max_attempts=10, starttime=t)
+
+    def test_remove_partition_sched(self):
+        """
+        Test that removing all the partitions from a scheduler.
+        """
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'partition': (DECR, 'P1')}, id="sc1")
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'partition': (DECR, 'P4')}, id="sc1")
+        log_msg = "Scheduler does not contain a partition"
+        self.server.schedulers['sc1'].log_match(log_msg, max_attempts=10,
+                                                starttime=self.server.ctime)
+        self.server.manager(MGR_CMD_UNSET, SCHED, 'partition',
+                            id="sc2")
+
+    def test_job_queue_partition(self):
+        """
+        Test job submitted to a queue assosciated to a partition will land
+        into a node assosciated with that partition.
+        """
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodes = ['vnode[0]']
+        self.check_vnodes(j, nodes, jid)
+        self.server.schedulers['sc1'].log_match(
+            str(jid) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq2',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodes = ['vnode[1]']
+        self.check_vnodes(j, nodes, jid)
+        self.server.schedulers['sc2'].log_match(
+            str(jid) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodes = ['vnode[2]']
+        self.check_vnodes(j, nodes, jid)
+        self.server.schedulers['sc3'].log_match(
+            str(jid) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+
+    def test_multiple_partition_same_sched(self):
+        """
+        Test that multiple partition jobs are serviced by same scheduler
+        if the partitions are set on the scheduler
+        """
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodes = ['vnode[0]']
+        self.check_vnodes(j, nodes, jid)
+        self.server.schedulers['sc1'].log_match(
+            str(jid) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodes = ['vnode[3]']
+        self.check_vnodes(j, nodes, jid)
+        self.server.schedulers['sc1'].log_match(
+            str(jid) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+
+    def test_multiple_queue_same_partition(self):
+        """
+        Test multiple queue assosciated with same partition
+        is serviced by same scheduler
+        """
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodes = ['vnode[0]']
+        self.check_vnodes(j, nodes, jid)
+        self.server.schedulers['sc1'].log_match(
+            str(jid) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        nodes = ['vnode[0]']
+        self.check_vnodes(j, nodes, jid)
+        self.server.schedulers['sc1'].log_match(
+            str(jid) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+
+    def test_preemption_highp_queue(self):
+        """
+        Test preemption occures only within queues
+        which are assigned to same scheduler
+        """
+        prio = {'Priority': 150}
+        self.server.manager(MGR_CMD_SET, QUEUE, prio, id='wq3')
+        self.server.manager(MGR_CMD_SET, QUEUE, prio, id='wq4')
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid3)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
+        t = int(time.time())
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid5 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid5)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        self.server.schedulers['sc1'].log_match(
+            str(jid1) + ';Job preempted by suspension',
+            max_attempts=10, starttime=t)
+
+    def test_backfill_per_scheduler(self):
+        """
+        Test backfilling is applicable only per scheduler
+        """
+        t = int(time.time())
+        self.server.schedulers['sc2'].set_sched_config(
+            {'strict_ordering': 'True ALL'})
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq2',
+                                   'Resource_List.select': '1:ncpus=2',
+                                   'Resource_List.walltime': 60})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq2',
+                                   'Resource_List.select': '1:ncpus=2',
+                                   'Resource_List.walltime': 60})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+        self.server.schedulers['sc2'].log_match(
+            str(jid2) + ';Job is a top job and will run at',
+            max_attempts=10, starttime=t)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=2',
+                                   'Resource_List.walltime': 60})
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=2',
+                                   'Resource_List.walltime': 60})
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
+        self.server.schedulers['sc3'].log_match(
+            str(jid4) + ';Job is a top job and will run at',
+            max_attempts=5, starttime=t, existence=False)
+
+    def test_resource_per_scheduler(self):
+        """
+        Test resources will be considered only by scheduler
+        to which resource is added in sched_config
+        """
+        a = {'type': 'float', 'flag': 'nh'}
+        self.server.manager(MGR_CMD_CREATE, RSC, a, id='gpus')
+        self.server.schedulers['sc3'].add_resource("gpus")
+        a = {'resources_available.gpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id='@default', expect=True)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:gpus=2',
+                                   'Resource_List.walltime': 60})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:gpus=2',
+                                   'Resource_List.walltime': 60})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+        job_comment = "Not Running: Insufficient amount of resource: "
+        job_comment += "gpus (R: 2 A: 0 T: 2)"
+        self.server.expect(JOB, {'comment': job_comment}, id=jid2)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq2',
+                                   'Resource_List.select': '1:gpus=2'})
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq2',
+                                   'Resource_List.select': '1:gpus=2'})
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
+
+    def test_restart_server(self):
+        """
+        Test after server restarts it can connect to all schedulers
+        and jobs will still be running
+        """
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        self.server.schedulers['sc1'].log_match(
+            str(jid1) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq2',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.schedulers['sc2'].log_match(
+            str(jid2) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.schedulers['sc3'].log_match(
+            str(jid3) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'workq',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
+        self.server.schedulers['default'].log_match(
+            str(jid4) + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        self.server.restart()
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
+
+    def test_resv_default_sched(self):
+        """
+        Test reservations will only go to defualt scheduler
+        """
+        t = int(time.time())
+        r = Reservation(TEST_USER)
+        a = {'Resource_List.select': '2:ncpus=1'}
+        r.set_attributes(a)
+        rid = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, rid)
+        self.server.schedulers['default'].log_match(
+            str(rid) + ';Reservation Confirmed',
+            max_attempts=10, starttime=t)
+
+    def test_job_sorted_per_scheduler(self):
+        """
+        Test jobs are sorted as per job_sort_formula
+        inside each scheduler
+        """
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'job_sort_formula': 'ncpus'})
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=2'})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=1'})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=2'})
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid3)
+        self.server.delete(jid1, wait=True)
+        self.server.expect(JOB, 'job_state', op=UNSET, id=jid1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid5 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid5)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid6 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid6)
+        self.server.delete(jid4, wait=True)
+        self.server.expect(JOB, 'job_state', op=UNSET, id=jid4)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid6)
+
+    def test_run_limts_per_scheduler(self):
+        """
+        Test run_limits applied at server level is
+        applied for every scheduler seperately.
+        """
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'max_run': '[u:PBS_GENERIC=1]'})
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=1'})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=1'})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=1'})
+        jc = "Not Running: User has reached server running job limit."
+        self.server.expect(JOB, {'comment': jc}, id=jid2)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
+        jc = "Not Running: User has reached server running job limit."
+        self.server.expect(JOB, {'comment': jc}, id=jid4)
+
+    def tearDown(self):
+        self.du.run_cmd(self.server.hostname, [
+                        'pkill', '-9', 'pbs_sched'], sudo=True)
+        sched_list = ['sc1', 'sc2', 'sc3']
+        for name in sched_list:
+            priv = self.server.schedulers[name].attributes['sched_priv']
+            self.du.rm(path=priv, recursive=True)
+            logs = self.server.schedulers[name].attributes['sched_log']
+            self.du.rm(path=logs, recursive=True)
+        TestFunctional.tearDown(self)

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -138,7 +138,6 @@ class TestMultipleSchedulers(TestFunctional):
         Test sched_priv can be only set to valid paths
         and check for appropriate comments
         """
-        sched = self.server.schedulers['sc1']
         if not os.path.exists('/var/sched_priv_do_not_exist'):
             self.server.manager(MGR_CMD_SET, SCHED,
                                 {'sched_priv': '/var/sched_priv_do_not_exist'},

--- a/test/tests/interfaces/pbs_sched_interface_test.py
+++ b/test/tests/interfaces/pbs_sched_interface_test.py
@@ -37,6 +37,7 @@
 # trademark licensing policies.
 
 from tests.interfaces import *
+import shutil
 
 
 @tags('multisched')
@@ -48,10 +49,34 @@ class TestSchedulerInterface(TestInterfaces):
 
     def setUp(self):
         TestInterfaces.setUp(self)
-
+        a = {'partition': 'P1',
+             'sched_host': self.server.hostname,
+             'sched_port': '15051'}
         self.server.manager(MGR_CMD_CREATE,
-                            SCHED,
+                            SCHED, a,
                             id="TestCommonSched")
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'sched_port': 15051},
+                            id="TestCommonSched")
+        self.sched_configure("TestCommonSched", '15051')
+
+    def sched_configure(self, sched_name, sched_port, sched_home=None):
+        pbs_home = self.server.pbs_conf['PBS_HOME']
+        if sched_home is None:
+            sched_home = pbs_home
+        sched_priv_dir = 'sched_priv_' + sched_name
+        sched_logs_dir = 'sched_logs_' + sched_name
+        if not os.path.exists(os.path.join(sched_home, sched_priv_dir)):
+            self.du.run_copy(self.server.hostname,
+                             os.path.join(pbs_home, 'sched_priv'),
+                             os.path.join(sched_home, sched_priv_dir),
+                             recursive=True)
+        if not os.path.exists(os.path.join(sched_home, sched_logs_dir)):
+            self.du.run_copy(self.server.hostname,
+                             os.path.join(pbs_home, 'sched_logs'),
+                             os.path.join(sched_home, sched_logs_dir),
+                             recursive=True)
+        self.server.schedulers[sched_name].start(sched_port, sched_home)
 
     def test_duplicate_scheduler_name(self):
         """
@@ -104,6 +129,7 @@ class TestSchedulerInterface(TestInterfaces):
                             SCHED,
                             id="testDeleteSched",
                             runas=ROOT_USER)
+        print self.server.schedulers
 
         # Check for attribute set permission
         try:
@@ -156,9 +182,129 @@ class TestSchedulerInterface(TestInterfaces):
         self.server.manager(MGR_CMD_LIST,
                             SCHED,
                             id="TestCommonSched")
-        sched = None
-        sched = self.server.schedulers['TestCommonSched']
-        self.assertNotEqual(sched, None)
-        self.assertEqual(
-            sched.attributes['sched_cycle_length'],
-            '00:20:00')
+        a = {'sched_cycle_length': '00:20:00'}
+        self.server.expect(SCHED, a, id='TestCommonSched', max_attempts=10)
+
+    def test_sched_default_attrs(self):
+        """
+        Test all sched attributes are set by default on default scheduler
+        """
+        sched_priv = os.path.join(
+            self.server.pbs_conf['PBS_HOME'], 'sched_priv')
+        sched_logs = os.path.join(
+            self.server.pbs_conf['PBS_HOME'], 'sched_logs')
+        a = {'sched_port': 15004,
+             'sched_host': self.server.hostname,
+             'sched_priv': sched_priv,
+             'sched_log': sched_logs,
+             'scheduling': 'True',
+             'scheduler_iteration': 600,
+             'state': 'idle',
+             'sched_cycle_length': '00:20:00'}
+        self.server.expect(SCHED, a, id='default', max_attempts=10)
+
+    def test_scheduling_attribute(self):
+        """
+        Test scheduling attribute on newly created scheduler is false
+        unless made true
+        """
+        self.server.expect(SCHED, {'scheduling': 'False'},
+                           id='TestCommonSched', max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'},
+                            runas=ROOT_USER, id='TestCommonSched')
+        self.server.expect(SCHED, {'scheduling': 'True'},
+                           id='TestCommonSched', max_attempts=10)
+
+    def test_set_sched_priv_log_duplicate_value(self):
+        """
+        Test setting of sched_priv and sched_log to a
+        value assigned to another scheduler
+        """
+        err_msg = "Another Sched object also has same "
+        err_msg += "value for its sched_priv directory"
+        try:
+            self.server.manager(MGR_CMD_SET, SCHED,
+                                {'sched_priv': '/var/spool/pbs/sched_priv'},
+                                runas=ROOT_USER, id='TestCommonSched')
+        except PbsManagerError, e:
+            self.assertTrue(err_msg in e.msg[0],
+                            "Error message is not expected")
+        err_msg = "Another Sched object also has same "
+        err_msg += "value for its sched_log directory"
+        try:
+            self.server.manager(MGR_CMD_SET, SCHED,
+                                {'sched_log': '/var/spool/pbs/sched_logs'},
+                                runas=ROOT_USER, id='TestCommonSched')
+        except PbsManagerError, e:
+            self.assertTrue(err_msg in e.msg[0],
+                            "Error message is not expected")
+
+    def test_set_default_sched_not_permitted(self):
+        """
+        Test setting partition on default scheduler
+        """
+        err_msg = "Operation is not permitted on default scheduler"
+        try:
+            self.server.manager(MGR_CMD_SET, SCHED,
+                                {'partition': 'P1'},
+                                runas=ROOT_USER)
+        except PbsManagerError, e:
+            self.assertTrue(err_msg in e.msg[0],
+                            "Error message is not expected")
+        try:
+            self.server.manager(MGR_CMD_SET, SCHED,
+                                {'sched_priv': '/var/spool/somedir'},
+                                runas=ROOT_USER)
+        except PbsManagerError, e:
+            self.assertTrue(err_msg in e.msg[0],
+                            "Error message is not expected")
+        try:
+            self.server.manager(MGR_CMD_SET, SCHED,
+                                {'sched_log': '/var/spool/somedir'},
+                                runas=ROOT_USER)
+        except PbsManagerError, e:
+            self.assertTrue(err_msg in e.msg[0],
+                            "Error message is not expected")
+
+    def test_sched_name_too_long(self):
+        """
+        Test creating a scheduler with name longer than 15 chars
+        """
+        try:
+            self.server.manager(MGR_CMD_CREATE, SCHED,
+                                runas=ROOT_USER, id="TestLongScheduler")
+        except PbsManagerError, e:
+            self.assertTrue("Scheduler name is too long" in e.msg[0],
+                            "Error message is not expected")
+
+    def test_set_default_sched_attrs(self):
+        """
+        Test setting scheduling and scheduler_iteration on default scheduler
+        and it updates server attributes and vice versa
+        """
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'False'},
+                            runas=ROOT_USER)
+        self.server.expect(SERVER, {'scheduling': 'False'})
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'scheduling': 'True'},
+                            runas=ROOT_USER)
+        self.server.manager(MGR_CMD_LIST, SCHED, id='default')
+        self.server.expect(SCHED, {'scheduling': 'True'},
+                           id='default', max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduler_iteration': 300},
+                            runas=ROOT_USER)
+        self.server.expect(SERVER, {'scheduler_iteration': 300})
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'scheduler_iteration': 500},
+                            runas=ROOT_USER)
+        self.server.manager(MGR_CMD_LIST, SCHED, id='default')
+        self.server.expect(SCHED, {'scheduler_iteration': 500},
+                           id='default', max_attempts=10)
+
+    def tearDown(self):
+        self.du.run_cmd(self.server.hostname, [
+                        'pkill', '-9', 'pbs_sched'], sudo=True)
+        TestInterfaces.tearDown(self)

--- a/test/tests/interfaces/pbs_sched_interface_test.py
+++ b/test/tests/interfaces/pbs_sched_interface_test.py
@@ -37,7 +37,6 @@
 # trademark licensing policies.
 
 from tests.interfaces import *
-import shutil
 
 
 @tags('multisched')
@@ -129,7 +128,6 @@ class TestSchedulerInterface(TestInterfaces):
                             SCHED,
                             id="testDeleteSched",
                             runas=ROOT_USER)
-        print self.server.schedulers
 
         # Check for attribute set permission
         try:


### PR DESCRIPTION
…re pbs_sched

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-747](https://pbspro.atlassian.net/browse/PP-747)**

#### Problem description
* This ticket is one of the major user-stories of the following EPIC.
**[PP-337](https://pbspro.atlassian.net/browse/PP-337)** Multiple schedulers servicing the PBS cluster

The current user-story actually implements major interface for the MultiSched feature. After this we can actually run multiple instances of scheduler each serving a set of partitions in parallel which actually accomplishes the following goal.

_As clusters get larger and workloads vary it is becoming critical that the jobs get evaluated in as short as time possible to ensure that the correct workload is being run. Using multiple schedulers to address this issue can allow for different scheduling policies and quicker turnaround time for large number of jobs or nodes._

#### Solution description
Nodes and Queues in PBS now have a special attribute called partition. This can be useful in combining or grouping a set of nodes and queues together.
For example we can set partition attribute on nodes and queues as follows.
```
qmgr -c "set node n1 partition=p1"
qmgr -c "set node n2 partition=p1"
qmgr -c "set queue q1 partition = p1"
```
Here we grouped n1,n2 and q1 under partition p1. Similarly we can come up with multiple partitions as per our requirements. Let us say we have one more partition p2 which groups nodes n3,n4,n5 and q2.

A scheduler other than the default scheduler can be associated to one or more partitions as given in the following example.
`qmgr -c "set sched sc1 partition=p1"`
To associate more than one partition,
`qmgr -c "set sched sc1 partition += p2"`

Now the scheduler sc1 can serve two partitions p1 and p2.

An important note here is we should configure the scheduler first in the server then only it can be started. If a server does not know a scheduler id then server rejects it and that scheduler won't come up.

If we try to start a scheduler which is not associated with at least one partition then the following error is thrown while it is coming up.
         "Scheduler should contain at least single partition"
Scheduler will only come up only if it is fully configured at the server.

Once the scheduler comes up successfully it is ready to serve partitions p1, p2 in this case.  All the scheduler features should work as expected. Some of them are as follows

* We can submit jobs to q1 which are handled by sc1 scheduler in this case.
    Example: qsub -q q1 -- /bin/sleep 100
    This job should be served by sc1 and we can observe the same in the log file in sched_logs_sc1 
    directory.  We can also observe the same in pbsnodes -av output i.e. this job should only go to one of 
    the nodes that is part of the partition p1.  
* qrun of a job submitted to the above queue or partition should work.
* suspend/resume functionality should work.
* Array jobs can also be submitted and its functionality should work.
* One can create resources of various types and each scheduler should work as expected and schedule 
   using these resources.
* Reservations until we implement next interface will now only be served by default scheduler.
* Have done all the code changes in such a way that backward compatibility with the default scheduler is 
   maintained.
* server's scheduler_iteration and scheduling attributes are still kept even though we have these 
  attributes for the scheduler object also. This is done to ensure the backward compatibility. If anybody 
  sets these attributes at one object then they are automatically reflected in another object.
* Certain operations like changing the scheduler port and sched_priv directory etc are not allowed on 
  default scheduler to maintain the backward compatibility.
* Dynamically one can associate multiple partitions to the scheduler. We no need to restart or SIGHUP 
   the corresponding scheduler.
* Dynamically one can dissociate a partition from the scheduler.
* One can change sched_priv/sched_log directory dynamically without restarting or SIGHUPing the 
  scheduler.
* If a partition is associated with one scheduler then it can not be associated to any other scheduler.
* Scheduler at any point in time if it fails in accepting the new configuration then it switches back to its 
   old configuration.
* All operations for queues that are having no partitions should be served by default scheduler.
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
