### PR TITLE
Fixed timing issue in mom_hook_sync test

### DIFF
--- a/test/tests/functional/pbs_mom_hook_sync.py
+++ b/test/tests/functional/pbs_mom_hook_sync.py
@@ -146,7 +146,7 @@ class TestMomHookSync(TestFunctional):
 
         # For testability, delay resuming the mom so we can
         # get a different timestamp on the hook updates
-        self.logger.info("Waiting 3 secs for earlier hook updates to complet")
+        self.logger.info("Waiting 3 secs for earlier hook updates to complete")
         time.sleep(3)
 
         now = int(time.time())
@@ -206,7 +206,7 @@ class TestMomHookSync(TestFunctional):
 
         # For testability, delay resuming the mom so we can
         # get a different timestamp on the hook updates
-        self.logger.info("Waiting 3 secs for earlier hook updates to complet")
+        self.logger.info("Waiting 3 secs for earlier hook updates to complete")
         time.sleep(3)
 
         now = int(time.time())
@@ -260,13 +260,12 @@ class TestMomHookSync(TestFunctional):
 
         # For testability, delay resuming the mom so we can
         # get a different timestamp on the hook updates
-        self.logger.info("Waiting 3 secs for earlier hook updates to complet")
+        self.logger.info("Waiting 3 secs for earlier hook updates to complete")
         time.sleep(3)
 
+        now = int(time.time())
         self.momB.signal('-KILL')
         self.momB.restart()
-
-        now = int(time.time())
 
         # Killing and restarting mom would cause server to sync
         # up its version of the mom hook file resulting in an
@@ -326,7 +325,7 @@ class TestMomHookSync(TestFunctional):
 
         # For testability, delay resuming the mom so we can
         # get a different timestamp on the hook updates
-        self.logger.info("Waiting 3 secs for earlier hook updates to complet")
+        self.logger.info("Waiting 3 secs for earlier hook updates to complete")
         time.sleep(3)
 
         # Killing and restarting mom would cause server to sync
@@ -334,10 +333,9 @@ class TestMomHookSync(TestFunctional):
         # delete mom hook action as that hook is now seen as a
         # server hook. Since it's now a server hook, no further
         # mom hook sends are done.
+        now = int(time.time())
         self.momB.signal('-KILL')
         self.momB.restart()
-
-        now = int(time.time())
 
         # Put another sleep delay so log_match() can see all the matches
         self.logger.info("Waiting 3 secs for new hook updates to complete")


### PR DESCRIPTION
#### Bug/feature Description
* Tests 3 and 4 were failing intermittently.

#### Cause / Analysis / Design
* The mom was restarted, then the time was recorded. If the machine was fast (or slow) enough, it would log the messages before the recorded time.

#### Solution Description
* Record the time first, then restart the mom.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


[ptl_160032.log](https://github.com/PBSPro/pbspro/files/1854067/ptl_160032.log)