### PR TITLE
Make PBS init script valgrind compatible and fix for temp file removal

### DIFF
--- a/src/cmds/scripts/Makefile.am
+++ b/src/cmds/scripts/Makefile.am
@@ -101,6 +101,7 @@ dist_sysconf_DATA = \
 	pbs_db_schema.sql
 
 CLEANFILES = \
+	pbs_init.d \
 	limits.pbs_mom \
 	limits.post_services
 

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -134,10 +134,8 @@ check_started() {
   fi
 
 # strip out everything except executable name
-  prog_name=`echo ${ps_out} | awk '{print $1}' | \
-	awk -F/ '{print $NF}' | awk '{print $1}'`
-
-  if [ "${prog_name}" = $2 ] ; then
+  prog_name=`echo ${ps_out} | grep -how "$2"`
+  if [ "x${prog_name}" = "x$2" ] ; then
     return 0;
   fi
 
@@ -840,6 +838,8 @@ conf=${PBS_CONF_FILE:-/etc/pbs.conf}
 
 # re-apply saved env variables
 . "${env_save}"
+
+rm -f "${env_save}"
 
 if [ -z "${PBS_EXEC}" ] ; then
     echo "PBS_EXEC is undefined." >&2


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *PBS init script doesn't detect any running daemons if daemons are started under memory tool like valgrind*
* *PBS init script doesn't remove temp file after its job is done*
* *make clean doesn't remove generated pbs_init.d file under src/cmds/scripts directory*

#### Affected Platform(s)
* *All Linux*

#### Cause / Analysis / Design
* *In check_started() [here](https://github.com/PBSPro/pbspro/blob/master/src/cmds/scripts/pbs_init.d.in#L137) it always assumes that first part of ps output will be PBS daemon executable name but that's not true if PBS daemon is started under valgrind like tool*
* *PBS init script doesn't remove env_save file after its job is done*

#### Solution Description
* *Corrected command to find PBS daemon executable name in PBS init script*
* *Added rm command to remove env_save temp file once its job is done*
* *Added pbs_init.d under CLEANFILES rules in Makefile.am so that it gets clean during make clean*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
