### PR TITLE
PP-1210: Expect function should validate server_state when scheduling is turned off

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6655,6 +6655,7 @@ class Server(PBSService):
 
         if expect:
             offset = None
+            attrop = PTL_OR
             if obj_type in (NODE, HOST):
                 obj_type = VNODE
             if obj_type in (VNODE, QUEUE):
@@ -6664,12 +6665,22 @@ class Server(PBSService):
             else:
                 op = EQ
 
+            # If scheduling is set to false then check for
+            # 'server_state' to be 'Idle'
+            if attrib and isinstance(attrib,
+                                     dict) and 'scheduling' in attrib.keys():
+                if str(attrib['scheduling']) in PTL_FALSE:
+                    attrib['server_state'] = 'Idle'
+                    attrop = PTL_AND
+
             if oid is None:
                 return self.expect(obj_type, attrib, oid, op=op,
-                                   max_attempts=max_attempts, offset=offset)
+                                   max_attempts=max_attempts,
+                                   attrop=attrop, offset=offset)
             for i in oid:
                 rc = self.expect(obj_type, attrib, i, op=op,
-                                 max_attempts=max_attempts, offset=offset)
+                                 max_attempts=max_attempts,
+                                 attrop=attrop, offset=offset)
                 if not rc:
                     break
         return rc


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

Issue ID:

- **[PP-1210](https://pbspro.atlassian.net/browse/PP-1210)**

#### Affected Platform(s) and PBS Version
* Platform: All
* version where observed: 18.0

#### Cause / Analysis / Design

- if a job is submitted after scheduling is turned off, there are chances that the job might get considered for the running scheduling cycle. 

#### Solution Description
* In order to handle the above mentioned race condition, PTL needs to Validate 'server_state' to be 'Idle' whenever scheduling is turned off along with verifying the scheduling attribute in qstat -Bf command

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
