### PR TITLE
Free the attribute so it doesn't leak memory

### DIFF
--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -664,6 +664,7 @@ remove_mom_from_vnodes(mominfo_t *pmom)
 		}
 
 	}
+	node_attr_def[(int)ND_ATR_Mom].at_free(&tmomattr);
 }
 
 /**


### PR DESCRIPTION
#
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Valgrind found a leak in decode_Mom_list:
==63289== 560 (280 direct, 280 indirect) bytes in 7 blocks are definitely lost in loss record 1,906 of 2,415
==63289== at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==63289== by 0x4EAA13: set_arst (attr_fn_arst.c:392)
==63289== by 0x47034E: decode_Mom_list (node_func.c:2296)
==63289== by 0x46D301: remove_mom_from_vnodes (node_func.c:654)
==63289== by 0x46D52E: effective_node_delete (node_func.c:724)
==63289== by 0x498934: mgr_node_delete (req_manager.c:2985)
==63289== by 0x49B625: req_manager (req_manager.c:4131)
==63289== by 0x4894AA: dispatch_request (process_request.c:956)
==63289== by 0x488FEE: process_request (process_request.c:725)
==63289== by 0x506F5F: wait_request (net_server.c:529)
==63289== by 0x487223: main (pbsd_main.c:2145)

Memory is leaked in the server 
each time a mom is deleted that has one or more vnodes associated to it.

Resolution: Fixed by freeing the mom attribute in remove_mom_from_vnodes once it isn't needed anymore.

#### Affected Platform(s)
* Platform: all

#### Logs:
[server_valgrind_nofix.log](https://github.com/PBSPro/pbspro/files/1881828/server_valgrind_nofix.log)
[server_valgrind_fix.log](https://github.com/PBSPro/pbspro/files/1881829/server_valgrind_fix.log)
[server_fix2.log](https://github.com/PBSPro/pbspro/files/1885883/server_fix2.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
