### PR TITLE
PP-1099: Add error checking in Scheduler for resources

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2327,4 +2327,3 @@ next_job(status *policy, server_info *sinfo, int flag)
 	}
 	return rjob;
 }
-

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1109,29 +1109,33 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 				return NULL;
 			}
 
-			set_resource_req(resreq, attrp->value);
-
-			if (resresv->resreq == NULL)
-				resresv->resreq = resreq;
+			if (set_resource_req(resreq, attrp->value) != 1) {
+				set_schd_error_codes(err, NEVER_RUN, ERR_SPECIAL);
+				set_schd_error_arg(err, SPECMSG, "Bad requested resource data");
+				resresv->is_invalid = 1;
+			} else {
+				if (resresv->resreq == NULL)
+					resresv->resreq = resreq;
 #ifdef NAS
-			if (!strcmp(attrp->resource, "nodect")) { /* nodect for sort */
-				/* localmod 040 */
-				count = strtol(attrp->value, &endp, 10);
-				if (*endp != '\n')
-					resresv->job->nodect = count;
-				else
-					resresv->job->nodect = 0;
-				/* localmod 034 */
-				resresv->job->accrue_rate = resresv->job->nodect; /* XXX should be SBU rate */
-			}
+				if (!strcmp(attrp->resource, "nodect")) { /* nodect for sort */
+					/* localmod 040 */
+					count = strtol(attrp->value, &endp, 10);
+					if (*endp != '\n')
+						resresv->job->nodect = count;
+					else
+						resresv->job->nodect = 0;
+					/* localmod 034 */
+					resresv->job->accrue_rate = resresv->job->nodect; /* XXX should be SBU rate */
+				}
 #endif
-			if (!strcmp(attrp->resource, "place")) {
-				resresv->place_spec = parse_placespec(attrp->value);
-				if (resresv->place_spec == NULL) {
-					set_schd_error_codes(err, NEVER_RUN, ERR_SPECIAL);
-					set_schd_error_arg(err, SPECMSG, "invalid placement spec");
-					resresv->is_invalid = 1;
+				if (!strcmp(attrp->resource, "place")) {
+					resresv->place_spec = parse_placespec(attrp->value);
+					if (resresv->place_spec == NULL) {
+						set_schd_error_codes(err, NEVER_RUN, ERR_SPECIAL);
+						set_schd_error_arg(err, SPECMSG, "invalid placement spec");
+						resresv->is_invalid = 1;
 
+					}
 				}
 			}
 		}

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -136,7 +136,7 @@ void free_resource_req(resource_req *req);
 /*
  *	set_resource_req - set the value and type of a resource req
  */
-void set_resource_req(resource_req *req, char *val);
+int set_resource_req(resource_req *req, char *val);
 
 /*
  *

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -659,14 +659,16 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 				return NULL;
 			}
 
-			set_resource_req(resreq, attrp->value);
-
-			if (advresv->resreq == NULL)
-				advresv->resreq = resreq;
-			if (!strcmp(attrp->resource, "place")) {
-				advresv->place_spec = parse_placespec(attrp->value);
-				if (advresv->place_spec == NULL)
-					advresv->is_invalid = 1;
+			if (set_resource_req(resreq, attrp->value) != 1)
+				advresv->is_invalid = 1;
+			else {
+				if (advresv->resreq == NULL)
+					advresv->resreq = resreq;
+				if (!strcmp(attrp->resource, "place")) {
+					advresv->place_spec = parse_placespec(attrp->value);
+					if (advresv->place_spec == NULL)
+						advresv->is_invalid = 1;
+				}
 			}
 		}
 		else if (!strcmp(attrp->name, ATTR_resv_nodes)) {

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -2944,6 +2944,11 @@ set_resource(schd_resource *res, char *val, enum resource_fields field)
 
 			/* if val is a string, avail will be set to SCHD_INFINITY */
 			res->avail = res_to_num(val, &(res->type));
+			if (res->avail == SCHD_INFINITY) {
+				/* Verify that this is a string type resource */
+				if (!res->def->type.is_string)
+					return 0;
+			}
 			res->str_avail = break_comma_list(val);
 			if (res->str_avail == NULL)
 				return 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1099](https://pbspro.atlassian.net/browse/PP-1099)**

#### Problem description, Cause and Analysis
I noticed that in some very rare instances, accounting E records end up having -2kb as the mem value in the exec_vnode field. While I've not been able to reproduce it, I'm pretty sure about why it's happening: Scheduler's set_resources_req() function calls res_to_num() to convert resource values into numeric. res_to_num() returns a numeric value for all resource types, except string, for string types, it returns SCHD_INFINITY, which translates to -2. So, if for some reason res_to_num() is not able to convert the mem value to a number, it will return SCHD_INFINITY. But because 'mem' is a consumable type, the scheduler looks at its numeric value while evaluating the job for placement, which means it'll think that the job is requesting -2kb mem, and end up creating the exec_vnode with it. So, set_resource_req() should check to see that a 'size' type attribute does not get set to SCHD_INFINITY.


#### Solution description
- Added a check inside set_resource_req() to verify that 'res_to_num()' returns SCHD_INFINITY for only string type resources.
- set_resource_req() now returns an int, 1 for Success, 0 for Error
- Some places in code now check for return value of set_resource_req() and error out if it returned an error.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__