### PR TITLE
PP-1093: pbs_server crashes when recovering database after default_qsub_arguments is set

### DIFF
--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -6758,6 +6758,8 @@ force_qsub_daemons_update(void)
 {
 	int s;
 	conn_t *cp = NULL;
+	if (svr_allconns.ll_next == (pbs_list_link *)0)
+		return;
 	for (cp = (conn_t *)GET_NEXT(svr_allconns);cp; cp = GET_NEXT(cp->cn_link)) {
 		if (cp->cn_authen & PBS_NET_CONN_FROM_QSUB_DAEMON)
 			cp->cn_authen |= PBS_NET_CONN_FORCE_QSUB_UPDATE;


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1093](https://pbspro.atlassian.net/browse/PP-1093)**

#### Problem description
* pbs_server crashes when recovering database after default_qsub_arguments is set

#### Cause / Analysis
* In force_qsub_daemons_update() GET_NEXT was dereferencing svr_allconns.ll_next, but it was 0.

#### Solution description
* Added a check to return from function if 0.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [X] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__