### PR TITLE
sometime test_soft_then_hard failing due to race condition

### DIFF
--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -341,6 +341,9 @@ e.accept()
         the job's soft_walltime is not extended past its hard walltime.
         It should first extend once and then extend to its hard walltime
         """
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'job_history_enable': 'True'})
+
         J = Job(TEST_USER,
                 attrs={'Resource_List.ncpus': 1, 'Resource_List.walltime': 16})
         jid = self.server.submit(J)
@@ -358,7 +361,8 @@ e.accept()
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
         self.server.expect(JOB, {'estimated.soft_walltime':
-                                 (MATCH_RE, '00:00:16|16')}, offset=4, id=jid)
+                                 (MATCH_RE, '00:00:16|16')}, offset=4,
+                           extend='x', id=jid)
 
         self.server.expect(JOB, 'queue', op=UNSET, id=jid)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description

* *Bugs: sometime test_soft_then_hard from pbs_soft_walltime.py failing while checking softwalltime cannot be set more than hard walltime as job gets killed immediately when it exceeds hard walltime*
* *This race condition is seen intermittently. It depends on how quickly PBS can detect exceeded walltime and kills the job.*


#### Affected Platform(s)
* *Platform (ALL)*

#### Cause / Analysis / Design
* *Bugs: sometime PBS mom finds out that job is exceeding walltime and kills the job causing the race condition where test is checking for job attribute while the job is deleted*

#### Solution Description
* *enable job history and look for job attribute is set or not with -fx*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

[test_soft_then_hard.txt](https://github.com/PBSPro/pbspro/files/1812968/test_soft_then_hard.txt)

