### PR TITLE
PP-1193: TestClientNagles is failing due to incorrect command being executed

### DIFF
--- a/test/tests/performance/pbs_client_nagle_performance.py
+++ b/test/tests/performance/pbs_client_nagle_performance.py
@@ -72,13 +72,14 @@ class TestClientNagles(TestPerformance):
         return :
               -1 on qdel fail
         """
+        qsel_list = self.server.select()
+        qsel_list = " ".join(qsel_list)
         command = self.time_command
         command += " -f \"%e\" "
-        command += os.path.join(
-            self.server.client_conf['PBS_EXEC'],
-            'bin',
-            'qdel `qselect`')
-
+        command += os.path.join(self.server.client_conf['PBS_EXEC'],
+                                'bin',
+                                'qdel ')
+        command += qsel_list
         # compute elapse time without -E option
         qdel_perf = self.du.run_cmd(self.server.hostname,
                                     command,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* qdel command is failed which results into test case is failed.
* Bugs: running pbs_client_nagle_performance.py test through PTL.
* If there is an issue ID, link to it: [PP-1193](https://pbspro.atlassian.net/browse/PP-1193)*

#### Affected Platform(s) and PBS Version
* Platform: All
* Bugs: PBS 18.2.0*

#### Cause / Analysis / Design
* qdel command failed in the PTL . qdel command is run with qselect command. in python file there is absolute path given for qdel command , but there is no absolute path for qselect command which results into test case failed.    

#### Solution Description
* save submitted job Id's and passed it to qdel command

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
