### PR TITLE
PP-1158: TestQmgr fails saying "No such file or directory"

### DIFF
--- a/test/tests/functional/pbs_qmgr.py
+++ b/test/tests/functional/pbs_qmgr.py
@@ -76,13 +76,18 @@ class TestQmgr(TestFunctional):
         node_prefix = "vn"
         nodename = node_prefix + "[0]"
         vndef_file = None
+        qmgr_path = os.path.join(self.server.pbs_conf["PBS_EXEC"], "bin",
+                                 "qmgr")
+        if not os.path.isfile(qmgr_path):
+            self.server.skipTest("qmgr binary not found!")
+
         try:
             # Check 1: New attributes are prefixed with spaces and not tabs
             # Execute qmgr -c 'list sched' and store output in a temp file
             if self.du.is_localhost(self.server.hostname) is True:
-                qmgr_cmd = ["qmgr", "-c", "list sched"]
+                qmgr_cmd = [qmgr_path, "-c", "list sched"]
             else:
-                qmgr_cmd = ["qmgr", "-c", "\'list sched\'"]
+                qmgr_cmd = [qmgr_path, "-c", "\'list sched\'"]
             with os.fdopen(fd, "w+") as tempfd:
                 ret = self.du.run_cmd(self.server.hostname, qmgr_cmd,
                                       stdout=tempfd)
@@ -107,9 +112,9 @@ class TestQmgr(TestFunctional):
             # Execute "qmgr 'list node vn[0]'"
             # The comment attribute should generate a line extension
             if self.du.is_localhost(self.server.hostname) is True:
-                qmgr_cmd = ["qmgr", "-c", "list node " + nodename]
+                qmgr_cmd = [qmgr_path, "-c", "list node " + nodename]
             else:
-                qmgr_cmd = ["qmgr", "-c", "\'list node " + nodename + "\'"]
+                qmgr_cmd = [qmgr_path, "-c", "\'list node " + nodename + "\'"]
             with open(fn, "w+") as tempfd:
                 ret = self.du.run_cmd(self.server.hostname, qmgr_cmd,
                                       stdout=tempfd)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1158](https://pbspro.atlassian.net/browse/PP-1158)**

#### Problem description
* TestQmgr PTL test would fail saying "OSError: No such file or directory"

#### Cause / Analysis
* The test was assuming that qmgr was in the system's PATH variable, so when it was run on a system where that was not the case, it would fail not being able to find the qmgr executable.

#### Solution description
* Corrected the test case to now use the full path to qmgr

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
