### PR TITLE
Do not enable the PBS_translate_mpp hook when reverting to default

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5154,9 +5154,6 @@ class Server(PBSService):
                     self.du.run_copy(self.hostname, self.dflt_mpp_hook,
                                      self.mpp_hook, mode=0644, sudo=True)
                     self.signal('-HUP')
-                a = {'enabled': 'true'}
-                self.manager(MGR_CMD_SET, MGR_OBJ_PBS_HOOK, a,
-                             'PBS_translate_mpp')
             hooks = self.status(HOOK, level=logging.DEBUG)
             hooks = [h['id'] for h in hooks]
             a = {ATTR_enable: 'false'}


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/Feature Description
* With the latest changes to disable the PBS_translate_mpp hook by default on a Cray X* series (see https://pbspro.atlassian.net/wiki/spaces/PD/pages/261554226/Disable+the+PBS+translate+mpp+hook+by+default), revert_to_defaults should also be updated to not enable the PBS_translate_mpp hook.
* Steps to reproduce the problem:
Run a PTL test on a Cray that runs through setUp.  Look at the test output.
Prior to the change you can see: set pbshook PBS_translate_mpp {'enabled': 'true'}
After the change, you won't see that.

Because this is a change to PTL revert_to_defaults, there is no need to write a PTL test.

#### Affected Platform(s)
* *Platform: Cray X* series, and Cray ALPS simulators

#### Cause / Analysis / Design
* There is an external design that has been updated: [see PP-719](https://pbspro.atlassian.net/wiki/spaces/PD/pages/50831929/PP-719+Enhance+setUp+in+PTL+specifically+for+Cray+platforms)
* *Here's a link to the discussion on the Forum: **[pbspro community forum](http://community.pbspro.org/t/pp-719-enhance-setup-in-ptl-specifically-for-cray-platforms/463/32)***

#### Solution Description
* Removed enabling PBS_translate_mpp hook in revert_to_defaults

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [X] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [X] I have updated the documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/spaces/PD/pages/50831929/PP-719+Enhance+setUp+in+PTL+specifically+for+Cray+platforms)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.

#### Test Logs:
[fix_revert_output.txt](https://github.com/PBSPro/pbspro/files/1839659/fix_revert_output.txt)

__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__