### PR TITLE
Fixed problem where hook fails to run after event change

### DIFF
--- a/src/include/hook_func.h
+++ b/src/include/hook_func.h
@@ -62,9 +62,13 @@ extern "C" {
 #define	MOM_HOOK_ACTION_DELETE_RESCDEF	0x10
 #define	MOM_HOOK_ACTION_SEND_CONFIG	0x20
 
+/* MOM_HOOK_ACTION_SEND_RESCDEF is really not part of this */
+#define MOM_HOOK_SEND_ACTIONS (MOM_HOOK_ACTION_SEND_ATTRS | MOM_HOOK_ACTION_SEND_SCRIPT | MOM_HOOK_ACTION_SEND_CONFIG)
+
 struct mom_hook_action {
 	char            hookname[MAXPATHLEN+1];
 	unsigned int	action;
+	int		do_delete_action_first; /* force order between delete and send actions */
 	long long int	tid;	/* transaction id to group actions under */
 };
 

--- a/test/tests/functional/pbs_mom_hook_sync.py
+++ b/test/tests/functional/pbs_mom_hook_sync.py
@@ -1,0 +1,363 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestMomHookSync(TestFunctional):
+    """
+    This test suite tests to make sure a hook does not disappear in
+    a series of hook event change from mom hook to server hook and
+    then back to a mom hook. This is a good exercise to make sure
+    hook updates are not lost even when mom is stopped, killed, and
+    restarted during hook event changes.
+    """
+
+    def setUp(self):
+        if len(self.moms) != 2:
+            self.skip_test(reason="need 2 mom hosts: -p moms=<m1>:<m2>")
+        TestFunctional.setUp(self)
+
+        self.momA = self.moms.values()[0]
+        self.momB = self.moms.values()[1]
+        self.momA.delete_vnode_defs()
+        self.momB.delete_vnode_defs()
+
+        self.hostA = self.momA.shortname
+        self.hostB = self.momB.shortname
+
+        rc = self.server.manager(MGR_CMD_DELETE, NODE, None, "")
+        self.assertEqual(rc, 0)
+
+        rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
+        self.assertEqual(rc, 0)
+
+        rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
+        self.assertEqual(rc, 0)
+
+        self.hook_name = "cpufreq"
+        hook_body = "import pbs\n"
+        a = {'event': 'execjob_begin', 'enabled': 'True'}
+        self.server.create_import_hook(self.hook_name, a, hook_body)
+
+        hook_config = """{
+    "apple"         : "pears",
+    "banana"         : "cucumbers"
+}
+"""
+        (fd, fn) = self.du.mkstemp()
+        os.write(fd, hook_config)
+        os.close(fd)
+        a = {'content-type': 'application/x-config',
+             'content-encoding': 'default',
+             'input-file': fn}
+        self.server.manager(MGR_CMD_IMPORT, HOOK, a, self.hook_name)
+        os.remove(fn)
+
+        self.server.log_match(
+            'successfully sent hook file.*cpufreq.HK ' +
+            'to %s.*' % self.momA.hostname,
+            max_attempts=10, regexp=True)
+
+        self.server.log_match(
+            'successfully sent hook file.*cpufreq.CF ' +
+            'to %s.*' % self.momA.hostname,
+            max_attempts=10, regexp=True)
+
+        self.server.log_match(
+            'successfully sent hook file.*cpufreq.PY ' +
+            'to %s.*' % self.momA.hostname,
+            max_attempts=10, regexp=True)
+
+        self.server.log_match(
+            'successfully sent hook file.*cpufreq.HK ' +
+            'to %s.*' % self.momB.hostname,
+            max_attempts=10, regexp=True)
+
+        self.server.log_match(
+            'successfully sent hook file.*cpufreq.CF ' +
+            'to %s.*' % self.momB.hostname,
+            max_attempts=10, regexp=True)
+
+        self.server.log_match(
+            'successfully sent hook file.*cpufreq.PY ' +
+            'to %s.*' % self.momB.hostname,
+            max_attempts=10, regexp=True)
+
+    def tearDown(self):
+        self.momB.signal("-CONT")
+        TestFunctional.tearDown(self)
+
+    def test_1(self):
+        """
+        Given an existing mom hook, suspend mom on hostB,
+        change the hook to be a server hook (causes a
+        delete action), then change it back to a mom hook
+        (results in a send action), and then resume mom.
+        The delete action occurs first and then the send
+        action so we end up with a mom hook in place.
+        """
+
+        self.momB.signal('-STOP')
+
+        # Turn current mom hook into a server hook
+        self.server.manager(MGR_CMD_SET, HOOK,
+                            {'event': 'queuejob'},
+                            id=self.hook_name)
+
+        # Turn current mom hook back to a mom hook
+        self.server.manager(MGR_CMD_SET, HOOK,
+                            {'event': 'exechost_periodic'},
+                            id=self.hook_name)
+
+        # For testability, delay resuming the mom so we can
+        # get a different timestamp on the hook updates
+        self.logger.info("Waiting 3 secs for earlier hook updates to complet")
+        time.sleep(3)
+
+        now = int(time.time())
+        self.momB.signal('-CONT')
+
+        # Put another sleep delay so log_match() can see all the matches
+        self.logger.info("Waiting 3 secs for new hook updates to complete")
+        time.sleep(3)
+        match_delete = self.server.log_match(
+            'successfully deleted hook file cpufreq.HK ' +
+            'from %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        # Without the fix, there won't be these sent hook file messages
+        match_sent1 = self.server.log_match(
+            'successfully sent hook file.*cpufreq.HK ' +
+            'to %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        match_sent2 = self.server.log_match(
+            'successfully sent hook file.*cpufreq.CF ' +
+            'to %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        match_sent3 = self.server.log_match(
+            'successfully sent hook file.*cpufreq.PY ' +
+            'to %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        # the higher the number, the earlier the line appears in the log
+        self.assertTrue(match_delete[0] > match_sent1[0])
+        self.assertTrue(match_delete[0] > match_sent2[0])
+        self.assertTrue(match_delete[0] > match_sent3[0])
+
+    def test_2(self):
+        """
+        Given an existing mom hook, suspend mom on hostB,
+        change the hook event to be another mom hook event
+        (results in a send action), change the hook to be a
+        server hook (causes a delete action),
+        and then resume mom.
+        The send action occurs first and then the delete
+        action so we end up with no mom hook in place.
+        """
+
+        self.momB.signal('-STOP')
+
+        # Turn current mom hook back to a mom hook
+        self.server.manager(MGR_CMD_SET, HOOK,
+                            {'event': 'exechost_periodic'},
+                            id=self.hook_name)
+
+        # Turn current mom hook into a server hook
+        self.server.manager(MGR_CMD_SET, HOOK,
+                            {'event': 'queuejob'},
+                            id=self.hook_name)
+
+        # For testability, delay resuming the mom so we can
+        # get a different timestamp on the hook updates
+        self.logger.info("Waiting 3 secs for earlier hook updates to complet")
+        time.sleep(3)
+
+        now = int(time.time())
+        self.momB.signal('-CONT')
+
+        # Put another sleep delay so log_match() can see all the matches
+        self.logger.info("Waiting 3 secs for new hook updates to complete")
+        time.sleep(3)
+        match_delete = self.server.log_match(
+            'successfully deleted hook file cpufreq.HK ' +
+            'from %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        # Only the hook control file (.HK) is sent since that contains
+        # the hook event change to exechost_periodic.
+        match_sent = self.server.log_match(
+            'successfully sent hook file .*cpufreq.HK ' +
+            'to %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        # the higher the number, the earlier the line appears in the log
+        self.assertTrue(match_sent[0] > match_delete[0])
+
+        self.server.log_match(
+            'successfully sent hook file .*cpufreq.CF ' +
+            'to %s.*' % self.momB.hostname, existence=False,
+            starttime=now, max_attempts=10, regexp=True)
+
+        self.server.log_match(
+            'successfully sent hook file .*cpufreq.PY ' +
+            'to %s.*' % self.momB.hostname, existence=False,
+            starttime=now, max_attempts=10, regexp=True)
+
+    def test_3(self):
+        """
+        Like test_1 except instead of resuming mom,
+        we kill -9 it and restart.
+        """
+
+        self.momB.signal('-STOP')
+
+        # Turn current mom hook into a server hook
+        self.server.manager(MGR_CMD_SET, HOOK,
+                            {'event': 'queuejob'},
+                            id=self.hook_name)
+
+        # Turn current mom hook back to a mom hook
+        self.server.manager(MGR_CMD_SET, HOOK,
+                            {'event': 'exechost_periodic'},
+                            id=self.hook_name)
+
+        # For testability, delay resuming the mom so we can
+        # get a different timestamp on the hook updates
+        self.logger.info("Waiting 3 secs for earlier hook updates to complet")
+        time.sleep(3)
+
+        self.momB.signal('-KILL')
+        self.momB.restart()
+
+        now = int(time.time())
+
+        # Killing and restarting mom would cause server to sync
+        # up its version of the mom hook file resulting in an
+        # additional send action, which would not alter the
+        # outcome, as send action occurs after the delete action.
+        self.server.log_match(
+            'Node;%s.*;' % (self.momB.hostname,) +
+            'Mom restarted on host',
+            starttime=now, max_attempts=10, regexp=True)
+
+        # Put another sleep delay so log_match() can see all the matches
+        self.logger.info("Waiting 3 secs for new hook updates to complete")
+        time.sleep(3)
+        match_delete = self.server.log_match(
+            'successfully deleted hook file cpufreq.HK ' +
+            'from %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        # Without the fix, there won't be these sent hook file messages
+        match_sent1 = self.server.log_match(
+            'successfully sent hook file.*cpufreq.HK ' +
+            'to %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        match_sent2 = self.server.log_match(
+            'successfully sent hook file.*cpufreq.CF ' +
+            'to %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        match_sent3 = self.server.log_match(
+            'successfully sent hook file.*cpufreq.PY ' +
+            'to %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        # the higher the number, the earlier the line appears in the log
+        self.assertTrue(match_delete[0] > match_sent1[0])
+        self.assertTrue(match_delete[0] > match_sent2[0])
+        self.assertTrue(match_delete[0] > match_sent3[0])
+
+    def test_4(self):
+        """
+        Like test_2 except instead of resuming mom,
+        we kill -9 it and restart.
+        """
+
+        self.momB.signal('-STOP')
+
+        # Turn current mom hook back to a mom hook
+        self.server.manager(MGR_CMD_SET, HOOK,
+                            {'event': 'exechost_periodic'},
+                            id=self.hook_name)
+
+        # Turn current mom hook into a server hook
+        self.server.manager(MGR_CMD_SET, HOOK,
+                            {'event': 'queuejob'},
+                            id=self.hook_name)
+
+        # For testability, delay resuming the mom so we can
+        # get a different timestamp on the hook updates
+        self.logger.info("Waiting 3 secs for earlier hook updates to complet")
+        time.sleep(3)
+
+        # Killing and restarting mom would cause server to sync
+        # up its version of the mom hook file resulting in an
+        # delete mom hook action as that hook is now seen as a
+        # server hook. Since it's now a server hook, no further
+        # mom hook sends are done.
+        self.momB.signal('-KILL')
+        self.momB.restart()
+
+        now = int(time.time())
+
+        # Put another sleep delay so log_match() can see all the matches
+        self.logger.info("Waiting 3 secs for new hook updates to complete")
+        time.sleep(3)
+        self.server.log_match(
+            'successfully deleted hook file cpufreq.HK ' +
+            'from %s.*' % self.momB.hostname,
+            starttime=now, max_attempts=10, regexp=True)
+
+        self.server.log_match(
+            'successfully sent hook file .*cpufreq.HK ' +
+            'to %s.*' % self.momB.hostname, existence=False,
+            starttime=now, max_attempts=10, regexp=True)
+
+        self.server.log_match(
+            'successfully sent hook file .*cpufreq.CF ' +
+            'to %s.*' % self.momB.hostname, existence=False,
+            starttime=now, max_attempts=10, regexp=True)
+
+        self.server.log_match(
+            'successfully sent hook file .*cpufreq.PY ' +
+            'to %s.*' % self.momB.hostname, existence=False,
+            starttime=now, max_attempts=10, regexp=True)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
The bug is that some send hook update requests can be "forgotten" if a hook
also has a pending delete hook request.

A hook could have both requests as illustrated in the following scenario:

Given 'cpufreq' already a mom hook (i.e. event is one of execjob_begin, execjob_prologue, etc...), run the following:

1. qmgr -c "set hook cpufreq event = queuejob
2. qmgr -c "set hook cpufreq event += execjob_begin"


The first one causes a delete hook action to be sent since 'cpufreq' was
a mom hook that is turned into a server hook (i.e. queuejob), so the server
sends out a request to delete all the mom hook-related files on the remote
host.

The second turns the server hook back into a mom hook, and this causes
a send hook update request to be sent to the remote mom, to copy all mom
hook-related files to the remote host.

these 2 requests can simultaneously be there, if say mom did not immediately
process 1 or 2.


* *If there is an issue ID, link to it: [PP-XXXX](https://pbspro.atlassian.net/browse/PP-XXXX)*

#### Affected Platform(s)
All platforms

#### Cause / Analysis / Design
Current mom hook files syncing scheme does not expect both actions to be
set, but if they do, only the delete hook action is allowed to go through.
So one ends up with the cpufreq mom hook disappearing from the sluggish
remote host.




#### Solution Description
The code for syncing mom hook files has been modified so that all
delete action and send hook update actions are performed, but paying
close attention to when the delete action should  go first, or when
the send actions should go first. If there's a send action (update hook attribute, python script content, config file) in place and
delete action is issued, the former will execute first. If the delete
action came in and there's no outstanding send action to process, then
delete action will be executed first, even if subsequence send actions come in.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
