### PR TITLE
PP-905: Ctrl+C during Interactive job startup causes race condition on Cray

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -1058,14 +1058,21 @@ task_find	(job		*pjob,
 #define JOB_EXEC_HOOK_DELETE   -19 /* a hook requested for job to be deleted */
 #define JOB_EXEC_RERUN_MS_FAIL -20 /* Mother superior connection failed */
 #define JOB_EXEC_FAIL_SECURITY -21 /* Security breach in PBS directory */
-#define JOB_EXEC_HOOKERROR	-22 /* job exec failed due to */
-				    /* unexpected exception or */
-				    /* hook execution timed out */
+#define JOB_EXEC_HOOKERROR	-22 /* job exec failed due to
+				     * unexpected exception or
+				     * hook execution timed out
+				     */
+#define JOB_EXEC_UPDATE_ALPS_RESV_ID 1 /* Update ALPS reservation ID to parent mom as soon
+					* as it is available.
+					* This is neither a success nor a failure exit code,
+					* so we are using a positive value
+					*/
 
-
-/* Fake "random" number added onto the end of the staging */
-/* and execution directory when sandbox=private	          */
-/* used in jobdirname()				          */
+/*
+ * Fake "random" number added onto the end of the staging
+ * and execution directory when sandbox=private
+ * used in jobdirname()
+ */
 #define FAKE_RANDOM	"x8z"
 
 /* The default project assigned to jobs when project attribute is unset */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug Description

* Ctrl+C during Interactive job startup causes race condition on Cray. 
  This leaves behind orphaned ALPS reservation in the Cray system and jobs are held because of lack of resources.

* Issue ID: [PP-905](https://pbspro.atlassian.net/browse/PP-905)

#### Affected Platform(s)
* Cray

#### Cause / Analysis / Design
* A user immediately does a Ctrl-C after submitting an interactive qsub that requests Cray compute nodes. But by this time PBS mom has forked, and one process is trying to create the ALPS reservation while another part is being killed off due to the Ctrl-C. The ALPS reservation is made successfully, but the ALPS reservation ID is not available when PBS is deleting the job so the ALPS reservation is not canceled. This causes ALPS reservations to be left behind. And since PBS thinks those resources are free, but ALPS disagrees, we end up with held jobs due to the mismatch.
The hook that keeps ALPS and PBS in sync will not be able to help with undoing the problem, because it's main purpose is to notice nodes coming up or going down. It wouldn't know what to do with nodes that are busy with an ALPS reservation. And because it runs only periodically, it will not prevent jobs from being held in between the times it runs.

#### Solution Description
* Report the ALPS reservation ID to parent mom as soon as it is available.Thus when the job is being deleted, parent mom will also cancel the ALPS reservation associated with the job as it will have the value of ALPS reservation ID available. 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
