### PR TITLE
Scheduler errors out if server_dyn_res script returns unexpected value

### DIFF
--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -709,7 +709,11 @@ query_server_dyn_res(server_info *sinfo)
 				}
 
 				if (set_resource(res, buf, RF_AVAIL) == 0) {
-					return -1;
+					snprintf(buf, sizeof(buf), "Script %s returned bad output",
+							conf.dynamic_res[i].program);
+					schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
+										"server_dyn_res", buf);
+					(void) set_resource(res, res_zero, RF_AVAIL);
 				}
 			}
 			else {

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -1,0 +1,90 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+from ptl.lib.pbs_ifl_mock import *
+
+
+class TestServerDynRes(TestFunctional):
+    def test_invalid_script_out(self):
+        """
+        Test that the scheduler handles incorrect output from server_dyn_res
+        script correctly
+        """
+        # Create a server_dyn_res of type long
+        attr = {"type": "long"}
+        resname = "mybadres"
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id=resname, expect=True)
+
+        # Add it as a server_dyn_res that returns a string output
+        script_body = "echo abc"
+        filename = "badoutfile"
+        tmpfilepath = os.path.join(os.sep, "tmp", filename)
+        with open(tmpfilepath, "w") as fd:
+            fd.write(script_body)
+        self.scheduler.add_server_dyn_res(resname, file=tmpfilepath)
+
+        # Add it to the scheduler's 'resources' line
+        self.scheduler.add_resource(resname)
+
+        # Submit a job
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+
+        # Make sure that "Problem with creating server data structure"
+        # is not logged in sched_logs
+        self.scheduler.log_match("Problem with creating server data structure",
+                                 existence=False, max_attempts=10)
+
+        # Also check that "Script %s returned bad output"
+        # is logged
+        self.scheduler.log_match("%s returned bad output" % (filename))
+
+        # The scheduler uses 0 as the available amount of the dynamic resource
+        # if the server_dyn_res script output is bad
+        # So, submit a job that requests 1 of the resource
+        attr = {"Resource_List." + resname: 1}
+        j = Job(TEST_USER, attrs=attr)
+        jid = self.server.submit(j)
+
+        # The job shouldn't run
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+
+        # Check for the expected log message for insufficient resources
+        self.scheduler.log_match(
+            "Insufficient amount of server resource: %s (R: 1 A: 0 T: 0)"
+            % (resname))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Scheduler fails to run any jobs if there's a server_dyn_res script which returns bad output
* sched logs show the error "Problem with creating server data structure".
* This can be reproduced by creating a server_dyn_res script which returns a string value for a long type resource.

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* query_server_dyn_res() bails if set_resource() fails. Post the check-in of #192, set_resource() was enhanced to do error checking for the resources being set. So, for example, if a long type resource is being set to a string value, the function will catch it and error out. So, it errors out if the server_dyn_res script returns bad output for a resource, and query_server_dyn_res() just bails, causing any job in the system, regardless of whether they requested this resource or not, to fail.


#### Solution Description
* query_server_dyn_res() should handle the case of bad server_dyn_res script output in the same way that it handles not being able to open the script or reading its contents, which is that it sets the value of the resource to 0 and moves on. This will mean that any job that requests it will fail, which is fine as the server_dyn_res script is messed up, but the jobs which don't deal with it at all work just fine.

#### Testing:
- [Before fix](https://github.com/PBSPro/pbspro/files/1742632/failed.log)
- [After fix](https://github.com/PBSPro/pbspro/files/1742633/passed.log)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
