### PR TITLE
PP-1240: Invalid JSON output

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -151,10 +151,11 @@ enum output_format_enum {
 /* This array contains the names users may specify for output format. */
 static char *output_format_names[] = {"default", "dsv", "json", NULL};
 
-static int output_format = FORMAT_DEFAULT;
+static int  output_format = FORMAT_DEFAULT;
 static char *dsv_delim = "|";
 static char *delimiter = "\n";
 static char *prev_resc_name = NULL;
+static int  first_stat = 1;
 
 static struct attrl *display_attribs = &basic_attribs[0];
 
@@ -271,8 +272,6 @@ istrue(char *string)
  * @param[in] e      - string holding string for end
  * @param[in] len    - length of string
  *
- * @return Void
- *
  */
 static void
 states(char *string, char *q, char *r, char *h, char *w, char *t, char *e, int len)
@@ -365,8 +364,6 @@ convert_feed_chars(char *val) {
  * @param[in] resource - resource name
  * @param[in] value - value for the attribute
  * @param[in] one_line - one line per attribute
- *
- * @return void
  *
  */
 void
@@ -552,8 +549,6 @@ prt_attr(char *name, char *resource, char *value, int one_line) {
  *
  * @param[in] nodes - name of exechosts
  * @param[in] no_newl - int value to decide which comment to be set
- *
- * @return Void
  *
  */
 static void
@@ -1215,9 +1210,11 @@ display_statjob(struct batch_status *status, struct batch_status *prtheader, int
 		printf    ("----------------  ---------------- ----------------  -------- - -----\n");
 	}
 
-	if(output_format == FORMAT_JSON)
+	if(output_format == FORMAT_JSON && first_stat) {
 		if (add_json_node(JSON_OBJECT, JSON_NULL, "Jobs", NULL) == NULL)
 			return 1;
+		first_stat = 0;
+	}
 	p = status;
 	while (p != NULL) {
 		jid = NULL;
@@ -1459,9 +1456,11 @@ display_statque(struct batch_status *status, int prtheader, int full, int alt_op
 		printf("---------------- ----- ----- --- --- ----- ----- ----- ----- ----- ----- ----\n");
 	}
 
-	if (output_format == FORMAT_JSON)
+	if (output_format == FORMAT_JSON && first_stat) {
 		if (add_json_node(JSON_OBJECT, JSON_NULL, "Queue", NULL) == NULL)
 			return 1;
+		first_stat = 0;
+	}
 	p = status;
 	while (p != NULL) {
 		name = NULL;
@@ -1606,9 +1605,11 @@ display_statserver(struct batch_status *status, int prtheader, int full, int alt
 		printf("---------------- ----- ----- ----- ----- ----- ----- ----- ----- -----------\n");
 	}
 
-	if(output_format == FORMAT_JSON)
+	if(output_format == FORMAT_JSON && first_stat) {
 		if (add_json_node(JSON_OBJECT, JSON_NULL, "Server", NULL) == NULL)
 			return 1;
+		first_stat = 0;
+	}
 	p = status;
 	while (p != NULL) {
 		name = NULL;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *Invalid JSON output*
* *If there is an issue ID, link to it: [PP-1240](https://pbspro.atlassian.net/browse/PP-1240)*

#### Cause / Analysis / Design
* *Discussion on the Forum **[pbspro community forum](http://community.pbspro.org/t/invalid-json-output/873)***
* *`qstat -fFjson` with two or more job IDs returns an erroneous JSON that includes extra `"Jobs":`
{' before each job ID and lacks a terminating '} *

#### Solution Description
* *The issue affects not only jobs, but queue and server query when more than one entry is involved*
* Introduced a static variable which tells whether it is the first stat, then only the tag is attached.
* 2 new PTL test cases to verify multiple job and multiple queue scenarios.

CC: @mike0042 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__