### PR TITLE
PP-1238: All schedulers are querying for few of default schedulers at…

### DIFF
--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -224,7 +224,7 @@ query_server(status *pol, int pbs_sd)
 	}
 
 	sched = pbs_statsched(pbs_sd, NULL, NULL);
-	sched = bs_find(sched, PBS_DFLT_SCHED_NAME);
+	sched = bs_find(sched, sc_name);
 
 	if (sched == NULL) {
 		errmsg = pbs_geterrmsg(pbs_sd);


### PR DESCRIPTION
…tributes instead of its own

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Multisched
* *[PP-1238](https://pbspro.atlassian.net/browse/PP-1238)*

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* All schedulers were querying for default scheduler attributes instead of its own.

#### Solution Description
* Passed the particular scheduler name to pbs_statsched() in query_server() instead of default scheduler name 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
