### PR TITLE
fixing sched_config errors for pbs_conf_resv_stale_vnode test

### DIFF
--- a/test/tests/functional/pbs_conf_resv_stale_vnode.py
+++ b/test/tests/functional/pbs_conf_resv_stale_vnode.py
@@ -62,7 +62,7 @@ class TestResvStaleVnode(TestFunctional):
                                   additive=True, mom=self.mom, expect=False)
 
         self.scheduler.set_sched_config({'node_sort_key':
-                                        'sort_priority HIGH'})
+                                        '\"sort_priority HIGH\"'})
 
     def test_conf_resv_stale_vnode(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *Bugs: some platform like Centos7 not take values without double quotes, for example, node_sort_key: sort_priority HIGH throws error* 
* *Bugs:This issue is observed on some platforms only like centos7, RHEL7.*

#### Affected Platform(s)
* *Platform: Centos7 and RHEL7*

#### Cause / Analysis / Design
* *Bugs: Test pbs_conf_resv_stale_vnode was failing at setUp due to error in reading sched_config file. on some platform following is not acceptable
node_sort_key: sort_priority HIGH 
but following is which is the documented way
node_sort_key: "sort_priority HIGH"*

#### Solution Description
* *Added double quotes around the values of sched_config attribute node_sort_key as documented in the examples.*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
