### PR TITLE
PP-1187: Miscelleneous fixes on TPP usage in net_server.c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_TARGET([])
 # FIXME: The subdir-objects option will be enabled by default in the future
 AM_INIT_AUTOMAKE([-Wall foreign])
+AC_USE_SYSTEM_EXTENSIONS
 
 # Checks for programs.
 AC_PROG_AWK

--- a/m4/pbs_decl_epoll_pwait.m4
+++ b/m4/pbs_decl_epoll_pwait.m4
@@ -51,6 +51,8 @@ AC_DEFUN([PBS_AC_DECL_EPOLL_PWAIT],
 #include <unistd.h>
 #include <poll.h>
 #include <signal.h>
+#include <stdio.h>
+#include <errno.h>
 #include <sys/epoll.h>
 int main()
 {

--- a/m4/pbs_decl_ppoll.m4
+++ b/m4/pbs_decl_ppoll.m4
@@ -40,13 +40,13 @@
 #
 # Prefix the macro names with PBS_ so they don't conflict with Python definitions
 #
-
 AC_DEFUN([PBS_AC_DECL_PPOLL],
 [
   AS_CASE([x$target_os],
     [xlinux*],
      AC_MSG_CHECKING(whether ppoll API is supported)
       AC_TRY_RUN(
+[
 [
 #include <unistd.h>
 #include <poll.h>
@@ -58,15 +58,15 @@ int main()
 	int n;
 	int fd[2];
 	struct timespec timeoutspec;
+	struct   pollfd  pollfds[1];
 	timeoutspec.tv_nsec = 1000;
 	timeoutspec.tv_sec = 0;
-	struct   pollfd  pollfds[1];
 	pipe(fd);
 	pollfds[0].fd = fd[0];
 	sigemptyset(&allsigs);
 	n = ppoll(pollfds, 1, &timeoutspec, &allsigs);
 	return (n);
-}
+}]
 ],
 	AC_DEFINE([PBS_HAVE_PPOLL], [], [Defined when ppoll is available])
 	AC_MSG_RESULT([yes]),

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -217,6 +217,5 @@ struct connection {
 	char            cn_username[PBS_MAXUSER];
 	char            cn_hostname[PBS_MAXHOSTNAME+1];
 	pbs_list_link   cn_link;  /* link to the next connection in the linked list */
-	pid_t           cn_pid;  /* process id of the creator */
 };
 #endif	/* _NET_CONNECT_H */

--- a/src/lib/Libtpp/tpp_common.h
+++ b/src/lib/Libtpp/tpp_common.h
@@ -368,7 +368,7 @@ typedef struct {
 typedef struct {
 	pthread_mutex_t mbox_mutex;
 	tpp_que_t mbox_queue;
-#ifdef HAVE_EVENTFD_H
+#ifdef HAVE_SYS_EVENTFD_H
 	int mbox_eventfd;
 #else
 	int mbox_pipe[2]; /* may be unused */

--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -74,7 +74,7 @@
 #include "tpp_common.h"
 #include "tpp_platform.h"
 
-#ifdef HAVE_EVENTFD_H
+#ifdef HAVE_SYS_EVENTFD_H
 #include <sys/eventfd.h>
 #endif
 
@@ -1357,7 +1357,7 @@ tpp_mbox_init(tpp_mbox_t *mbox)
 	tpp_init_lock(&mbox->mbox_mutex);
 	TPP_QUE_CLEAR(&mbox->mbox_queue);
 
-#ifdef HAVE_EVENTFD_H
+#ifdef HAVE_SYS_EVENTFD_H
 	if ((mbox->mbox_eventfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) == -1) {
 		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "eventfd() error, errno=%d", errno);
 		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
@@ -1405,7 +1405,7 @@ tpp_mbox_init(tpp_mbox_t *mbox)
 int
 tpp_mbox_getfd(tpp_mbox_t *mbox)
 {
-#ifdef HAVE_EVENTFD_H
+#ifdef HAVE_SYS_EVENTFD_H
 	return mbox->mbox_eventfd;
 #else
 	return mbox->mbox_pipe[0];
@@ -1427,7 +1427,7 @@ tpp_mbox_getfd(tpp_mbox_t *mbox)
 void
 tpp_mbox_destroy(tpp_mbox_t *mbox)
 {
-#ifdef HAVE_EVENTFD_H
+#ifdef HAVE_SYS_EVENTFD_H
 	close(mbox->mbox_eventfd);
 #else
 	if (mbox->mbox_pipe[0] > -1)
@@ -1460,7 +1460,7 @@ tpp_mbox_destroy(tpp_mbox_t *mbox)
 int
 tpp_mbox_monitor(void *em_ctx, tpp_mbox_t *mbox)
 {
-#ifdef HAVE_EVENTFD_H
+#ifdef HAVE_SYS_EVENTFD_H
 	/* add eventfd to the poll set */
 	if (tpp_em_add_fd(em_ctx, mbox->mbox_eventfd, EM_IN) == -1) {
 		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "em_add_fd() error, errno=%d", errno);
@@ -1501,7 +1501,7 @@ tpp_mbox_monitor(void *em_ctx, tpp_mbox_t *mbox)
 int
 tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 {
-#ifdef HAVE_EVENTFD_H
+#ifdef HAVE_SYS_EVENTFD_H
 	uint64_t u;
 #else
 	char b;
@@ -1518,7 +1518,7 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 
 	/* if no more data, clear all notifications */
 	if (cmd == NULL) {
-#ifdef HAVE_EVENTFD_H
+#ifdef HAVE_SYS_EVENTFD_H
 		read(mbox->mbox_eventfd, &u, sizeof(uint64_t));
 #else
 		while (tpp_pipe_read(mbox->mbox_pipe[0], &b, sizeof(char)) == sizeof(char));
@@ -1610,7 +1610,7 @@ tpp_mbox_post(tpp_mbox_t *mbox, unsigned int tfd, int cmdval, void *data)
 {
 	tpp_cmd_t *cmd;
 	ssize_t s;
-#ifdef HAVE_EVENTFD_H
+#ifdef HAVE_SYS_EVENTFD_H
 	uint64_t u;
 #else
 	char b;
@@ -1639,7 +1639,7 @@ tpp_mbox_post(tpp_mbox_t *mbox, unsigned int tfd, int cmdval, void *data)
 
 	while (1) {
 		/* send a notification to the thread */
-#ifdef HAVE_EVENTFD_H
+#ifdef HAVE_SYS_EVENTFD_H
 		u = 1;
 		s = write(mbox->mbox_eventfd, &u, sizeof(uint64_t));
 		if (s == sizeof(uint64_t))

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -9955,8 +9955,8 @@ main(int argc, char *argv[])
 		scan_for_exiting();
 	(void)mom_close_poll();
 
-	rpp_shutdown();
 	net_close(-1);		/* close all network connections */
+	rpp_shutdown();
 
 	/* Have we any jobs that can be purged before we go away? */
 

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -6288,8 +6288,8 @@ bg_sync_mom_hookfiles(void)
 	 */
 
 	/* standard rpp closure and net close */
-	rpp_terminate();
 	net_close(-1);
+	rpp_terminate();
 
 	/* Reset signal actions for most to SIG_DFL */
 	sigemptyset(&act.sa_mask);
@@ -6615,8 +6615,8 @@ bg_delete_mom_hooks(void *minfo)
 	 */
 
 	/* standard rpp closure and net close */
-	rpp_terminate();
 	net_close(-1);
+	rpp_terminate();
 
 	/* Reset signal actions for most to SIG_DFL */
 	sigemptyset(&act.sa_mask);
@@ -6826,8 +6826,8 @@ run_periodic_hook(struct work_task *ptask)
 #ifndef WIN32
 	else {
 		/* Close all server connections */
-		rpp_terminate();
 		net_close(-1);
+		rpp_terminate();
 		/* Unprotect child from being killed by kernel */
 		daemon_protect(0, PBS_DAEMON_PROTECT_OFF);
 		ret = server_process_hooks(PBS_BATCH_HookPeriodic, NULL, NULL, phook, 

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2244,9 +2244,9 @@ try_db_again:
 	/* Shut down interpreter now before closing network connections */
 	pbs_python_ext_shutdown_interpreter(&svr_interp_data); /* stop python if started */
 
-	rpp_shutdown();
 	shutdown_ack();
 	net_close(-1);		/* close all network connections */
+	rpp_shutdown();
 
 	/*
 	 * SERVER is going to be shutdown, delete AVL tree using

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -5903,8 +5903,8 @@ start_vnode_provisioning(struct prov_vnode_info * prov_vnode_info)
 	else if (pid == 0) {	/* child process */
 		alarm(0);
 		/* standard rpp closure and net close */
-		rpp_terminate();
 		net_close(-1);
+		rpp_terminate();
 
 		/* Reset signal actions for most to SIG_DFL */
 		sigemptyset(&act.sa_mask);

--- a/src/server/svr_mail.c
+++ b/src/server/svr_mail.c
@@ -636,10 +636,10 @@ svr_mailowner_id(char *jid, job *pjob, int mailpoint, int force, char *text)
 	 * From here on, we are a child process of the server.
 	 * Fix up file descriptors and signal handlers.
 	 */
-
-	if(pfn_rpp_terminate)
-		rpp_terminate();
 	net_close(-1);
+	if (pfn_rpp_terminate)
+		rpp_terminate();
+
 	/* Unprotect child from being killed by kernel */
 	daemon_protect(0, PBS_DAEMON_PROTECT_OFF);
 
@@ -894,8 +894,8 @@ svr_mailownerResv(resc_resv *presv, int mailpoint, int force, char *text)
 	 * Fix up file descriptors and signal handlers.
 	 */
 
-	rpp_terminate();
 	net_close(-1);
+	rpp_terminate();
 
 	/* Unprotect child from being killed by kernel */
 	daemon_protect(0, PBS_DAEMON_PROTECT_OFF);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1187](https://pbspro.atlassian.net/browse/PP-1187)**

#### Problem description
* In -DDEBUG mode server prints the following errors:
close_conn: Not the creator. Not closing connection
close_conn: Not the creator. Not closing connection
At qterm, it prints:
close_conn: Not the creator. Not closing connection
Server@centosvm1: cleanup_conn, tpp_em_del_fd, Remove from poll list failed for sock 10, errno=9
close_conn: Not the creator. Not closing connection

#### Cause / Analysis
* The net_server.c code wrongly used the cn_pid field. Actually it even never initialized the values, though it had error checks using it. Besides a few macros were not working, as well as order of the rpp_terminate() and net_close() in various code files were wrong.

#### Solution description
- pbs_decl_epoll_pwait.m4 macro was erroring out and not detecting epoll_pwait() system call. This is because the generated program did not include the necessary headers (and now with no-prototypes being errors, the compilation failed on them)

- pbs_decl_ppoll.m4 macro had an error already. The included c code which used C arrays has to be escaped using additional []. Also _GNU_SOURCE has to be included to enable the ppoll() interface

- connection structure in net_connect.h does not need the cn_pid field. The owner pid stuff is transparently taken care of in the tpp layer. See tpp_em.c:tpp_em_add/del/mod_fd() calls. The basic issue is that epoll() and fork() has to be carefully used together. When fork() is called on a program using epoll(), the inherited/cloned epoll_fd points to the same kernel structures representing the epoll object. Thus when an fd is removed from the epoll monitoring by calling epoll_ctl() it actually also affects the parent, usually which nasty consequences. The TPP layer therefore transparently keeps track of who was the creator of the epoll_fd and rejects calls to epoll_ctl() of that epoll_fd from other related (child) pids

- net_server.c: made few fixes to function headers, formatting and made certain variable namings similar to make the code more readable

- tpp_common.h: If PBS_HAVE_PPOLL is defined, we need to enable _GNU_SOURCE  before including headers to enable the ppoll interface

- tpp_em.c: HAVE_EVENTFD_H was wrongly being used. After OSS, the macro enabling it was changed to HAVE_SYS_EVENTFD_H, however the code continued to use HAVE_EVENTFD_H, which means it was never enabled. Changed HAVE_EVENTFD_H to HAVE_SYS_EVENTFD_H in tpp_em.c

- mom_main.c, hook_func.c, pbsd_main.c, svr_func.c, svr_mail.c: Changed the order or rpp_shutdown() and net_close(). If rpp_shutdown() is called first, then it destroys the rpp fd which results into an error message when net_close() is called. Instead in the swapped order, net_close() closes whatever it can close and rpp_terminate() closes the rpp side of the structures, without causing an error to be printed in the logs

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
