### PR TITLE
PP-1178: Fix test TestResvStaleVnode to include priority level in set…

### DIFF
--- a/test/tests/functional/pbs_conf_resv_stale_vnode.py
+++ b/test/tests/functional/pbs_conf_resv_stale_vnode.py
@@ -62,7 +62,8 @@ class TestResvStaleVnode(TestFunctional):
         self.server.create_vnodes('vnode', a, 1, fname='fname2', delall=False,
                                   additive=True, mom=self.mom, expect=False)
 
-        self.scheduler.set_sched_config({'node_sort_key': 'sort_priority'})
+        self.scheduler.set_sched_config({'node_sort_key':
+                                        'sort_priority HIGH'})
 
     def test_conf_resv_stale_vnode(self):
         """


### PR DESCRIPTION
…_sched_config

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1178](https://pbspro.atlassian.net/browse/PP-1178)**

#### Problem description
Test was failing because priority level was not set in setup for scheduler.set_sched_config({'node_sort_key': 'sort_priority'})

#### Cause / Analysis
Set priority to HIGH- scheduler.set_sched_config({'node_sort_key': 'sort_priority HIGH'})

#### Solution description
Set priority to HIGH- scheduler.set_sched_config({'node_sort_key': 'sort_priority HIGH'})

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
