### PR TITLE
PP-1108: Update PTL fw to keep data consistent between PTL and PBS

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6619,7 +6619,7 @@ class Server(PBSService):
                             break
                     if rc == 0:
                         rc = tmprc
-
+        bs_list = []
         if cmd == MGR_CMD_DELETE and oid is not None and rc == 0:
             for i in oid:
                 if obj_type == MGR_OBJ_HOOK and i in self.hooks:
@@ -6633,17 +6633,26 @@ class Server(PBSService):
                 if obj_type == SCHED and i in self.schedulers:
                     del self.schedulers[i]
 
-        bs_list = []
-        if cmd == MGR_CMD_SET:
-            if rc == 0 and id is not None:
+        elif cmd == MGR_CMD_SET and rc == 0 and id is not None:
+            if isinstance(id, list):
+                for name in id:
+                    tbsl = copy.deepcopy(attrib)
+                    tbsl['name'] = name
+                    bs_list.append(tbsl)
+                    self.update_attributes(obj_type, bs_list)
+            else:
                 tbsl = copy.deepcopy(attrib)
                 tbsl['id'] = id
                 bs_list.append(tbsl)
                 self.update_attributes(obj_type, bs_list)
 
-        if cmd == MGR_CMD_CREATE:
-            if rc == 0:
-                bsl = self.status(obj_type, attrib, id, extend)
+        elif cmd == MGR_CMD_CREATE and rc == 0:
+            if isinstance(id, list):
+                for name in id:
+                    bsl = self.status(obj_type, id=name, extend=extend)
+                    self.update_attributes(obj_type, bsl)
+            else:
+                bsl = self.status(obj_type, id=id, extend=extend)
                 self.update_attributes(obj_type, bsl)
 
         if rc != 0:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description

[PP-1108](https://pbspro.atlassian.net/browse/PP-1108)

#### Cause / Analysis / Design

Code added as part of PP-747 to maintain data consistency, Passes attrib to status call when qmgr create command is called .
The code does not handle the case multiple id's are passed to qmgr set or qmgr create command.


#### Solution Description
Removed passing of attrib to status call
If id is set of list then traverse through the list and update attributes if qmgr set and do a status call if qmgr create is called.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
