### PR TITLE
PP-1184: Jobs don't run properly when MoM started with -N option (putenv calls are flawed)

### DIFF
--- a/src/cmds/pbs_attach.c
+++ b/src/cmds/pbs_attach.c
@@ -142,7 +142,7 @@ win_attach(BOOL use_cmd, int newsid, int port, int doparent, pid_t pid, char *jo
 		 * installations of MPICH will not open a new session and escape
 		 * the new task.
 		 */
-		(void)putenv("MPICH_PROCESS_GROUP=no");
+		(void)setenv("MPICH_PROCESS_GROUP", "no", 1);
 
 		if ((ac > 0) && (av != NULL) && (*av != NULL) && (*av[0] != '\0')) {
 			/* create a suspended process */
@@ -398,7 +398,7 @@ main(int argc, char *argv[])
 		 ** installations of MPICH will not call setsid() and escape
 		 ** the new task.
 		 */
-		(void)putenv("MPICH_PROCESS_GROUP=no");
+		(void)setenv("MPICH_PROCESS_GROUP", "no", 1);
 
 		argv += optind;
 		argc -= optind;

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -5272,7 +5272,6 @@ do_daemon_stuff(char *file, char *handle, char *server)
 	int svr_sock = -1;
 	HANDLE handles[2];
 	time_t connect_time = 0;
-	char env_string[2*MAXPATHLEN+1] = {0};
 
 	sd_svr = -1; /* not connected */
 	hEventParent = atoi(handle);
@@ -5374,8 +5373,7 @@ do_daemon_stuff(char *file, char *handle, char *server)
 		if (_chdir(qsub_cwd) != 0)
 			goto error;
 
-		snprintf(env_string, sizeof(env_string) -1, "PWD=%s", qsub_cwd);
-		if (putenv(env_string) != 0)
+		if (setenv("PWD", qsub_cwd, 1) != 0)
 			goto error;
 
 		if (sd_svr == -1) {
@@ -5602,7 +5600,6 @@ do_daemon_stuff(void)
 	mode_t cmask = 0077;
 	time_t connect_time = time(0);
 	sigset_t newsigmask, oldsigmask;
-	char env_string[2*MAXPATHLEN+1] = {0};
 	char *err_op = "";
 	char log_buf[LOG_BUF_SIZE];
 
@@ -5710,9 +5707,8 @@ do_daemon_stuff(void)
 			goto error;
 		}
 
-		snprintf(env_string, sizeof(env_string) -1, "PWD=%s", qsub_cwd);
-		if (putenv(env_string) != 0) {
-			err_op = "putenv";
+		if (setenv("PWD", qsub_cwd, 1) != 0) {
+			err_op = "setenv";
 			goto error;
 		}
 

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -424,7 +424,6 @@ enum mgr_obj {
 #define BLUEGENE		"bluegene"
 /* SUSv2 guarantees that host names are limited to 255 bytes */
 #define PBS_MAXHOSTNAME		255	/* max host name length */
-#define ENV_BUF_SIZE		32767 /* max size of buffer for return value of GetEnvironmentVariable */
 #ifndef MAXPATHLEN
 #define MAXPATHLEN		1024	/* max path name length */
 #endif

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -424,6 +424,7 @@ enum mgr_obj {
 #define BLUEGENE		"bluegene"
 /* SUSv2 guarantees that host names are limited to 255 bytes */
 #define PBS_MAXHOSTNAME		255	/* max host name length */
+#define ENV_BUF_SIZE		32767 /* max size of buffer for return value of GetEnvironmentVariable */
 #ifndef MAXPATHLEN
 #define MAXPATHLEN		1024	/* max path name length */
 #endif

--- a/src/include/win.h
+++ b/src/include/win.h
@@ -449,6 +449,11 @@ extern void get_token_info(HANDLE htok,
 extern int wsystem(char *cmdline, HANDLE user_handle);
 
 /* Saving/restoring environment */
+#define ENV_BUF_SIZE            32767 /* max size of buffer for return value of GetEnvironmentVariable */
+
+#define getenv _getenv_win
+#define setenv _setenv_win
+
 extern void save_env(void);
 extern int _setenv_win(char *key, char *value, int overwrite);
 extern char *_getenv_win(char *key);
@@ -456,11 +461,6 @@ extern char *get_saved_env(char *e);
 extern void create_env_avltree();
 extern void update_env_avltree();
 extern void destroy_env_avltree();
-
-#ifdef WIN32
-#define getenv _getenv_win
-#define setenv _setenv_win
-#endif
 
 /* Privileges */
 extern int has_privilege(char *);

--- a/src/include/win.h
+++ b/src/include/win.h
@@ -450,10 +450,17 @@ extern int wsystem(char *cmdline, HANDLE user_handle);
 
 /* Saving/restoring environment */
 extern void save_env(void);
+extern int _setenv_win(char *key, char *value, int overwrite);
+extern char *_getenv_win(char *key);
 extern char *get_saved_env(char *e);
 extern void create_env_avltree();
 extern void update_env_avltree();
 extern void destroy_env_avltree();
+
+#ifdef WIN32
+#define getenv _getenv_win
+#define setenv _setenv_win
+#endif
 
 /* Privileges */
 extern int has_privilege(char *);

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -669,13 +669,13 @@ __pbs_connect_extend(char *server, char *extend_data)
 		/* the following lousy hack is needed since the socket call needs */
 		/* SYSTEMROOT env variable properly set! */
 		if (getenv("SYSTEMROOT") == NULL) {
-			putenv("SYSTEMROOT=C:\\WINNT");	/* Try WINNT */
-			putenv("SystemRoot=C:\\WINNT");	/* Try WINNT */
+			setenv("SYSTEMROOT", "C:\\WINNT", 1);
+			setenv("SystemRoot", "C:\\WINNT", 1);
 		}
 		connection[out].ch_socket = socket(AF_INET, SOCK_STREAM, 0);
 		if (connection[out].ch_socket < 0) {
-			putenv("SYSTEMROOT=C:\\WINDOWS");	/* Try XP */
-			putenv("SystemRoot=C:\\WINDOWS");	/* Try XP */
+			setenv("SYSTEMROOT", "C:\\WINDOWS", 1);
+			setenv("SystemRoot", "C:\\WINDOWS", 1);
 			connection[out].ch_socket = socket(AF_INET, SOCK_STREAM, 0);
 
 		}
@@ -1103,13 +1103,13 @@ pbs_connect_noblk(char *server, int tout)
 	/* the following lousy hack is needed since the socket call needs */
 	/* SYSTEMROOT env variable properly set! */
 	if (getenv("SYSTEMROOT") == NULL) {
-		putenv("SYSTEMROOT=C:\\WINNT");	/* Try WINNT */
-		putenv("SystemRoot=C:\\WINNT");	/* Try WINNT */
+		setenv("SYSTEMROOT", "C:\\WINNT", 1);
+		setenv("SystemRoot", "C:\\WINNT", 1);
 	}
 	connection[out].ch_socket = socket(AF_INET, SOCK_STREAM, 0);
 	if (connection[out].ch_socket < 0) {
-		putenv("SYSTEMROOT=C:\\WINDOWS");	/* Try XP */
-		putenv("SystemRoot=C:\\WINDOWS");	/* Try XP */
+		setenv("SYSTEMROOT", "C:\\WINDOWS", 1);
+		setenv("SystemRoot", "C:\\WINDOWS", 1);
 		connection[out].ch_socket = socket(AF_INET, SOCK_STREAM, 0);
 	}
 #else

--- a/src/lib/Libwin/env.c
+++ b/src/lib/Libwin/env.c
@@ -49,9 +49,67 @@ static char	sysrootdir[MAXPATHLEN+1] = "";
 static char	sysdrive[MAXPATHLEN+1] = "";
 static char	temp_path[MAXPATHLEN+1] = "";
 static char	user_domain[PBS_MAXHOSTNAME+1] = "";
+static char	value_buf[ENV_BUF_SIZE] = "";
 /**
  * @file	env.c
  */
+/**
+ * @brief
+ * 	_setenv_win: Set an environment variable
+ *  
+ * @param[in] key - string holding key for environment variable
+ * @param[in] value - string holding value for environment variable
+ * @param[in] interrupt - int value to override existing value, not used in Windows
+ *	
+ * @return	int
+ * @retval	0			success
+ * @retval	non-zero	error
+
+ */
+int
+_setenv_win(char* key, char* value, int overwrite)
+{
+	errno = 0;
+
+	if(!GetEnvironmentVariable(key, value_buf, ENV_BUF_SIZE) && !overwrite)
+		if(!GetLastError() == ERROR_ENVVAR_NOT_FOUND)
+			return 0;
+
+	if(!SetEnvironmentVariable(key, value)){
+		errno = GetLastError();
+		return errno;
+	}
+
+	return 0;
+}
+/**
+ * @brief
+ * 	_getenv_win: Get value of an environment variable
+ *  
+ * @param[in] key - string holding key for environment variable
+ * @param[in] value - string buffer where value for environment variable will be returned
+ * @param[in] buffer size - int value to specify max length
+ *	
+ * @return	char*
+ * @retval	value of key in environment		success
+ * @retval	NULL					error
+
+ */
+char*
+_getenv_win(char* key)
+{
+	errno = 0;
+	memset(value_buf, 0, 255);
+
+	if(!GetEnvironmentVariable(key, value_buf, ENV_BUF_SIZE)){
+		if(GetLastError() == ERROR_ENVVAR_NOT_FOUND){
+			errno = ERROR_ENVVAR_NOT_FOUND;
+			return NULL;
+		}
+	}
+
+	return value_buf;
+}
 /**
  * @brief
  * 	save_env: gets/sets some important environment variable values that can
@@ -116,11 +174,9 @@ save_env(void)
 	}
 
 	/* Set the SYSTEMROOT and SystemRoot environment variables */
-	sprintf(env_string, "SYSTEMROOT=%s", sysrootdir);
-	putenv(env_string);
+	setenv("SYSTEMROOT", sysrootdir, 1);
 
-	sprintf(env_string, "SystemRoot=%s", sysrootdir);
-	putenv(env_string);
+	setenv("SystemRoot", sysrootdir, 1);
 
 	/* The following figures out the value for SYSTEMDRIVE */
 	strcpy(sysdrive, "C:");
@@ -129,11 +185,9 @@ save_env(void)
 	}
 
 	/* Set the SYSTEMDRIVE and SystemDrive environment variables */
-	sprintf(env_string, "SYSTEMDRIVE=%s", sysdrive);
-	putenv(env_string);
+	setenv("SYSTEMDRIVE", sysdrive, 1);
 
-	sprintf(env_string, "SystemDrive=%s", sysdrive);
-	putenv(env_string);
+	setenv("SystemDrive", sysdrive, 1);
 
 	/* The following figures out the value for TEMP */
 	strcpy(temp_path, "");

--- a/src/lib/Libwin/env.c
+++ b/src/lib/Libwin/env.c
@@ -62,7 +62,7 @@ static char	value_buf[ENV_BUF_SIZE] = "";
  * @param[in] interrupt - int value to override existing value, not used in Windows
  *	
  * @return	int
- * @retval	0			success
+ * @retval	0		success
  * @retval	non-zero	error
 
  */
@@ -91,15 +91,15 @@ _setenv_win(char* key, char* value, int overwrite)
  * @param[in] buffer size - int value to specify max length
  *	
  * @return	char*
- * @retval	value of key in environment		success
- * @retval	NULL					error
+ * @retval	value of key in the environment 	success
+ * @retval	NULL								error
 
  */
-char*
-_getenv_win(char* key)
+char *
+_getenv_win(char *key)
 {
 	errno = 0;
-	memset(value_buf, 0, 255);
+	memset(value_buf, 0, sizeof(value_buf));
 
 	if(!GetEnvironmentVariable(key, value_buf, ENV_BUF_SIZE)){
 		if(GetLastError() == ERROR_ENVVAR_NOT_FOUND){

--- a/src/lib/Libwin/passwd.c
+++ b/src/lib/Libwin/passwd.c
@@ -250,7 +250,7 @@ cache_data(char *func, char *key, char *value_array,
 	int	free_slot = -1;
 	int	oldest_slot = -1;
 	time_t	now;
-	char	func_key[CACHE_STR_SIZE*2 + 1];
+	char	func_key[CACHE_STR_SIZE*2 + 1] = {'\0'};
 	char	*varray = NULL;	   	/* pointer to value_array */
 	char	*end_varray = NULL;   /* pointer to end of value_array */
 
@@ -392,7 +392,7 @@ SID*
 sid_dup(SID *src_sid)
 {
 	DWORD	sid_len_need;
-	SID	*dest_sid;
+	SID	*dest_sid = NULL;
 
 	if ((src_sid == NULL) || (!IsValidSid(src_sid)))
 		return (NULL);	/* nothing happens */
@@ -565,8 +565,8 @@ get_full_username(char *username,
 	DWORD		sid_sz = 0;
 	TCHAR		domain[PBS_MAXHOSTNAME+1] = "";
 	DWORD		domain_sz;
-	char		tryname[PBS_MAXHOSTNAME+UNLEN+2];	/* dom\user0 */
-	char		actual_name[PBS_MAXHOSTNAME+UNLEN+2];	/* dom\user0 */
+	char		tryname[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'};	/* dom\user0 */
+	char		actual_name[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'};	/* dom\user0 */
 
 	if (username == NULL)
 		return (NULL);
@@ -789,10 +789,10 @@ get_dcinfo(char *net_name,
 static void
 resolve_username(char *username[PBS_MAXHOSTNAME+UNLEN+2]) /* domain\user0 */
 {
-	char uname[UNLEN+1];
-	char dname[PBS_MAXHOSTNAME+1];
-	char actual_dname[PBS_MAXHOSTNAME+1];
-	char domain_ctrl[PBS_MAXHOSTNAME+1];
+	char uname[UNLEN+1] = {'\0'};
+	char dname[PBS_MAXHOSTNAME+1] = {'\0'};
+	char actual_dname[PBS_MAXHOSTNAME+1] = {'\0'};
+	char domain_ctrl[PBS_MAXHOSTNAME+1] = {'\0'};
 	char *p;
 
 	if (username == NULL)
@@ -828,10 +828,10 @@ resolve_username(char *username[PBS_MAXHOSTNAME+UNLEN+2]) /* domain\user0 */
 static void
 resolve_grpname(char *grpname[PBS_MAXHOSTNAME+GNLEN+2]) /* domain\user0 */
 {
-	char gname[GNLEN+1];
-	char dname[PBS_MAXHOSTNAME+1];
-	char actual_dname[PBS_MAXHOSTNAME+1];
-	char domain_ctrl[PBS_MAXHOSTNAME+1];
+	char gname[GNLEN+1] = {'\0'};
+	char dname[PBS_MAXHOSTNAME+1] = {'\0'};
+	char actual_dname[PBS_MAXHOSTNAME+1] = {'\0'};
+	char domain_ctrl[PBS_MAXHOSTNAME+1] = {'\0'};
 	char *p;
 
 	if (grpname == NULL)
@@ -928,7 +928,7 @@ getusersid2(char *uname,
 {
 	SID		*sid = NULL;
 	SID_NAME_USE	type = 0;
-	char 		username[PBS_MAXHOSTNAME+UNLEN+2]; /* domain\user0 */
+	char 		username[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'}; /* domain\user0 */
 	char		*p = NULL;
 	HANDLE		hToken = INVALID_HANDLE_VALUE;
 	DWORD		dwBufferSize = 0;
@@ -1364,15 +1364,15 @@ getGlobalGroups(char *user, GROUP_USERS_INFO_0 **groupsp)
 	DWORD nread, total;
 	DWORD pref = 16;
 	DWORD rc;
-	wchar_t userw[UNLEN+1];
+	wchar_t userw[UNLEN+1] = {'\0'};
 
-	char    dname[PBS_MAXHOSTNAME+1];
+	char    dname[PBS_MAXHOSTNAME+1] = {'\0'};
 
-	char    domain_name[PBS_MAXHOSTNAME+1];
-	char    user_name[PBS_MAXHOSTNAME+1];
+	char    domain_name[PBS_MAXHOSTNAME+1] = {'\0'};
+	char    user_name[PBS_MAXHOSTNAME+1] = {'\0'};
 
-	char    dctrl[PBS_MAXHOSTNAME+1];
-	wchar_t dctrlw[PBS_MAXHOSTNAME+1];
+	char    dctrl[PBS_MAXHOSTNAME+1] = {'\0'};
+	wchar_t dctrlw[PBS_MAXHOSTNAME+1] = {'\0'};
 	char	*p = NULL;
 
 	/* user: <domain_name>\<user_name> */
@@ -1447,15 +1447,15 @@ getLocalGroups(char *user, GROUP_USERS_INFO_0 **groupsp)
 	DWORD nread, total;
 	DWORD pref = 16;
 	DWORD rc;
-	wchar_t userw[UNLEN+1];
+	wchar_t userw[UNLEN+1] = {'\0'};
 
-	char    dname[PBS_MAXHOSTNAME+1];
+	char    dname[PBS_MAXHOSTNAME+1] = {'\0'};
 
-	char    domain_name[PBS_MAXHOSTNAME+1];
-	char    user_name[PBS_MAXHOSTNAME+1];
+	char    domain_name[PBS_MAXHOSTNAME+1] = {'\0'};
+	char    user_name[PBS_MAXHOSTNAME+1] = {'\0'};
 
-	char    dctrl[PBS_MAXHOSTNAME+1];
-	wchar_t dctrlw[PBS_MAXHOSTNAME+1];
+	char    dctrl[PBS_MAXHOSTNAME+1] = {'\0'};
+	wchar_t dctrlw[PBS_MAXHOSTNAME+1] = {'\0'};
 	char	*p = NULL;
 
 	/* user: <domain_name>\<user_name> */
@@ -1471,7 +1471,7 @@ getLocalGroups(char *user, GROUP_USERS_INFO_0 **groupsp)
 
 	strcpy(dctrl, domain_name);
 	if (GetComputerDomainName(dname) == 1) {
-		char    dname_a[PBS_MAXHOSTNAME+1];
+		char    dname_a[PBS_MAXHOSTNAME+1] = {'\0'};
 
 		get_dcinfo(domain_name, dname_a, dctrl);
 	}
@@ -1594,8 +1594,8 @@ isMember(char *user, char *group)
 	GROUP_USERS_INFO_0 *groups = NULL;
 	DWORD	nread;
 	DWORD	i;
-	wchar_t groupw[GNLEN+1];
-	char		realuser[PBS_MAXHOSTNAME+UNLEN+2]; /* dom\user0 */
+	wchar_t groupw[GNLEN+1] = {'\0'};
+	char		realuser[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'}; /* dom\user0 */
 	SID_NAME_USE	sid_type;
 	SID		*sid = NULL;
 
@@ -1897,7 +1897,7 @@ getdefgrpname(char *user)
 
 	GROUP_USERS_INFO_0 *groups = NULL;
 	char	*group;
-	char	realuser[PBS_MAXHOSTNAME+UNLEN+2]; /* dom\user0 */
+	char	realuser[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'}; /* dom\user0 */
 	DWORD	sid_sz = 0;
 	SID_NAME_USE	sid_type;
 	SID		*sid = NULL;
@@ -1974,7 +1974,7 @@ getdefgrpsid(char *user)
 char *
 getlogin(void)
 {
-	static char	usern[UNLEN+1];
+	static char	usern[UNLEN+1] = {'\0'};
 	int		sz;
 	int		ret;
 
@@ -2038,7 +2038,7 @@ getlogin(void)
 char *
 getlogin_full(void)
 {
-	static char	usern[PBS_MAXHOSTNAME+UNLEN+2];
+	static char	usern[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'};
 	int		sz;
 	int		ret;
 
@@ -2195,10 +2195,10 @@ getgids(char *user, SID *grp[], DWORD rids[])
 	GROUP_USERS_INFO_0 *groups = NULL;
 	DWORD	nread;
 	DWORD	i, j, k;
-	char	group[GNLEN+1];
+	char	group[GNLEN+1] = {'\0'};
 	SID		*g;
 	int		found;
-	char    realuser[PBS_MAXHOSTNAME+UNLEN+2]; /* dom\user0 */
+	char    realuser[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'}; /* dom\user0 */
 	SID_NAME_USE    sid_type;
 	SID             *sid = NULL;
 
@@ -2360,9 +2360,9 @@ inGroups(char *gname, SID *gidlist[], int len)
 char *
 default_local_homedir(char *username, HANDLE usertoken, int ret_profile_path)
 {
-	static  char 	homestr[MAXPATHLEN+1];
-	char		profilepath[MAXPATHLEN+1];
-	char		personal_path[MAX_PATH];
+	static  char 	homestr[MAXPATHLEN+1] = {'\0'};
+	char		profilepath[MAXPATHLEN+1] = {'\0'};
+	char		personal_path[MAX_PATH] = {'\0'};
 	char		logb[LOG_BUF_SIZE] = {'\0' } ;
 	DWORD		profsz;
 	HANDLE		userlogin;
@@ -2468,7 +2468,7 @@ map_unc_path(char *path, struct passwd *pw)
 
 	DWORD       ret;
 	NETRESOURCE nr;
-	static char local_drive[MAXPATHLEN+1];
+	static char local_drive[MAXPATHLEN+1] = {'\0'};
 	int	    lsize = MAXPATHLEN+1;
 
 	strcpy(local_drive, "");
@@ -2572,8 +2572,8 @@ getAssignedHomeDirectory(char *user)
 	char	*homedir = NULL;
 	char	*sysdrv = NULL;
 	int	len;
-	char	realuser[PBS_MAXHOSTNAME+UNLEN+2]; /* dom\user0 */
-	wchar_t	realuserw[PBS_MAXHOSTNAME+UNLEN+2]; /* dom\user0 */
+	char	realuser[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'}; /* dom\user0 */
+	wchar_t	realuserw[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'}; /* dom\user0 */
 	SID_NAME_USE sid_type;
 	SID	*sid = NULL;
 	char	*p;
@@ -2726,9 +2726,9 @@ getRhostsFile(char *user, HANDLE userlogin)
 {
 
 	struct  stat sbuf;
-	static char rhosts_file[MAXPATHLEN+1];
+	static char rhosts_file[MAXPATHLEN+1] = {'\0'};
 	char	*homedir = NULL;
-	char	profilepath[MAXPATHLEN+1];
+	char	profilepath[MAXPATHLEN+1] = {'\0'};
 
 
 	homedir = getAssignedHomeDirectory(user);
@@ -2995,7 +2995,7 @@ print_token_groups(TOKEN_GROUPS *token_groups)
 {
 	int	i;
 	char	*gname = NULL;
-	char	buf[80];
+	char	buf[80] = {'\0'};
 	char	logb[LOG_BUF_SIZE] = {'\0' } ;
 
 	strcpy(logb, "");
@@ -3040,7 +3040,7 @@ create_token_privs_byuser(SID *usid, DWORD attrib, HANDLE hLsa)
 	LSA_UNICODE_STRING *lsaRights = NULL;
 	ULONG numRights = 0;
 	int	len, i;
-	char privname[GNLEN+1];
+	char privname[GNLEN+1] = {'\0'};
 
 	if (hLsa == INVALID_HANDLE_VALUE || usid == NULL)
 		return (NULL);
@@ -3078,7 +3078,7 @@ create_token_privs_bygroups(TOKEN_GROUPS *token_groups, DWORD attrib, HANDLE hLs
 	LSA_UNICODE_STRING *lsaRights = NULL;
 	ULONG numRights = 0;
 	int	len, i, j, k;
-	char privname[GNLEN+1];
+	char privname[GNLEN+1] = {'\0'};
 	LUID	luid;
 	BOOL	found_match;
 
@@ -3206,8 +3206,8 @@ print_token_privs(TOKEN_PRIVILEGES *token_privs)
 	int i;
 	LUID luid;
 	DWORD cb;
-	char  buf[512];
-	char  buf2[512];
+	char  buf[512] = {'\0'};
+	char  buf2[512] = {'\0'};
 	char  logb[LOG_BUF_SIZE] = {'\0' } ;
 
 	if (token_privs == NULL)
@@ -3397,8 +3397,8 @@ print_dacl(ACL *pdacl)
 	ACL_SIZE_INFORMATION    sizeInfo;
 	ACCESS_ALLOWED_ACE      *pace;
 	int                     i;
-	char			bigbuf[1024];
-	char			buf2[80];
+	char			bigbuf[1024] = {'\0'};
+	char			buf2[80] = {'\0'};
 	char			*secname;
 
 	GetAclInformation(pdacl, &sizeInfo, sizeof(sizeInfo), AclSizeInformation);
@@ -3940,8 +3940,8 @@ setuser_with_password(char *user,
 {
 
 	SID     *usid;
-	char    thepass[PWLEN+1];
-	char    realname[UNLEN+1];
+	char    thepass[PWLEN+1] = {'\0'};
+	char    realname[UNLEN+1] = {'\0'};
 	char    domain[PBS_MAXHOSTNAME+1] = "";
 	struct	passwd *pwdp = NULL;
 	int	i;
@@ -4986,7 +4986,7 @@ struct passwd *
 getpwuid(uid_t uid)
 {
 	struct  passwd *pwdp = NULL;
-	char	*username;
+	char	*username = NULL;
 	int	i;
 
 	if (uid == NULL)
@@ -5028,10 +5028,10 @@ cache_usertoken_and_homedir(char *user,
 	int (*decrypt_func)(char *, int, size_t, char **),
 	int force)
 {
-	char	msg[4096];
+	char	msg[4096] = {'\0'};
 	char	*credb = NULL;
 	size_t	credl = 0;
-	struct passwd *pwdp;
+	struct passwd *pwdp = NULL;
 	int	i;
 
 	if (user == (char *)0)
@@ -5219,7 +5219,7 @@ wrap_NetUserGetInfo(LPCWSTR servername,
 
 	if ((netst == ERROR_LOGON_FAILURE) || (netst == ERROR_ACCESS_DENIED)) {
 		struct passwd *pw = NULL;
-		char	user_name[UNLEN+1];
+		char	user_name[UNLEN+1] = {'\0'};
 		int	i;
 
 		wcstombs(user_name, username, UNLEN);
@@ -5351,10 +5351,10 @@ has_read_access_domain_users_end:
 int
 check_executor(void)
 {
-	char 	dname[PBS_MAXHOSTNAME+1];
-	char 	exec_unamef[PBS_MAXHOSTNAME+UNLEN+2]; /* <dom>\<user>0 */
-	char 	exec_uname[PBS_MAXHOSTNAME+UNLEN+2];
-	char	exec_dname[PBS_MAXHOSTNAME+1];
+	char 	dname[PBS_MAXHOSTNAME+1] = {'\0'};
+	char 	exec_unamef[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'}; /* <dom>\<user>0 */
+	char 	exec_uname[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'};
+	char	exec_dname[PBS_MAXHOSTNAME+1] = {'\0'};
 	char	*p = NULL;
 	int	ret = 0;
 
@@ -5376,9 +5376,9 @@ check_executor(void)
 	}
 
 	if (GetComputerDomainName(dname)) {
-		char    	dname_a[PBS_MAXHOSTNAME+1];
-		char    	dctrl[PBS_MAXHOSTNAME+1];
-		wchar_t 	dctrlw[PBS_MAXHOSTNAME+1];
+		char    	dname_a[PBS_MAXHOSTNAME+1] = {'\0'};
+		char    	dctrl[PBS_MAXHOSTNAME+1] = {'\0'};
+		wchar_t 	dctrlw[PBS_MAXHOSTNAME+1] = {'\0'};
 
 
 		if (stricmp(exec_dname, dname) != 0) {

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -4289,14 +4289,14 @@ verifyexit:
 
 /**
  * @brief
- *	if mode is 0, then calls "putenv(env_var=env_val)" if env_var
+ *	if mode is 0, then calls "setenv(env_var, env_val, 1)" if env_var
  *	is not defined in the current environment.
- *	if mode is 1, then calls "putenv(env_var=env_val)" if env_var
+ *	if mode is 1, then calls "setenv(env_var, env_val, 1)" if env_var
  *	is not defined in the current environment, and env_val is an existent
  *	file path.
  *	if mode is 2, then if env_var is not defined in the current environment,
  *	then execute 'cmd_get_val' to get the value for env_val, and call
- *	putenv(env_var=env_val). Any passed env_val in this case will be ignored
+ *	setenv(env_var, env_val, 1). Any passed env_val in this case will be ignored
  *	and should just be set to NULL.
  *
  * @param[in] env_var - environment variable
@@ -4309,7 +4309,7 @@ verifyexit:
  *
  */
 static int
-putenv_if_not_exist(char *env_var, char *env_val, int mode, char *cmd_get_val)
+setenv_if_not_exists(char *env_var, char *env_val, int mode, char *cmd_get_val)
 {
 	char	*str = NULL;
 	char	*env_str = NULL;
@@ -4470,7 +4470,7 @@ add_restrict_user_exceptions(char *user)
 static int
 set_bgl_environment()
 {
-	if (putenv_if_not_exist("BRIDGE_CONFIG_FILE",
+	if (setenv_if_not_exists("BRIDGE_CONFIG_FILE",
 		BRIDGE_CONFIG_FILE, 1, NULL) == -1) {
 		return (-1);
 	}
@@ -4478,25 +4478,25 @@ set_bgl_environment()
 		getenv("BRIDGE_CONFIG_FILE"));
 	log_event(PBSEVENT_SYSTEM, 0, LOG_DEBUG, __func__, log_buffer);
 
-	if (putenv_if_not_exist("DB_PROPERTY", DB_PROPERTY, 1, NULL) == -1) {
+	if (setenv_if_not_exists("DB_PROPERTY", DB_PROPERTY, 1, NULL) == -1) {
 		return (-1);
 	}
 	sprintf(log_buffer, "DB_PROPERTY=%s", getenv("DB_PROPERTY"));
 	log_event(PBSEVENT_SYSTEM, 0, LOG_DEBUG, __func__, log_buffer);
 
-	if (putenv_if_not_exist("MMCS_SERVER_IP", mom_host, 0, NULL) == -1) {
+	if (setenv_if_not_exists("MMCS_SERVER_IP", mom_host, 0, NULL) == -1) {
 		return (-1);
 	}
 	sprintf(log_buffer, "MMCS_SERVER_IP=%s", getenv("MMCS_SERVER_IP"));
 	log_event(PBSEVENT_SYSTEM, 0, LOG_DEBUG, __func__, log_buffer);
 
-	if (putenv_if_not_exist("DB2DIR", NULL, 2, DB2DIR_GET_CMD) == -1) {
+	if (setenv_if_not_exists("DB2DIR", NULL, 2, DB2DIR_GET_CMD) == -1) {
 		return (-1);
 	}
 	sprintf(log_buffer, "DB2DIR=%s", getenv("DB2DIR"));
 	log_event(PBSEVENT_SYSTEM, 0, LOG_DEBUG, __func__, log_buffer);
 
-	if (putenv_if_not_exist("DB2INSTANCE", NULL, 2,
+	if (setenv_if_not_exists("DB2INSTANCE", NULL, 2,
 		DB2INSTANCE_GET_CMD) == -1) {
 		return (-1);
 	}

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -4393,9 +4393,7 @@ putenv_if_not_exist(char *env_var, char *env_val, int mode, char *cmd_get_val)
 		log_err(-1, __func__, "malloc failed");
 		return (-1);
 	}
-	sprintf(env_str, "%s=%s", env_var, env_val);
-	/* malloced string becomes part of environment */
-	putenv(env_str);
+	setenv(env_var, env_val, 1);
 
 	return (0);
 }

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -1323,7 +1323,7 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 		(void)SetEnvironmentVariable(PBS_HOOK_CONFIG_FILE, NULL);
 	}
 #else
-	if (putenv(env_pbs_hook_config) != 0) {
+	if (setenv(PBS_HOOK_CONFIG_FILE, hook_config_path, 1) != 0) {
 		log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_HOOK,
 			LOG_ERR, phook->hook_name, "Failed to set PBS_HOOK_CONFIG_FILE");
 		return (-1);
@@ -1346,7 +1346,7 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 		env_ret = snprintf(env_pbs_conf, sizeof(env_pbs_conf),
 			"PBS_CONF_FILE=%s", pbs_conf.pbs_conf_file);
 		if ((env_ret < 0) || ((size_t)env_ret != strlen(env_pbs_conf)) ||
-			(putenv(env_pbs_conf) != 0)) {
+			(setenv("PBS_CONF_FILE", pbs_conf.pbs_conf_file, 1) != 0 )) {
 			log_err(errno, __func__, "Failed to set PBS_CONF_FILE");
 			goto run_hook_exit;
 		}

--- a/src/resmom/mom_inter.c
+++ b/src/resmom/mom_inter.c
@@ -535,10 +535,8 @@ init_x11_display(
 
 		return (-1);
 	}
-	sprintf(homeenv, "HOME=%s",
-		homedir);
 
-	putenv(homeenv);
+	setenv("HOME", homedir, 1);
 
 	for (n = 0; n < NUM_SOCKS; n++)
 		socks[n].active = 0;

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -10165,9 +10165,7 @@ main(int argc, char *argv[])
 				_snprintf(conf_path, 79, "%spbs.conf", argv[0]);
 				*p = psave;
 				if (stat(conf_path, &sbuf) == 0) {
-					_snprintf(conf_env, 79,
-						"PBS_CONF_FILE=%s", conf_path);
-					putenv(conf_env);
+					setenv("PBS_CONF_FILE", conf_path, 1);
 				}
 			}
 		}

--- a/src/resmom/prolog.c
+++ b/src/resmom/prolog.c
@@ -637,7 +637,7 @@ int   pe_io_type;
 				/* set PBS_JOBDIR to user HOME*/
 				sprintf(buf, "PBS_JOBDIR=%s", pjob->ji_grpcache->gc_homedir);
 			}
-			if (putenv(buf) != 0)
+			if (setenv("PBS_JOBDIR", pjob->ji_grpcache->gc_homedir, 1) != 0) 
 				log_err(-1, "run_pelog", "set environment variable PBS_JOBDIR");
 		}
 

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -339,7 +339,6 @@ set_gridproxy(char *filename, char *data, size_t dsize, uid_t uid, gid_t gid)
 	int		ret = -1;
 	char		*cred;
 	size_t		len;
-	char		*envstr;
 	int		fd = -1;
 
 	if (pbs_decrypt_data(data, PBS_CREDTYPE_AES, dsize, &cred, &len))
@@ -392,7 +391,6 @@ fork_to_user(struct batch_request *preq)
 	struct passwd 	*pwdp = NULL;
 	struct rq_cpyfile       *rqcpf;
 	static char     buf[MAXPATHLEN+1];
-	char            *envstr;
 	char		lpath[MAXPATHLEN+1];
 	job		*pjob;
 
@@ -501,7 +499,6 @@ struct batch_request *preq;
 	gid_t		user_rgid;
 	int		fds[2];
 	int		usek5dce = 0;
-	char		*envstr;
 	struct rq_cpyfile	*rqcpf;
 	static char	buf[MAXPATHLEN+1];
 
@@ -601,11 +598,7 @@ struct batch_request *preq;
 					frk_err(PBSE_SYSTEM, preq); /* no return */
 				}
 				cred_pipe = fds[1];
-				sprintf(buf, "PBS_PWPIPE=%d", fds[0]);
-				if ((envstr = strdup(buf)) == NULL) {
-					log_err(errno, __func__, "Unable to allocate Memory!\n");
-					frk_err(PBSE_SYSTEM, preq);
-				}
+				
 				sprintf(buf, "%d", fds[0]);
 				setenv("PBS_PWPIPE", buf, 1);
 				fcntl(cred_pipe, F_SETFD, 1);	/* close on exec */

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -339,22 +339,14 @@ set_gridproxy(char *filename, char *data, size_t dsize, uid_t uid, gid_t gid)
 	int		ret = -1;
 	char		*cred;
 	size_t		len;
-	char		buf[MAXPATHLEN+1];
 	char		*envstr;
 	int		fd = -1;
 
 	if (pbs_decrypt_data(data, PBS_CREDTYPE_AES, dsize, &cred, &len))
 		goto done;
 
-	sprintf(buf, "X509_USER_PROXY=%s", filename);
-	envstr = strdup(buf);
-	if (envstr == NULL) {
-		sprintf(log_buffer, "putenv: out of memory");
-		goto done;
-	}
-
 	if (setenv("X509_USER_PROXY", filename, 1) == -1) {
-		sprintf(log_buffer, "putenv: %s %s", buf, strerror(errno));
+		sprintf(log_buffer, "setenv: %s=%s %s", "X509_USER_PROXY", filename, strerror(errno));
 		goto done;
 	}
 

--- a/src/scheduler/pbs_sched_win.c
+++ b/src/scheduler/pbs_sched_win.c
@@ -1745,9 +1745,7 @@ main(int argc, char *argv[])
 				_snprintf(conf_path, 79, "%spbs.conf", argv[0]);
 				*p = psave;
 				if (stat(conf_path, &sbuf) == 0) {
-					_snprintf(conf_env, 79, "PBS_CONF_FILE=%s",
-						conf_path);
-					putenv(conf_env);
+					setenv("PBS_CONF_FILE", conf_path, 1);
 				}
 			}
 		}

--- a/src/server/pbs_comm.c
+++ b/src/server/pbs_comm.c
@@ -297,7 +297,6 @@ main(int argc, char *argv[])
 
 		if (getenv("PBS_CONF_FILE") == NULL) {
 			char conf_path[80];
-			char conf_env[80];
 			char *p;
 			char psave;
 			struct stat sbuf;

--- a/src/server/pbs_comm.c
+++ b/src/server/pbs_comm.c
@@ -308,9 +308,7 @@ main(int argc, char *argv[])
 				_snprintf(conf_path, 79, "%spbs.conf", argv[0]);
 				*p = psave;
 				if (stat(conf_path, &sbuf) == 0) {
-					_snprintf(conf_env, 79, "PBS_CONF_FILE=%s",
-						conf_path);
-					putenv(conf_env);
+					setenv("PBS_CONF_FILE", conf_path, 1);
 				}
 			}
 		}

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2668,7 +2668,6 @@ main(int argc, char *argv[])
 
 		if (getenv("PBS_CONF_FILE") == NULL) {
 			char conf_path[80];
-			char conf_env[80];
 			char *p;
 			char psave;
 			struct stat sbuf;

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2679,9 +2679,7 @@ main(int argc, char *argv[])
 				_snprintf(conf_path, 79, "%spbs.conf", argv[0]);
 				*p = psave;
 				if (stat(conf_path, &sbuf) == 0) {
-					_snprintf(conf_env, 79, "PBS_CONF_FILE=%s",
-						conf_path);
-					putenv(conf_env);
+					setenv("PBS_CONF_FILE", conf_path, 1);
 				}
 			}
 		}

--- a/src/tools/pbsTclInit.c
+++ b/src/tools/pbsTclInit.c
@@ -124,7 +124,7 @@ pbsTcl_Init(Tcl_Interp *interp)
 int
 main(int argc, char *argv[])
 {
-	char	tcl_libpath[MAXPATHLEN+13];	/* 13 for "TCL_LIBRARY=" + \0 */
+	char	tbuf_env[256];
 	int rc;
 
 	/*the real deal or just pbs_version and exit?*/
@@ -149,14 +149,14 @@ main(int argc, char *argv[])
 
 	if (!getenv("TCL_LIBRARY")) {
 		if (pbs_conf.pbs_exec_path) {
-			sprintf((char *)tcl_libpath,
+			sprintf(tbuf_env, 
 #ifdef WIN32
-				"TCL_LIBRARY=%s/lib/tcl%s",
+                                "%s/lib/tcl%s",
 #else
-				"TCL_LIBRARY=%s/tcltk/lib/tcl%s",
+                                "%s/tcltk/lib/tcl%s",
 #endif
 				pbs_conf.pbs_exec_path, TCL_VERSION);
-			putenv(tcl_libpath);
+			setenv("TCL_LIBRARY", tbuf_env, 1);
 		}
 	}
 	if (pbs_conf.pbs_use_tcp == 1) {

--- a/src/tools/pbsTkInit.c
+++ b/src/tools/pbsTkInit.c
@@ -110,8 +110,7 @@ int
 main(int argc, char *argv[])
 {
 
-	char    tcl_libpath[MAXPATHLEN+13];     /* 13 for "TCL_LIBRARY=" + \0 */
-	char    tk_libpath[MAXPATHLEN+12];     /* 12 for "TK_LIBRARY=" + \0 */
+	char	tbuf_env[256];
 
 	/*the real deal or just pbs_version and exit?*/
 
@@ -127,24 +126,23 @@ main(int argc, char *argv[])
 
 	if (!getenv("TCL_LIBRARY")) {
 		if (pbs_conf.pbs_exec_path) {
-			sprintf((char *)tcl_libpath,
-				"TCL_LIBRARY=%s/tcltk/lib/tcl%s",
-				pbs_conf.pbs_exec_path, TCL_VERSION);
-			putenv(tcl_libpath);
+			sprintf(tbuf_env, "%s/tcltk/lib/tcl%s",
+                                pbs_conf.pbs_exec_path, TCL_VERSION);
+			setenv("TCL_LIBRARY", tbuf_env, 1);
 		}
 	}
 
 
 	if (!getenv("TK_LIBRARY")) {
 		if (pbs_conf.pbs_exec_path) {
-			sprintf((char *)tk_libpath,
+			sprintf(tbuf_env, 
 #ifdef WIN32
-				"TK_LIBRARY=%s/lib/tk%s",
+                                "%s/lib/tk%s",
 #else
-				"TK_LIBRARY=%s/tcltk/lib/tk%s",
+                                "%s/tcltk/lib/tk%s",
 #endif
-				pbs_conf.pbs_exec_path, TK_VERSION);
-			putenv(tk_libpath);
+                                pbs_conf.pbs_exec_path, TK_VERSION);
+			setenv("TK_LIBRARY", tbuf_env, 1);
 		}
 	}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1184](https://pbspro.atlassian.net/browse/PP-1184)**

#### Problem description
* Debug executables crash breaking at getenv(), and jobs directly go into 'E' state when pbs_mom is run with option -N.

#### Cause / Analysis
* Using putenv() instead of setenv() on Linux is dangerous. putenv() usage can be dangerous as it takes the character pointer we pass as parameter and uses that directly to add to the environment without making a copy of the strings. If that pointer is freed or modified, the associated environment variable also changes. These are just two of the very basic problems with using putenv(), there would be a lot of other problems associated with using this implementation. The recommended function to set environment variables is setenv(). Along with this, there was mixed usage of CRT functions (getenv(), putenv()) and Win API functions (GetEnvironmentVariable(), SetEnvironmentVariable()), which can lead to a disparity in environments and eventually cause deep rooted problems in the product, showing up as unexpected behavior or seemingly random crashes.

#### Solution description
* Changed the way we insert and retrieve strings from the environment. I've used setenv() and getenv() for Linux, SetEnvironmentVariable() and GetEnvironmentVariable() for Windows.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
