### PR TITLE
[WIP] PP-905: Ctrl+C During Interactive Job Startup Race Condition on Cray

### DIFF
--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -5833,30 +5833,30 @@ alps_cancel_reservation(job *pjob)
 	snprintf(filename, MAXPATHLEN, "%s/aux/%s.alpsresv", pbs_conf.pbs_home_path, pjob->ji_qs.ji_jobid);
 	
 	if (pjob->ji_extended.ji_ext.ji_reservation < 0) {
-		       /* 
+		       /*
 			* The job structure doesn't have ALPS reservation ID information.
 			* This can happen when we hit various race conditions.  To help
 			* with this issue, we have previously saved the ALPS resv ID
 			* in a file.
 			*
 			* The format of the file will consist of one line entry that
-			* has the string alps_resv_id a space and the ALPS reservation ID
-			* number.  We retrieve it here so the ALPS reservation can
-			* be canceled.
+			* has the ALPS reservation ID number. We retrieve it here so
+			* the ALPS reservation can be canceled.
 			*/
 		FILE    *fp = NULL;
 		long    value;
 
 		fp = fopen(filename, "r");
 		if (fp == NULL) {
-			snprintf(log_buffer, sizeof(log_buffer), "Can't open the file %s", filename);
+			snprintf(log_buffer, sizeof(log_buffer),
+				"Unable to open the file %s containing the ALPS Reservation ID", filename);
 			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 				(char *)__func__, log_buffer);
 			return (-1);
 		}
-		if (fscanf(fp, "alps_resv_id %ld", &value) != 1) {
-			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_DEBUG, 
-				(char *)__func__, "failed to read the alps_resv_id value");
+		if (fscanf(fp, "%ld", &value) != 1) {
+			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_DEBUG,
+				(char *)__func__, "failed to read the ALPS reservation ID value");
 			(void)fclose(fp);
 			(void)unlink(filename);
 			return (-1);

--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -5815,9 +5815,9 @@ alps_confirm_reservation(job *pjob)
 int
 alps_cancel_reservation(job *pjob)
 {
-	char buf[1024];
-	basil_response_t *brp;
-	char	filename[MAXPATHLEN];
+	char			buf[1024];
+	basil_response_t	*brp;
+	char			filename[MAXPATHLEN];
 
 	if (!pjob) {
 		log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_NODE, LOG_NOTICE, __func__,
@@ -5833,7 +5833,7 @@ alps_cancel_reservation(job *pjob)
 	snprintf(filename, MAXPATHLEN, "%s/aux/%s.alpsresv", pbs_conf.pbs_home_path, pjob->ji_qs.ji_jobid);
 	
 	if (pjob->ji_extended.ji_ext.ji_reservation < 0) {
-		/* 
+		       /* 
 			* The job structure doesn't have ALPS reservation ID information.
 			* This can happen when we hit various race conditions.  To help
 			* with this issue, we have previously saved the ALPS resv ID
@@ -5865,7 +5865,7 @@ alps_cancel_reservation(job *pjob)
 		pjob->ji_extended.ji_ext.ji_reservation = value;
 	}
 
-	/* At this point we have no further use for the file that contains
+	       /* At this point we have no further use for the file that contains
 		* the ALPS reservation ID.  Get rid of the file.
 		*/
 	(void)unlink(filename);

--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -5839,7 +5839,7 @@ alps_cancel_reservation(job *pjob)
 		 * We retrieve the ALPS reservation ID from the file and
 		 * cancel the ALPS reservation.
 		 */
-		FILE    *fp = NULL;
+		FILE    *fp;
 		long    value;
 
 		fp = fopen(filename, "r");

--- a/src/resmom/linux/mom_start.c
+++ b/src/resmom/linux/mom_start.c
@@ -2097,14 +2097,13 @@ set_job(job *pjob, struct startjob_rtn *sjr)
 					 */
 			sjr->sj_reservation = 0;
 		}
-		
+
 		/*
-		 * If we have a valid reservation id, save it off in case
-		 * the ALPS reservation information isn't part of the job struct
-		 * (e.g. job got killed before ALPS reservation ID was noted)
-		 * Then we can use this to cancel the ALPS reservation so we
-		 * don't leave orphaned ALPS reservations around.
+		 * Save the ALPS reservation ID so that it can be used to
+		 * delete the reservation in case of race conditions
+		 * where the ID doesn't get recorded in the job structure.
 		 */
+
 		if(pjob->ji_extended.ji_ext.ji_reservation > 0) {
 			FILE	*fp = NULL;
 			char	filename[MAXPATHLEN];
@@ -2119,7 +2118,7 @@ set_job(job *pjob, struct startjob_rtn *sjr)
 					log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_JOB, LOG_ERR, 
 						(char *)__func__, log_buffer);
 				} else {
-					fprintf(fp, "%ld\n",pjob->ji_extended.ji_ext.ji_reservation);
+					fprintf(fp, "%ld\n", pjob->ji_extended.ji_ext.ji_reservation);
 					(void)fclose(fp);
 				}
 			} else {

--- a/src/resmom/linux/mom_start.c
+++ b/src/resmom/linux/mom_start.c
@@ -2119,7 +2119,7 @@ set_job(job *pjob, struct startjob_rtn *sjr)
 					log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_JOB, LOG_ERR, 
 						(char *)__func__, log_buffer);
 				} else {
-					fprintf(fp, "alps_resv_id %ld\n",pjob->ji_extended.ji_ext.ji_reservation);
+					fprintf(fp, "%ld\n",pjob->ji_extended.ji_ext.ji_reservation);
 					(void)fclose(fp);
 				}
 			} else {

--- a/src/resmom/linux/mom_start.c
+++ b/src/resmom/linux/mom_start.c
@@ -2110,8 +2110,8 @@ set_job(job *pjob, struct startjob_rtn *sjr)
 			char	filename[MAXPATHLEN];
 			int	rc;
 
-			if (rc = snprintf(filename, MAXPATHLEN, "%s/aux/%s.alpsresv", 
-				pbs_conf.pbs_home_path, pjob->ji_qs.ji_jobid) < MAXPATHLEN) {
+			if ((rc = snprintf(filename, MAXPATHLEN, "%s/aux/%s.alpsresv", 
+				pbs_conf.pbs_home_path, pjob->ji_qs.ji_jobid)) < MAXPATHLEN) {
 				fp = fopen(filename, "w");
 				if (fp == NULL) {
 					snprintf(log_buffer, sizeof(log_buffer),


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-905](https://pbspro.atlassian.net/browse/PP-905)**

#### Problem description
* Ctrl+C during Interactive job startup causes race condition on Cray

#### Cause / Analysis
* A user immediately does a Ctrl-C after submitting an interactive qsub that requests Cray compute nodes.  But by this time PBS mom has forked, and one process is trying to create the ALPS reservation while another part is being killed off due to the Ctrl-C.  The ALPS reservation is made successfully, but the ALPS reservation ID is not available when PBS is deleting the job so the ALPS reservation is not canceled.  This causes ALPS reservations to be left behind.  And since PBS thinks those resources are free, but ALPS disagrees, we end up with held jobs due to the mismatch. 
The hook that keeps ALPS and PBS in sync will not be able to help with undoing the problem, because it's main purpose is to notice nodes coming up or going down.  It wouldn't know what to do with nodes that are busy with an ALPS reservation.  And because it runs only periodically, it will not prevent jobs from being held in between the times it runs.

#### Solution description
* Create a temporary job specific file to hold the ALPS reservation ID in $PBS_HOME/aux/.  Then when the job is being deleted, if the ALPS reservation ID is not set, check to see if the file exists, and the information we need is in it, if it is, use the ALPS reservation ID to cancel the ALPS reservation.  Delete the file too.


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
