### PR TITLE
PP-1152: wait longer for cycle to end

### DIFF
--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -70,7 +70,7 @@ class TestJobEquivClassPerf(TestPerformance):
 
         # Wait for cycle to finish
         self.scheduler.log_match("Leaving Scheduling Cycle", starttime=t,
-                                 max_attempts=300)
+                                 max_attempts=300, interval=3)
 
         c = self.scheduler.cycles(lastN=1)[0]
         cycle_time = c.end - c.start


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* TestJobEquivClassPerf.test_basic could time out on slower machines

#### Cause / Analysis / Design
* test_basic needs to wait for a cycle to complete before it can see the order the jobs were started in.  It would do a log_match() for 'Leaving scheduling cycle' for 300 seconds.  On slower machines, the cycle could take longer and the log_match() would fail
#### Solution Description
* Add interval=3 to the log_match() increasing the wait to 15m.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
