### PR TITLE
PP-1211: Using eligible_time, parent array job misses the stime, comment, and …

### DIFF
--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1121,7 +1121,8 @@ complete_running(job *jobp)
 		/* if this is first subjob to run, mark */
 		/* parent Array as state "Begun"	*/
 		parent = jobp->ji_parentaj;
-		if (parent->ji_qs.ji_state == JOB_STATE_QUEUED) {
+		if (parent->ji_qs.ji_state == JOB_STATE_QUEUED ||
+			(parent->ji_qs.ji_state == JOB_STATE_BEGUN && parent->ji_qs.ji_stime == 0)) {
 			svr_setjobstate(parent, JOB_STATE_BEGUN, JOB_SUBSTATE_BEGUN);
 
 			/* Also set the parent job's stime */

--- a/test/tests/functional/pbs_complete_running_parent_job.py
+++ b/test/tests/functional/pbs_complete_running_parent_job.py
@@ -1,0 +1,86 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class Test_complete_running_parent_job(TestFunctional):
+    """
+    This test suite is for testing the complete_running() procedure
+    is processed for parent array job.
+    """
+
+    def setUp(self):
+        """
+        Set eligible_time_enable = True.
+        This is due to test the issue in PP-1211
+        """
+
+        TestFunctional.setUp(self)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {
+                            'eligible_time_enable': True}, expect=True)
+
+    def test_parent_job_S_accounting_record(self):
+        """
+        Submit an array job and test whether the 'S' accounting record
+        is created for parent job.
+        """
+
+        J = Job(TEST_USER, attrs={ATTR_J: '1-2'})
+        J.set_sleep_time(1)
+        parent_jid = self.server.submit(J)
+
+        self.server.accounting_match(msg='.*;S;' +
+                                     re.escape(parent_jid) + ".*",
+                                     id=parent_jid, regexp=True)
+
+    def test_parent_job_comment_and_stime(self):
+        """
+        Submit an array job and test whether the comment and stime is set
+        for parent job.
+        """
+
+        J = Job(TEST_USER, attrs={ATTR_J: '1-2'})
+        J.set_sleep_time(10)
+        parent_jid = self.server.submit(J)
+
+        attr = {
+            ATTR_comment: (MATCH_RE, 'Job Array Began at .*'),
+            ATTR_stime: (MATCH_RE, '.+')
+        }
+        self.server.expect(JOB, attr, id=parent_jid, attrop=PTL_AND)


### PR DESCRIPTION
…'S' accounting record.

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Parent array job misses the stime, comment, and 'S' accounting record with eligible_time_enable = True.
* [PP-1211](https://pbspro.atlassian.net/browse/PP-1211)

#### Affected Platform(s) and PBS Version
* Platform: all, tested on debian
* Bugs: 18.1

#### Cause / Analysis / Design
* The routine for setting stime, comment, and 'S' record of parent job is called once the first subjob is started and the parent job turns to 'B' too. The routine is in complete_running().
* The problem is following: with eligible_time_enable enabled the req_modifyjob() is called before complete_running(). req_modifyjob() calls svr_evaljobstate(), which sets the parent array job to 'B', therefore the complete_running() do nothing because the parent job state is already 'B'. 

#### Solution Description
* Since svr_evaljobstate() is called from plenty of places, I decided to extend the condition in complete_running(): If the stime is **not** set and the parent job is in 'B' then we still process the routine in complete_running() because this is the first time we call complete_running() for a subjob of a particular arrayjob.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
