### PR TITLE
PP-1050: pbs_mom not coming up after powering on the compute node on mom installation on ICE

### DIFF
--- a/src/cmds/scripts/pbs_postinstall.in
+++ b/src/cmds/scripts/pbs_postinstall.in
@@ -405,7 +405,7 @@ install_pbsinitd() {
 				eval "sed -i 's;\(^[[:space:]]*ExecStart=\)[^[:space:]]*;\1${PBS_EXEC}/libexec/pbs_init.d;' \"$pbs_unitfile\""
 				eval "sed -i 's;\(^[[:space:]]*ExecStop=\)[^[:space:]]*;\1${PBS_EXEC}/libexec/pbs_init.d;' \"$pbs_unitfile\""
 				if command -v systemctl >/dev/null 2>&1; then
-					systemctl daemon-reload && systemctl enable pbs
+					systemctl enable pbs && systemctl daemon-reload
 					if [ $? != 0 -a -d "${presetdir}" ]; then
 						echo "*** Creating preset file ${presetdir}/95-pbs.preset"
 						echo "enable pbs.service" > "${presetdir}/95-pbs.preset"

--- a/src/lib/Libnet/hnls.c
+++ b/src/lib/Libnet/hnls.c
@@ -393,9 +393,9 @@ get_if_info(char *msg)
 				msg[LOG_BUF_SIZE - 1] = '\0';
 				return NULL;
 			}
-			for (i = 0; i < c; i++){
+			for (i = 0; i < c; i++) {
 				curr->ifhostnames[i] = (char*)calloc(PBS_MAXHOSTNAME, sizeof(char));
-				if (curr->ifhostnames[i]) {
+				if (!(curr->ifhostnames[i])) {
 					free(addrlistp);
 					free_if_info(head);
 					free_if_hostnames(hostnames);

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2411,7 +2411,7 @@ sched_settings_frm_svr(struct batch_status *status)
 		char comment[MAX_LOG_SIZE] = {0};
 
 		if (tmp_log_dir != NULL) {
-			(void)snprintf(path_log,  sizeof(path_log), tmp_log_dir);
+			(void)snprintf(path_log,  sizeof(path_log), "%s", tmp_log_dir);
 			log_close(1);
 			if (log_open(logfile, path_log) == -1) {
 				/* update the sched comment attribute with the reason for failure */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* pbs_mom not coming up after powering on the compute node on mom installation on ICE
* *If there is an issue ID, link to it: [PP-1050](https://pbspro.atlassian.net/browse/PP-1050)*

#### Affected Platform(s)
* HP ICE with Rhel7

#### Cause / Analysis / Design
* *systemctl enable command is not getting executed as daemon-reload fails*

#### Solution Description
* *Changed the order of execution of systemctl enable command and systemctl daemon-relaod*
* Fixed error check condition in get_if_info() for Windows.
* Fixed warning while using snprintf

CC: @sid2364 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
