### PR TITLE
PP-1095: starting "pbs_mom -p" with running job results in SIGSEGV

### DIFF
--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -2248,6 +2248,10 @@ init_abort_jobs(int recover)
 				ti_jobtask)) {
 				ptask->ti_flags |= TI_FLAGS_ORPHAN;
 			}
+
+			if (pj->ji_qs.ji_substate == JOB_SUBSTATE_RUNNING)
+				start_walltime(pj);
+
 			if (mom_do_poll(pj))
 				append_link(&mom_polljobs, &pj->ji_jobque, pj);
 		}

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -6982,7 +6982,7 @@ mom_over_limit(job *pjob)
 				svr_resc_size);
 			assert(rd != NULL);
 			preswalltime = find_resc_entry(at, rd);
-			assert(rd != NULL);
+			assert(preswalltime != NULL);
 			walltime_sum = preswalltime->rs_value.at_val.at_long;
 			if (walltime_sum > average_trialperiod) {
 				rd = find_resc_def(svr_resc_def, "cput",


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1095](https://pbspro.atlassian.net/browse/PP-1095)**

#### Problem description
* If a running job exists and pbs_mom is started with -p then pbs_mom crashes.

#### Cause / Analysis
* In PP-772, it has been forgotten calling of start_walltime() for running jobs that are recovered after pbs_mom -p start.

#### Solution description
* Calling start_walltime() for running jobs in init_abort_jobs()

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
