### PR TITLE
PP-1100: Build wineditline with MSVC rather than GCC to avoid linking errors

### DIFF
--- a/.appveyor/set_paths.bat
+++ b/.appveyor/set_paths.bat
@@ -62,6 +62,13 @@ if not defined __BUILDDIR (
 if not defined __BINARIESDIR (
     set __BINARIESDIR=%CD%\binaries
 )
+if exist "%VS90COMNTOOLS%vsvars32.bat" (
+    call "%VS90COMNTOOLS%vsvars32.bat"
+) else (
+    echo "Could not find %VS90COMNTOOLS%vsvars32.bat"
+    exit 1
+)
+
 set __RANDOM_VAL=%RANDOM::=_%
 set __RANDOM_VAL-%RANDOM_VAL:.=%
 set __BUILDJUNCTION=%__BUILDDIR:~0,2%\__withoutspace_builddir_%__RANDOM_VAL%
@@ -99,7 +106,7 @@ set BINARIESDIR=%CD%
 for /F "usebackq tokens=*" %%i in (`""%MSYSDIR%\bin\bash.exe" -c "pwd""`) do set BINARIESDIR_M=%%i
 
 if not defined LIBEDIT_VERSION (
-    set LIBEDIT_VERSION=2.201
+    set LIBEDIT_VERSION=2.203
 )
 if not defined LIBICAL_VERSION (
     set LIBICAL_VERSION=1.0.1

--- a/win_configure/projects.VS2008/qmgr.vcproj
+++ b/win_configure/projects.VS2008/qmgr.vcproj
@@ -72,7 +72,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="secur32.lib Userenv.lib mpr.lib ws2_32.lib netapi32.lib odbc32.lib odbccp32.lib libedit_static.a"
+				AdditionalDependencies="secur32.lib Userenv.lib mpr.lib ws2_32.lib netapi32.lib odbc32.lib odbccp32.lib edit_static.lib"
 				OutputFile="..\..\..\win_build\src\cmds\Debug\qmgr.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -165,7 +165,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="secur32.lib Userenv.lib mpr.lib ws2_32.lib netapi32.lib odbc32.lib odbccp32.lib libedit_static.a"
+				AdditionalDependencies="secur32.lib Userenv.lib mpr.lib ws2_32.lib netapi32.lib odbc32.lib odbccp32.lib edit_static.lib"
 				OutputFile="..\..\..\win_build\src\cmds\Release\qmgr.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1100](https://pbspro.atlassian.net/browse/PP-1100)**

#### Problem description
I have noticed that PBSPro fails linking `qmgr` on Windows due to linking errors against `libedit_static.a`.

#### Cause / Analysis
 I think ths is caused by incompatibility between the static library built by `gcc` and MSVC.

#### Solution description
As I am the author of `wineditline`, I have made a couple of fixes to the current WinEditLine release such that it can be built with VS2008 with the `/MT` switch as required by PBSPro, thus removing the need to build it with `gcc`.
Linking `qmgr` against `edit_static.lib` built by VS2008 succeeds without problems.
I believe this PR will be useful to PBSPro users who wish to build the software from source under Windows

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
