### PR TITLE
PP-747: Modify the sched object to have additional options to configure pbs_sched

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -566,6 +566,8 @@ extern int action_sched_priv(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_log(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_user(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_port(attribute *pattr, void *pobj, int actmode);
+extern int action_sched_host(attribute *pattr, void *pobj, int actmode);
+extern int action_sched_partition(attribute *pattr, void *pobj, int actmode);
 /* Extern functions from queue_attr_def */
 extern int decode_null(attribute *patr, char *name, char *rn, char *val);
 extern int set_null(attribute *patr, attribute *new, enum batch_op op);

--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -294,7 +294,8 @@ extern "C" {
 #define PBSE_PARTITION_NOT_IN_QUE 15220  /* Partition does not belong to the queue */
 #define PBSE_INVALID_PARTITION_QUE 15221 /* Invalid partition to the queue */
 #define PBSE_ALPS_SWITCH_ERR 15222	/* ALPS failed to do the suspend/resume */
-
+#define PBSE_SCHED_OP_NOT_PERMITTED 15223 /* Operation not permitted on default scheduler */
+#define PBSE_SCHED_PARTITION_ALREADY_EXISTS 15224 /* Partition already exists */
 
 /* the following structure is used to tie error number      */
 /* with text to be returned to a client, see svr_messages.c */

--- a/src/include/pbs_share.h
+++ b/src/include/pbs_share.h
@@ -92,3 +92,12 @@
 
 /* Default scheduler name */
 #define PBS_DFLT_SCHED_NAME "default"
+#define SC_DAEMON "scheduler"
+
+/* scheduler-attribute values (state) */
+#define SC_DOWN	"down"
+#define SC_IDLE "idle"
+#define SC_SCHEDULING "scheduling"
+
+#define MAX_INT_LEN 10
+

--- a/src/include/sched_cmds.h
+++ b/src/include/sched_cmds.h
@@ -56,6 +56,8 @@
 #define SCH_SCHEDULE_ETE_ON 15		/* eligible_time_enable is turned ON */
 #define SCH_SCHEDULE_RESV_RECONFIRM 16		/* Reconfirm a reservation */
 #define SCH_SCHEDULE_RESTART_CYCLE 17		/* Restart a scheduling cycle */
+#define SCH_ATTRS_CONFIGURE 18
+
 
 extern int schedule(int cmd, int sd, char *runjid);
-extern void set_scheduler_flag(int);
+

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -262,7 +262,7 @@ extern int			sched_save_db(pbs_sched *, int mode);
 extern enum failover_state	are_we_primary(void);
 extern int			have_socket_licensed_nodes(void);
 extern void			unlicense_socket_licensed_nodes(void);
-extern void			set_sched_default(pbs_sched *);
+extern void			set_sched_default(pbs_sched *, int unset_flag);
 
 #ifdef	__cplusplus
 }

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -48,6 +48,7 @@ extern "C" {
 #include "pbs_db.h"
 #include "reservation.h"
 #include "resource.h"
+#include "pbs_sched.h"
 
 /* Protocol types when connecting to another server (eg mom) */
 #define PROT_INVALID	-1
@@ -57,7 +58,7 @@ extern "C" {
 extern int   check_num_cpus(void);
 extern int   chk_hold_priv(long hold, int priv);
 extern void  close_client(int sfds);
-extern int   contact_sched(int, char *jobid);
+extern int   contact_sched(int, char *jobid, pbs_net_t pbs_scheduler_addr, unsigned int pbs_scheduler_port);
 extern void  count_node_cpus(void);
 extern int   ctcpus(char *buf, int *hascpp);
 extern void  get_jobowner(char *from, char *to);
@@ -76,8 +77,8 @@ extern void  process_dis_request(int);
 extern int   save_flush(void);
 extern void  save_setup(int);
 extern int   save_struct(char *, unsigned int);
-extern int   schedule_jobs(void);
-extern int   schedule_high(void);
+extern int   schedule_jobs(pbs_sched *);
+extern int   schedule_high(pbs_sched *);
 extern void  shutdown_nodes(void);
 extern char *site_map_user(char *, char *);
 extern char *site_map_resvuser(char *, char *);
@@ -97,7 +98,7 @@ extern void  mark_node_down(char *, char *);
 extern void  mark_node_offline_by_mom(char *, char *);
 extern void  clear_node_offline_by_mom(char *, char *);
 extern void  mark_which_queues_have_nodes(void);
-extern void  set_sched_sock(int);
+extern void  set_sched_sock(int, pbs_sched *);
 extern void  pbs_close_stdfiles(void);
 extern int   is_job_array(char *id);
 extern char *get_index_from_jid(char *newjid);
@@ -282,6 +283,7 @@ extern int   chk_characteristic(struct pbsnode *pnode, int *pneed_todo);
 extern int   is_valid_str_resource(attribute *pattr, void *pobject, int actmode);
 extern int   setup_arrayjob_attrs(attribute *, void *, int);
 extern int   deflt_chunk_action(attribute *pattr, void *pobj, int mode);
+extern int   action_svr_iteration(attribute *pattr, void *pobj, int mode);
 extern void  update_node_rassn(attribute *, enum batch_op);
 extern int   cvt_nodespec_to_select(char *, char **, size_t *, attribute *);
 extern int is_valid_resource(attribute *pattr, void *pobject, int actmode);

--- a/src/lib/Libattr/master_sched_attr_def.xml
+++ b/src/lib/Libattr/master_sched_attr_def.xml
@@ -98,8 +98,8 @@
 	<member_at_set>set_str</member_at_set>
 	<member_at_comp>comp_str</member_at_comp>
 	<member_at_free>free_str</member_at_free>
-	<member_at_action>NULL_FUNC</member_at_action>
-	<member_at_flags><both>ATR_DFLAG_OPRD | ATR_DFLAG_MGRD | ATR_DFLAG_SvWR</both></member_at_flags>
+	<member_at_action>action_sched_host</member_at_action>
+	<member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
 	<member_verify_function>
@@ -271,10 +271,10 @@
 	<member_name><both>ATTR_partition</both></member_name>		<!-- "partition" -->
 	<member_at_decode>decode_arst</member_at_decode>
 	<member_at_encode>encode_arst</member_at_encode>
-	<member_at_set>set_arst</member_at_set>
+	<member_at_set>set_arst_uniq</member_at_set>
 	<member_at_comp>comp_arst</member_at_comp>
 	<member_at_free>free_arst</member_at_free>
-	<member_at_action>NULL_FUNC</member_at_action>
+	<member_at_action>action_sched_partition</member_at_action>
 	<member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_ARST</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
@@ -387,7 +387,7 @@
 	<member_at_comp>comp_str</member_at_comp>
 	<member_at_free>free_str</member_at_free>
 	<member_at_action>NULL_FUNC</member_at_action>
-	<member_at_flags><both>READ_ONLY</both></member_at_flags>
+	<member_at_flags><both>READ_ONLY | ATR_DFLAG_SSET</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
 	<member_verify_function>

--- a/src/lib/Libattr/master_svr_attr_def.xml
+++ b/src/lib/Libattr/master_svr_attr_def.xml
@@ -883,7 +883,7 @@
 	<member_at_set>set_l</member_at_set>
 	<member_at_comp>comp_l</member_at_comp>
 	<member_at_free>free_null</member_at_free>
-	<member_at_action>NULL_FUNC</member_at_action>
+	<member_at_action>action_svr_iteration</member_at_action>
 	<member_at_flags><both>NO_USER_SET</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SERVER</member_at_parent>

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -399,13 +399,15 @@ char *msg_sched_exist = "Scheduler already exists";
 char *msg_sched_name_big = "Scheduler name is too long";
 char *msg_unknown_sched = "Unknown Scheduler";
 char *msg_no_del_sched = "Can not delete Scheduler";
-char *msg_sched_priv_exists = "Another Sched object also has same value for its sched_priv directory";
-char *msg_sched_logs_exists = "Another Sched object also has same value for its sched_log directory";
-char *msg_route_que_no_partition = "Can not assign a partition to route queue";
+char *msg_sched_priv_exists = "Another scheduler also has same value for its sched_priv directory";
+char *msg_sched_logs_exists = "Another scheduler also has same value for its sched_log directory";
+char *msg_route_que_no_partition = "Cannot assign a partition to route queue";
 char *msg_cannot_set_route_que = "Route queues are incompatible with the partition attribute";
 char *msg_queue_not_in_partition = "Queue %s is not part of partition for node";
 char *msg_partition_not_in_queue = "Partition %s is not part of queue for node";
 char *msg_invalid_partion_in_queue = "Invalid partition in queue";
+char *msg_sched_op_not_permitted = "Operation is not permitted on default scheduler";
+char *msg_sched_part_already_used = "Partition is already associated with other scheduler";
 
 char *msg_resv_not_empty = "Reservation not empty";
 char *msg_stdg_resv_occr_conflict = "Requested time(s) will interfere with a later occurrence";
@@ -590,6 +592,8 @@ struct pbs_err_to_txt pbs_err_to_txt[] = {
 	{PBSE_ALPS_SWITCH_ERR, &msg_alps_switch_err},
 	{PBSE_SOFTWT_STF, &msg_softwt_stf},
 	{PBSE_BAD_NODE_STATE, &msg_bad_node_state},
+	{PBSE_SCHED_OP_NOT_PERMITTED, &msg_sched_op_not_permitted},
+	{PBSE_SCHED_PARTITION_ALREADY_EXISTS, &msg_sched_part_already_used},
 	{ 0, (char **)0 }		/* MUST be the last entry */
 };
 

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1568,11 +1568,16 @@ check_nodes(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv
 		else
 			nodepart = NULL;
 
-		/* if there are nodes assigned to the queue, then check those */
-		if (resresv->is_job && qinfo->has_nodes)
-			ninfo_arr = qinfo->nodes;
-		/* last up we're not in a queue with nodes -- use the unassociated nodes */
-		else
+		if (resresv->is_job) {
+			/* if there are nodes assigned to the queue, then check those */
+			if (qinfo->has_nodes)
+				ninfo_arr = qinfo->nodes;
+			else if (qinfo->partition != NULL)
+				ninfo_arr = qinfo->nodes_in_partition;
+			else
+				ninfo_arr = sinfo->unassoc_nodes;
+		} else
+			/* last up we're not in a queue with nodes -- use the unassociated nodes */
 			ninfo_arr = sinfo->unassoc_nodes;
 	}
 

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -396,6 +396,7 @@ struct queue_info
 	resource_resv **jobs;		/* array of jobs that reside in queue */
 	resource_resv **running_jobs;	/* array of jobs in the running state */
 	node_info **nodes;		/* array of nodes associated with the queue */
+	node_info **nodes_in_partition; /* array of nodes associated with the queue's partition */
 	counts *group_counts;		/* group resource and running counts */
 	counts *project_counts;	/* project resource and running counts */
 	counts *user_counts;		/* user resource and running counts */
@@ -415,6 +416,7 @@ struct queue_info
 	int num_parts;		/* number of node partitions(node_group_key) */
 	int num_topjobs;	/* current number of top jobs in this queue */
 	int backfill_depth;	/* total allowable topjobs in this queue*/
+	char *partition;	/* partition to which queue belongs to */
 };
 
 struct job_info
@@ -604,6 +606,7 @@ struct node_info
 	node_info *svr_node;		/* ptr to svr's node if we're a resv node */
 	node_partition *hostset;      /* other vnodes on on the same host */
 	node_scratch nscr;            /* scratch space local to node search code */
+	char *partition;	      /* partition to which node belongs to */
 };
 
 struct resv_info
@@ -819,6 +822,7 @@ struct resresv_set
 	char *user;			/* user of set, can be NULL */
 	char *group;			/* group of set, can be NULL */
 	char *project;			/* project of set, can be NULL */
+	char *partition;		/* partition of set, can be NULL */
 	selspec *select_spec;		/* select spec of set */
 	place *place_spec;		/* place spec of set */
 	resource_req *req;		/* ATTR_L (qsub -l) resources of set.  Only contains resources on the resources line */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -82,6 +82,9 @@
 #include <sched_cmds.h>
 #include <time.h>
 #include <log.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include "data_types.h"
 #include "fifo.h"
 #include "queue_info.h"
@@ -109,6 +112,7 @@
 #include "pbs_share.h"
 #include "pbs_internal.h"
 #include "limits_if.h"
+#include "pbs_version.h"
 
 
 #ifdef NAS
@@ -555,8 +559,21 @@ schedule(int cmd, int sd, char *runjobid)
 			reset_global_resource_ptrs();
 			free(conf.prime_sort);
 			free(conf.non_prime_sort);
-			if(schedinit() != 0)
+
+			if(schedinit() != 0) {
 				return 0;
+			}
+			break;
+		case SCH_ATTRS_CONFIGURE:
+			/*
+			 * This is required since there is a probability that scheduler's configuration has been changed at
+			 * server through qmgr.
+			 */
+			if (!update_svr_schedobj(connector, 0, 0)) {
+				sprintf(log_buffer, "update_svr_schedobj failed");
+				log_err(-1, __func__, log_buffer);
+				return 0;
+			}
 			break;
 		case SCH_QUIT:
 #ifdef PYTHON
@@ -585,6 +602,12 @@ intermediate_schedule(int sd, char *jobid)
 {
 	int ret; /* to re schedule or not */
 	int cycle_cnt = 0; /* count of cycles run */
+
+	/*
+	 * This is required since there is a probability that scheduler's configuration has been changed at
+	 * server through qmgr.
+	 */
+	update_svr_schedobj(connector, 0, 0);
 
 	do {
 		ret = scheduling_cycle(sd, jobid);
@@ -2328,3 +2351,316 @@ next_job(status *policy, server_info *sinfo, int flag)
 	}
 	return rjob;
 }
+
+/**
+ * @brief
+ *	Helper function used to copy the attribute values from batch_status to the corresponding
+ *	scheduler global variables which hold its priv_dir, log_dir and partitions
+ *
+ * @param[in] status - populated batch_status after stating this scheduler from server
+ *
+ * @retval
+ * @return 0 - Failure
+ * @return  1 - Success
+ *
+ * @mt-safe: No
+ * @par Side Effects:
+ *	None
+ *
+ *
+ */
+static int
+sched_settings_frm_svr(struct batch_status *status)
+{
+	struct attrl *attr;
+	char *tmp_priv_dir = NULL;
+	char *tmp_log_dir = NULL;
+	char *tmp_partitions = NULL;
+	struct	attropl	*attribs;
+	char *tmp_comment = NULL;
+	int clear_comment = 0;
+	int ret = 0;
+	extern char *partitions;
+
+	attr = status->attribs;
+
+	 /* resetting the following before fetching from batch_status. */
+	while (attr != NULL) {
+		if (attr->name != NULL && attr->value != NULL) {
+			if (!strcmp(attr->name, ATTR_sched_priv)) {
+				if ((tmp_priv_dir = string_dup(attr->value)) == NULL)
+					goto cleanup;
+			} else if (!strcmp(attr->name, ATTR_sched_log)) {
+				if ((tmp_log_dir = string_dup(attr->value)) == NULL)
+					goto cleanup;
+			} else if (!strcmp(attr->name, ATTR_partition)) {
+				if ((tmp_partitions = string_dup(attr->value)) == NULL)
+					goto cleanup;
+			} else if (!strcmp(attr->name, ATTR_comment)) {
+				if ((tmp_comment = string_dup(attr->value)) == NULL)
+					goto cleanup;
+			}
+		}
+		attr = attr->next;
+	}
+
+	if (!dflt_sched) {
+		int err;
+		int priv_dir_update_fail = 0;
+		struct attropl *patt;
+		char comment[MAX_LOG_SIZE] = {0};
+
+		if (tmp_log_dir != NULL) {
+			(void)snprintf(path_log,  sizeof(path_log), tmp_log_dir);
+			log_close(1);
+			if (log_open(logfile, path_log) == -1) {
+				/* update the sched comment attribute with the reason for failure */
+				attribs = calloc(2, sizeof(struct attropl));
+				if (attribs == NULL) {
+					schdlog(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, MEM_ERR_MSG);
+					goto cleanup;
+				}
+				strncpy(comment, "Unable to change the sched_log directory", MAX_LOG_SIZE - 1);
+				patt = attribs;
+				patt->name = ATTR_comment;
+				patt->value = comment;
+				patt->next = patt + 1;
+				patt++;
+				patt->name = ATTR_scheduling;
+				patt->value = "0";
+				patt->next = NULL;
+
+				err = pbs_manager(connector,
+					MGR_CMD_SET, MGR_OBJ_SCHED,
+					sc_name, attribs, NULL);
+				free(attribs);
+				if (err) {
+					snprintf(log_buffer, sizeof(log_buffer), "Failed to update scheduler comment %s at the server", comment);
+					schdlog(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, log_buffer);
+				}
+				goto cleanup;
+			} else {
+				if (tmp_comment != NULL)
+					clear_comment = 1;
+				snprintf(log_buffer, sizeof(log_buffer), "scheduler log directory is changed to %s", tmp_log_dir);
+				schdlog(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG,
+						"reconfigure", log_buffer);
+			}
+		}
+
+		if (tmp_priv_dir != NULL) {
+			int c;
+			#if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
+				c  = chk_file_sec(tmp_priv_dir, 1, 0, S_IWGRP|S_IWOTH, 1);
+				c |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, S_IWGRP|S_IWOTH, 0);
+				if (c != 0) {
+					snprintf(log_buffer, sizeof(log_buffer), "PBS failed validation checks for directory %s", tmp_priv_dir);
+					schdlog(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, log_buffer);
+					strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
+					priv_dir_update_fail = 1;
+				}
+			#endif  /* not DEBUG and not NO_SECURITY_CHECK */
+			if (c == 0) {
+				if (chdir(tmp_priv_dir) == -1) {
+					snprintf(log_buffer, sizeof(log_buffer), "PBS failed validation checks for directory %s", tmp_priv_dir);
+					strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
+					schdlog(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, log_buffer);
+					priv_dir_update_fail = 1;
+				} else {
+					int lockfds;
+					(void)unlink("sched.lock");
+					lockfds = open("sched.lock", O_CREAT|O_WRONLY, 0644);
+					if (lockfds < 0) {
+						snprintf(log_buffer, sizeof(log_buffer), "PBS failed validation checks for directory %s", tmp_priv_dir);
+						strncpy(comment, "PBS failed validation checks for sched_priv directory", MAX_LOG_SIZE -1);
+						schdlog(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, log_buffer);
+						priv_dir_update_fail = 1;
+					} else {
+						/* write schedulers pid into lockfile */
+						#ifdef WIN32
+							lseek(lockfds, (off_t)0, SEEK_SET);
+						#else
+							(void)ftruncate(lockfds, (off_t)0);
+						#endif
+							(void)sprintf(log_buffer, "%d\n", getpid());
+						(void)write(lockfds, log_buffer, strlen(log_buffer));
+						snprintf(log_buffer, sizeof(log_buffer), "scheduler priv directory has changed to %s", tmp_priv_dir);
+						schdlog(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG,
+								"reconfigure", log_buffer);
+						if (tmp_comment != NULL)
+							clear_comment = 1;
+					}
+				}
+			}
+
+		}
+
+
+		if (priv_dir_update_fail) {
+			/* update the sched comment attribute with the reason for failure */
+			attribs = calloc(2, sizeof(struct attropl));
+			if (attribs == NULL) {
+				schdlog(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, MEM_ERR_MSG);
+				strncpy(comment, "Unable to change the sched_priv directory", MAX_LOG_SIZE);
+				goto cleanup;
+			}
+			patt = attribs;
+			patt->name = ATTR_comment;
+			patt->value = comment;
+			patt->next = patt + 1;
+			patt++;
+			patt->name = ATTR_scheduling;
+			patt->value = "0";
+			patt->next = NULL;
+			err = pbs_manager(connector,
+				MGR_CMD_SET, MGR_OBJ_SCHED,
+				sc_name, attribs, NULL);
+			free(attribs);
+			if (err) {
+				snprintf(log_buffer, sizeof(log_buffer), "Failed to update scheduler comment %s at the server", comment);
+				schdlog(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, log_buffer);
+			}
+			goto cleanup;
+		}
+		if (cstrcmp(partitions, tmp_partitions) != 0) {
+			free(partitions);
+			partitions = NULL;
+			if ((tmp_partitions != NULL) && (partitions = string_dup(tmp_partitions)) == NULL)
+				goto cleanup;
+		}
+	}
+	if (clear_comment) {
+		int err;
+		struct attropl *patt;
+
+		attribs = calloc(1, sizeof(struct attropl));
+		if (attribs == NULL) {
+			schdlog(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, MEM_ERR_MSG);
+			goto cleanup;
+		}
+
+		patt = attribs;
+		patt->name = ATTR_comment;
+		patt->value = malloc(1);
+		if (patt->value == NULL) {
+			snprintf(log_buffer, sizeof(log_buffer), "can't update scheduler attribs, malloc failed");
+			schdlog(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, log_buffer);
+			goto cleanup;
+		}
+		patt->value[0] = '\0';
+		patt->next = NULL;
+		err = pbs_manager(connector,
+				MGR_CMD_UNSET, MGR_OBJ_SCHED,
+			sc_name, attribs, NULL);
+		free(attribs->value);
+		free(attribs);
+		if (err) {
+			snprintf(log_buffer, sizeof(log_buffer), "Failed to update scheduler comment at the server");
+			schdlog(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, log_buffer);
+			goto cleanup;
+		}
+		clear_comment = 0;
+	}
+	ret = 1;
+cleanup:
+	free(tmp_log_dir);
+	free(tmp_priv_dir);
+	free(tmp_comment);
+	free(tmp_partitions);
+	return ret;
+
+}
+
+/**
+ * @brief
+ *	Updates a set of attribute values of scheduler to the server and also does a status of this scheduler
+ *	on server and fetches the updates of its attributes.
+ *
+ * @param[in] connector - socket descriptor to server
+ * @param[in] cmd     - scheduler command
+ * @param[in] alarm_time  - value to be updated for scheduler cycle length.
+ *
+ *
+ * @retval Error code
+ * @return 0 - Failure
+ * @return 1 - Success
+ *
+ * @par Side Effects:
+ *	None
+ *
+ *
+ */
+int
+update_svr_schedobj(int connector, int cmd, int alarm_time)
+{
+	char timestr[128];
+	char port_str[MAX_INT_LEN];
+	static	int svr_knows_me = 0;
+	int	err;
+	struct	attropl	*attribs, *patt;
+	struct batch_status *ss = NULL;
+
+	/* This command is only sent on restart of the server */
+	if (cmd == SCH_SCHEDULE_FIRST)
+		svr_knows_me = 0;
+
+	if ((cmd != SCH_SCHEDULE_NULL && svr_knows_me) || cmd == SCH_ERROR || connector < 0)
+		return 1;
+
+	/* Stat the scheduler to get details of sched */
+	ss = pbs_statsched(connector, sc_name, NULL, NULL);
+	if (ss == NULL) {
+		sprintf(log_buffer, "Unable to retrieve the scheduler attributes from server");
+		log_err(-1, __func__, log_buffer);
+		return 0;
+	}
+	if (!sched_settings_frm_svr(ss))
+		return 0;
+
+	if (!dflt_sched && (partitions == NULL)) {
+		sprintf(log_buffer, "Scheduler does not contain a partition");
+		log_err(-1, __func__, log_buffer);
+		return 0;
+	}
+
+	pbs_statfree(ss);
+
+	/* update the sched with new values */
+	attribs = calloc(4, sizeof(struct attropl));
+	if (attribs == NULL) {
+		schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_SCHED, LOG_INFO, __func__, MEM_ERR_MSG);
+		return 0;
+	}
+	patt = attribs;
+	patt->name = ATTR_SchedHost;
+	patt->value = scheduler_host_name;
+	patt->next = patt + 1;
+	patt++;
+	patt->name = ATTR_sched_port;
+	snprintf(port_str, MAX_INT_LEN, "%d", sched_port);
+	patt->value = port_str;
+	patt->next = patt + 1;
+	patt++;
+	patt->name = ATTR_version;
+	patt->value = pbs_version;
+	if (alarm_time) {
+		patt->next = patt + 1;
+		patt++;
+		patt->name = ATTR_sched_cycle_len;
+		snprintf(timestr, sizeof(timestr), "%d", alarm_time);
+		patt->value = timestr;
+	}
+	patt->next = NULL;
+
+	err = pbs_manager(connector,
+		MGR_CMD_SET, MGR_OBJ_SCHED,
+		sc_name, attribs, NULL);
+	if (err == 0 && svr_knows_me == 0)
+		svr_knows_me = 1;
+
+	free(attribs);
+
+	return 1;
+}
+
+

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -41,7 +41,9 @@
 extern "C" {
 #endif
 
+#include  <limits.h>
 #include "data_types.h"
+int connector;
 
 /*
  *      schedinit - initialize conf struct and parse conf files
@@ -220,6 +222,9 @@ int main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rer
  *	return success 1 or error 0
  */
 int scheduler_simulation_task(int pbs_sd, int debug);
+
+int update_svr_schedobj(int connector, int cmd, int alarm_time);
+
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/globals.c
+++ b/src/scheduler/globals.c
@@ -41,6 +41,7 @@
 #include "globals.h"
 #include "constant.h"
 #include "sort.h"
+#include "limits.h"
 
 
 
@@ -157,3 +158,15 @@ resdef **boolres = NULL;
 
 /* AOE name used to compare nodes, free when exit cycle */
 char *cmp_aoename = NULL;
+
+char *partitions = NULL;
+char scheduler_host_name[PBS_MAXHOSTNAME + 1] = "Me";  /* arbitrary string */
+char *sc_name = NULL;
+int sched_port = -1;
+char *logfile = NULL;
+#ifdef WIN32
+char path_log[_MAX_PATH];
+#else
+char path_log[_POSIX_PATH_MAX];
+#endif
+int dflt_sched = 0;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 #include "data_types.h"
-
+#include "limits.h"
 /* resources to check */
 extern const struct rescheck res_to_check[];
 
@@ -74,6 +74,19 @@ const struct enum_conv resind[RES_HIGH+1];
 extern resdef **allres;
 extern resdef **consres;
 extern resdef **boolres;
+
+extern char *partitions;
+extern char scheduler_host_name[PBS_MAXHOSTNAME+1];
+extern char *sc_name;
+extern int sched_port;
+extern char *logfile;
+#ifdef WIN32
+extern char path_log[_MAX_PATH];
+#else
+extern char path_log[_POSIX_PATH_MAX];
+#endif
+extern int dflt_sched;
+
 
 /**
  * @brief

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1966,6 +1966,7 @@ new_resresv_set(void)
 	rset->user = NULL;
 	rset->group = NULL;
 	rset->project = NULL;
+	rset->partition = NULL;
 	rset->place_spec = NULL;
 	rset->req = NULL;
 	rset->select_spec = NULL;
@@ -1987,6 +1988,7 @@ free_resresv_set(resresv_set *rset) {
 	free(rset->user);
 	free(rset->group);
 	free(rset->project);
+	free(rset->partition);
 	free_selspec(rset->select_spec);
 	free_place(rset->place_spec);
 	free_resource_req_list(rset->req);
@@ -2044,6 +2046,11 @@ dup_resresv_set(resresv_set *oset, server_info *nsinfo)
 	}
 	rset->project = string_dup(oset->project);
 	if (oset->project != NULL && rset->project == NULL) {
+		free_resresv_set(rset);
+		return NULL;
+	}
+	rset->partition = string_dup(oset->partition);
+	if (oset->partition != NULL && rset->partition == NULL) {
 		free_resresv_set(rset);
 		return NULL;
 	}
@@ -2279,6 +2286,12 @@ create_resresv_set_by_resresv(status *policy, server_info *sinfo, resource_resv 
 		rset->group = string_dup(resresv->group);
 	if (resresv_set_use_proj(sinfo))
 		rset->project = string_dup(resresv->project);
+
+	if (resresv->is_job && resresv->job != NULL) {
+		if (resresv->job->queue->partition != NULL)
+			rset->partition = string_dup(resresv->job->queue->partition);
+	}
+
 	rset->select_spec = dup_selspec(resresv_set_which_selspec(resresv));
 	if (rset->select_spec == NULL) {
 		free_resresv_set(rset);
@@ -2317,7 +2330,7 @@ create_resresv_set_by_resresv(status *policy, server_info *sinfo, resource_resv 
  * @retval -1 if not found or on error
  */
 int
-find_resresv_set(status *policy, resresv_set **rsets, char *user, char *group, char *project, selspec *sel, place *pl, resource_req *req, queue_info *qinfo)
+find_resresv_set(status *policy, resresv_set **rsets, char *user, char *group, char *project, char *partition, selspec *sel, place *pl, resource_req *req, queue_info *qinfo)
 {
 	int i;
 
@@ -2343,6 +2356,11 @@ find_resresv_set(status *policy, resresv_set **rsets, char *user, char *group, c
 		if ((project != NULL && rsets[i]->project == NULL) || (project == NULL && rsets[i]->project != NULL))
 			continue;
 		if (project != NULL && cstrcmp(project, rsets[i]->project) != 0)
+			continue;
+
+		if ((partition != NULL && rsets[i]->partition == NULL) || (partition == NULL && rsets[i]->partition != NULL))
+			continue;
+		if (partition != NULL && cstrcmp(partition, rsets[i]->partition) != 0)
 			continue;
 
 		if (compare_selspec(rsets[i]->select_spec, sel) == 0)
@@ -2371,6 +2389,7 @@ find_resresv_set_by_resresv(status *policy, resresv_set **rsets, resource_resv *
 	char *user = NULL;
 	char *grp = NULL;
 	char *proj = NULL;
+	char *partition = NULL;
 	queue_info *qinfo = NULL;
 	selspec *sspec;
 
@@ -2386,13 +2405,18 @@ find_resresv_set_by_resresv(status *policy, resresv_set **rsets, resource_resv *
 	if (resresv_set_use_proj(resresv->server))
 		proj = resresv->project;
 
+	if (resresv->is_job && resresv->job != NULL) {
+		if (resresv->job->queue->partition != NULL)
+			partition = resresv->job->queue->partition;
+	}
+
 	sspec = resresv_set_which_selspec(resresv);
 
 	if (resresv->is_job && resresv->job != NULL)
 		if (resresv_set_use_queue(resresv->job->queue))
 			qinfo = resresv->job->queue;
 
-	return find_resresv_set(policy, rsets, user, grp, proj, sspec, resresv->place_spec, resresv->resreq, qinfo);
+	return find_resresv_set(policy, rsets, user, grp, proj, partition, sspec, resresv->place_spec, resresv->resreq, qinfo);
 }
 
 /**

--- a/src/scheduler/job_info.h
+++ b/src/scheduler/job_info.h
@@ -377,7 +377,7 @@ resresv_set **dup_resresv_set_array(resresv_set **osets, server_info *nsinfo);
 resresv_set *create_resresv_set_by_resresv(status *policy, server_info *sinfo, resource_resv *resresv);
 
 /* find a resresv_set by its internal components */
-int find_resresv_set(status *policy, resresv_set **rsets, char *user, char *group, char *project, selspec *sel, place *pl, resource_req *req, queue_info *qinfo);
+int find_resresv_set(status *policy, resresv_set **rsets, char *user, char *group, char *project, char *partition, selspec *sel, place *pl, resource_req *req, queue_info *qinfo);
 
 /* find a resresv_set with a resresv as a template */
 int find_resresv_set_by_resresv(status *policy, resresv_set **rsets, resource_resv *resresv);

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -1701,3 +1701,4 @@ res_to_str_re(void *p, enum resource_fields fld, char **buf,
 		return "";
 	return *buf;
 }
+

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -178,6 +178,12 @@ void update_node_on_run(nspec *ns, resource_resv *resresv, char *job_state);
 int node_queue_cmp(node_info *ninfo, void *arg);
 
 /*
+ *      node_partition_cmp - used with node_filter to filter nodes attached to a
+ *                           specific partition
+ */
+int node_partition_cmp(node_info *ninfo, void *arg);
+
+/*
  *      update_node_on_end - update a node when a job ends
  */
 void update_node_on_end(node_info *ninfo, resource_resv *resresv, char *job_state);
@@ -650,6 +656,8 @@ void set_current_eoe(node_info *node, char *eoe);
 
 /* check nodes for eligibility and mark them ineligible if not */
 void check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, place *pl, schd_error *err);
+
+int node_in_partition(node_info *ninfo);
 
 
 #ifdef	__cplusplus

--- a/src/scheduler/pbs_sched_win.c
+++ b/src/scheduler/pbs_sched_win.c
@@ -119,13 +119,16 @@
 #include	"pbs_ifl.h"
 #include	"pbs_ecl.h"
 #include	"log.h"
-#include	"resmon.h"
 #include	"sched_cmds.h"
 #include	"server_limits.h"
 #include	"net_connect.h"
 #include	"rm.h"
 #include	"rpp.h"
-#include 	"pbs_internal.h"
+#include	"pbs_internal.h"
+#include	"pbs_share.h"
+#include	"config.h"
+#include	"fifo.h"
+#include	"globals.h"
 
 
 struct		connect_handle connection[NCONNECTS];
@@ -136,6 +139,8 @@ int		second_connection = -1;
 struct tpp_config tpp_conf; /* global settings for tcp */
 
 #define		START_CLIENTS	2	/* minimum number of clients */
+#define		MAX_PORT_NUM 65535
+#define		STARTING_PORT_NUM 15050
 pbs_net_t	*okclients = NULL;	/* accept connections from */
 int		numclients = 0;		/* the number of clients */
 char		*configfile = NULL;	/* name of file containing
@@ -144,19 +149,13 @@ char		*configfile = NULL;	/* name of file containing
 char		*oldpath;
 char		**glob_argv;
 char		usage[] =
-	"[-d home][-L logfile][-p file][-S port][-R port][-n][-c clientsfile]";
+	"[-d home][-L logfile][-p file][-I schedname][-S port][-R port][-n][-c clientsfile]";
 struct	sockaddr_in	saddr;
 extern char	*msg_noloopbackstopdaemon;
 #ifndef WIN32
 sigset_t	allsigs;
 #endif
 
-static char    *logfile = (char *)0;
-#ifdef WIN32
-static char	path_log[_MAX_PATH];
-#else
-static char	path_log[_POSIX_PATH_MAX];
-#endif
 int 		pbs_rm_port;
 int		got_sigpipe = 0;   /* needed for UNIX so we need the symbol */
 
@@ -667,70 +666,6 @@ server_command(char **jid)
 }
 
 
-/**
- * @brief
- * 		update_svr_schedobj - sends scheduler attributes to pbs_server on the first
- *			 contact of the server.
- *
- * @param[in]	cmd	-	scheduling command from the server -- see sched_cmds.h
- * @param[in]	alarm	-	alarm value, set if non-zero
- *
- * @par Side-Effects: none
- *
- * @par MT-Unsafe
- *
- * @return	void
- */
-static	char scheduler_name[PBS_MAXHOSTNAME+1] = "Me";  /*arbitrary string*/
-
-static void
-update_svr_schedobj(int cmd, int alarm_time)
-{
-	char timestr[128];
-
-	/*same host:port with a new scheduler*/
-	static	int svr_knows_me = 0;
-
-	int	err;
-	struct	attropl	*attribs, *patt;
-
-	if (!(cmd == SCH_SCHEDULE_NULL  ||
-		cmd == SCH_SCHEDULE_FIRST ||
-		svr_knows_me == 0))
-		return;
-
-	attribs = (struct  attropl *)calloc(3, sizeof(struct attropl));
-	if (attribs == NULL) {
-		sprintf(log_buffer, "can't update scheduler attribs, calloc failed");
-		log_err(-1, __func__, log_buffer);
-		return;
-	}
-	patt = attribs;
-	patt->name = ATTR_SchedHost;
-	patt->value = scheduler_name;
-	patt->next = patt + 1;
-	patt++;
-	patt->name = ATTR_version;
-	patt->value = pbs_version;
-	patt->next = NULL;
-	if (alarm_time) {
-		patt->next = patt + 1;
-		patt++;
-		patt->name = ATTR_sched_cycle_len;
-		snprintf(timestr, sizeof(timestr), "%d", alarm_time);
-		patt->value = timestr;
-		patt->next = NULL;
-	}
-
-	err = pbs_manager(connector,
-		MGR_CMD_SET, MGR_OBJ_SCHED,
-		"scheduler", attribs, NULL);
-	if (err == 0 && svr_knows_me == 0)
-		svr_knows_me = 1;
-
-	free(attribs);
-}
-
 #ifdef WIN32
 
 /**
@@ -815,28 +750,28 @@ lock_out(int fds, int op)
 static int
 are_we_primary()
 {
-        char server_host[PBS_MAXHOSTNAME+1];
-        char hn1[PBS_MAXHOSTNAME+1];
+	char server_host[PBS_MAXHOSTNAME+1];
+	char hn1[PBS_MAXHOSTNAME+1];
 
-        if (pbs_conf.pbs_leaf_name) {
-                char *endp;
-                snprintf(server_host, sizeof(server_host), "%s", pbs_conf.pbs_leaf_name);
+	if (pbs_conf.pbs_leaf_name) {
+		char *endp;
+		snprintf(server_host, sizeof(server_host), "%s", pbs_conf.pbs_leaf_name);
                 endp = strchr(server_host, ','); /* find the first name */
                 if (endp)
                         *endp = '\0';
                 endp = strchr(server_host, ':'); /* cut out the port */
-                if (endp)
-                        *endp = '\0';
-        } else {
-                if ((gethostname(server_host, (sizeof(server_host) - 1)) == -1) ||
-                        (get_fullhostname(server_host, server_host, (sizeof(server_host) - 1)) == -1)) {
-                        log_err(-1, __func__, "Unable to get my host name");
-                        return -1;
-                }
-        }
-        strncpy(scheduler_name, server_host, sizeof(scheduler_name));
-        scheduler_name [ sizeof(scheduler_name) -1 ] = '\0';
-        /* both secondary and primary should be set or neither set */
+		if (endp)
+			*endp = '\0';
+	} else {
+		if ((gethostname(server_host, (sizeof(server_host) - 1)) == -1) ||
+			(get_fullhostname(server_host, server_host, (sizeof(server_host) - 1)) == -1)) {
+			log_err(-1, __func__, "Unable to get my host name");
+			return -1;
+		}
+	}
+	strncpy(scheduler_host_name, server_host, sizeof(scheduler_host_name));
+	scheduler_host_name[sizeof(scheduler_host_name) - 1] = '\0';
+	/* both secondary and primary should be set or neither set */
 	if ((pbs_conf.pbs_secondary == NULL) && (pbs_conf.pbs_primary == NULL))
 		return 1;
 	if ((pbs_conf.pbs_secondary == NULL) || (pbs_conf.pbs_primary == NULL))
@@ -955,7 +890,6 @@ main(int argc, char *argv[])
 #endif
 
 	char		host[PBS_MAXHOSTNAME+1];
-	unsigned int	port;
 
 #ifndef DEBUG
 	char		*dbfile = "sched_out";
@@ -1068,7 +1002,7 @@ main(int argc, char *argv[])
 
 	glob_argv = argv;
 
-	port = pbs_conf.scheduler_service_port;
+	sched_port = pbs_conf.scheduler_service_port;
 	pbs_rm_port = pbs_conf.manager_service_port;
 
 #ifndef WIN32
@@ -1076,7 +1010,7 @@ main(int argc, char *argv[])
 #endif
 
 	opterr = 0;
-	while ((c = getopt(argc, argv, "lL:S:R:d:p:c:a:n")) != EOF) {
+	while ((c = getopt(argc, argv, "lL:S:I:R:d:p:c:a:n")) != EOF) {
 		switch (c) {
 			case 'l':
 #ifdef _POSIX_MEMLOCK
@@ -1088,9 +1022,12 @@ main(int argc, char *argv[])
 			case 'L':
 				logfile = optarg;
 				break;
+			case 'I':
+				sc_name = optarg;
+				break;
 			case 'S':
-				port = atoi(optarg);
-				if (port == 0) {
+				sched_port = atoi(optarg);
+				if (sched_port == 0) {
 					fprintf(stderr,
 						"%s: illegal port\n", optarg);
 					errflg = 1;
@@ -1131,6 +1068,12 @@ main(int argc, char *argv[])
 				break;
 		}
 	}
+
+	if (sc_name == NULL) {
+		sc_name = PBS_DFLT_SCHED_NAME;
+		dflt_sched = 1;
+	}
+
 	if (errflg) {
 #ifdef WIN32
 		usage2(argv[0]);
@@ -1154,8 +1097,12 @@ main(int argc, char *argv[])
 
 		exit(1);
 	}
+	if (dflt_sched) {
+		(void)sprintf(log_buffer, "%s/sched_priv", pbs_conf.pbs_home_path);
+	} else {
+		(void)sprintf(log_buffer, "%s/sched_priv_%s", pbs_conf.pbs_home_path, sc_name);
+	}
 
-	(void)sprintf(log_buffer, "%s/sched_priv", pbs_conf.pbs_home_path);
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
 #ifdef WIN32
 	/* For windows, do not check full path. Allow system to put in */
@@ -1178,8 +1125,11 @@ main(int argc, char *argv[])
 #endif
 		exit(1);
 	}
-	(void)sprintf(path_log,   "%s/sched_logs", pbs_conf.pbs_home_path);
-
+	if (dflt_sched) {
+		(void)sprintf(path_log,   "%s/sched_logs", pbs_conf.pbs_home_path);
+	} else {
+		(void)sprintf(path_log,   "%s/sched_logs_%s", pbs_conf.pbs_home_path, sc_name);
+	}
 
 	/* The following is code to reduce security risks                */
 	/* start out with standard umask, system resource limit infinite */
@@ -1311,8 +1261,10 @@ main(int argc, char *argv[])
 		log_err(errno, __func__, "setsockopt");
 		die(0);
 	}
+
+
 	saddr.sin_family = AF_INET;
-	saddr.sin_port = htons(port);
+	saddr.sin_port = htons(sched_port);
 	saddr.sin_addr.s_addr = INADDR_ANY;
 	if (bind(server_sock, (struct sockaddr *)&saddr, sizeof(saddr)) < 0) {
 #ifdef WIN32
@@ -1321,6 +1273,8 @@ main(int argc, char *argv[])
 		log_err(errno, __func__, "bind");
 		die(0);
 	}
+
+
 	if (listen(server_sock, 5) < 0) {
 #ifdef WIN32
 		errno = WSAGetLastError();
@@ -1520,14 +1474,13 @@ main(int argc, char *argv[])
 		set_tpp_funcs(log_tppmsg);
 
 		if (pbs_conf.auth_method == AUTH_RESV_PORT) {
-				rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, pbs_conf.scheduler_service_port,
-												pbs_conf.pbs_leaf_routers, pbs_conf.pbs_use_compression,
-												TPP_AUTH_RESV_PORT, NULL, NULL);
+		rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, sched_port,
+				pbs_conf.pbs_leaf_routers, pbs_conf.pbs_use_compression, TPP_AUTH_RESV_PORT, NULL, NULL);
 		} else {
-				/* for all non-resv-port based authentication use a callback from TPP */
-				rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, pbs_conf.scheduler_service_port,
-														pbs_conf.pbs_leaf_routers, pbs_conf.pbs_use_compression,
-														TPP_AUTH_EXTERNAL, get_ext_auth_data, validate_ext_auth_data);
+			/* for all non-resv-port based authentication use a callback from TPP */
+			rc = set_tpp_config(&pbs_conf, &tpp_conf, nodename, sched_port,
+					pbs_conf.pbs_leaf_routers, pbs_conf.pbs_use_compression,
+					TPP_AUTH_EXTERNAL, get_ext_auth_data, validate_ext_auth_data);
 		}
 
 		free(nodename);
@@ -1602,8 +1555,7 @@ main(int argc, char *argv[])
 		cmd = server_command(&runjobid);
 
 		/*based on cmd: send|not scheduler's PBS version to server*/
-		update_svr_schedobj(cmd, alarm_time);
-
+		update_svr_schedobj(connector, cmd, alarm_time);
 
 #ifndef WIN32
 		if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)

--- a/src/scheduler/queue_info.h
+++ b/src/scheduler/queue_info.h
@@ -108,6 +108,8 @@ void
 update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 	char *job_state);
 
+int queue_in_partition(queue_info *qinfo);
+
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -141,6 +141,7 @@
 #include "fairshare.h"
 #include "check.h"
 #include "pbs_sched.h"
+#include "fifo.h"
 #ifdef NAS
 #include "site_code.h"
 #endif
@@ -172,7 +173,7 @@ query_server(status *pol, int pbs_sd)
 {
 	struct batch_status *server;	/* info about the server */
 	struct batch_status *sched;	/* info about the server's scheduler object */
-	struct batch_status *bs_resvs;	/* batch status of the reservations */
+	struct batch_status *bs_resvs = NULL;	/* batch status of the reservations */
 	server_info *sinfo;		/* scheduler internal form of server info */
 	queue_info **qinfo;		/* array of queues on the server */
 	counts *cts;			/* used to count running per user/grp */
@@ -245,7 +246,8 @@ query_server(status *pol, int pbs_sd)
 	 * will populate internal data structures based on this batch status
 	 * after all other data is queried
 	 */
-	bs_resvs = stat_resvs(pbs_sd);
+	if (dflt_sched)
+		bs_resvs = stat_resvs(pbs_sd);
 
 	/* get the nodes, if any - NOTE: will set sinfo -> num_nodes */
 	if ((sinfo->nodes = query_nodes(pbs_sd, sinfo)) == NULL) {

--- a/src/send_hooks_win/w32_send_hooks.c
+++ b/src/send_hooks_win/w32_send_hooks.c
@@ -135,8 +135,6 @@ long		new_log_event_mask = 0;
 int	 	server_init_type = RECOV_WARM;
 char	        server_name[PBS_MAXSERVERNAME+1]; /* host_name[:service|port] */
 int		svr_delay_entry = 0;
-int		svr_do_schedule = SCH_SCHEDULE_NULL;
-int		svr_do_sched_high = SCH_SCHEDULE_NULL;
 int		svr_total_cpus = 0;		/* total number of cpus on nodes   */
 int		have_blue_gene_nodes = 0;
 int		svr_ping_rate = SVR_DEFAULT_PING_RATE;	/* time between sets of node pings */

--- a/src/send_job_win/w32_send_job.c
+++ b/src/send_job_win/w32_send_job.c
@@ -145,8 +145,6 @@ long		new_log_event_mask = 0;
 int	 	server_init_type = RECOV_WARM;
 char	        server_name[PBS_MAXSERVERNAME+1]; /* host_name[:service|port] */
 int		svr_delay_entry = 0;
-int		svr_do_schedule = SCH_SCHEDULE_NULL;
-int		svr_do_sched_high = SCH_SCHEDULE_NULL;
 int		svr_total_cpus = 0;		/* total number of cpus on nodes   */
 int		have_blue_gene_nodes = 0;
 int		svr_ping_rate = SVR_DEFAULT_PING_RATE;	/* time between sets of node pings */

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -143,6 +143,7 @@
 #include "reservation.h"
 #include "cmds.h"
 #include "server.h"
+#include "pbs_sched.h"
 
 
 /* External functions */
@@ -4306,7 +4307,7 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 	*num_run += 1;
 	if (pbs_python_get_scheduler_restart_cycle_flag() == TRUE) {
 
-		set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE);
+		set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE, dflt_scheduler);
 		log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_HOOK,
 			LOG_INFO, phook->hook_name,
 			"requested for scheduler to restart cycle");

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -109,6 +109,7 @@
 #include "resv_node.h"
 #include "queue.h"
 #include "sched_cmds.h"
+#include "pbs_sched.h"
 
 #ifdef WIN32
 #include <direct.h>
@@ -155,7 +156,6 @@ static int  set_resvAttrs_off_jobAttrs(resc_resv*, job*);
 /* Global Data items */
 #ifndef PBS_MOM
 extern struct server   server;
-extern int scheduler_sock;
 #endif	/* PBS_MOM */
 extern char *msg_abt_err;
 extern char *path_jobs;
@@ -520,7 +520,7 @@ job_free(job *pj)
 					 * If so, then reject the request.
 					 */
 					if ((tbr->rq_orgconn != -1) &&
-						(tbr->rq_orgconn == scheduler_sock)) {
+						(find_sched_from_sock(tbr->rq_orgconn) != NULL)) {
 						tbr->rq_conn = tbr->rq_orgconn;
 						req_reject(PBSE_HISTJOBID, 0, tbr);
 					}
@@ -1692,7 +1692,7 @@ resv_purge(resc_resv *presv)
 
 	/*Release any nodes that were associated to this reservation*/
 	free_resvNodes(presv);
-	set_scheduler_flag(SCH_SCHEDULE_TERM);
+	set_scheduler_flag(SCH_SCHEDULE_TERM, dflt_scheduler);
 
 	strcpy(dbresv.ri_resvid, presv->ri_qs.ri_resvID);
 	obj.pbs_db_obj_type = PBS_DB_RESV;

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -176,6 +176,7 @@
 #include	"hook_func.h"
 #include	"sched_cmds.h"
 #include	"provision.h"
+#include 	"pbs_sched.h"
 #include	"svrfunc.h"
 
 #if !defined(H_ERRNO_DECLARED) && !defined(WIN32)
@@ -1952,7 +1953,8 @@ find_degraded_occurrence(resc_resv *presv, struct pbsnode *np,
 			occr_found = 1;
 			if (degraded_op == Set_Degraded_Time) {
 				/* we keep track of the occurrence time to determine the earliest
-				 * degraded time */
+				 * degraded time
+				 */
 				occr_time = get_occurrence(rrule, dtstart, tz, j);
 
 				/* Set the degraded start time to the earliest occurrence
@@ -2080,6 +2082,7 @@ void
 set_resv_retry(resc_resv *presv, long retry_time)
 {
 	struct work_task *pwt;
+	extern void resv_retry_handler(struct work_task *ptask);
 
 	if (presv == NULL)
 		return;
@@ -2969,6 +2972,7 @@ deallocate_job(mominfo_t *pmom, job *pjob)
 	char	*new_exec_vnode = NULL;
 	attribute deallocated_attr;
 	char	*jobid;
+	pbs_sched *psched;
 
 	if ((pmom == NULL) || (pjob == NULL)) {
 		return;
@@ -3035,7 +3039,11 @@ deallocate_job(mominfo_t *pmom, job *pjob)
 		free(new_exec_vnode);
 
 	}
-	set_scheduler_flag(SCH_SCHEDULE_TERM);
+	if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
+		set_scheduler_flag(SCH_SCHEDULE_TERM, psched);
+	else {
+		log_err(-1, __func__, "Unable to find scheduler associated with partition");
+	}
 	free(freed_vnode_list);
 }
 /**
@@ -3958,7 +3966,7 @@ update2_to_vnode(vnal_t *pvnal, int new, mominfo_t *pmom, int *madenew, int from
 				}
 				if (strcmp(psrp->vna_val, "1") == 0) {
 
-					set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE);
+					set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE, dflt_scheduler);
 					snprintf(log_buffer,
 					   sizeof(log_buffer),
 					   "hook '%s' requested for "
@@ -5078,7 +5086,7 @@ found:
 
 		case IS_RESCUSED:
 		case IS_RESCUSED_FROM_HOOK:
-#ifdef DEBUG
+#ifdef  DEBUG
 			if (command == IS_RESCUSED)
 				DBPRT(("%s: IS_RESCUSED\n", __func__))
 				else
@@ -5271,7 +5279,7 @@ found:
 			}
 			free(hook_euser);
 			hook_euser = NULL;
-			set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE);
+			set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE, dflt_scheduler);
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_NODE,
 				LOG_INFO, pmom->mi_host,
 				"requested for scheduler to restart cycle");
@@ -8684,6 +8692,7 @@ free_sister_vnodes(job *pjob, char *vnodelist, char *err_msg,
 			int err_msg_sz, struct batch_request *reply_req)
 {
 	int		rc = 0;
+	pbs_sched	*psched;
 
 	if (pjob == NULL) {
 		log_err(PBSE_INTERNAL, __func__, "bad pjob parameter");
@@ -8710,7 +8719,11 @@ free_sister_vnodes(job *pjob, char *vnodelist, char *err_msg,
 	/* increment everything found in new exec_vnode */
 	set_resc_assigned((void *)pjob, 0,  INCR);
 						
-	set_scheduler_flag(SCH_SCHEDULE_TERM);
+	if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
+		set_scheduler_flag(SCH_SCHEDULE_TERM, psched);
+	else {
+		log_err(-1, __func__, "Unable to find scheduler associated with partition");
+	}
 	rc = send_job_exec_update_to_mom(pjob, err_msg, err_msg_sz, reply_req);
 
 	if (rc == 0) {

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -708,12 +708,16 @@ pbsd_init(int type)
 			/* Create and save default to DB*/
 			dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME);
 			(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
-			set_sched_default(dflt_scheduler);
+			set_sched_default(dflt_scheduler, 0);
 		} else {
 			/* set default values for all schedulers */
 			psched = (pbs_sched *) GET_NEXT(svr_allscheds);
 			while (psched != (pbs_sched *) 0) {
-				set_sched_default(psched);
+				set_sched_default(psched, 0);
+				if (psched != dflt_scheduler) {
+					psched->pbs_scheduler_port = psched->sch_attr[SCHED_ATR_sched_port].at_val.at_long;
+					psched->pbs_scheduler_addr = get_hostaddr(psched->sch_attr[SCHED_ATR_SchedHost].at_val.at_str);
+				}
 				psched = (pbs_sched *) GET_NEXT(psched->sc_link);
 			}
 		}
@@ -734,10 +738,11 @@ pbsd_init(int type)
 				printf("%s\n", log_buffer);
 				return -1;
 			}
-			svr_save_db(&server, SVR_SAVE_NEW);
-		} else {
-			svr_save_db(&server, SVR_SAVE_NEW);
 		}
+		svr_save_db(&server, SVR_SAVE_NEW);
+		dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME);
+		(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
+		set_sched_default(dflt_scheduler, 0);
 	}
 
 	/* 4. Check License information */

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -139,6 +139,7 @@
 #include "provision.h"
 #include "pbs_db.h"
 #include "pbs_sched.h"
+#include "pbs_share.h"
 
 #include <pbs_python.h>  /* for python interpreter */
 
@@ -161,11 +162,10 @@ extern int put_sched_cmd(int sock, int cmd, char *jobid);
 extern void setup_ping(int delay);
 
 /* External data items */
-extern	int		svr_chngNodesfile;
+extern	int	svr_chngNodesfile;
 extern  pbs_list_head svr_requests;
 extern char     *msg_err_malloc;
 extern int       pbs_failover_active;
-extern int	scheduler_sock, scheduler_sock2;
 
 /* Local Private Functions */
 
@@ -224,8 +224,6 @@ char	       *pbs_o_host = "PBS_O_HOST";
 pbs_net_t	pbs_mom_addr;
 unsigned int	pbs_mom_port;
 unsigned int	pbs_rm_port;
-pbs_net_t	pbs_scheduler_addr;
-unsigned int	pbs_scheduler_port;
 pbs_net_t	pbs_server_addr;
 unsigned int	pbs_server_port_dis;
 /*
@@ -272,20 +270,18 @@ char	       *pbs_server_id;
 int		reap_child_flag = 0;
 time_t		secondary_delay = 30;
 struct server	server;		/* the server structure */
-pbs_sched	*dflt_scheduler;	/* the default scheduler */
+pbs_sched	*dflt_scheduler = NULL;	/* the default scheduler */
 char	        primary_host[PBS_MAXHOSTNAME+1];   /* host_name of primary */
 int		shutdown_who;		/* see req_shutdown() */
 char	       *mom_host = server_host;
 long		new_log_event_mask = 0;
 int		server_init_type = RECOV_WARM;
 int		svr_delay_entry = 0;
-int             svr_do_schedule = SCH_SCHEDULE_NULL;
-int             svr_do_sched_high = SCH_SCHEDULE_NULL; /* high priority cmds */
 int             svr_ping_rate = SVR_DEFAULT_PING_RATE;    /* time between sets of node pings */
 int             ping_nodes_rate = SVR_DEFAULT_PING_RATE; /* time between ping nodes as determined from server_init_type */
-pbs_list_head   svr_deferred_req;
-pbs_list_head   svr_queues;            /* list of queues                   */
-pbs_list_head   svr_alljobs;           /* list of all jobs in server       */
+pbs_list_head	svr_deferred_req;
+pbs_list_head	svr_queues;            /* list of queues                   */
+pbs_list_head	svr_alljobs;           /* list of all jobs in server       */
 pbs_list_head	svr_newjobs;           /* list of incomming new jobs       */
 pbs_list_head	svr_allresvs;          /* all reservations in server */
 pbs_list_head	svr_newresvs;          /* temporary list for new resv jobs */
@@ -369,9 +365,9 @@ int tpp_network_up = 0;
 void
 net_restore_handler(void *data)
 {
-    log_tppmsg(LOG_INFO, NULL, "net restore handler called");
-    tpp_network_up = 1;
-    ping_nodes(NULL);
+	log_tppmsg(LOG_INFO, NULL, "net restore handler called");
+	tpp_network_up = 1;
+	ping_nodes(NULL);
 }
 
 /**
@@ -907,6 +903,7 @@ main(int argc, char **argv)
 	struct stat 		sb_sa;
 	struct batch_request	*periodic_req;
 	char			hook_msg[HOOK_MSG_SIZE];
+	pbs_sched		*psched;
 	char			*keep_daemon_name = NULL;
 #ifndef WIN32
 	pid_t			sid = -1;
@@ -934,6 +931,9 @@ main(int argc, char **argv)
 	int				try_db = 0;
 	int 			db_stop_counts = 0;
 	int 			db_stop_email_sent = 0;
+
+	pbs_net_t		pbs_scheduler_addr;
+	unsigned int		pbs_scheduler_port;
 
 	extern int		optind;
 	extern char		*optarg;
@@ -1933,10 +1933,10 @@ try_db_again:
 		svr_mailowner(0, 0, 1, log_buffer);
 		if (server.sv_attr[(int)SRV_ATR_scheduling].at_val.at_long) {
 			/* Scheduling is true, see if we can contact scheduler */
-			if (contact_sched(SCH_SCHEDULE_NULL, NULL) < 0) {
+			if (contact_sched(SCH_SCHEDULE_NULL, NULL, pbs_scheduler_addr, pbs_scheduler_port) < 0) {
 				/* No - try bringing up scheduler here */
 				pbs_scheduler_addr = get_hostaddr(pbs_conf.pbs_secondary);
-				if (contact_sched(SCH_SCHEDULE_NULL, NULL) < 0) {
+				if (contact_sched(SCH_SCHEDULE_NULL, NULL, pbs_scheduler_addr, pbs_scheduler_port) < 0) {
 					char **workenv;
 					char schedcmd[MAXPATHLEN+1];
 					/* save the current, "safe", environment.          */
@@ -1971,6 +1971,10 @@ try_db_again:
 		(void)set_task(WORK_Timed, time_now, primary_handshake, NULL);
 
 	}
+	dflt_scheduler->pbs_scheduler_addr = pbs_scheduler_addr;
+	dflt_scheduler->pbs_scheduler_port = pbs_scheduler_port;
+	strncpy(dflt_scheduler->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_SCHEDULING, SC_STATUS_LEN);
+	dflt_scheduler->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str[SC_STATUS_LEN] = '\0';
 
 #ifdef WIN32
 	sprintf(log_buffer, msg_startup2, getpid(), pbs_server_port_dis,
@@ -2075,53 +2079,56 @@ try_db_again:
 				clear_exec_vnode();
 				first_run = 0;
 			}
+			for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+				/* if time or event says to run scheduler, do it */
 
-			/* if time or event says to run scheduler, do it */
+				/* if we have a high prio sched command, send it 1st */
+				if (psched->sch_attr[SCHED_ATR_scheduling].at_val.at_long &&
+					psched->svr_do_sched_high != SCH_SCHEDULE_NULL)
+					schedule_high(psched);
 
-			/* if we have a high prio sched command, send it 1st */
-			if (svr_do_sched_high != SCH_SCHEDULE_NULL)
-				schedule_high();
+				if (psched->svr_do_schedule == SCH_SCHEDULE_RESTART_CYCLE) {
 
-
-			if (svr_do_schedule == SCH_SCHEDULE_RESTART_CYCLE) {
-
-				/* send only to existing connection */
-				/* since it is for interrupting current */
-				/* cycle */
-				/* NOTE: both primary and secondary scheduler */
-				/* connect must have been setup to be valid */
-				if ((scheduler_sock2 != -1) &&
-					(scheduler_sock != -1)) {
-					if (put_sched_cmd(scheduler_sock2,
-						svr_do_schedule, NULL) == 0) {
-						log_event(PBSEVENT_DEBUG2,
+					/* send only to existing connection */
+					/* since it is for interrupting current */
+					/* cycle */
+					/* NOTE: both primary and secondary scheduler */
+					/* connect must have been setup to be valid */
+					if ((psched->scheduler_sock2 != -1) &&
+						(psched->scheduler_sock != -1)) {
+						if (put_sched_cmd(psched->scheduler_sock2,
+								psched->svr_do_schedule, NULL) == 0) {
+							sprintf(log_buffer, "sent scheduler restart scheduling cycle request to %s", psched->sc_name);
+							log_event(PBSEVENT_DEBUG2,
+								PBS_EVENTCLASS_SERVER,
+								LOG_NOTICE, msg_daemonname, log_buffer);
+						}
+					} else {
+						sprintf(log_buffer, "no valid secondary connection to scheduler %s: restart scheduling cycle request ignored",
+								psched->sc_name);
+						log_event(PBSEVENT_DEBUG3,
 							PBS_EVENTCLASS_SERVER,
-							LOG_NOTICE, msg_daemonname,
-							"sent scheduler restart scheduling cycle request");
+							LOG_NOTICE, msg_daemonname, log_buffer);
 					}
-				} else {
-					log_event(PBSEVENT_DEBUG3,
-						PBS_EVENTCLASS_SERVER,
-						LOG_NOTICE, msg_daemonname,
-						"no valid secondary connection to scheduler: restart scheduling cycle request ignored");
+					psched->svr_do_schedule = SCH_SCHEDULE_NULL;
+				} else if (((svr_unsent_qrun_req) || ((psched->svr_do_schedule != SCH_SCHEDULE_NULL) &&
+					psched->sch_attr[(int)SCHED_ATR_scheduling].at_val.at_long))
+					&& can_schedule()) {
+					/*
+					 * If svr_unsent_qrun_req is set to one there are pending qrun
+					 * request, then do schedule_jobs irrespective of the server scheduling
+					 * state.
+					 * If svr_unsent_qrun_req is not set then do the existing checking and do
+					 * scheduling only if server scheduling is turned on.
+					 */
+
+					psched->sch_next_schedule = time_now +
+							psched->sch_attr[(int)	SCHED_ATR_schediteration].at_val.at_long;
+					if (psched->sch_attr[SCHED_ATR_scheduling].at_val.at_long &&
+							(schedule_jobs(psched) == 0) && (svr_unsent_qrun_req))
+						svr_unsent_qrun_req = 0;
 				}
-				svr_do_schedule = SCH_SCHEDULE_NULL;
-			} else if (((svr_unsent_qrun_req) || ((svr_do_schedule != SCH_SCHEDULE_NULL) &&
-				server.sv_attr[(int)SRV_ATR_scheduling].at_val.at_long))
-				&& can_schedule()) {
-				/*
-				 * If svr_unsent_qrun_req is set to one there are pending qrun
-				 * request, then do schedule_jobs irrespective of the server scheduling 
-				 * state.
-				 * If svr_unsent_qrun_req is not set then do the existing checking and do 
-				 * scheduling only if server scheduling is turned on.
-				 */
-				server.sv_next_schedule = time_now + server.sv_attr[(int)SRV_ATR_scheduler_iteration].at_val.at_long;
-				if((schedule_jobs() == 0) && (svr_unsent_qrun_req))
-					svr_unsent_qrun_req = 0;
 			}
-
-
 		} else if (*state == SV_STATE_HOT) {
 
 			/* Are there HOT jobs to rerun */
@@ -2221,7 +2228,7 @@ try_db_again:
 	/* if brought up the Secondary Scheduler, take it down */
 
 	if (brought_up_alt_sched == 1)
-		(void)contact_sched(SCH_QUIT, NULL);
+		(void)contact_sched(SCH_QUIT, NULL, pbs_scheduler_addr, pbs_scheduler_port);
 
 	/* if Moms are to to down as well, tell them */
 
@@ -2403,16 +2410,19 @@ next_task()
 {
 
 	time_t		   tilwhen;
-	time_t		   delay;
+	pbs_sched	   *psched;
 
 	tilwhen = default_next_task();
 
 	/* should the scheduler be run?  If so, adjust the delay time  */
 
-	if ((delay = server.sv_next_schedule - time_now) <= 0)
-		set_scheduler_flag(SCH_SCHEDULE_TIME);
-	else if (delay < tilwhen)
-		tilwhen = delay;
+	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+		time_t delay;
+		if ((delay = psched->sch_next_schedule - time_now) <= 0)
+			set_scheduler_flag(SCH_SCHEDULE_TIME, psched);
+		else if (delay < tilwhen)
+			tilwhen = delay;
+	}
 
 	next_sync_mom_hookfiles();
 

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -110,6 +110,7 @@
 #include "dis.h"
 #include "pbs_nodes.h"
 #include "svrfunc.h"
+#include "pbs_sched.h"
 
 /* global data items */
 
@@ -127,7 +128,6 @@ extern char  *msg_request;
 
 extern int    is_local_root(char *, char *);
 extern void   req_stat_hook(struct batch_request *);
-extern int    scheduler_sock;
 
 /* Private functions local to this file */
 
@@ -584,8 +584,7 @@ process_request(int sfds)
 #ifndef PBS_MOM
 	/* If the request is coming on the socket we opened to the  */
 	/* scheduler,  change the "user" from "root" to "Scheduler" */
-
-	if (request->rq_conn == scheduler_sock) {
+	if (find_sched_from_sock(request->rq_conn) != NULL) {
 		strncpy(request->rq_user, PBS_SCHED_DAEMON_NAME, PBS_MAXUSER);
 		request->rq_user[PBS_MAXUSER] = '\0';
 	}

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -77,6 +77,7 @@
 #include "pbs_db.h"
 #include "pbs_nodes.h"
 #include <memory.h>
+#include "pbs_sched.h"
 
 
 /* Global Data */
@@ -358,6 +359,7 @@ queuestart_action(attribute *pattr, void *pobject, int actmode)
 	long	oldtype;
 	long 	newaccruetype = -1;	/* if determining accrue type */
 	pbs_queue *pque = (pbs_queue *) pobject;
+	pbs_sched *psched;
 
 	if ((pque != NULL) && (server.sv_attr[SRV_ATR_EligibleTimeEnable].at_val.at_long == 1)) {
 
@@ -402,8 +404,14 @@ queuestart_action(attribute *pattr, void *pobject, int actmode)
 			}
 
 			/* if scheduling = True, notify scheduler to start */
-			if (server.sv_attr[SRV_ATR_scheduling].at_val.at_long)
-				set_scheduler_flag(SCH_SCHEDULE_STARTQ);
+			if (server.sv_attr[SRV_ATR_scheduling].at_val.at_long) {
+				if (find_assoc_sched_pque(pque, &psched))
+					set_scheduler_flag(SCH_SCHEDULE_STARTQ, psched);
+				else {
+					sprintf(log_buffer, "No scheduler associated with the partition %s", pque->qu_attr[QA_ATR_partition].at_val.at_str);
+					log_err(-1, __func__, log_buffer);
+				}
+			}
 		}
 	}
 

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -102,6 +102,8 @@ extern time_t time_now;
 /* External functions */
 
 extern int issue_to_svr(char *, struct batch_request *, void (*func)(struct work_task *));
+extern struct batch_request *cpy_stage(struct batch_request *, job *, enum job_atr, int);
+extern resc_resv  *chk_rescResv_request(char *, struct batch_request *);
 
 /* Private Functions in this file */
 

--- a/src/server/req_getcred.c
+++ b/src/server/req_getcred.c
@@ -54,6 +54,7 @@
 #include "credential.h"
 #include "net_connect.h"
 #include "batch_request.h"
+#include "pbs_share.h"
 
 
 /* External Global Data Items Referenced */
@@ -83,10 +84,13 @@ req_connect(struct batch_request *preq)
 		return;
 	}
 
-	if ( (preq->rq_extend != NULL) && \
-		(strcmp(preq->rq_extend, QSUB_DAEMON) == 0) ) {
-		conn->cn_authen |= PBS_NET_CONN_FROM_QSUB_DAEMON;
+	if (preq->rq_extend != NULL) {
+		if (strcmp(preq->rq_extend, QSUB_DAEMON) == 0)
+			conn->cn_authen |= PBS_NET_CONN_FROM_QSUB_DAEMON;
+		else if (strcmp(preq->rq_extend, SC_DAEMON) == 0)
+			conn->cn_authen |= PBS_NET_CONN_FROM_PRIVIL;
 	}
+
 
 	if ((conn->cn_authen &
 		(PBS_NET_CONN_AUTHENTICATED|PBS_NET_CONN_FROM_PRIVIL))==0) {

--- a/src/server/req_holdjob.c
+++ b/src/server/req_holdjob.c
@@ -84,6 +84,8 @@ extern char	*msg_jobholdrel;
 extern char	*msg_mombadhold;
 extern char	*msg_postmomnojob;
 extern time_t	 time_now;
+extern job  *chk_job_request(char *, struct batch_request *, int *);
+
 
 int chk_hold_priv(long val, int perm);
 

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -95,6 +95,7 @@
 #include "dis.h"
 #include "rpp.h"
 #include "libutil.h"
+#include "pbs_sched.h"
 
 
 /* External Global Data Items */
@@ -624,6 +625,7 @@ void
 rel_resc(job *pjob)
 {
 	conn_t *conn = NULL;
+	pbs_sched *psched;
 
 	free_nodes(pjob);
 
@@ -650,7 +652,14 @@ rel_resc(job *pjob)
 
 	/* Mark that scheduler should be called */
 
-	set_scheduler_flag(SCH_SCHEDULE_TERM);
+	if (find_assoc_sched_jid(pjob->ji_qs.ji_jobid, &psched))
+		set_scheduler_flag(SCH_SCHEDULE_TERM, psched);
+	else {
+		pbs_queue *pq;
+		pq = find_queuebyname( pjob->ji_qs.ji_queue);
+		sprintf(log_buffer, "Unable to reach scheduler associated with partition %s", pq->qu_attr[QA_ATR_partition].at_val.at_str);
+		log_err(-1, __func__, log_buffer);
+	}
 }
 /**
  * @brief

--- a/src/server/req_message.c
+++ b/src/server/req_message.c
@@ -77,6 +77,9 @@ static void post_message_req(struct work_task *);
 
 extern char *msg_messagejob;
 
+extern job  *chk_job_request(char *, struct batch_request *, int *);
+
+
 
 /**
  * @brief

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -112,6 +112,7 @@
 #include "user.h"
 #include "hook.h"
 #include "pbs_internal.h"
+#include "pbs_sched.h"
 #ifndef PBS_MOM
 #include "pbs_db.h"
 #endif
@@ -2405,7 +2406,7 @@ req_commit(struct batch_request *preq)
 		}
 		delete_link(&presv->ri_allresvs);
 		append_link(&svr_allresvs, &presv->ri_allresvs, presv);
-		set_scheduler_flag(SCH_SCHEDULE_NEW);
+		set_scheduler_flag(SCH_SCHEDULE_NEW, dflt_scheduler);
 		Update_Resvstate_if_resv(pj);
 	}
 
@@ -3221,7 +3222,7 @@ req_resvSub(struct batch_request *preq)
 	 * is available for consideration
 	 */
 	append_link(&svr_allresvs, &presv->ri_allresvs, presv);
-	set_scheduler_flag(SCH_SCHEDULE_NEW);
+	set_scheduler_flag(SCH_SCHEDULE_NEW, dflt_scheduler);
 }
 
 

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -80,6 +80,8 @@ static void req_rerunjob2(struct batch_request *preq, job *pjob);
 extern char *msg_manager;
 extern char *msg_jobrerun;
 extern time_t time_now;
+extern job  *chk_job_request(char *, struct batch_request *, int *);
+
 
 
 /**

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -104,6 +104,7 @@
 #include "hook.h"
 #include "provision.h"
 #include "pbs_share.h"
+#include "pbs_sched.h"
 
 
 /* External Functions Called: */
@@ -141,11 +142,11 @@ extern char *msg_init_substate;
 extern char *msg_manager;
 extern char *msg_stageinfail;
 extern char *msg_job_abort;
-extern int   scheduler_sock;
-extern int   svr_do_schedule;
 extern pbs_list_head svr_deferred_req;
 extern time_t time_now;
 extern int   svr_totnodes;	/* non-zero if using nodes */
+extern job  *chk_job_request(char *, struct batch_request *, int *);
+
 
 /* private data */
 
@@ -309,6 +310,7 @@ req_runjob(struct batch_request *preq)
 	int		  x, y, z;
 	struct deferred_request *pdefr;
 	char		  hook_msg[HOOK_MSG_SIZE];
+	pbs_sched	  *psched;
 
 	if (license_expired) {
 		req_reject(PBSE_LICENSEINV, 0, preq);
@@ -332,15 +334,22 @@ req_runjob(struct batch_request *preq)
 		return;
 	}
 	
+	if (!find_assoc_sched_jid(jid, &psched)) {
+		sprintf(log_buffer, "Unable to reach scheduler associated with job %s", jid);
+		log_err(-1, __func__, log_buffer);
+		req_reject(PBSE_NOSCHEDULER, 0, preq);
+		return;
+	}
+
 #ifndef NAS /* localmod 133 */
-	if ((scheduler_sock != -1) && was_job_alteredmoved(parent)) {
+	if ((psched->scheduler_sock != -1) && was_job_alteredmoved(parent)) {
 		int index = find_attr(sched_attr_def, ATTR_throughput_mode, SCHED_ATR_LAST);
 		/* do not blacklist altered/moved jobs when throughput_mode is enabled */
 		if ((index == -1) ||
-			((dflt_scheduler->sch_attr[index].at_flags & ATR_VFLAG_SET) &&
-			 (dflt_scheduler->sch_attr[index].at_val.at_long == 0))) {
+			((psched->sch_attr[index].at_flags & ATR_VFLAG_SET) &&
+			 (psched->sch_attr[index].at_val.at_long == 0))) {
 			req_reject(PBSE_NORUNALTEREDJOB, 0, preq);
-			set_scheduler_flag(SCH_SCHEDULE_NEW);
+			set_scheduler_flag(SCH_SCHEDULE_NEW, psched);
 			return;
 		}
 	}
@@ -424,7 +433,7 @@ req_runjob(struct batch_request *preq)
 
 		/* if runjob request is from the Scheduler, */
 		/* it must have a destination specified     */
-		if (preq->rq_conn == scheduler_sock) {
+		if (preq->rq_conn == psched->scheduler_sock) {
 			sprintf(log_buffer,
 				"runjob request from scheduler with null destination");
 			log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_JOB, LOG_INFO,
@@ -458,7 +467,7 @@ req_runjob(struct batch_request *preq)
 		/* ensure that request is removed if client connect is closed */
 		net_add_close_func(preq->rq_conn, clear_from_defr);
 
-		if (schedule_jobs() == -1) {
+		if (schedule_jobs(psched) == -1) {
 			/* unable to contact the Scheduler, reject */
 			req_reject(PBSE_NOSCHEDULER, 0, preq);
 			/* unlink and free the deferred request entry */
@@ -1596,7 +1605,7 @@ post_sendmom(struct work_task *pwt)
 							}
 							if ((phook->fail_action & HOOK_FAIL_ACTION_SCHEDULER_RESTART_CYCLE) != 0) {
 
-								set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE);
+								set_scheduler_flag(SCH_SCHEDULE_RESTART_CYCLE, dflt_scheduler);
 								log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_HOOK, LOG_INFO, phook->hook_name, "requested for scheduler to restart cycle");
 							}
 						}
@@ -1734,7 +1743,7 @@ where_to_runjob(struct batch_request *preq, job *pjob)
 	}
 
 	/* If the request did not come from the scheduler, update the comment. */
-	if (preq->rq_conn != scheduler_sock) {
+	if (find_sched_from_sock(preq->rq_conn) == NULL) {
 		char comment[MAXCOMMENTLEN];
 		nspec = pjob->ji_wattr[(int)JOB_ATR_exec_vnode].at_val.at_str;
 		if ((nspec != NULL) && (*nspec != '\0')) {

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -80,7 +80,7 @@
 #include "log.h"
 #include "pbs_nodes.h"
 #include "svrfunc.h"
-
+#include "pbs_sched.h"
 
 /* Private Data */
 
@@ -91,7 +91,6 @@ extern pbs_list_head svr_alljobs;
 extern time_t	 time_now;
 extern char	 statechars[];
 extern long svr_history_enable;
-extern int scheduler_sock;
 extern int scheduler_jobs_stat;
 
 /* Private Functions  */
@@ -334,6 +333,7 @@ req_selectjobs(struct batch_request *preq)
 	char		   *pstate = NULL;
 	int		    rc;
 	struct select_list *selistp;
+	pbs_sched	   *psched;
 
 	/*
 	 * if the letter T (or t) is in the extend string,  select subjobs
@@ -367,7 +367,8 @@ req_selectjobs(struct batch_request *preq)
 	 * approach to query for jobs, e.g., by issuing a single pbs_statjob()
 	 * instead of a per-queue selstat()
 	 */
-	if ((scheduler_sock != -1) && (preq->rq_conn == scheduler_sock) && (!scheduler_jobs_stat)) {
+	psched = find_sched_from_sock(preq->rq_conn);
+	if ((psched != NULL) && (psched == dflt_scheduler) && (!scheduler_jobs_stat)) {
 		scheduler_jobs_stat = 1;
 	}
 

--- a/src/server/req_shutdown.c
+++ b/src/server/req_shutdown.c
@@ -267,7 +267,7 @@ req_shutdown(struct batch_request *preq)
 		(void)failover_send_shutdown(FAILOVER_SecdShutdown);
 
 	if (shutdown_who & SHUT_WHO_SCHED)
-		(void)contact_sched(SCH_QUIT, NULL);	/* tell scheduler to quit */
+		(void)contact_sched(SCH_QUIT, NULL, dflt_scheduler->pbs_scheduler_addr, dflt_scheduler->pbs_scheduler_port);	/* tell scheduler to quit */
 
 	if (shutdown_who & SHUT_WHO_SECDONLY) {
 		reply_ack(preq);

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -119,7 +119,7 @@ static int bad;
 
 /* The following private support functions are included */
 
-static int  status_que(pbs_queue *, struct batch_request *, pbs_list_head *);
+static int status_que(pbs_queue *, struct batch_request *, pbs_list_head *);
 static int status_node(struct pbsnode *, struct batch_request *, pbs_list_head *);
 static int status_resv(resc_resv *, struct batch_request *, pbs_list_head *);
 extern pbs_sched *find_scheduler(char *sched_name);
@@ -473,7 +473,7 @@ req_stat_que(struct batch_request *preq)
  * 		status_que - Build the status reply for a single queue.
  *
  * @param[in,out]	pque	-	ptr to que to status
- * @param[in]	preq	-	ptr to the decoded request
+ * @param[in]		preq	-	ptr to the decoded request
  * @param[in,out]	pstathd	-	head of list to append status to
  *
  * @return	int
@@ -579,12 +579,12 @@ req_stat_node(struct batch_request *preq)
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
 
-	if (type == 0) {		/*get status of the named node*/
+	if (type == 0) {		/* get status of the named node */
 		rc = status_node(pnode, preq, &preply->brp_un.brp_status);
 
-	} else {			/*get status of all nodes     */
+	} else {			/* get status of all nodes */
 
-		for (i=0; i<svr_totnodes; i++) {
+		for (i = 0; i < svr_totnodes; i++) {
 			pnode = pbsndlist[i];
 
 			rc = status_node(pnode, preq,

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -65,6 +65,9 @@
 #include "work_task.h"
 #include "pbs_error.h"
 #include "batch_request.h"
+#include "pbs_sched.h"
+#include "queue.h"
+#include "pbs_share.h"
 
 
 /* Global Data */
@@ -73,6 +76,7 @@ extern struct server server;
 extern pbs_net_t pbs_scheduler_addr;
 extern unsigned int pbs_scheduler_port;
 extern char      server_name[];
+extern struct connection *svr_conn;
 extern int	 svr_do_schedule;
 extern int	 svr_do_sched_high;
 extern char     *msg_sched_called;
@@ -158,6 +162,104 @@ err:
 
 /**
  * @brief
+ * 		find_assoc_sched_jid - find the corresponding scheduler which is responsible
+ * 		for handling this job.
+ *
+ * @param[in]	jid - job id
+ * @param[out]	target_sched - pointer to the corresponding scheduler to which the job belongs to
+ *
+ * @retval - 1  if success
+ * 	   - 0 if fail
+ */
+int
+find_assoc_sched_jid(char *jid, pbs_sched **target_sched)
+{
+	job *pj;
+	int t;
+
+	*target_sched = NULL;
+
+	t = is_job_array(jid);
+	if ((t == IS_ARRAY_NO) || (t == IS_ARRAY_ArrayJob))
+		pj = find_job(jid);		/* regular or ArrayJob itself */
+	else
+		pj = find_arrayparent(jid); /* subjob(s) */
+
+	if (pj == NULL)
+		return 0;
+
+	return find_assoc_sched_pque(pj->ji_qhdr, target_sched);
+}
+
+/**
+ * @brief
+ * 		find_assoc_sched_pque - find the corresponding scheduler which is responsible
+ * 		for handling this job.
+ *
+ * @param[in]	pq		- pointer to pbs_queue
+ * @param[out]  target_sched	- pointer to the corresponding scheduler to which the job belongs to
+ *
+  * @retval - 1 if success
+ * 	    - 0 if fail
+ */
+int
+find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched)
+{
+	pbs_sched *psched;
+
+	*target_sched = NULL;
+	if (pq == NULL)
+		return 0;
+
+	if (pq->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
+		attribute *part_attr;
+		for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
+			if (part_attr->at_flags & ATR_VFLAG_SET) {
+				int k;
+				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
+					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
+							&& (!strcmp(part_attr->at_val.at_arst->as_string[k],
+									pq->qu_attr[QA_ATR_partition].at_val.at_str))) {
+						*target_sched = psched;
+						return 1;
+					}
+				}
+			}
+		}
+	} else {
+		*target_sched = dflt_scheduler;
+		return 1;
+	}
+	return 0;
+
+}
+
+
+/**
+ * @brief
+ * 		find_sched_from_sock - find the corresponding scheduler which is having
+ * 		the given socket.
+ *
+ * @param[in]	sock	- socket descriptor
+ *
+ * @retval - pointer to the corresponding pbs_sched object if success
+ * 		 -  NULL if fail
+ */
+pbs_sched *
+find_sched_from_sock(int sock)
+{
+	pbs_sched *psched;
+
+	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+		if (psched->scheduler_sock == sock || psched->scheduler_sock2 == sock)
+			return psched;
+	}
+	return NULL;
+}
+
+/**
+ * @brief
  * 		contact_sched - open connection to the scheduler and send it a command
  *		Jobid is passed if and only if the cmd is SCH_SCHEDULE_AJOB
  *
@@ -166,7 +268,7 @@ err:
  */
 
 int
-contact_sched(int cmd, char *jobid)
+contact_sched(int cmd, char *jobid, pbs_net_t pbs_scheduler_addr, unsigned int pbs_scheduler_port)
 {
 	int sock;
 	conn_t *conn;
@@ -239,20 +341,28 @@ contact_sched(int cmd, char *jobid)
  * @retval	-1	: error
  */
 int
-schedule_high()
+schedule_high(pbs_sched *psched)
 {
 	int s;
-	if (scheduler_sock == -1) {
-		if ((s = contact_sched(svr_do_sched_high, NULL)) < 0)
+
+	if (psched == NULL)
+		return -1;
+
+	if (psched->scheduler_sock == -1) {
+		if ((s = contact_sched(psched->svr_do_sched_high, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) < 0)
 			return (-1);
-		set_sched_sock(s);
-		if (scheduler_sock2 == -1) {
-			if ((s = contact_sched(SCH_SCHEDULE_NULL, NULL)) >= 0)
-				scheduler_sock2 = s;
+		set_sched_sock(s, psched);
+		if (psched->scheduler_sock2 == -1) {
+			if ((s = contact_sched(SCH_SCHEDULE_NULL, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) >= 0)
+				psched->scheduler_sock2 = s;
 		}
-		svr_do_sched_high = SCH_SCHEDULE_NULL;
+		psched->svr_do_sched_high = SCH_SCHEDULE_NULL;
 		return 0;
 	}
+	strncpy(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_SCHEDULING, SC_STATUS_LEN);
+	psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str[SC_STATUS_LEN] = '\0';
+	psched->sch_attr[(int) SCHED_ATR_sched_state].at_flags = ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+
 	return 1;
 }
 
@@ -273,7 +383,7 @@ schedule_high()
  */
 
 int
-schedule_jobs()
+schedule_jobs(pbs_sched *psched)
 {
 	int cmd;
 	int s;
@@ -281,12 +391,15 @@ schedule_jobs()
 	struct deferred_request *pdefr;
 	char  *jid = NULL;
 
+	if (psched == NULL)
+		return -1;
+
 	if (first_time)
 		cmd = SCH_SCHEDULE_FIRST;
 	else
-		cmd = svr_do_schedule;
+		cmd = psched->svr_do_schedule;
 
-	if (scheduler_sock == -1) {
+	if (psched->scheduler_sock == -1) {
 
 		/* are there any qrun requests from manager/operator */
 		/* which haven't been sent,  they take priority      */
@@ -312,16 +425,21 @@ schedule_jobs()
 			pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
 		}
 
-		if ((s = contact_sched(cmd, jid)) < 0)
+		if ((s = contact_sched(cmd, jid, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) < 0)
 			return (-1);
 		else if (pdefr != NULL)
 			pdefr->dr_sent = 1;   /* mark entry as sent to sched */
-		set_sched_sock(s);
-		if (scheduler_sock2 == -1) {
-			if ((s = contact_sched(SCH_SCHEDULE_NULL, NULL)) >= 0)
-				scheduler_sock2 = s;
+		set_sched_sock(s, psched);
+		if (psched->scheduler_sock2 == -1) {
+			if ((s = contact_sched(SCH_SCHEDULE_NULL, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) >= 0)
+				psched->scheduler_sock2 = s;
 		}
-		svr_do_schedule = SCH_SCHEDULE_NULL;
+		psched->svr_do_schedule = SCH_SCHEDULE_NULL;
+
+		strncpy(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_SCHEDULING, SC_STATUS_LEN);
+		psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str[SC_STATUS_LEN] = '\0';
+		psched->sch_attr[(int) SCHED_ATR_sched_state].at_flags = ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+
 		first_time = 0;
 
 		/* if there are more qrun requests queued up, reset cmd so */
@@ -329,7 +447,9 @@ schedule_jobs()
 		pdefr = GET_NEXT(svr_deferred_req);
 		while (pdefr) {
 			if (pdefr->dr_sent == 0) {
-				svr_do_schedule = SCH_SCHEDULE_AJOB;
+				pbs_sched *target_sched;
+				if (find_assoc_sched_jid(pdefr->dr_preq->rq_ind.rq_queuejob.rq_jid, &target_sched))
+					target_sched->svr_do_schedule = SCH_SCHEDULE_AJOB;
 				break;
 			}
 			pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
@@ -338,6 +458,7 @@ schedule_jobs()
 		return (0);
 	} else
 		return (1);	/* scheduler was busy */
+
 }
 
 /**
@@ -361,13 +482,23 @@ static void
 scheduler_close(int sock)
 {
 	struct deferred_request *pdefr;
+	pbs_sched *psched;
 
-	if ((sock != -1) && (sock == scheduler_sock2)) {
-		scheduler_sock2 = -1;
+	psched = find_sched_from_sock(sock);
+
+	if (psched == NULL)
+		return;
+
+	strncpy(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_IDLE, SC_STATUS_LEN);
+	psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str[SC_STATUS_LEN] = '\0';
+	psched->sch_attr[(int) SCHED_ATR_sched_state].at_flags = ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+
+	if ((sock != -1) && (sock == psched->scheduler_sock2)) {
+		psched->scheduler_sock2 = -1;
 		return;	/* nothing to check if scheduler_sock2 */
 	}
 
-	set_sched_sock(-1);
+	set_sched_sock(-1, psched);
 
 	/* clear list of jobs which were altered/modified during cycle */
 	am_jobs.am_used = 0;
@@ -450,20 +581,36 @@ was_job_alteredmoved(job *pjob)
  *		certain flag values should not be overwritten
  *
  * @param[in]	flag	-	pointer to job in question.
+ * @parm[in] psched -   pointer to sched object. Then set the flag only for this object.
+ *                                     NULL. Then set the flag for all the scheduler objects.
  */
 void
-set_scheduler_flag(int flag)
+set_scheduler_flag(int flag, pbs_sched *psched)
 {
-	/* high priority commands:
-	 * Note: A) usually SCH_QUIT is sent directly and not via here
-	 *       B) if we ever add a 3rd high prio command, we can lose them
-	 */
-	if (flag == SCH_CONFIGURE || flag == SCH_QUIT) {
-		if (svr_do_sched_high == SCH_QUIT)
-			return; /* keep only SCH_QUIT */
+	int single_sched;
 
-		svr_do_sched_high = flag;
+	if (psched)
+		single_sched = 1;
+	else {
+		single_sched = 0;
+		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
 	}
-	else
-		svr_do_schedule = flag;
+
+	for (; psched ; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+		/* high priority commands:
+		 * Note: A) usually SCH_QUIT is sent directly and not via here
+		 *       B) if we ever add a 3rd high prio command, we can lose them
+		 */
+		if (flag == SCH_CONFIGURE || flag == SCH_QUIT) {
+			if (psched->svr_do_sched_high == SCH_QUIT)
+				return; /* keep only SCH_QUIT */
+
+			psched->svr_do_sched_high = flag;
+		}
+		else
+			psched->svr_do_schedule = flag;
+		if (single_sched)
+			break;
+	}
+
 }

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -47,6 +47,7 @@
 #include <string.h>
 #include <memory.h>
 #include <pbs_config.h>
+#include "pbs_share.h"
 #include "pbs_sched.h"
 #include "log.h"
 #include "pbs_ifl.h"
@@ -83,8 +84,11 @@ sched_alloc(char *sched_name)
 
 	CLEAR_LINK(psched->sc_link);
 	strncpy(psched->sc_name, sched_name, PBS_MAXSCHEDNAME);
-	psched->sc_name[PBS_MAXSCHEDNAME - 1] = '\0';
-
+	psched->sc_name[PBS_MAXSCHEDNAME] = '\0';
+	psched->svr_do_schedule = SCH_SCHEDULE_NULL;
+	psched->svr_do_sched_high = SCH_SCHEDULE_NULL;
+	psched->scheduler_sock = -1;
+	psched->scheduler_sock2 = -1;
 	append_link(&svr_allscheds, &psched->sc_link, psched);
 
 	/* set the working attributes to "unspecified" */
@@ -197,8 +201,41 @@ sched_delete(pbs_sched *psched)
 int
 action_sched_port(attribute *pattr, void *pobj, int actmode)
 {
-	if (actmode == ATR_ACTION_ALTER) {
-		/*TODO*/
+	pbs_sched *psched;
+	psched = (pbs_sched *) pobj;
+
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
+		if ( dflt_scheduler && psched != dflt_scheduler) {
+			psched->pbs_scheduler_port = pattr->at_val.at_long;
+		}
+	}
+	return PBSE_NONE;
+}
+
+/**
+ * @brief
+ * 		action routine for the sched's "sched_host" attribute
+ *
+ * @param[in]	pattr	-	attribute being set
+ * @param[in]	pobj	-	Object on which attribute is being set
+ * @param[in]	actmode	-	the mode of setting, recovery or just alter
+ *
+ * @return	error code
+ * @retval	PBSE_NONE	-	Success
+ * @retval	!PBSE_NONE	-	Failure
+ *
+ */
+int
+action_sched_host(attribute *pattr, void *pobj, int actmode)
+{
+	pbs_sched *psched;
+	psched = (pbs_sched *) pobj;
+
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
+		if ( dflt_scheduler && psched != dflt_scheduler)
+			psched->pbs_scheduler_addr = get_hostaddr(pattr->at_val.at_str);
+		if (psched->pbs_scheduler_addr == (pbs_net_t)0)
+			return PBSE_BADATVAL;
 	}
 	return PBSE_NONE;
 }
@@ -220,7 +257,13 @@ int
 action_sched_priv(attribute *pattr, void *pobj, int actmode)
 {
 	pbs_sched* psched;
-	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER) {
+
+	psched = (pbs_sched *) pobj;
+
+	if (pobj == dflt_scheduler)
+		return PBSE_SCHED_OP_NOT_PERMITTED;
+
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
 		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
 		while (psched != (pbs_sched*) 0) {
 			if (psched->sch_attr[SCHED_ATR_sched_priv].at_flags & ATR_VFLAG_SET) {
@@ -234,6 +277,7 @@ action_sched_priv(attribute *pattr, void *pobj, int actmode)
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
+	set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
 	return PBSE_NONE;
 }
 
@@ -254,7 +298,12 @@ int
 action_sched_log(attribute *pattr, void *pobj, int actmode)
 {
 	pbs_sched* psched;
-	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER) {
+	psched = (pbs_sched *) pobj;
+
+	if (pobj == dflt_scheduler)
+		return PBSE_SCHED_OP_NOT_PERMITTED;
+
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
 		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
 		while (psched != (pbs_sched*) 0) {
 			if (psched->sch_attr[SCHED_ATR_sched_log].at_flags & ATR_VFLAG_SET) {
@@ -268,6 +317,7 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
+	set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
 	return PBSE_NONE;
 }
 
@@ -287,8 +337,10 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 int
 action_sched_iteration(attribute *pattr, void *pobj, int actmode)
 {
-	if (actmode == ATR_ACTION_ALTER) {
-		/*TODO*/
+	if (pobj == dflt_scheduler) {
+			server.sv_attr[SRV_ATR_scheduler_iteration].at_val.at_long = pattr->at_val.at_long;
+			server.sv_attr[SRV_ATR_scheduler_iteration].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+			svr_save_db(&server, SVR_SAVE_FULL);
 	}
 	return PBSE_NONE;
 }
@@ -332,13 +384,28 @@ int
 poke_scheduler(attribute *pattr, void *pobj, int actmode)
 {
 	if (pobj == &server || pobj == dflt_scheduler) {
+		if (pobj == &server) {
+			/* set this attribute on main scheduler */
+			if (dflt_scheduler) {
+				dflt_scheduler->sch_attr[SCHED_ATR_scheduling].at_val.at_long = pattr->at_val.at_long;
+				dflt_scheduler->sch_attr[SCHED_ATR_scheduling].at_flags |=
+						ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+				(void)sched_save_db(dflt_scheduler, SVR_SAVE_FULL);
+			}
+		} else {
+			server.sv_attr[SRV_ATR_scheduling].at_val.at_long = pattr->at_val.at_long;
+			server.sv_attr[SRV_ATR_scheduling].at_flags |= ATR_VFLAG_MODCACHE;
+			svr_save_db(&server, SVR_SAVE_QUICK);
+		}
 		if (actmode == ATR_ACTION_ALTER) {
 			if (pattr->at_val.at_long)
-				set_scheduler_flag(SCH_SCHEDULE_CMD);
+				set_scheduler_flag(SCH_SCHEDULE_CMD, dflt_scheduler);
 		}
-		/*TODO also set this attribute on main scheduler */
 	} else {
-		/*TODO need add the code for other scheduler apart from main scheduler. */
+		if (actmode == ATR_ACTION_ALTER) {
+			if (pattr->at_val.at_long)
+				set_scheduler_flag(SCH_SCHEDULE_CMD, (pbs_sched *)pobj);
+		}
 	}
 	return PBSE_NONE;
 }
@@ -347,10 +414,13 @@ poke_scheduler(attribute *pattr, void *pobj, int actmode)
  * @brief
  * 		Sets default scheduler attributes
  *
- * @param[in]	psched	-	Scheduler
- */
+ * @param[in] psched		- Scheduler
+ * @parma[in] unset_flag	- flag to indicate if this function is called after unset of any sched attributes.
+ *
+ *
+  */
 void
-set_sched_default(pbs_sched* psched)
+set_sched_default(pbs_sched *psched, int unset_flag)
 {
 	if (!psched)
 		return;
@@ -359,11 +429,25 @@ set_sched_default(pbs_sched* psched)
 		psched->sch_attr[(int) SCHED_ATR_sched_cycle_len].at_flags =
 				ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
 	}
+	if (!unset_flag && (psched->sch_attr[(int) SCHED_ATR_schediteration].at_flags & ATR_VFLAG_SET) == 0) {
+		psched->sch_attr[(int) SCHED_ATR_schediteration].at_val.at_long = PBS_SCHEDULE_CYCLE;
+		psched->sch_attr[(int) SCHED_ATR_schediteration].at_flags =
+				ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+	}
+	if ((psched->sch_attr[(int) SCHED_ATR_scheduling].at_flags & ATR_VFLAG_SET) == 0) {
+		if (psched != dflt_scheduler)
+			psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long = 0;
+		else
+			psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long = 1;
+		psched->sch_attr[(int) SCHED_ATR_scheduling].at_flags =
+				ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+	}
 	if ((psched->sch_attr[(int) SCHED_ATR_sched_state].at_flags & ATR_VFLAG_SET) == 0) {
 		psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str = malloc(SC_STATUS_LEN + 1);
-		if (psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str == NULL)
+		if (psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str == NULL) {
+			log_err(errno, __func__, "no memory");
 			return;
-		else {
+		} else {
 			if (psched != dflt_scheduler)
 				strncpy(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_DOWN, SC_STATUS_LEN);
 			else
@@ -374,5 +458,88 @@ set_sched_default(pbs_sched* psched)
 		}
 
 	}
+	if ((psched->sch_attr[(int) SCHED_ATR_sched_priv].at_flags & ATR_VFLAG_SET) == 0) {
+		psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str = malloc(MAXPATHLEN + 1);
+		if (psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str == NULL) {
+			log_err(errno, __func__, "no memory");
+			return;
+		} else {
+			if (psched != dflt_scheduler)
+				(void) snprintf(psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str, MAXPATHLEN, "%s/sched_priv_%s",
+						pbs_conf.pbs_home_path, psched->sc_name);
+			else
+				(void) snprintf(psched->sch_attr[(int) SCHED_ATR_sched_priv].at_val.at_str, MAXPATHLEN, "%s/sched_priv",
+						pbs_conf.pbs_home_path);
+			psched->sch_attr[(int) SCHED_ATR_sched_priv].at_flags =
+			ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		}
+
+	}
+	if ((psched->sch_attr[(int) SCHED_ATR_sched_log].at_flags & ATR_VFLAG_SET) == 0) {
+		psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str = malloc(MAXPATHLEN + 1);
+		if (psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str == NULL) {
+			log_err(errno, __func__, "no memory");
+			return;
+		} else {
+			if (psched != dflt_scheduler)
+				(void) snprintf(psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str, MAXPATHLEN, "%s/sched_logs_%s",
+						pbs_conf.pbs_home_path, psched->sc_name);
+			else
+				(void) snprintf(psched->sch_attr[(int) SCHED_ATR_sched_log].at_val.at_str, MAXPATHLEN, "%s/sched_logs",
+						pbs_conf.pbs_home_path);
+			psched->sch_attr[(int) SCHED_ATR_sched_log].at_flags =
+			ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		}
+
+	}
 }
 
+
+/**
+ * @brief
+ * 		action routine for the scheduler's partition attribute
+ *
+ * @param[in]	pattr	-	pointer to attribute structure
+ * @param[in]	pobj	-	not used
+ * @param[in]	actmode	-	action mode
+ *
+ *
+ * @return	error code
+ * @retval	PBSE_NONE	-	Success
+ * @retval	!PBSE_NONE	-	Failure
+ *
+ */
+
+int
+action_sched_partition(attribute *pattr, void *pobj, int actmode)
+{
+	pbs_sched* psched;
+	pbs_sched* pin_sched;
+	attribute *part_attr;
+	int i;
+	int k;
+	if (pobj == dflt_scheduler)
+		return PBSE_SCHED_OP_NOT_PERMITTED;
+	pin_sched = (pbs_sched *) pobj;
+
+	for (i = 0; i < pattr->at_val.at_arst->as_usedptr; ++i) {
+		if (pattr->at_val.at_arst->as_string[i] == NULL)
+			continue;
+		for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+			if (psched == pobj) {
+				continue;
+			}
+			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
+			if (part_attr->at_flags & ATR_VFLAG_SET) {
+				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
+					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
+							&& (!strcmp(pattr->at_val.at_arst->as_string[i],
+									part_attr->at_val.at_arst->as_string[k])))
+						return PBSE_SCHED_PARTITION_ALREADY_EXISTS;
+				}
+			}
+		}
+	}
+	set_scheduler_flag(SCH_ATTRS_CONFIGURE, pin_sched);
+	return PBSE_NONE;
+}

--- a/src/server/setup_resc.c
+++ b/src/server/setup_resc.c
@@ -60,6 +60,7 @@
 #include "pbs_nodes.h"
 #include <sys/file.h>
 #include "libutil.h"
+#include "pbs_sched.h"
 
 extern char *msg_daemonname;
 #ifndef PBS_MOM
@@ -130,7 +131,7 @@ add_resource_def(char *name, int type, int perms)
 
 	}
 #ifndef PBS_MOM
-	set_scheduler_flag(SCH_CONFIGURE);
+	set_scheduler_flag(SCH_CONFIGURE, NULL);
 #endif
 
 	return 0;

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -467,7 +467,7 @@ chk_job_request(char *jobid, struct batch_request *preq, int *rc)
 		p2 = strchr(jobid, '.');
 		if (p2) 
 			*p2 = '\0';
-		strcat(jobid, p1);
+		strncat(jobid, p1, PBS_MAXSVRJOBID-1);
 	}
 
 	if (svr_authorize_jobreq(preq, pjob) == -1) {

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -191,11 +191,10 @@
 #include "pbs_db.h"
 #include "libutil.h"
 #include "pbs_ecl.h"
+#include "pbs_sched.h"
 
 extern struct python_interpreter_data  svr_interp_data;
 
-
-extern int    scheduler_sock;
 extern time_t time_now;
 extern char  *resc_in_err;
 extern char  *msg_daemonname;
@@ -315,7 +314,7 @@ encode_svrstate(attribute *pattr, pbs_list_head *phead, char *atname, char *rsna
 	if (pattr->at_val.at_long == SV_STATE_RUN) {
 		if (server.sv_attr[(int)SRV_ATR_scheduling].at_val.at_long == 0)
 			psname = svr_idle;
-		else if (scheduler_sock != -1)
+		else if (dflt_scheduler->scheduler_sock != -1)
 			psname = svr_sched;
 	}
 
@@ -799,12 +798,13 @@ set_rpp_highwater(attribute *pattr, void *pobj, int actmode)
  *		scheduler.   Done here because also need to invalidate the server
  *		state attribute cache.
  *
- * @param[in]	s	-	internal socket used to communicate with the scheduler
+ * @param[in] s		-	internal socket used to communicate with the scheduler
+ * @param[in] psched	-	pointer to sched object
  */
 void
-set_sched_sock(int s)
+set_sched_sock(int s, pbs_sched *psched)
 {
-	scheduler_sock = s;
+	psched->scheduler_sock = s;
 	server.sv_attr[(int)SRV_ATR_State].at_flags |= ATR_VFLAG_MODCACHE;
 }
 
@@ -926,6 +926,33 @@ ssignon_transition_okay(attribute *pattr, void *pobject, int actmode)
 
 	return (0);
 
+}
+
+/**
+ * @brief
+ * 		action_svr_iteration - the "action" routine for the server
+ *		scheduler_iteration attribute
+ * @param[in]	pattr	-	pointer to attribute structure
+ * @param[in]	pobject -	pointer to some parent object.
+ * @param[in]	actmode	-	the action to take (e.g. ATR_ACTION_ALTER)
+ *
+ * @return	int
+ * @retval	0	: success
+ * @retval	!0	: PBSE Error Code
+ */
+int
+action_svr_iteration(attribute *pattr, void *pobj, int mode)
+{
+	/* set this attribute on main scheduler */
+	if (dflt_scheduler) {
+		if (mode == ATR_ACTION_NEW || mode == ATR_ACTION_ALTER || mode == ATR_ACTION_RECOV) {
+			dflt_scheduler->sch_attr[SCHED_ATR_schediteration].at_val.at_long = pattr->at_val.at_long;
+			dflt_scheduler->sch_attr[SCHED_ATR_schediteration].at_flags |=
+					ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+			(void)sched_save_db(dflt_scheduler, SVR_SAVE_FULL);
+		}
+	}
+	return PBSE_NONE;
 }
 
 /**
@@ -1590,7 +1617,7 @@ eligibletime_action(attribute *pattr, void *pobject, int actmode)
 		/* if scheduling is true, need to run the scheduling cycle */
 		/* so that, accrue type is determined for cases */
 		if (server.sv_attr[SRV_ATR_scheduling].at_val.at_long)
-			set_scheduler_flag(SCH_SCHEDULE_ETE_ON);
+			set_scheduler_flag(SCH_SCHEDULE_ETE_ON, NULL);
 
 	}
 

--- a/src/server/svr_migrate_data.c
+++ b/src/server/svr_migrate_data.c
@@ -374,7 +374,7 @@ svr_migrate_data_from_fs(void)
 		(void) pbs_db_end_trx(svr_db_conn, PBS_DB_ROLLBACK);
 		return (-1);
 	}
-	set_sched_default(dflt_scheduler);
+	set_sched_default(dflt_scheduler, 0);
 	/* save current working dir before any chdirs */
 	if (getcwd(origdir, MAXPATHLEN) == NULL) {
 		fprintf(stderr, "getcwd failed\n");

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -102,6 +102,7 @@
 #include <memory.h>
 #include "server.h"
 #include "hook.h"
+#include "pbs_sched.h"
 
 
 #define	RETRY	3	/* number of times to retry network move */
@@ -142,7 +143,6 @@ extern unsigned int pbs_server_port_dis;
 extern int	resc_access_perm;
 extern time_t	time_now;
 extern int svr_create_tmp_jobscript(job *pj, char *script_name);
-extern int	scheduler_sock;
 extern int	scheduler_jobs_stat;
 extern	char	*path_hooks_workdir;
 extern struct work_task *add_mom_deferred_list(int stream, mominfo_t *minfo, void (*func)(), char *msgid, void *parm1, void *parm2);
@@ -320,7 +320,7 @@ local_move(job *jobp, struct batch_request *req)
 	 * had changes resulting from the move that would impact scheduling or
 	 * placement, add job to list of jobs which cannot be run in this cycle.
 	 */
-	if ((req == NULL || (req->rq_conn != scheduler_sock)) && (scheduler_jobs_stat))
+	if ((req == NULL || (find_sched_from_sock(req->rq_conn) == NULL)) && (scheduler_jobs_stat))
 		am_jobs_add(jobp);
 
 	return 0;

--- a/src/server/svr_recov_db.c
+++ b/src/server/svr_recov_db.c
@@ -435,6 +435,9 @@ sched_recov_db(void)
 	if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0)
 		goto db_err;
 
+	if (server.sv_attr[SRV_ATR_scheduling].at_val.at_long)
+		set_scheduler_flag(SCH_SCHEDULE_ETE_ON, NULL);
+
 	return 0;
 
 db_err:

--- a/src/server/w32_svr_periodic_hook.c
+++ b/src/server/w32_svr_periodic_hook.c
@@ -139,8 +139,6 @@ long		new_log_event_mask = 0;
 int	 	server_init_type = RECOV_WARM;
 char	        server_name[PBS_MAXSERVERNAME+1]; /* host_name[:service|port] */
 int		svr_delay_entry = 0;
-int		svr_do_schedule = SCH_SCHEDULE_NULL;
-int		svr_do_sched_high = SCH_SCHEDULE_NULL;
 int		svr_total_cpus = 0;		/* total number of cpus on nodes   */
 int		have_blue_gene_nodes = 0;
 int		svr_ping_rate = SVR_DEFAULT_PING_RATE;	/* time between sets of node pings */

--- a/src/start_provision_win/w32_start_provision.c
+++ b/src/start_provision_win/w32_start_provision.c
@@ -141,8 +141,6 @@ long		new_log_event_mask = 0;
 int	 	server_init_type = RECOV_WARM;
 char	        server_name[PBS_MAXSERVERNAME+1]; /* host_name[:service|port] */
 int		svr_delay_entry = 0;
-int		svr_do_schedule = SCH_SCHEDULE_NULL;
-int		svr_do_sched_high = SCH_SCHEDULE_NULL;
 int		svr_total_cpus = 0;		/* total number of cpus on nodes   */
 int		have_blue_gene_nodes = 0;
 int		svr_ping_rate = SVR_DEFAULT_PING_RATE;	/* time between sets of node pings */

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -97,6 +97,7 @@
 #include "libutil.h"
 #include "cmds.h"
 #include "svrfunc.h"
+#include "pbs_sched.h"
 
 #define PBS_PYTHON 1.1
 #define MAXBUF	4096
@@ -175,7 +176,7 @@ set_resources_min_max(attribute *old, attribute *new, enum batch_op op)
 }
 
 void
-set_scheduler_flag(int flag)
+set_scheduler_flag(int flag, pbs_sched *psched)
 {
 	return;
 }
@@ -399,6 +400,12 @@ int
 deflt_chunk_action(attribute *pattr, void *pobj, int mode)
 {
 
+	return 0;
+}
+
+int
+action_svr_iteration(attribute *pattr, void *pobj, int mode)
+{
 	return 0;
 }
 

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -1,0 +1,581 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestMultipleSchedulers(TestFunctional):
+
+    """
+    Test suite to test different scheduler interfaces
+    """
+
+    def setup_sc1(self):
+        a = {'partition': 'P1,P4',
+             'sched_host': self.server.hostname,
+             'sched_port': '15050'}
+        self.server.manager(MGR_CMD_CREATE, SCHED,
+                            a, id="sc1")
+        self.scheds['sc1'].create_scheduler()
+        self.scheds['sc1'].start()
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc1", expect=True)
+
+    def setup_sc2(self):
+        dir_path = '/var/spool/pbs/sched_dir'
+        if not os.path.exists(dir_path):
+            self.du.mkdir(path=dir_path, sudo=True)
+        a = {'partition': 'P2',
+             'sched_priv': os.path.join(dir_path, 'sched_priv_sc2'),
+             'sched_log': os.path.join(dir_path, 'sched_logs_sc2'),
+             'sched_host': self.server.hostname,
+             'sched_port': '15051'}
+        self.server.manager(MGR_CMD_CREATE, SCHED,
+                            a, id="sc2")
+        self.scheds['sc2'].create_scheduler(dir_path)
+        self.scheds['sc2'].start(dir_path)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc2", expect=True)
+
+    def setup_sc3(self):
+        a = {'partition': 'P3',
+             'sched_host': self.server.hostname,
+             'sched_port': '15052'}
+        self.server.manager(MGR_CMD_CREATE, SCHED,
+                            a, id="sc3")
+        self.scheds['sc3'].create_scheduler()
+        self.scheds['sc3'].start()
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc3", expect=True)
+
+    def setup_queues_nodes(self):
+        a = {'queue_type': 'execution',
+             'started': 'True',
+             'enabled': 'True'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq1')
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq2')
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq3')
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq4')
+        p1 = {'partition': 'P1'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq1', expect=True)
+        p2 = {'partition': 'P2'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p2, id='wq2', expect=True)
+        p3 = {'partition': 'P3'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p3, id='wq3', expect=True)
+        p4 = {'partition': 'P4'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p4, id='wq4', expect=True)
+        a = {'resources_available.ncpus': 2}
+        self.server.create_vnodes('vnode', a, 5, self.mom)
+        self.server.manager(MGR_CMD_SET, NODE, p1, id='vnode[0]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, p2, id='vnode[1]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, p3, id='vnode[2]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, p4, id='vnode[3]', expect=True)
+
+    def common_setup(self):
+        self.setup_sc1()
+        self.setup_sc2()
+        self.setup_sc3()
+        self.setup_queues_nodes()
+
+    def check_vnodes(self, j, vnodes, jid):
+        self.server.status(JOB, 'exec_vnode', id=jid)
+        nodes = j.get_vnodes(j.exec_vnode)
+        for vnode in vnodes:
+            if vnode not in nodes:
+                self.assertFalse(True, str(vnode) +
+                                 " is not in exec_vnode list as expected")
+
+    def test_set_sched_priv(self):
+        """
+        Test sched_priv can be only set to valid paths
+        and check for appropriate comments
+        """
+        self.setup_sc1()
+        if not os.path.exists('/var/sched_priv_do_not_exist'):
+            self.server.manager(MGR_CMD_SET, SCHED,
+                                {'sched_priv': '/var/sched_priv_do_not_exist'},
+                                id="sc1")
+        msg = 'PBS failed validation checks for sched_priv directory'
+        a = {'sched_priv': '/var/sched_priv_do_not_exist',
+             'comment': msg,
+             'scheduling': 'False'}
+        self.server.expect(SCHED, a, id='sc1', attrop=PTL_AND, max_attempts=10)
+        pbs_home = self.server.pbs_conf['PBS_HOME']
+        self.du.run_copy(self.server.hostname,
+                         os.path.join(pbs_home, 'sched_priv'),
+                         os.path.join(pbs_home, 'sc1_new_priv'),
+                         recursive=True)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'sched_priv': '/var/spool/pbs/sc1_new_priv'},
+                            id="sc1")
+        a = {'sched_priv': '/var/spool/pbs/sc1_new_priv'}
+        self.server.expect(SCHED, a, id='sc1', max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc1")
+        # Blocked by PP-1202 will revisit once its fixed
+        # self.server.expect(SCHED, 'comment', id='sc1', op=UNSET)
+
+    def test_set_sched_log(self):
+        """
+        Test sched_log can be only set to valid paths
+        and check for appropriate comments
+        """
+        self.setup_sc1()
+        if not os.path.exists('/var/sched_log_do_not_exist'):
+            self.server.manager(MGR_CMD_SET, SCHED,
+                                {'sched_log': '/var/sched_log_do_not_exist'},
+                                id="sc1")
+        a = {'sched_log': '/var/sched_log_do_not_exist',
+             'comment': 'Unable to change the sched_log directory',
+             'scheduling': 'False'}
+        self.server.expect(SCHED, a, id='sc1', max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc1")
+        pbs_home = self.server.pbs_conf['PBS_HOME']
+        self.du.mkdir(path=os.path.join(pbs_home, 'sc1_new_logs'),
+                      sudo=True)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'sched_log': '/var/spool/pbs/sc1_new_logs'},
+                            id="sc1")
+        a = {'sched_log': '/var/spool/pbs/sc1_new_logs'}
+        self.server.expect(SCHED, a, id='sc1', max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc1")
+        # Blocked by PP-1202 will revisit once its fixed
+        # self.server.expect(SCHED, 'comment', id='sc1', op=UNSET)
+
+    def test_start_scheduler(self):
+        """
+        Test that scheduler wont start without appropriate folders created.
+        Scheduler will log a message if started without partition. Test
+        scheduler states down, idle, scheduling.
+        """
+        self.setup_queues_nodes()
+        pbs_home = self.server.pbs_conf['PBS_HOME']
+        self.server.manager(MGR_CMD_CREATE, SCHED,
+                            id="sc5")
+        a = {'sched_host': self.server.hostname,
+             'sched_port': '15055',
+             'scheduling': 'True'}
+        self.server.manager(MGR_CMD_SET, SCHED, a, id="sc5")
+        # Try starting without sched_priv and sched_logs
+        ret = self.scheds['sc5'].start()
+        self.server.expect(SCHED, {'state': 'down'}, id='sc5', max_attempts=10)
+        msg = "sched_priv dir is not present for scheduler"
+        self.assertTrue(ret['rc'], msg)
+        self.du.run_copy(self.server.hostname,
+                         os.path.join(pbs_home, 'sched_priv'),
+                         os.path.join(pbs_home, 'sched_priv_sc5'),
+                         recursive=True)
+        ret = self.scheds['sc5'].start()
+        msg = "sched_logs dir is not present for scheduler"
+        self.assertTrue(ret['rc'], msg)
+        self.du.run_copy(self.server.hostname,
+                         os.path.join(pbs_home, 'sched_logs'),
+                         os.path.join(pbs_home, 'sched_logs_sc5'),
+                         recursive=True)
+        ret = self.scheds['sc5'].start()
+        self.scheds['sc5'].log_match(
+            "Scheduler does not contain a partition",
+            max_attempts=10, starttime=self.server.ctime)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'partition': 'P3'}, id="sc5")
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'Scheduling': 'True'}, id="sc5")
+        self.server.expect(SCHED, {'state': 'idle'}, id='sc5', max_attempts=10)
+        a = {'resources_available.ncpus': 100}
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[2]', expect=True)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'False'}, id="sc5")
+        for _ in xrange(500):
+            j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3'})
+            self.server.submit(j)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc5")
+        self.server.expect(SCHED, {'state': 'scheduling'},
+                           id='sc5', max_attempts=10)
+
+    def test_resource_sched_reconfigure(self):
+        """
+        Test all schedulers will reconfigure while creating,
+        setting or deleting a resource
+        """
+        self.common_setup()
+        t = int(time.time())
+        self.server.manager(MGR_CMD_CREATE, RSC, id='foo')
+        for name in self.scheds:
+            self.scheds[name].log_match(
+                "Scheduler is reconfiguring",
+                max_attempts=10, starttime=t)
+        # sleeping to make sure we are not checking for the
+        # same scheduler reconfiguring message again
+        time.sleep(1)
+        t = int(time.time())
+        attr = {ATTR_RESC_TYPE: 'long'}
+        self.server.manager(MGR_CMD_SET, RSC, attr, id='foo')
+        for name in self.scheds:
+            self.scheds[name].log_match(
+                "Scheduler is reconfiguring",
+                max_attempts=10, starttime=t)
+        # sleeping to make sure we are not checking for the
+        # same scheduler reconfiguring message again
+        time.sleep(1)
+        t = int(time.time())
+        self.server.manager(MGR_CMD_DELETE, RSC, id='foo')
+        for name in self.scheds:
+            self.scheds[name].log_match(
+                "Scheduler is reconfiguring",
+                max_attempts=10, starttime=t)
+
+    def test_remove_partition_sched(self):
+        """
+        Test that removing all the partitions from a scheduler
+        unsets partition attribute on scheduler and update scheduler logs.
+        """
+        self.setup_sc1()
+        # self.setup_sc2()
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'partition': (DECR, 'P1')}, id="sc1")
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'partition': (DECR, 'P4')}, id="sc1")
+        log_msg = "Scheduler does not contain a partition"
+        self.scheds['sc1'].log_match(log_msg, max_attempts=10,
+                                     starttime=self.server.ctime)
+        # Blocked by PP-1202 will revisit once its fixed
+        # self.server.manager(MGR_CMD_UNSET, SCHED, 'partition',
+        #                    id="sc2", expect=True)
+
+    def test_job_queue_partition(self):
+        """
+        Test job submitted to a queue associated to a partition will land
+        into a node associated with that partition.
+        """
+        self.common_setup()
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.check_vnodes(j, ['vnode[0]'], jid)
+        self.scheds['sc1'].log_match(
+            jid + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq2',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.check_vnodes(j, ['vnode[1]'], jid)
+        self.scheds['sc2'].log_match(
+            jid + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.check_vnodes(j, ['vnode[2]'], jid)
+        self.scheds['sc3'].log_match(
+            jid + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+
+    def test_multiple_partition_same_sched(self):
+        """
+        Test that scheduler will serve the jobs from different
+        partition and run on nodes assigned to respective partitions.
+        """
+        self.setup_sc1()
+        self.setup_queues_nodes()
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        self.check_vnodes(j, ['vnode[0]'], jid1)
+        self.scheds['sc1'].log_match(
+            jid1 + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.check_vnodes(j, ['vnode[3]'], jid2)
+        self.scheds['sc1'].log_match(
+            jid2 + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.check_vnodes(j, ['vnode[0]'], jid3)
+        self.scheds['sc1'].log_match(
+            jid3 + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+
+    def test_multiple_queue_same_partition(self):
+        """
+        Test multiple queue associated with same partition
+        is serviced by same scheduler
+        """
+        self.setup_sc1()
+        self.setup_queues_nodes()
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.check_vnodes(j, ['vnode[0]'], jid)
+        self.scheds['sc1'].log_match(
+            jid + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+        p1 = {'partition': 'P1'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq4')
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.check_vnodes(j, ['vnode[0]'], jid)
+        self.scheds['sc1'].log_match(
+            jid + ';Job run', max_attempts=10,
+            starttime=self.server.ctime)
+
+    def test_preemption_highp_queue(self):
+        """
+        Test preemption occures only within queues
+        which are assigned to same partition
+        """
+        self.common_setup()
+        prio = {'Priority': 150, 'partition': 'P1'}
+        self.server.manager(MGR_CMD_SET, QUEUE, prio, id='wq4')
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        t = int(time.time())
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid5 = self.server.submit(j)
+        self.server.expect(JOB, ATTR_comment, op=SET, id=jid5)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid5)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        self.server.schedulers['sc1'].log_match(
+            jid1 + ';Job preempted by suspension',
+            max_attempts=10, starttime=t)
+
+    def test_backfill_per_scheduler(self):
+        """
+        Test backfilling is applicable only per scheduler
+        """
+        self.common_setup()
+        t = int(time.time())
+        self.scheds['sc2'].set_sched_config(
+            {'strict_ordering': 'True ALL'})
+        a = {ATTR_queue: 'wq2',
+             'Resource_List.select': '1:ncpus=2',
+             'Resource_List.walltime': 60}
+        j = Job(TEST_USER1, attrs=a)
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        j = Job(TEST_USER1, attrs=a)
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+        self.scheds['sc2'].log_match(
+            jid2 + ';Job is a top job and will run at',
+            max_attempts=10, starttime=t)
+        a['queue'] = 'wq3'
+        j = Job(TEST_USER1, attrs=a)
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        j = Job(TEST_USER1, attrs=a)
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
+        self.scheds['sc3'].log_match(
+            jid4 + ';Job is a top job and will run at',
+            max_attempts=5, starttime=t, existence=False)
+
+    def test_resource_per_scheduler(self):
+        """
+        Test resources will be considered only by scheduler
+        to which resource is added in sched_config
+        """
+        self.common_setup()
+        a = {'type': 'float', 'flag': 'nh'}
+        self.server.manager(MGR_CMD_CREATE, RSC, a, id='gpus')
+        self.scheds['sc3'].add_resource("gpus")
+        a = {'resources_available.gpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id='@default', expect=True)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:gpus=2',
+                                   'Resource_List.walltime': 60})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:gpus=2',
+                                   'Resource_List.walltime': 60})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+        job_comment = "Not Running: Insufficient amount of resource: "
+        job_comment += "gpus (R: 2 A: 0 T: 2)"
+        self.server.expect(JOB, {'comment': job_comment}, id=jid2)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq2',
+                                   'Resource_List.select': '1:gpus=2'})
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq2',
+                                   'Resource_List.select': '1:gpus=2'})
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
+
+    def test_restart_server(self):
+        """
+        Test after server restarts sched attributes are persistent
+        """
+        self.setup_sc1()
+        sched_priv = os.path.join(
+            self.server.pbs_conf['PBS_HOME'], 'sched_priv_sc1')
+        sched_logs = os.path.join(
+            self.server.pbs_conf['PBS_HOME'], 'sched_logs_sc1')
+        a = {'sched_port': 15050,
+             'sched_host': self.server.hostname,
+             'sched_priv': sched_priv,
+             'sched_log': sched_logs,
+             'scheduling': 'True',
+             'scheduler_iteration': 600,
+             'state': 'idle',
+             'sched_cycle_length': '00:20:00'}
+        self.server.expect(SCHED, a, id='sc1',
+                           attrop=PTL_AND, max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduler_iteration': 300,
+                             'sched_cycle_length': '00:10:00'},
+                            id='sc1')
+        self.server.restart()
+        a['scheduler_iteration'] = 300
+        a['sched_cycle_length'] = '00:10:00'
+        self.server.expect(SCHED, a, id='sc1',
+                           attrop=PTL_AND, max_attempts=10)
+
+    def test_resv_default_sched(self):
+        """
+        Test reservations will only go to defualt scheduler
+        """
+        self.setup_queues_nodes()
+        t = int(time.time())
+        r = Reservation(TEST_USER)
+        a = {'Resource_List.select': '2:ncpus=1'}
+        r.set_attributes(a)
+        rid = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, rid)
+        self.scheds['default'].log_match(
+            rid + ';Reservation Confirmed',
+            max_attempts=10, starttime=t)
+
+    def test_job_sorted_per_scheduler(self):
+        """
+        Test jobs are sorted as per job_sort_formula
+        inside each scheduler
+        """
+        self.common_setup()
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'job_sort_formula': 'ncpus'})
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'False'}, id="default")
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=1'})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=2'})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="default")
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'False'}, id="sc3")
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid3)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc3")
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
+
+    def test_qrun_job(self):
+        """
+        Test jobs can be run by qrun by a newly created scheduler.
+        """
+        self.setup_sc1()
+        self.setup_queues_nodes()
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'False'}, id="sc1")
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
+                                   'Resource_List.select': '1:ncpus=2'})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
+        self.server.runjob(jid1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+
+    def test_run_limts_per_scheduler(self):
+        """
+        Test run_limits applied at server level is
+        applied for every scheduler seperately.
+        """
+        self.common_setup()
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'max_run': '[u:PBS_GENERIC=1]'})
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=1'})
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=1'})
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+        j = Job(TEST_USER1, attrs={'Resource_List.select': '1:ncpus=1'})
+        jc = "Not Running: User has reached server running job limit."
+        self.server.expect(JOB, {'comment': jc}, id=jid2)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
+                                   'Resource_List.select': '1:ncpus=1'})
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
+        jc = "Not Running: User has reached server running job limit."
+        self.server.expect(JOB, {'comment': jc}, id=jid4)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
This ticket is one of the major user-stories of the following EPIC.
[PP-337](https://pbspro.atlassian.net/browse/PP-337) Multiple schedulers servicing the PBS cluster

The current user-story actually implements major interface for the MultiSched feature. After this we can actually run multiple instances of scheduler each serving a set of partitions in parallel which actually accomplishes the following goal.

As clusters get larger and workloads vary it is becoming critical that the jobs get evaluated in as short as time possible to ensure that the correct workload is being run. Using multiple schedulers to address this issue can allow for different scheduling policies and quicker turnaround time for large number of jobs or nodes.

#### Affected Platform(s) and PBS Version
* *All Platforms*

#### Cause / Analysis / Design / Solution Description
Nodes and Queues in PBS now have a special attribute called partition. This can be useful in combining or grouping a set of nodes and queues together.
For example we can set partition attribute on nodes and queues as follows.

qmgr -c "set node n1 partition=p1"
qmgr -c "set node n2 partition=p1"
qmgr -c "set queue q1 partition = p1"
Here we grouped n1,n2 and q1 under partition p1. Similarly we can come up with multiple partitions as per our requirements. Let us say we have one more partition p2 which groups nodes n3,n4,n5 and q2.

A scheduler other than the default scheduler can be associated to one or more partitions as given in the following example.
qmgr -c "set sched sc1 partition=p1"
To associate more than one partition,
qmgr -c "set sched sc1 partition += p2"

Now the scheduler sc1 can serve two partitions p1 and p2.

An important note here is we should configure the scheduler first in the server then only it can be started. If a server does not know a scheduler id then server rejects it and that scheduler won't come up.

If we try to start a scheduler which is not associated with at least one partition then the following error is thrown while it is coming up.
"Scheduler should contain at least single partition"
Scheduler will only come up only if it is fully configured at the server.

Once the scheduler comes up successfully it is ready to serve partitions p1, p2 in this case. All the scheduler features should work as expected. Some of them are as follows

We can submit jobs to q1 which are handled by sc1 scheduler in this case.
Example: qsub -q q1 -- /bin/sleep 100
This job should be served by sc1 and we can observe the same in the log file in sched_logs_sc1
directory. We can also observe the same in pbsnodes -av output i.e. this job should only go to one of
the nodes that is part of the partition p1.
qrun of a job submitted to the above queue or partition should work.
suspend/resume functionality should work.
Array jobs can also be submitted and its functionality should work.
One can create resources of various types and each scheduler should work as expected and schedule
using these resources.
Reservations until we implement next interface will now only be served by default scheduler.
Have done all the code changes in such a way that backward compatibility with the default scheduler is
maintained.
server's scheduler_iteration and scheduling attributes are still kept even though we have these
attributes for the scheduler object also. This is done to ensure the backward compatibility. If anybody
sets these attributes at one object then they are automatically reflected in another object.
Certain operations like changing the scheduler port and sched_priv directory etc are not allowed on
default scheduler to maintain the backward compatibility.
Dynamically one can associate multiple partitions to the scheduler. We no need to restart or SIGHUP
the corresponding scheduler.
Dynamically one can dissociate a partition from the scheduler.
One can change sched_priv/sched_log directory dynamically without restarting or SIGHUPing the
scheduler.
If a partition is associated with one scheduler then it can not be associated to any other scheduler.
Scheduler at any point in time if it fails in accepting the new configuration then it switches back to its
old configuration.
All operations for queues that are having no partitions should be served by default scheduler.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
