### PR TITLE
Fix for equiv classes not working with limited resources not in resou…

### DIFF
--- a/src/include/limits_if.h
+++ b/src/include/limits_if.h
@@ -147,8 +147,7 @@ extern int	is_oldlimattr(const struct attrl *);
  * @retval NULL		: attribute value is not an old limit attribute
  *
  */
-char *
-convert_oldlim_to_new(const struct attrl *a);
+extern char *	convert_oldlim_to_new(const struct attrl *a);
 
 /**	@fn int lim_setlimits(const struct attrl *a, enum limtype lt, void *p)
  *	@brief set resource or run-time limits
@@ -215,7 +214,17 @@ extern int	check_soft_limits(server_info *, queue_info *, resource_resv *);
  *             resource definitions are updated.
  *      @return void
  */
-extern void clear_limres(void);
+extern void 	clear_limres(void);
+
+/**
+ * 	@fn schd_resource query_limres()
+ * 	@brief returns a linked list of resources being limited.
+ * 	@par This is to be treated as read-only.  Modifying this will adversely
+ * 	     affect the limits code
+ *
+ * 	@return schd_resource *
+ */
+extern schd_resource *query_limres(void);
 
 
 #ifdef	__cplusplus

--- a/src/scheduler/limits.c
+++ b/src/scheduler/limits.c
@@ -2900,10 +2900,11 @@ lim_setreslimits(const struct attrl *a, void *ctx)
 		return (1);
 	}
 }
+
 /**
  * @brief
  * 		free and clear saved limit resources.  Must be called whenever
- *             resource definitions are updated.
+ *		resource definitions are updated.
  *
  * @return void
  */
@@ -2913,6 +2914,21 @@ clear_limres(void)
 	free_resource_list(limres);
 	limres = NULL;
 }
+
+/**
+ *      @brief returns a linked list of resources being limited.
+ *
+ *      @par This is to be treated as read-only.  Modifying this will adversely
+ *           affect the limits code
+ *
+ *      @return schd_resource *
+ */
+schd_resource *
+query_limres(void)
+{
+	return limres;
+}
+
 /**
  * @brief
  *		lim_setrunlimits	set new-style run limits

--- a/src/scheduler/resource.c
+++ b/src/scheduler/resource.c
@@ -90,6 +90,7 @@
 #include "limits_if.h"
 #include "sort.h"
 #include "parse.h"
+#include "limits_if.h"
 
 
 


### PR DESCRIPTION
…rces line

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Job's requesting limit resources could cause jobs not requesting those resources to not run if the resources were not on the sched_config resources line.
#### Affected Platform(s)
* All
#### Cause / Analysis / Design
* The scheduler only creates equivalence classes for jobs requesting resources on the sched_config resources line(and a few others).  If any limit was placed on a resource that was not on the resources line, an equivalence class would not be created for it.  This means a job requesting a limit resource could cause a job not requesting that limit resource to not run.
#### Solution Description
* The solution is to add the limit resources to the array of resources used to create equivalence classes.  The limits code already keeps track of all resources that are being limited.  This is stored in a static global to the limits code.  The limits code is treated more like a library to the scheduler.  I chose to leave this variable static to the limits code and write a getter function for it.  I use this function when creating the array of resources which are used to create equivalence classes.
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
