### PR TITLE
PP-1164 On windows walltime is not see on qstat output or accounting log

### DIFF
--- a/src/resmom_win/start_exec.c
+++ b/src/resmom_win/start_exec.c
@@ -2483,6 +2483,7 @@ finish_exec(job *pjob)
 
 	/* start of walltime shouldn't account for task_save() by PBS */
 	pjob->ji_qs.ji_stime = time_now;
+	start_walltime(pjob);
 
 	rc = ResumeThread(pi.hThread);
 	if (rc == -1) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug Description
On windows, resources_used.walltime is not displayed in qstat output or accounting log.
* *JIRA issue: [PP-1164](https://pbspro.atlassian.net/browse/PP-1164)*

#### Affected Platform(s) and PBS Version
* *Platform: Windows
* *Bugs: 18.1.0

#### Cause / Analysis / Design
* update_walltime() returns early and does not create new resource entry
* start_walltime() is not called in resmom_win/start_exec.c

#### Solution Description
* moved `walltime_stamp == 0` condition check to correct place (after checking whether resources_used.walltime is present)
* call start_walltime() in start_exec.c

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
