### PR TITLE
Restore ability to build with -DDEBUG flag

### DIFF
--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -3318,7 +3318,7 @@ join_err:
 			 ** Sender is (must be) mom superior commanding me to execute
 			 ** a prologue hook.
 			 */
-			DBPRT(("%s: %s for %s\n", id, "IM_EXEC_PROLOGUE", pjob->ji_qs.ji_jobid));
+			DBPRT(("%s: %s for %s\n", __func__, "IM_EXEC_PROLOGUE", pjob->ji_qs.ji_jobid));
 			mom_hook_input_init(&hook_input);
 			hook_input.pjob = pjob;
 
@@ -4498,7 +4498,7 @@ join_err:
 						sprintf(log_buffer, "IM_EXEC_PROLOGUE ERROR and I'm not MS");
 						goto err;
 					}
-					DBPRT(("%s: IM_EXEC_PROLOGUE %s returned ERROR %d\n", id, jobid, errcode))
+					DBPRT(("%s: IM_EXEC_PROLOGUE %s returned ERROR %d\n", __func__, jobid, errcode))
 					job_start_error(pjob, errcode, netaddr(addr), "IM_EXEC_PROLOGUE");
 					if (errmsg != NULL) {
 						log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB,


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1101](https://pbspro.atlassian.net/browse/PP-1101)**

#### Problem description
* Previously unable to build with CFLAGS=-DDEBUG to turn on the debug printing

#### Cause / Analysis
* Seems just some simple code fixes, missed because this code vanishes unless DEBUG defined

#### Solution description
A couple of `DBPRT` statememts contained `id` with the expectation
that `DOID()` macro would be defined earlier in the function. For these
statements `id` is replaced with `__func__` since that seems to be
what is used at other places in the file.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
