### PR TITLE
PP-826: Do not display vnode_pool in pbsnodes -av output on Windows

### DIFF
--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -524,10 +524,6 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 	pnode->nd_attr[(int)ND_ATR_Sharing].at_flags =
 		ATR_VFLAG_SET|ATR_VFLAG_DEFLT;
 
-	pnode->nd_attr[(int)ND_ATR_vnode_pool].at_val.at_long = 0;
-	pnode->nd_attr[(int)ND_ATR_vnode_pool].at_flags =
-		ATR_VFLAG_SET|ATR_VFLAG_DEFLT;
-
 	pat1 = &pnode->nd_attr[(int)ND_ATR_ResourceAvail];
 	pat2 = &pnode->nd_attr[(int)ND_ATR_ResourceAssn];
 
@@ -1630,7 +1626,8 @@ setup_nodes()
 				np->nd_moms[0]->mi_modtime = mom_modtime;
 		}
 		if (np) {
-			if (np->nd_attr[(int)ND_ATR_vnode_pool].at_val.at_long > 0) {
+			if ((np->nd_attr[(int)ND_ATR_vnode_pool].at_flags & ATR_VFLAG_SET) &&
+			    (np->nd_attr[(int)ND_ATR_vnode_pool].at_val.at_long > 0)) {
 				mominfo_t *pmom = np->nd_moms[0];
 				if (pmom &&
 				    (np == ((mom_svrinfo_t *)(pmom->mi_data))->msr_children[0])) {

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -3163,7 +3163,8 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 
 		/* If this is the "natural vnode" (i.e. 0th entry) */
 		if (pnode->nd_nummoms == 1) {
-			if (pnode->nd_attr[(int)ND_ATR_vnode_pool].at_val.at_long > 0) {
+			if ((pnode->nd_attr[(int)ND_ATR_vnode_pool].at_flags & ATR_VFLAG_SET) &&
+			    (pnode->nd_attr[(int)ND_ATR_vnode_pool].at_val.at_long > 0)) {
 				smp->msr_vnode_pool = pnode->nd_attr[(int)ND_ATR_vnode_pool].at_val.at_long;
 			}
 		}
@@ -3648,7 +3649,8 @@ struct batch_request *preq;
 
 	mymom   = pnode->nd_moms[0];
 	vn_pool = pnode->nd_attr[(int)ND_ATR_vnode_pool].at_val.at_long;
-	if (vn_pool > 0) {
+	if ((pnode->nd_attr[(int)ND_ATR_vnode_pool].at_flags & ATR_VFLAG_SET) && 
+	   (vn_pool > 0)) {
 		if (add_mom_to_pool(mymom) == PBSE_NONE) {
 			/* cross link any vnodes of an existing Mom in pool */
 			int i;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-826](https://pbspro.atlassian.net/browse/PP-826)**

#### Problem description
* On Windows pbsnodes -a output was incorrectly displaying an attribute that should not have been displayed, vnode_pool.

#### Cause / Analysis
* vnode_pool was being initialized and set in initialize_pbsnode()

#### Solution description
* Removed the initialization and set of vnode_pool in initialize_pbsnode()

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [X] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
