### PR TITLE
PP-1224 PBS Comm fails to open log file under valgrind

### DIFF
--- a/src/server/pbs_comm.c
+++ b/src/server/pbs_comm.c
@@ -576,14 +576,11 @@ set_limits()
 	{
 		struct rlimit64 rlimit;
 
-		rlimit.rlim_cur = TPP_MAXOPENFD; 
+		rlimit.rlim_cur = TPP_MAXOPENFD;
 		rlimit.rlim_max = TPP_MAXOPENFD;
 
-		if (setrlimit64(RLIMIT_NOFILE, &rlimit) == -1){
-			sprintf(log_buffer, "Could not set max open files limit");
-			log_err(errno, __func__, log_buffer);
-			sprintf(log_buffer, "%s errno=%d", log_buffer, errno);
-			log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
+		if (setrlimit64(RLIMIT_NOFILE, &rlimit) == -1) {
+			log_err(errno, __func__, "could not set max open files limit");
 		}
 
 		rlimit.rlim_cur = RLIM64_INFINITY;
@@ -622,24 +619,20 @@ set_limits()
 #ifndef WIN32
 	{
 		struct rlimit rlimit;
-		int curerror;
 
-		rlimit.rlim_cur = TPP_MAXOPENFD; 
+		rlimit.rlim_cur = TPP_MAXOPENFD;
 		rlimit.rlim_max = TPP_MAXOPENFD;
-		if (setrlimit(RLIMIT_NOFILE, &rlimit) == -1){
-			sprintf(log_buffer, "Could not set max open files limit");
-			log_err(errno, __func__, log_buffer);
-			sprintf(log_buffer, "%s errno=%d", log_buffer, errno);
-			log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
+		if (setrlimit(RLIMIT_NOFILE, &rlimit) == -1) {
+			log_err(errno, __func__, "could not set max open files limit");
 		}
 		rlimit.rlim_cur = RLIM_INFINITY;
 		rlimit.rlim_max = RLIM_INFINITY;
-		(void)setrlimit(RLIMIT_CPU,   &rlimit);
+		(void)setrlimit(RLIMIT_CPU, &rlimit);
 #ifdef	RLIMIT_RSS
-		(void)setrlimit(RLIMIT_RSS  , &rlimit);
+		(void)setrlimit(RLIMIT_RSS, &rlimit);
 #endif	/* RLIMIT_RSS */
 #ifdef	RLIMIT_VMEM
-		(void)setrlimit(RLIMIT_VMEM  , &rlimit);
+		(void)setrlimit(RLIMIT_VMEM, &rlimit);
 #endif	/* RLIMIT_VMEM */
 #ifdef	RLIMIT_CORE
 		if (pbs_conf.pbs_core_limit) {
@@ -672,20 +665,12 @@ set_limits()
 				rlimit.rlim_cur = MIN_STACK_LIMIT;
 				rlimit.rlim_max = MIN_STACK_LIMIT;
 				if (setrlimit(RLIMIT_STACK, &rlimit) == -1) {
-					curerror = errno;
-					sprintf(log_buffer, "Stack limit setting failed");
-					log_err(curerror, __func__, log_buffer);
-					sprintf(log_buffer, "%s errno=%d", log_buffer, curerror);
-					log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
+					log_err(errno, __func__, "setting stack limit failed");
 					exit(1);
 				}
 			}
 		} else {
-			curerror = errno;
-			sprintf(log_buffer, "Getting current Stack limit failed");
-			log_err(curerror, __func__, log_buffer);
-			sprintf(log_buffer, "%s errno=%d", log_buffer, curerror);
-			log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_SERVER, LOG_ERR, (char *)__func__, log_buffer);
+			log_err(errno, __func__, "getting current stack limit failed");
 			exit(1);
 		}
 #endif  /* not linux */
@@ -912,9 +897,6 @@ main(int argc, char **argv)
 	(void)setgroups(1, (gid_t *)&i);	/* secure suppl. groups */
 #endif
 
-	/* set pbs_comm's process limits */
-	set_limits();
-
 	log_event_mask = &pbs_conf.pbs_comm_log_events;
 	tpp_set_logmask(*log_event_mask);
 
@@ -1000,10 +982,11 @@ main(int argc, char **argv)
 		return 1;
 	}
 
-
-
 	(void) snprintf(path_log, sizeof(path_log), "%s/%s", pbs_conf.pbs_home_path, PBS_COMM_LOGDIR);
 	(void) log_open(log_file, path_log);
+
+	/* set pbs_comm's process limits */
+	set_limits(); /* set_limits can call log_record, so call only after opening log file */
 
 	/* set tcp function pointers */
 	set_tpp_funcs(log_tppmsg);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
The function setrlimits is called before opening the log file in pbs_comm. setrlimits calls log_err() which results in opening the log file to stdout, which never gets closed and thus no log file is created. Besides, there was code sprinting log_buffer to itself, resulting in valgrind catching that as a source and destination overlap. [PP-1224](https://pbspro.atlassian.net/browse/PP-1224)*

#### Affected Platform(s)
* All Linux

#### Solution Description
Moved the setrlimits call to after the log file is opened. Besides, fixed the setrlimit function to not use overalapped sprintf.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
