### PR TITLE
PP-1166: mom hook updates forgotten if acks not received before timeout

### DIFF
--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -316,6 +316,7 @@ extern "C" {
 #define ATTR_python_restart_max_objects "python_restart_max_objects"
 #define ATTR_python_restart_min_interval "python_restart_min_interval"
 #define ATTR_power_provisioning "power_provisioning"
+#define ATTR_sync_mom_hookfiles_timeout "sync_mom_hookfiles_timeout"
 
 /* additional scheduler "attribute" names */
 

--- a/src/include/qmgr_svr_public.h
+++ b/src/include/qmgr_svr_public.h
@@ -133,4 +133,5 @@ ATTR_python_restart_max_hooks,
 ATTR_python_restart_max_objects,
 ATTR_python_restart_min_interval,
 ATTR_show_hidden_attribs,
+ATTR_python_sync_mom_hookfiles_timeout,
 #endif	/* _QMGR_SVR_PUBLIC_H */

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -155,6 +155,7 @@ enum srv_atr {
 	SVR_ATR_restrict_res_to_release_on_suspend,
 	SRV_ATR_PowerProvisioning,
 	SRV_ATR_show_hidden_attribs,
+	SRV_ATR_sync_mom_hookfiles_timeout,
 	/* This must be last */
 	SRV_ATR_LAST
 };

--- a/src/lib/Libattr/master_svr_attr_def.xml
+++ b/src/lib/Libattr/master_svr_attr_def.xml
@@ -1656,6 +1656,23 @@
 	<ECL>NULL_VERIFY_VALUE_FUNC</ECL>
 	</member_verify_function>
    </attributes>
+   <attributes>	
+   /* SRV_ATR_sync_mom_hookfiles_timeout */
+	<member_name><both>ATTR_sync_mom_hookfiles_timeout</both></member_name> <!-- "sync_mom_hookfiles_timeout" -->
+	<member_at_decode>decode_l</member_at_decode>
+	<member_at_encode>encode_l</member_at_encode>
+	<member_at_set>set_l</member_at_set>
+	<member_at_comp>comp_l</member_at_comp>
+	<member_at_free>free_null</member_at_free>
+	<member_at_action>NULL_FUNC</member_at_action>
+	<member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
+	<member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
+	<member_at_parent>PARENT_TYPE_SERVER</member_at_parent>
+	<member_verify_function>
+	<ECL>verify_datatype_long</ECL>
+	<ECL>verify_value_non_zero_positive</ECL>
+	</member_verify_function>
+   </attributes>
    <tail>
       <SVR>
 	};

--- a/test/tests/functional/pbs_hook_timeout.py
+++ b/test/tests/functional/pbs_hook_timeout.py
@@ -1,0 +1,185 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+import os
+from tests.functional import *
+
+
+class TestHookTimeout(TestFunctional):
+
+    """
+    Test to make sure hooks are resent to moms that don't ack when
+    the hooks are sent
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        if len(self.moms) != 3:
+            self.skip_test('Test requires 3 moms, use -p <moms>')
+
+        self.momA = self.moms.values()[0]
+        self.momB = self.moms.values()[1]
+        self.momC = self.moms.values()[2]
+        self.momA.delete_vnode_defs()
+        self.momB.delete_vnode_defs()
+        self.momC.delete_vnode_defs()
+
+        self.hostA = self.momA.shortname
+        self.hostB = self.momB.shortname
+        self.hostC = self.momC.shortname
+
+        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
+
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
+
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
+
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostC)
+
+        self.server.expect(VNODE, {'state=free': 3}, op=EQ, count=True,
+                           max_attempts=10, interval=2)
+
+    @timeout(600)
+    def test_hook_send(self):
+        """
+        Test when the server doesn't receive an ACK from a mom for
+        sending hooks he resends them
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047},
+                            expect=True)
+        timeout_max_attempt = 7
+
+        # Make momB unresponsive
+        self.logger.info("Stopping MomB")
+        self.momB.signal("-STOP")
+
+        start_time = int(time.time())
+
+        hook_body = "import pbs\n"
+        a = {'event': 'execjob_epilogue', 'enabled': 'True'}
+
+        rv = self.server.create_import_hook("test", a, hook_body)
+        self.assertTrue(rv)
+
+        # First batch of hook update is for the *.HK files
+        self.server.log_match(
+            "Timing out previous send of mom hook updates "
+            "(send replies expected=3 received=2)", n=600,
+            max_attempts=timeout_max_attempt, interval=30,
+            starttime=start_time)
+
+        # sent hook control file
+        for h in [self.hostA, self.hostB, self.hostC]:
+            hfile = os.path.join(self.server.pbs_conf['PBS_HOME'],
+                                 "server_priv", "hooks", "test.HK")
+            if h != self.hostB:
+                exist = True
+            else:
+                exist = False
+            self.server.log_match(
+                ".*successfully sent hook file %s to %s.*" %
+                (hfile, h), max_attempts=5, interval=1,
+                regexp=True, existence=exist,
+                starttime=start_time)
+
+        # Second batch of hook update is for the *.PY files + resend of
+        # *.HK file to momB
+        self.server.log_match(
+            "Timing out previous send of mom hook updates "
+            "(send replies expected=4 received=2)", n=600,
+            max_attempts=timeout_max_attempt, interval=30,
+            starttime=start_time)
+
+        # sent hook content file
+        for h in [self.hostA, self.hostB, self.hostC]:
+            hfile = os.path.join(self.server.pbs_conf['PBS_HOME'],
+                                 "server_priv", "hooks", "test.PY")
+            if h != self.hostB:
+                exist = True
+            else:
+                exist = False
+
+            self.server.log_match(
+                ".*successfully sent hook file %s to %s.*" %
+                (hfile, h), max_attempts=3, interval=1,
+                regexp=True, existence=exist,
+                starttime=start_time)
+
+        # Now check to make sure moms have received the hook files
+        for m in [self.momA, self.momB, self.momC]:
+            if m != self.momB:
+                exist = True
+            else:
+                exist = False
+            m.log_match(
+                "test.HK;copy hook-related file request received",
+                regexp=True, max_attempts=3, interval=1,
+                existence=exist, starttime=start_time)
+
+            m.log_match(
+                "test.PY;copy hook-related file request received",
+                regexp=True, max_attempts=3, interval=1,
+                existence=exist, starttime=start_time)
+
+        # Ensure that hook send updates are retried for
+        # the *.HK and *.PY file to momB
+        self.server.log_match(
+            "Timing out previous send of mom hook updates "
+            "(send replies expected=2 received=0)", n=600,
+            max_attempts=timeout_max_attempt, interval=30,
+            starttime=start_time)
+
+        # Submit a job, it should still run
+        a = {'Resource_List.select': '3:ncpus=1',
+             'Resource_List.place': 'scatter'}
+        j1 = Job(TEST_USER, attrs=a)
+        j1id = self.server.submit(j1)
+
+        # Wait for the job to start running.
+        a = {ATTR_state: (EQ, 'R'), ATTR_substate: (EQ, 41)}
+        self.server.expect(JOB, a, op=PTL_AND, id=j1id)
+
+        self.server.log_match(
+            "%s;vnode %s's parent mom.*has a pending copy hook "
+            "or delete hook request.*" % (j1id, self.hostB),
+            max_attempts=5, interval=1, regexp=True,
+            starttime=start_time)
+
+    def tearDown(self):
+        self.momB.signal("-CONT")
+        TestFunctional.tearDown(self)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1166](https://pbspro.atlassian.net/browse/PP-1166)**

#### Problem description
* If within the current set of hook updates there are some that have not received acks from the respective moms, these updates could be "forgotten" on the next hook updates run, after timing out the previous run.

#### Cause / Analysis
* It’s a fix to the bug where  if some of the hook updates that got sent previously did not return with an ack within the default 2 minutes time limit, those updates are not resent unless there's a new pending hook update to a hook attribute or content.

#### Solution description
The previous code would start new hook mom hook updates iff:
 
1. there are new hook updates to be sent out AND there's no previous batch
   hook updates already running,
or
2. There are new hook updates to be sent out AND there'a previous batch
   of hook updates already running but has timed out.
 
The above condition was captured in the original code under the if condition:
 
              if (do_sync_mom_hookfiles &&
                (!sync_mom_hookfiles_proc_running ||
                        (current_time > timeout_time))) {
               if (bg_sync_mom_hookfiles() == 0) {
 
This did not catch the case where there's no new hook updates to be sent out
and yet the previous batch of hook updates have timed out, and not completing
some of its actions. It's captured in the new condition:
 
              if (do_sync_mom_hookfiles || timed_out) {
                             if (bg_sync_mom_hookfiles() == 0) {
                                           ...
                             }
 
 
The bg_sync_mom_hookfiles() is what causes a new batch of hook updates to
be sent, picking whatever was not sucessfully done previously.


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
