### PR TITLE
PP-1198: Fix bug introduced by TPP changes to register all ip address.

### DIFF
--- a/src/include/rpp.h
+++ b/src/include/rpp.h
@@ -146,7 +146,7 @@ extern void			(*pfn_rpp_add_close_func)(int, void (*func)(int));
 #define rpp_add_close_func(x, y) (*pfn_rpp_add_close_func)(x, y)
 
 extern char	*netaddr(struct sockaddr_in *);
-
+extern char *get_all_ips(char *, char *, size_t);
 #define	RPP_ADVISE_TIMEOUT	1
 
 

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -185,7 +185,6 @@ char		*mom_domain;
 #endif	/* WIN32 */
 
 extern void	mom_vnlp_report(vnl_t *vnl, char *header);
-extern char *get_all_ips(char *msg);
 
 int		alien_attach = 0;		/* attach alien procs */
 int		alien_kill = 0;			/* kill alien procs */
@@ -9074,13 +9073,12 @@ main(int argc, char *argv[])
 			if (p)
 				*p = '\0';
 		} else {
-			nodename = get_all_ips(log_buffer);
+			nodename = get_all_ips(mom_host, log_buffer, sizeof(log_buffer) - 1);
 		}
 		if (!nodename) {
 			log_err(-1, "pbsd_main", log_buffer);
-			(void) sprintf(log_buffer, "Unable to determine TPP node name");
-			fprintf(stderr, "%s", log_buffer);
-			return (3);
+			fprintf(stderr, "%s\n", "Unable to determine TPP node name");
+			return (1);
 		}
 
 	    /* set tcp function pointers */

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -122,7 +122,6 @@ char		*configfile = NULL;	/* name of file containing
 						 client names to be added */
 
 extern char		*msg_daemonname;
-extern char *get_all_ips(char *msg);
 char		**glob_argv;
 char		usage[] =
 	"[-d home][-L logfile][-p file] [-S port][-R port][-n][-N][-c clientsfile]";
@@ -1366,13 +1365,12 @@ main(int argc, char *argv[])
 			if (p)
 				*p = '\0';
 		} else {
-			nodename = get_all_ips(log_buffer);
+			nodename = get_all_ips(host, log_buffer, sizeof(log_buffer) - 1);
 		}
 		if (!nodename) {
 			log_err(-1, "pbsd_main", log_buffer);
-			(void) sprintf(log_buffer, "Unable to determine TPP node name");
-			fprintf(stderr, "%s", log_buffer);
-			return (3);
+			fprintf(stderr, "%s\n", "Unable to determine TPP node name");
+			return (1);
 		}
 
 		/* set tpp function pointers */

--- a/src/scheduler/pbs_sched_win.c
+++ b/src/scheduler/pbs_sched_win.c
@@ -1508,13 +1508,12 @@ main(int argc, char *argv[])
 			if ( p != NULL)
 				*p = '\0';
 		} else {
-			nodename = get_all_ips(log_buffer);
+			nodename = get_all_ips(host, log_buffer, sizeof(log_buffer) - 1);
 		}
 		if (!nodename) {
 			log_err(-1, "pbsd_main", log_buffer);
-			(void) sprintf(log_buffer, "Unable to determine TPP node name");
-			fprintf(stderr, "%s", log_buffer);
-			return (3);
+			fprintf(stderr, "%s\n", "Unable to determine TPP node name");
+			return (1);
 		}
 
 		/* set tpp function pointers */

--- a/src/tools/pbsTclInit.c
+++ b/src/tools/pbsTclInit.c
@@ -68,7 +68,6 @@ extern	int	quiet;
 #endif /* localmod 099 */
 
 extern	void	add_cmds(Tcl_Interp *interp);
-extern char *get_all_ips(char *msg);
 
 #define SHOW_NONE 0xff
 int log_mask;
@@ -166,12 +165,16 @@ main(int argc, char *argv[])
 		struct 			timeval tv;
 
 		if (!pbs_conf.pbs_leaf_name) {
-			pbs_conf.pbs_leaf_name = get_all_ips(log_buffer);
+			char my_hostname[PBS_MAXHOSTNAME+1];
+			if (gethostname(my_hostname, (sizeof(my_hostname) - 1)) < 0) {
+				fprintf(stderr, "Failed to get hostname\n");
+				return -1;
+			}
+			pbs_conf.pbs_leaf_name = get_all_ips(my_hostname, log_buffer, sizeof(log_buffer) - 1);
 			if (!pbs_conf.pbs_leaf_name) {
-				log_err(-1, "pbsd_main", log_buffer);
-				(void) sprintf(log_buffer, "Unable to determine TPP node name");
-				fprintf(stderr, "%s", log_buffer);
-				return (3);
+				fprintf(stderr, "%s\n", log_buffer);
+				fprintf(stderr, "%s\n", "Unable to determine TPP node name");
+				return -1;
 			}
 		}
 

--- a/src/unsupported/pbs_rmget.c
+++ b/src/unsupported/pbs_rmget.c
@@ -47,8 +47,6 @@
 #include "rpp.h"
 #include "log.h"
 
-extern char *get_all_ips(char *msg);
-
 #define SHOW_NONE 0xff
 int log_mask;
 
@@ -117,12 +115,16 @@ main(int argc, char *argv[])
 		struct 			timeval tv;
 
 		if (!pbs_conf.pbs_leaf_name) {
-			pbs_conf.pbs_leaf_name = get_all_ips(log_buffer);
+			char my_hostname[PBS_MAXHOSTNAME+1];
+			if (gethostname(my_hostname, (sizeof(my_hostname) - 1)) < 0) {
+				fprintf(stderr, "Failed to get hostname\n");
+				return -1;
+			}
+			pbs_conf.pbs_leaf_name = get_all_ips(my_hostname, log_buffer, sizeof(log_buffer) - 1);
 			if (!pbs_conf.pbs_leaf_name) {
-				log_err(-1, "pbsd_main", log_buffer);
-				(void) sprintf(log_buffer, "Unable to determine TPP node name");
-				fprintf(stderr, "%s", log_buffer);
-				return (3);
+				fprintf(stderr, "%s\n", log_buffer);
+				fprintf(stderr, "%s\n", "Unable to determine TPP node name");
+				return -1;
 			}
 		}
 


### PR DESCRIPTION
The bug basically changed the order of ip addresses registered, so the first ip registered was not the one that was resolvable from the hostname. This cause receiving pbs daemons to reject such messages as received from "bad host". **[PP-1198](https://pbspro.atlassian.net/browse/PP-1198)**

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Problem description
* If the hostname of the server host does not resolve to the first ip address in the list of interfaces listed by ip address, then mom could reject the connection from server. (on the same machine or remote machine). This results in the server marking the node down.

#### Cause / Analysis
*  TPP client side uses the first IP in the list of registered addresses to automatically bind to (since the tpp client code does not use a bind) source address. In fix introduced by PR #483 , in default installation (without a PBS_LEAF_NAME specified), all ips detected from all interfaces were registered to the comm. This also changed the order in the list of ip's detected, and in some cases, the first IP was no longer the IP that resolved from the machines hostname. This resulted in a different IP being sent by the server to the mom, which the mom did not have any knowledge about and would reject as "bad host".

#### Solution description
* Detect the ip's that can be resolved from the machine's hostname and add them to the top of the list of ip's registered to the pbs_comm. That way, the old behavior is retained, as well as all detected ip's are registered.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to the Jira ticket and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to the Jira ticket** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
