### PR TITLE
PP-844: Fixed test_normal_user_unable_to_see_res_released ptl test

### DIFF
--- a/test/tests/functional/pbs_release_limited_res_suspend.py
+++ b/test/tests/functional/pbs_release_limited_res_suspend.py
@@ -776,10 +776,10 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # stat the job as a normal user
         attrs = self.server.status(JOB, id=jid1, runas=TEST_USER)
-        self.assertFalse("resources_released" in attrs,
+        self.assertFalse("resources_released" in attrs[0],
                          "Normal user can see resources_released "
                          "which is not expected")
 
-        self.assertFalse("resource_released_list.mem" in attrs,
+        self.assertFalse("resource_released_list.mem" in attrs[0],
                          "Normal user can see resources_released_list "
                          "which is not expected")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-844](https://pbspro.atlassian.net/browse/PP-844)**

#### Problem description
The ptl script submitted under [THIS](https://github.com/PBSPro/pbspro/pull/446) pull request was wrongly using return value of self.server.status() method

#### Cause / Analysis
Return value of self.server.status() is an array of dict rather than a dict

#### Solution description
Treat the return value as a list of dict

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
