### PR TITLE
Make the ALPS reservation_mode default to none instead of SHARED

### DIFF
--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -5304,9 +5304,15 @@ alps_create_reserve_request(job *pjob, basil_request_reserve_t **req)
 		/*
 		 * If the user requested place=excl then we need to pass
 		 * that information into the ALPS reservation.
-		 * If not exclusive set it to shared by default
 		 */
-		p->rsvn_mode = (rpv == rlplace_excl)?basil_rsvn_mode_exclusive:basil_rsvn_mode_shared;
+		p->rsvn_mode = basil_rsvn_mode_none;	/* initialize it */
+		if (rpv == rlplace_excl) {
+			/*
+			 * The user asked for the node exclusively.
+			 * Set it in the ALPS reservation.
+			 */
+			p->rsvn_mode = basil_rsvn_mode_exclusive;
+		}
 		if (ns->ncpus != ns->threads) {
 			sprintf(log_buffer, "ompthreads %ld does not match"
 				" ncpus %ld", ns->threads, ns->ncpus);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Cray requested that ALPS reservation_mode not be set to SHARED when making an ALPS reservation request, as undefined behavior may occur under some Cray configuration conditions.  Cray instead requested that no reservation_mode be provided by default.  Please note, this change does not affect the situations under which an ALPS reservation_mode is set to EXCLUSIVE.

The mom_logs without these code changes would have an ALPS XML reservation request that looks something like this with reservation_mode=SHARED:
```
<?xml version="1.0"?>
<BasilRequest protocol="1.4" method="RESERVE">
 <ReserveParamArray user_name="crayadm" batch_id="1.sdb">
  <ReserveParam architecture="XT" width="1" reservation_mode="SHARED" depth="16" nppn="1">
   <NodeParamArray>
    <NodeParam>16</NodeParam>
   </NodeParamArray>
  </ReserveParam>
 </ReserveParamArray>
</BasilRequest>
```
But with the changes the mom_log would instead look like this:
```
<?xml version="1.0"?>
<BasilRequest protocol="1.4" method="RESERVE">
 <ReserveParamArray user_name="crayadm" batch_id="1.sdb">
  <ReserveParam architecture="XT" width="1" depth="16" nppn="1">
   <NodeParamArray>
    <NodeParam>16</NodeParam>
   </NodeParamArray>
  </ReserveParam>
 </ReserveParamArray>
</BasilRequest>
```

#### Affected Platform(s) and PBS Version
* *Platform Cray X* series*
* *Bugs: version where observed 18.1.0*

#### Solution Description
* By default, reservation_mode in an ALPS reservation request is not set.

NOTE: I did not write an automated test because it will not have recurring value.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__