### PR TITLE
PP-1155 Corrected log_match() message to have Mom's hostname rather than its shortname

### DIFF
--- a/test/tests/functional/pbs_cray_vnode_pool.py
+++ b/test/tests/functional/pbs_cray_vnode_pool.py
@@ -47,6 +47,8 @@ class TestVnodePool(TestFunctional):
     """
 
     def setUp(self):
+        if not self.du.get_platform().startswith('cray'):
+            self.skipTest("This test can only run on a cray")
         TestFunctional.setUp(self)
         if len(self.moms.values()) < 2:
             self.skipTest("Provide at least 2 moms while invoking test")
@@ -121,7 +123,7 @@ class TestVnodePool(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB, attrib=attr)
 
         self.server.log_match("Mom %s added to vnode_pool %s" %
-                              (self.hostB, '1'), max_attempts=5,
+                              (self.momB.hostname, '1'), max_attempts=5,
                               starttime=start_time)
 
         _msg = "Hello (no inventory required) from server"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* The test "test_two_moms_single_vnode_pool" in pbs_cray_vnode_pool.py fails due to a log_match error on MoM's FQDN.
* [PP-1155](https://pbspro.atlassian.net/browse/PP-1155)

#### Affected Platform(s) and PBS Version
* All Linux flavors
*  PBS 18.2.0

#### Cause / Analysis / Design
Server log prints MoM’s hostname when adding a MoM to a vnode_pool. But the log_match() message expects MoM's shortname. Hence the test fails.


#### Solution Description
Corrected log_match() message to have Mom's hostname rather than its shortname

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.

[pbs_cray_vnode_pool_fix_1.log](https://github.com/PBSPro/pbspro/files/1697313/pbs_cray_vnode_pool_fix_1.log)
[pbs_cray_vnode_pool_fix_2.log](https://github.com/PBSPro/pbspro/files/1697314/pbs_cray_vnode_pool_fix_2.log)
[pbs_cray_vnode_pool_fix_3.log](https://github.com/PBSPro/pbspro/files/1697315/pbs_cray_vnode_pool_fix_3.log)


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__