### PR TITLE
PP-1089-1090: Skipping tests instead of failing them when no.of MoMs …

### DIFF
--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -49,7 +49,6 @@ class TestPbsExecutePrologue(TestFunctional):
     def setUp(self):
         if len(self.moms) != 3:
             self.skip_test(reason="need 3 mom hosts: -p moms=<m1>:<m2>:<m3>")
-            return
 
         TestFunctional.setUp(self)
 

--- a/test/tests/functional/pbs_job_requeue_timeout_error.py
+++ b/test/tests/functional/pbs_job_requeue_timeout_error.py
@@ -50,9 +50,7 @@ class TestJobRequeueTimeoutErrorMsg(TestFunctional):
         TestFunctional.setUp(self)
 
         if len(self.moms) != 2:
-            self.logger.error('test requires two MoMs as input, ' +
-                              '  use -p moms=<mom1>:<mom2>')
-            self.assertEqual(len(self.moms), 2)
+            self.skip_test(reason="need 2 mom hosts: -p moms=<m1>:<m2>")
 
         self.server.set_op_mode(PTL_CLI)
 

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -271,7 +271,6 @@ class TestPbsNodeRampDown(TestFunctional):
 
         if len(self.moms) != 3:
             self.skip_test(reason="need 3 mom hosts: -p moms=<m1>:<m2>:<m3>")
-            return
 
         TestFunctional.setUp(self)
         Job.dflt_attributes[ATTR_k] = 'oe'

--- a/test/tests/functional/pbs_only_small_files_over_tpp.py
+++ b/test/tests/functional/pbs_only_small_files_over_tpp.py
@@ -50,9 +50,7 @@ class TestOnlySmallFilesOverTPP(TestFunctional):
         TestFunctional.setUp(self)
 
         if len(self.moms) != 2:
-            self.logger.error('test requires two MoMs as input, ' +
-                              '  use -p moms=<mom1>:<mom2>')
-            self.assertEqual(len(self.moms), 2)
+            self.skip_test(reason="need 2 mom hosts: -p moms=<m1>:<m2>")
 
         self.server.set_op_mode(PTL_CLI)
 


### PR DESCRIPTION
…hosts provided is not as per the expectations of the test.

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1089](https://pbspro.atlassian.net/browse/PP-1089)**
* **[PP-1090](https://pbspro.atlassian.net/browse/PP-1090)**

#### Problem description
* TestJobRequeueTimeoutErrorMsg and TestOnlySmallFilesOverTPP were asserting if the no.of MoM hosts provided was not as expected by the test instead of skipping.

#### Cause / Analysis
* The two test suites need to be skipped if the no.of MoM hosts is not as per the expectations.

#### Solution description
* Changed the code to skip instead of assert.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
