### PR TITLE
PP-1223: test_root_owned_script.Test_RootOwnedScript failed with error Permission denied: '/root'

### DIFF
--- a/test/tests/functional/pbs_root_owned_script.py
+++ b/test/tests/functional/pbs_root_owned_script.py
@@ -45,8 +45,11 @@ class Test_RootOwnedScript(TestFunctional):
     """
 
     def setUp(self):
-        """Set up the parameters required for Test_RootOwnedScript
         """
+        Set up the parameters required for Test_RootOwnedScript
+        """
+        if os.getuid() != 0:
+            self.skipTest("Test need to run as root")
         TestFunctional.setUp(self)
         mom_conf_attr = {'$reject_root_scripts': 'true'}
         qmgr_attr = {'acl_roots': ROOT_USER}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* test_root_owned_script.Test_RootOwnedScript failed with error Permission denied: '/root'
*  [PP-1223](https://pbspro.atlassian.net/browse/PP-1223)

#### Affected Platform(s)
* Platform All

#### Cause / Analysis / Design
* test_root_owned_script.Test_RootOwnedScript is failed due to permission issue. 
in test case job is submitted through 'ROOT_USER' , while submitting it got failed with error OSError: [Errno 13] Permission denied: '/root'

#### Solution Description
* The test should run as root user, so if the user running the test is not root it will skip.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
