### PR TITLE
PP-1221: PBS Scheduler can crash if query_queue_info returns NULL

### DIFF
--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -314,6 +314,7 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 			}
 
 			qinfo_arr[qidx++] = qinfo;
+			qinfo_arr[qidx] = NULL;
 
 		} else
 			free_queue_info(qinfo);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Scheduler can crash if query_queue_info returns NULL by any chance.
[PP-1221](https://pbspro.atlassian.net/browse/PP-1221)

#### Affected Platform(s) and PBS Version
* All 
#### Cause / Analysis / Design
qinfo_arr is allocated properly but not initialized.

#### Solution Description
* Initialize each element of qinfo_arry to NULL before we go to the next iteration. This way we are sure that even if query_queue_info() returns NULL scheduler will not crash.
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
