### PR TITLE
Fix race condition between cgroup periodic and begin handler

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -689,6 +689,9 @@ class HookUtils(object):
                    caller_name())
         pbs.logmsg(pbs.EVENT_DEBUG4, "%s: Host assigned job resources: %s" %
                    (caller_name(), jobutil.assigned_resources))
+        # add jobid to cgroup_jobs file to tell periodic handler that this
+        # job is new and its cgroup should not be cleaned up
+        cgroup.add_jobid_to_cgroup_jobs(event.job.id)
         # Make sure the parent cgroup directories exist
         cgroup.create_paths()
         # Make sure the cgroup does not already exist
@@ -737,6 +740,9 @@ class HookUtils(object):
         Handler for execjob_epilogue events.
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, "%s: Method called" % caller_name())
+        # delete this jobid from cgroup_jobs in case hook events before me
+        # failed to do that
+        cgroup.remove_jobid_from_cgroup_jobs(event.job.id)
         # The resources_used information has a base type of pbs_resource.
         # Update the usage data
         cgroup.update_job_usage(event.job.id, event.job.resources_used)
@@ -751,6 +757,9 @@ class HookUtils(object):
         Handler for execjob_end events.
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, "%s: Method called" % caller_name())
+        # delete this jobid from cgroup_jobs in case hook events before me
+        # failed to do that
+        cgroup.remove_jobid_from_cgroup_jobs(event.job.id)
         # The cgroup is usually deleted in the execjob_epilogue event
         # There are certain corner cases where epilogue can fail or skip
         # Delete files again here to make sure we catch those
@@ -777,6 +786,9 @@ class HookUtils(object):
         Handler for execjob_launch events.
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, "%s: Method called" % caller_name())
+        # delete this jobid from cgroup_jobs in case hook events before me
+        # failed to do that
+        cgroup.remove_jobid_from_cgroup_jobs(event.job.id)
         # Add the parent process id to the appropriate cgroups.
         cgroup.add_pids(os.getppid(), jobutil.job.id)
         # FUTURE: Add environment variable to the job environment
@@ -911,6 +923,9 @@ class HookUtils(object):
         Handler for execjob_attach events.
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, "%s: Method called" % caller_name())
+        # delete this jobid from cgroup_jobs in case hook events before me
+        # failed to do that
+        cgroup.remove_jobid_from_cgroup_jobs(event.job.id)
         pbs.logjobmsg(jobutil.job.id, "%s: Attaching PID %s" %
                       (caller_name(), event.pid))
         # Add the job process id to the appropriate cgroups.
@@ -1730,6 +1745,11 @@ class CgroupUtils(object):
         self.host_job_env_dir = os.path.join(PBS_MOM_HOME, 'aux')
         self.host_job_env_filename = os.path.join(self.host_job_env_dir,
                                                   '%s.env')
+        # temporarily stores list of new jobs that came after job_list was
+        # written to mom hook input file (work around for periodic
+        # and begin race condition)
+        self.cgroup_jobs_file = os.path.join(PBS_MOM_HOME, 'mom_priv', 'hooks',
+                                             'hook_data', 'cgroup_jobs')
         # information for offlining nodes
         self.offline_file = os.path.join(PBS_MOM_HOME, 'mom_priv', 'hooks',
                                          ('%s.offline' %
@@ -3445,12 +3465,29 @@ class CgroupUtils(object):
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, "%s: Method called" % caller_name())
         pbs.logmsg(pbs.EVENT_DEBUG4, "Local jobs: %s" % (local_jobs))
+        new_jobs = set()
+        mom_priv_jobs_dir = os.path.join(PBS_MOM_HOME, 'mom_priv', 'jobs')
+        # Make a list of jobs from jobids in cgroup_jobs file and .JB files.
+        # These jobs are new since local_jobs was written to mom hook input
+        # file. We should not mistake their cgroups as orphans
+        cgroup_jobs = self.read_cgroup_jobs()
+        pbs.logmsg(pbs.EVENT_DEBUG4,
+                   'cgroup_jobs file content: %s' % cgroup_jobs)
+        if cgroup_jobs:
+            for jobid in cgroup_jobs:
+                new_jobs.add(jobid)
+            self.empty_cgroup_jobs_file()
+        for p in glob.glob(os.path.join(mom_priv_jobs_dir, '*.JB')):
+            pbs.logmsg(pbs.EVENT_DEBUG4, 'Found file %s' % p)
+            jobid = os.path.splitext(os.path.basename(p))[0]
+            new_jobs.add(jobid)
+        pbs.logmsg(pbs.EVENT_DEBUG4, 'New jobs: %s' % str(new_jobs))
         remaining = 0
         for key in self.paths:
             path = os.path.dirname(self._cgroup_path(key))
             for subdir in glob.glob(os.path.join(path, '[0-9]*')):
                 jobid = os.path.basename(subdir)
-                if jobid not in local_jobs:
+                if jobid not in local_jobs and jobid not in new_jobs:
                     if not jobid.endswith('-orphan'):
                         try:
                             os.rename(subdir, subdir + '-orphan')
@@ -3734,6 +3771,68 @@ class CgroupUtils(object):
             except:
                 raise
         return self.assigned_resources is not None
+
+    def add_jobid_to_cgroup_jobs(self, jobid):
+        pbs.logmsg(pbs.EVENT_DEBUG4, 'Adding jobid %s to cgroup_jobs' % jobid)
+        try:
+            with open(self.cgroup_jobs_file, 'a') as f:
+                if f.tell() > 0:
+                    f.write(' ')
+                f.write(jobid)
+            return True
+        except IOError:
+            pbs.logmsg(pbs.EVENT_DEBUG, 'Failed to open cgroup_jobs file.')
+        except KeyboardInterrupt:
+            raise
+        return False
+
+    def remove_jobid_from_cgroup_jobs(self, jobid):
+        pbs.logmsg(pbs.EVENT_DEBUG4,
+                   'Removing jobid %s from cgroup_jobs' % jobid)
+        try:
+            with open(self.cgroup_jobs_file, 'r+') as f:
+                jobid_set = set(f.readline().split())
+                f.seek(0)
+                jobid_set.discard(jobid)
+                f.write(' '.join(jobid_set))
+                f.truncate()
+            return True
+        except IOError:
+            pbs.logmsg(pbs.EVENT_DEBUG, 'Failed to open cgroup_jobs file.')
+        except KeyboardInterrupt:
+            raise
+        return False
+
+    def read_cgroup_jobs(self):
+        jobids = []
+        try:
+            with open(self.cgroup_jobs_file, 'r') as f:
+                jobids = f.readline().split()
+        except IOError:
+            pbs.logmsg(pbs.EVENT_DEBUG, 'Failed to open cgroup_jobs file.')
+        except KeyboardInterrupt:
+            raise
+        return jobids
+
+    def delete_cgroup_jobs_file(self, jobid):
+        pbs.logmsg(pbs.EVENT_DEBUG4,
+                   'Deleting file: %s' % self.cgroup_jobs_file)
+        if os.path.isfile(self.cgroup_jobs_file):
+            os.remove(self.cgroup_jobs_file)
+        return True
+
+    def empty_cgroup_jobs_file(self):
+        pbs.logmsg(pbs.EVENT_DEBUG4,
+                   'Emptying file: %s' % self.cgroup_jobs_file)
+        try:
+            with open(self.cgroup_jobs_file, 'w') as f:
+                f.truncate()
+            return True
+        except IOError:
+            pbs.logmsg(pbs.EVENT_DEBUG, 'Failed to open cgroup_jobs file.')
+        except KeyboardInterrupt:
+            raise
+        return False
 
 
 def set_global_vars():


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
There is a race condition between cgroup hook's `exechost_periodic` and `execjob_begin` handler that causes some jobs' cgroup to be mistaken as orphans and cleaned up by periodic hook. 

#### Affected Platform(s)
All platform that cgroup hook supports

#### Cause / Analysis / Design
The periodic hook relies on a list of jobs written to mom hook input file for identifying orphaned cgroups. However there is a gap between the time mom writes the list to the input file and the time that periodic hook is run. During this time gap, a begin hook of a new job could run and creates a cgroup, which could be cleaned up by periodic hook. Even with new locking method in place, the race still exists since mom itself does not participate in the locking. 

#### Solution Description
Let the begin hook write out a `.new` file to indicate a new job. The periodic handler can look for these `.new` files and `.JB` files and compile a list of job ids and avoid cleaning up cgroups corresponding to these job ids.  Hooks after the begin hook will need to clean these files up because after the begin hook finish a `.JB` file will be created. 


No new PTL test because `test_cgroups_race_condition` in #578 will also test this issue.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.

__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__


[PTL test log](https://github.com/PBSPro/pbspro/files/1831749/test_output2.txt)

