### PR TITLE
PP-1209: Incorrect termination of buffer

### DIFF
--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -1318,8 +1318,7 @@ initialize(void)
 			exclhost = vnode_sharing_to_str(shareval);
 
 		/* search for host */
-		strncpy(rp->key, host, PBS_MAXHOSTNAME);
-		xxrp.buf[PBS_MAXHOSTNAME + sizeof(AVL_IX_REC)] = '\0';
+		snprintf(rp->key, PBS_MAXHOSTNAME, "%s", host);
 
 		/* look to see if host has a sharing value saved */
 		avl = avl_find_key(rp, &ix);

--- a/src/server/vnparse.c
+++ b/src/server/vnparse.c
@@ -635,8 +635,7 @@ vn_addvnr(vnl_t *vnlp, char *id, char *attr, char *attrval,
 	}
 
 	/* the index was created with string keys */
-	strncpy(rp->key, id, PBS_MAXHOSTNAME);
-	xxrp.buf[PBS_MAXHOSTNAME + sizeof(AVL_IX_REC)] = '\0';
+	snprintf(rp->key, PBS_MAXHOSTNAME, "%s", id);
 	if ((vnrlp = id2vnrl(vnlp, id, rp)) == NULL) {
 		if ((newid = strdup(id)) == NULL) {
 			free(newval);
@@ -716,9 +715,7 @@ id2vnrl(vnl_t *vnlp, char *id, AVL_IX_REC *rp)
 
 	if (rp == NULL) {
 		rp = &xxrp.xrp;
-
-		strncpy(rp->key, id, PBS_MAXHOSTNAME);
-		xxrp.buf[PBS_MAXHOSTNAME + sizeof(AVL_IX_REC)] = '\0';
+		snprintf(rp->key, PBS_MAXHOSTNAME, "%s", id);
 	}
 
 	if (avl_find_key(rp, &vnlp->vnl_ix) == AVL_IX_OK) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* [PP-1209](https://pbspro.atlassian.net/browse/PP-1209)
* When the compiler warnings were removed, some code was modified relating to AVL trees. After the code was merged, it was noted that the buffer being used was terminated in the wrong place.

#### Affected Platform(s) and PBS Version
* All platforms are affected
* The problem was identified in the master branch, and has not made it to any tagged releases

#### Cause / Analysis / Design
* An error was introduced that terminated a buffer a few bytes after the place it should have. There was no data corruption, because the byte being changed was still within the allocated buffer. It only affects the corner case where a host name is exactly PBS_MAXHOSTNAME characters long.

#### Solution Description
* Use snprintf() rather than strncpy() to automatically terminate the buffer in the correct location.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
