### PR TITLE
PP-1109: After a server restart, all running jobs disappear from pbsn…

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7061,7 +7061,13 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				return (PBSE_UNKNODE);
 			}
 
-			if (pnode->nd_state & (INUSE_DOWN | INUSE_STALE)) {
+			/*
+			 * Initially don't allow allow jobs/resvs to be placed on down or stale nodes.
+			 * If the job is already on a down/stale node and is being recovered from the
+			 * database, allow it back onto that node.  Nodes may not be back up before
+			 * jobs are recovered from the database.
+			 */
+			if (svr_init == FALSE && (pnode->nd_state & (INUSE_DOWN | INUSE_STALE))) {
 				free(phowl);
 				free(execvncopy);
 				return (PBSE_BAD_NODE_STATE);

--- a/test/tests/functional/pbs_node_jobs_restart.py
+++ b/test/tests/functional/pbs_node_jobs_restart.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under a
+# commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestNodeJobsRestart(TestFunctional):
+    """
+    Make sure that jobs remain on the node's jobs line after a server restart
+    """
+
+    def test_node_jobs_restart(self):
+        """
+        Make sure that jobs attribute remains set properly after the
+        server is restarted
+        """
+        J = Job()
+        jid = self.server.submit(J)
+        self.server.expect(JOB, 'exec_vnode', op=SET, id=jid)
+
+        job_nodes = J.get_vnodes(J.exec_vnode)
+        svr_nodes = self.server.status(NODE, id=job_nodes[0])
+        msg = 'Job ' + jid + ' not in node ' + job_nodes[0] + '\'s jobs line'
+        self.assertTrue(jid in svr_nodes[0]['jobs'], msg)
+
+        self.server.restart()
+
+        self.server.expect(NODE, 'jobs', op=SET, id=job_nodes[0])
+        svr_nodes2 = self.server.status(NODE, id=job_nodes[0])
+        self.assertTrue(jid in svr_nodes2[0]['jobs'], msg)


### PR DESCRIPTION
…odes

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1109](https://pbspro.atlassian.net/browse/PP-1109)**

#### Problem description
* When the server restarts, the nodes lose their jobs attribute

#### Cause / Analysis
* The commit of PP-966 disallowed jobs to run on down nodes.  This was done in set_nodes().  It turns out that set_nodes() is also called when the  server is starting up and jobs are being recovered.  When the jobs are being recovered, the nodes are likely not up yet.  This means set_nodes() would fail and the node's jobs attribute wouldn't be set.

#### Solution description
* set_nodes() has a parameter which is true when the server is starting.  I changed the check for down nodes to only happen when the server is not starting.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
