### PR TITLE
PP-1131: Missing vnode configuration in “TestReservations.test_sched_…

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -179,12 +179,20 @@ class TestReservations(TestFunctional):
         when the advance reservation ends.
         """
         now = int(time.time())
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname,
+                            expect=True, sudo=True)
+
         a = {'Resource_List.select': "1:ncpus=2",
              'reserve_start': now + 5,
              'reserve_end': now + 12,
              }
         r = Reservation(TEST_USER, a)
         rid = self.server.submit(r)
+
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, rid)
+
         attr = {'Resource_List.walltime': '00:00:20'}
         j = Job(TEST_USER, attr)
         jid = self.server.submit(j)


### PR DESCRIPTION
…cycle_starts_on_resv_end” test causes a reservation failure

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1131](https://pbspro.atlassian.net/browse/PP-1131)**

#### Problem description
* TestReservations.test_sched_cycle_starts_on_resv_end intends to capture a conflict between reservation and job run.The test has no vnode configuration (resources_available.ncpus not set) and hence reservation with “ncpus =2” fails. The test then submits a job intending to capture a conflict error message between this reservation and the job run. But the log match fails as the reservation done in the previous step was unsuccessful, resulting in "no" conflict.

#### Solution description
* Set resources_available.ncpus=2 on vnode. Also check if reservation is confirmed before submitting the job.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
