### PR TITLE
memory leak fixes in server

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -4293,6 +4293,7 @@ mom_running_jobs(int stream)
 	char             exec_host_name[PBS_MAXHOSTNAME+2]="UNKNOWN2";
 	char             *slash_pos = NULL;
 	int              exec_host_hostlen = 0;
+	char		*pset = NULL;
 
 	njobs = disrui(stream, &rc);    /* number of jobs in update */
 	if (rc)
@@ -4321,7 +4322,7 @@ mom_running_jobs(int stream)
 		execvnod = disrst(stream, &rc);
 		if (rc)
 			goto err;
-		(void)disrst(stream, &rc);	/* pset is not currently used */
+		pset = disrst(stream, &rc);	/* pset is not currently used */
 		if (rc)
 			goto err;
 
@@ -4418,6 +4419,8 @@ mom_running_jobs(int stream)
 		jobid = NULL;
 		free(execvnod);
 		execvnod = NULL;
+		free(pset);
+		pset = NULL;
 	}
 	return;
 
@@ -4427,6 +4430,7 @@ err:
 	log_err(errno, "mom_running_jobs", log_buffer);
 	free(jobid);
 	free(execvnod);
+	free(pset);
 }
 
 

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -150,6 +150,7 @@ que_free(pbs_queue *pq)
 	int		 i;
 	attribute	*pattr;
 	attribute_def	*pdef;
+	key_value_pair  *pkvp = NULL;
 
 	/* remove any malloc working attribute space */
 
@@ -158,6 +159,15 @@ que_free(pbs_queue *pq)
 		pattr = &pq->qu_attr[i];
 
 		pdef->at_free(pattr);
+	}
+	/* free default chunks set on queue */
+	pkvp = pq->qu_seldft;
+	if (pkvp) {
+		for (i = 0; i < pq->qu_nseldft; ++i) {
+			free((pkvp+i)->kv_keyw);
+			free((pkvp+i)->kv_val);
+		}
+		free(pkvp);
 	}
 
 	/* now free the main structure */

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -2297,8 +2297,10 @@ mgr_node_set(struct batch_request *preq)
 							reply_text(preq, PBSE_PARTITION_NOT_IN_QUE, log_buffer);
 							break;
 
-						default:  req_reject(rc, 0, preq);
+						default:
+							req_reject(rc, 0, preq);
 					}
+					free(warn_nodes);
 					return;
 				}
 
@@ -2587,8 +2589,10 @@ mgr_node_unset(struct batch_request *preq)
 							reply_badattr(rc, bad, plist, preq);
 							break;
 
-						default:  req_reject(rc, 0, preq);
+						default:
+							req_reject(rc, 0, preq);
 					}
+					free(warn_nodes);
 					return;
 				}
 

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -634,4 +634,11 @@
    fun:log_record
    fun:*
 }
-
+{
+   From PBSPro (server) - Suppress allocations that clear up when python interpreter restarts
+   Memcheck:Leak
+   fun:malloc
+   fun:PyString_FromString
+   fun:pbs_python_populate_attributes_to_python_class
+   fun:*
+}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Memory leaks found in server under following scenarios:
* When one tries to set/unset a node attribute that is not allowed to be unset or has no permission to be unset (like resources_assigned)
* When a queue has default_chunk set on it and then the queue is deleted
* When there are jobs running on an execution host and mom is started with -p option to preserve the running jobs.

#### Affected Platform(s)
* all

#### Cause / Analysis / Design
These leaks were trivial and straightforward.
here are the valgrind snippets of the leaks in the order they have been listed in previous section - 

==113219== 8 bytes in 1 blocks are definitely lost in loss record 28 of 1,733
==113219==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==113219==    by 0x45DEB5: mgr_node_unset (req_manager.c:2541)
==113219==    by 0x45FE77: req_manager (req_manager.c:4861)
==113219==    by 0x4A1782: wait_request (net_server.c:568)
==113219==    by 0x428BD0: main (pbsd_main.c:2140)

==113219== 40 (32 direct, 8 indirect) bytes in 1 blocks are definitely lost in loss record 122 of 1,733
==113219==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==113219==    by 0x476116: deflt_chunk_action (svr_func.c:1041)
==113219==    by 0x45A379: mgr_set_attr2 (req_manager.c:943)
==113219==    by 0x45D4A4: mgr_set_attr (req_manager.c:1037)
==113219==    by 0x45D4A4: mgr_queue_set (req_manager.c:1821)
==113219==    by 0x45FEF7: req_manager (req_manager.c:4816)
==113219==    by 0x4A1782: wait_request (net_server.c:568)
==113219==    by 0x428BD0: main (pbsd_main.c:2140)

==113219== 2 bytes in 2 blocks are definitely lost in loss record 4 of 1,733
==113219==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==113219==    by 0x4CE7D5: disrst (disrst.c:99)
==113219==    by 0x4482E2: mom_running_jobs (node_manager.c:4324)
==113219==    by 0x44D38C: is_request (node_manager.c:4662)
==113219==    by 0x452218: do_rpp (pbsd_main.c:466)
==113219==    by 0x45223C: rpp_request (pbsd_main.c:515)
==113219==    by 0x4A1782: wait_request (net_server.c:568)
==113219==    by 0x428BD0: main (pbsd_main.c:2140)

#### Solution Description
* Added code to free up memory when it is not needed anymore.
* I've also added code to suppress a leak that valgrind reports when hooks are used but it is not actually a leak because it gets freed when python interpreter restarts

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

* Valgrind Logs

[server_log_withoutleak.txt](https://github.com/PBSPro/pbspro/files/1885960/server_log_withoutleak.txt)
[server_log_withleak.txt](https://github.com/PBSPro/pbspro/files/1885961/server_log_withleak.txt)



