### PR TITLE
PP-1137: Stack corruption in pbs_account.exe

### DIFF
--- a/src/tools/pbs_account_win.c
+++ b/src/tools/pbs_account_win.c
@@ -690,23 +690,23 @@ decrypt_sa_password(char *crypted, int credtype, size_t len, char **passwd)
 int
 add_service_account(char *password)
 {
-	char 	dname[PBS_MAXHOSTNAME+1];
-	char	dctrl[PBS_MAXHOSTNAME+1];
-	wchar_t	unamew[UNLEN+1];
-	wchar_t	dnamew[UNLEN+1];
-	wchar_t	dctrlw[PBS_MAXHOSTNAME+1];
+	char 	dname[PBS_MAXHOSTNAME+1] = {'\0'};
+	char	dctrl[PBS_MAXHOSTNAME+1] = {'\0'};
+	wchar_t	unamew[UNLEN+1] = {L'\0'};
+	wchar_t	dnamew[UNLEN+1] = {L'\0'};
+	wchar_t	dctrlw[PBS_MAXHOSTNAME+1] = {L'\0'};
 
-	NET_API_STATUS nstatus;
+	NET_API_STATUS nstatus = 0;
 	USER_INFO_1	*ui1_ptr = NULL; /* better indicator of lookup */
 	/*  permission */
 	struct passwd	*pw = NULL;
 
-	char 	sa_name[PBS_MAXHOSTNAME+UNLEN+2]; /* service account fullname */
+	char 	sa_name[PBS_MAXHOSTNAME+UNLEN+2] = {'\0'}; /* service account fullname */
 	/* domain\user\0 */
 	int	ret_val = 0;
-	int	in_domain_environment;
-	USER_INFO_1	ui;
-	wchar_t	passwordw[LM20_PWLEN+1];
+	int	in_domain_environment = 0;
+	USER_INFO_1	ui = {0};
+	wchar_t	passwordw[LM20_PWLEN+1] = {L'\0'};
 
 	/* find domain name, group name to add service account to */
 	in_domain_environment = GetComputerDomainName(dname);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1137](https://pbspro.atlassian.net/browse/PP-1137)**

#### Problem description
* pbs_account binary crash due to stack corruption

#### Cause / Analysis
* Wrongly use of uninitialized variable which leads to not null-terminated string

#### Solution description
* Initialize variables with null char before use

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
