### PR TITLE
PP-1153 race condition in log match for TestPbsHookAlarmLargeMultinod…

### DIFF
--- a/test/tests/functional/pbs_hook_alarm_large_multinode_job.py
+++ b/test/tests/functional/pbs_hook_alarm_large_multinode_job.py
@@ -36,6 +36,7 @@
 # trademark licensing policies.
 
 from tests.functional import *
+from time import sleep
 
 
 class TestPbsHookAlarmLargeMultinodeJob(TestFunctional):
@@ -138,20 +139,26 @@ import pbs
 e=pbs.event()
 pbs.logmsg(pbs.LOG_DEBUG, "executing epilogue hook %s" % (e.hook_name,))
 """
+        search_after = int(time.time())
         a = {'event': hook_event, 'enabled': 'True',
              'alarm': '15'}
         self.server.create_import_hook(hook_name, a, hook_body)
 
         j = Job(TEST_USER)
-        a = {'Resource_List.select': '5000:ncpus=1:mem=1gb',
-             'Resource_List.walltime': 10}
+        a = {'Resource_List.select': '5000:ncpus=1:mem=1gb'}
 
         j.set_attributes(a)
+        j.set_sleep_time(10)
 
         jid = self.server.submit(j)
-
         self.server.expect(JOB, {'job_state': 'R'},
                            jid, max_attempts=15, interval=2)
+
+        self.logger.info("Wait 10s for job to finish")
+        sleep(10)
+
+        self.server.log_match("dequeuing from", starttime=search_after)
+
         self.mom.log_match(
             "pbs_python;executing epilogue hook %s" % (hook_name,), n=100,
             max_attempts=5, interval=5, regexp=True)
@@ -175,20 +182,26 @@ import pbs
 e=pbs.event()
 pbs.logmsg(pbs.LOG_DEBUG, "executing end hook %s" % (e.hook_name,))
 """
+        search_after = int(time.time())
         a = {'event': hook_event, 'enabled': 'True',
              'alarm': '15'}
         self.server.create_import_hook(hook_name, a, hook_body)
 
         j = Job(TEST_USER)
-        a = {'Resource_List.select': '5000:ncpus=1:mem=1gb',
-             'Resource_List.walltime': 10}
+        a = {'Resource_List.select': '5000:ncpus=1:mem=1gb'}
 
         j.set_attributes(a)
+        j.set_sleep_time(10)
 
         jid = self.server.submit(j)
-
         self.server.expect(JOB, {'job_state': 'R'},
                            jid, max_attempts=15, interval=2)
+
+        self.logger.info("Wait 10s for job to finish")
+        sleep(10)
+
+        self.server.log_match("dequeuing from", starttime=search_after)
+
         self.mom.log_match(
             "pbs_python;executing end hook %s" % (hook_name,), n=100,
             max_attempts=5, interval=5, regexp=True)


### PR DESCRIPTION
…eJob.test_epi_hook

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1153](https://pbspro.atlassian.net/browse/PP-1153)**

#### Problem description
* It has been observed that on some machine job took longer to get killed and message appeared later in TestPbsHookAlarmLargeMultinodeJob test suite.

#### Solution description
* Wait for Jobs to get dequeued and then check for log match.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
