### PR TITLE
PP-1201: deleted job that was not cleared from list, causes server cr…

### DIFF
--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -165,6 +165,7 @@ extern char  server_name[];
 extern char *pbs_server_name;
 extern pbs_list_head svr_newjobs;
 extern pbs_list_head svr_alljobs;
+extern int is_called_by_job_purge;
 
 #ifdef PBS_MOM
 #include "mom_func.h"
@@ -913,6 +914,12 @@ job_purge(job *pjob)
 			log_joberr(-1, __func__, msg_err_purgejob_db,
 				pjob->ji_qs.ji_jobid);
 		}
+	}
+
+	if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_HasNodes) {
+		is_called_by_job_purge = 1;
+		free_nodes(pjob);
+		is_called_by_job_purge = 0;
 	}
 
 	if (pjob->ji_resvp && !(pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob)) {


### PR DESCRIPTION
…ash in post_discard_job()

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Issue-ID
<!--- Replace XXXX below (2 places) with the actual JIRA id -->
* **[PP-1201](https://pbspro.atlassian.net/browse/PP-1201)**

#### Problem description
* deleted job that was not cleared from list, causes server crash in post_discard_job()

#### Cause / Analysis
* It seems like one of the old problems we had forever, which is some kind of a race where we somehow delete a job inside server, but miss to remove it from the job list in the subnode of a pnode. How, or which part (or sequence) leads to this is still beyond me - I tried several cases including job dependencies etc. but cannot trigger such a behavior. If think what we are witnessing is the same case as has appeared in our older versions. So this far, it does not look like a memory corruption, but a case of deleted job that was not cleared from a list, and thus later walked upon and tripped upon..

#### Solution description
* If we go by this theory, we can add the following:

a) Add a call to "free_node()" from job_purge(). This will catch and clean the nd_psn->jobs list even if we missed it elsewhere in this final stage, which is job_purge.

b) Inside of "free_node()" we print into logs of how this was invoked. If we get a job trace in the logs that originates from job_purge() and flows into free_nodes(), then we have just found our corner case! Of course this would mean the user will not see a crash but will have to provide us their logs periodically (or run a grep periodically)

If we subscribe to the theory above, then adding a "free_nodes" to job_purge() prevents the crash (or a database panic) later on. Also, the additional logging then reveals to us the exact corner case that caused this. Besides a bit of additional logging the impact for a user is minimal. Maybe we should enable this till we figure out the exact root cause of this bug.

CC: @subhasisb , @sid2364 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
