### PR TITLE
PP-1092: Adding a call to TestFunctional.setUp as the tests were fail…

### DIFF
--- a/test/tests/functional/pbs_job_routing.py
+++ b/test/tests/functional/pbs_job_routing.py
@@ -45,6 +45,7 @@ class TestJobRouting(TestFunctional):
     """
 
     def setUp(self):
+        TestFunctional.setUp(self)
         self.momA = self.moms.values()[0]
         self.momA.delete_vnode_defs()
 


### PR DESCRIPTION
…ing on testbed systems

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1092](https://pbspro.atlassian.net/browse/PP-1092)**

#### Problem description
* Test cases in TestJobRouting were failing on testbed systems

#### Cause / Analysis
* TestFunctional.setUp was not called in setUp()

#### Solution description
* Added the call to TestFunctional.setUp(self).

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
