### PR TITLE
PP-1060: Job with future qsub -a time immediately start accruing eligib…

### DIFF
--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -616,10 +616,17 @@ modify_job_attr(job *pjob, svrattrl *plist, int perm, int *bad)
 		return (rc);
 	}
 
-	/* Now copy the new values into the job attribute array */
+	/* Now copy the new values into the job attribute array for the purposes of running the action functions */
 
 	for (i = 0; i < JOB_ATR_LAST; i++) {
 		if (newattr[i].at_flags & ATR_VFLAG_MODIFY) {
+			/*
+			 * The function update_eligible_time() expects it is the only one setting accrue_type.
+			 * If we set it here, it will get confused.  There is no action function for accrue_type,
+			 * so pre-setting it for the action function calls isn't required.
+			 */
+			if (i == JOB_ATR_accrue_type)
+				continue;
 			job_attr_def[i].at_free(&pattr[i]);
 			if ((pre_copy[i].at_type == ATR_TYPE_LIST) ||
 				(pre_copy[i].at_type == ATR_TYPE_RESC)) {

--- a/test/tests/functional/pbs_eligible_time.py
+++ b/test/tests/functional/pbs_eligible_time.py
@@ -1,0 +1,111 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2017 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestEligibleTime(TestFunctional):
+    """
+    Test suite for eligible time tests
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        a = {'eligible_time_enable': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+    def test_qsub_a(self):
+        """
+        Test that jobs requsting qsub -a <time> do not accrue
+        eligible time until <time> is reached
+        """
+        a = {'scheduling': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        now = int(time.time())
+        now += 120
+        s = time.strftime("%H%M.%S", time.localtime(now))
+
+        J1 = Job(TEST_USER, attrs={ATTR_a: s})
+        jid = self.server.submit(J1)
+        self.server.expect(JOB, {ATTR_state: 'W'}, id=jid)
+
+        self.logger.info("Sleeping 120s till job is out of 'W' state")
+        time.sleep(120)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid)
+        # eligible_time should really be 0, but just incase there is some
+        # lag on some slow systems, add a little leeway.
+        self.server.expect(JOB, {'eligible_time': 10}, op=LT)
+
+    def test_job_array(self):
+        """
+        Test that a job array switches from accruing eligible time
+        to ineligible time when its last subjob starts running
+        """
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+
+        a = {'log_events': 2047}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        J1 = Job(TEST_USER, attrs={ATTR_J: '1-3'})
+        J1.set_sleep_time(20)
+        jid = self.server.submit(J1)
+        jid_short = jid.split('[')[0]
+        sjid1 = jid_short + '[1]'
+        sjid2 = jid_short + '[2]'
+        sjid3 = jid_short + '[3]'
+
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=sjid1, extend='t')
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=sjid2, extend='t')
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=sjid3, extend='t')
+        # accrue_type = 2 is eligible_time
+        self.server.expect(JOB, {'accrue_type': 2}, id=jid)
+
+        self.logger.info("Sleeping 20s till subjobs end")
+        time.sleep(20)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=sjid3, extend='t')
+        self.server.expect(JOB, {'accrue_type': 1}, id=jid)
+
+        # The job array has [] in its ID.
+        # These are regexp, so they need to be escaped.
+        jid_esp = jid.replace('[', '\[').replace(']', '\]')
+        m = jid_esp + ";Accrue type has changed to ineligible_time, "
+        m += "previous accrue type was eligible_time for 2[0-5] secs, "
+        m += "total eligible_time=00:00:2[0-5]"
+        self.server.log_match(m, regexp=True)


### PR DESCRIPTION
…le_time

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1060](https://pbspro.atlassian.net/browse/PP-1060)**

#### Problem description
* Jobs that are submitted with a future start time (i.e., qsub -a) will immediately start accruing eligible time.  They should start accruing eligible time only when their time arrives.
#### Cause / Analysis
* As part of PP-938 all of the attributes are updated before the action functions are called.  If the action functions fail, the attributes will be reverted.  The problem was accrue_type.  The update_eligible_time() function expected it was the only entity changing the accrue_type.  It got confused when the accrue_type was set outside of the function and behaved badly.

#### Solution description
* Don't set accrue_type before calling the action functions.  There is no action function for accrue_type, so it doesn't need to be set.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
