### PR TITLE
PP-1096 daemon protect (Linux OOM protection function) is wrong

### DIFF
--- a/src/lib/Libutil/daemon_protect.c
+++ b/src/lib/Libutil/daemon_protect.c
@@ -3,6 +3,7 @@
  */
 #include <sys/types.h>
 #include <unistd.h>
+#include <string.h>
 #include <stdio.h>
 #include <fcntl.h>
 #include "server_limits.h"
@@ -61,16 +62,16 @@ daemon_protect(pid_t pid, enum PBS_Daemon_Protect action)
 	 *	which is older to -17 to protect or 0 to unprotect.
 	 */
 	snprintf(fname, MAXPATHLEN, oom_protect_new.oom_path, pid);
-	if ((fd = open(fname, O_WRONLY)) != -1) {
-		write(fd, oom_protect_new.oom_value[(int)action], sizeof(oom_protect_new.oom_value[(int)action])-1);
+	if ((fd = open(fname, O_WRONLY|O_TRUNC)) != -1) {
+		write(fd, oom_protect_new.oom_value[(int)action], strlen(oom_protect_new.oom_value[(int)action]));
 
 	} else {
 
 		/* failed to open "oom_score_adj", now try "oom_adj" */
 		/* found in older Linux kernels			     */
 		snprintf(fname, MAXPATHLEN, oom_protect_old.oom_path, pid);
-		if ((fd = open(fname, O_WRONLY)) != -1) {
-			write(fd, oom_protect_old.oom_value[(int)action], sizeof(oom_protect_old.oom_value[(int)action])-1);
+		if ((fd = open(fname, O_WRONLY|O_TRUNC)) != -1) {
+			write(fd, oom_protect_old.oom_value[(int)action], strlen(oom_protect_old.oom_value[(int)action]));
 		}
 	}
 	if (fd != -1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1096](https://pbspro.atlassian.net/browse/PP-1096)**

#### Problem description
* daemon_protect writes to `/proc/<PID>/oom_score_adj`, and when it does, it writes the entire content of the buffer instead of just the length of the string. This showed up when compiling with AddressSanitizer.

#### Cause / Analysis
* It uses sizeof() instead of strlen(). 

#### Solution description
* Change sizeof()-1 to strlen().

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
