### PR TITLE
mail fork error is not logged

### DIFF
--- a/src/server/svr_mail.c
+++ b/src/server/svr_mail.c
@@ -639,7 +639,12 @@ svr_mailowner_id(char *jid, job *pjob, int mailpoint, int force, char *text)
 	 */
 
 #ifndef WIN32
-	if (fork())
+	mcpid = fork();
+	if (mcpid == -1) { /* Error on fork */
+		log_err(errno, __func__, "fork failed\n");
+		return;
+	}
+	if (mcpid > 0)
 		return;		/* its all up to the child now */
 
 	/*
@@ -752,15 +757,20 @@ svr_mailowner_id(char *jid, job *pjob, int mailpoint, int force, char *text)
 	mcpid = fork();
 	if(mcpid == 0) {
 		/* this child will be sendmail with its stdin set to the pipe */
-      if (mfds[0] != 0) {
-            (void)close(0);
-            if (dup(mfds[0]) == -1)
+		if (mfds[0] != 0) {
+			(void)close(0);
+			if (dup(mfds[0]) == -1)
 				exit(1);
-        }
-        (void)close(1);
-        (void)close(2);
-        if (execv(SENDMAIL_CMD, margs) == -1)
+		}
+		(void)close(1);
+		(void)close(2);
+		if (execv(SENDMAIL_CMD, margs) == -1)
 			exit(1);
+	}
+	if (mcpid == -1) {/* Error on fork */
+		log_err(errno, __func__, "fork failed\n");
+		(void)close(mfds[0]);
+		exit(1);
 	}
 
 	/* parent (not the real server though) will write body of message on pipe */
@@ -896,7 +906,12 @@ svr_mailownerResv(resc_resv *presv, int mailpoint, int force, char *text)
 	 */
 
 #ifndef WIN32
-	if (fork())
+	mcpid = fork();
+	if (mcpid == -1) { /* Error on fork */
+		log_err(errno, __func__, "fork failed\n");
+		return;
+	}
+	if (mcpid > 0)
 		return;		/* its all up to the child now */
 
 	/*
@@ -995,15 +1010,20 @@ svr_mailownerResv(resc_resv *presv, int mailpoint, int force, char *text)
 	mcpid = fork();
 	if(mcpid == 0) {
 		/* this child will be sendmail with its stdin set to the pipe */
-      if (mfds[0] != 0) {
-            (void)close(0);
-            if (dup(mfds[0]) == -1)
+		if (mfds[0] != 0) {
+			(void)close(0);
+			if (dup(mfds[0]) == -1)
 				exit(1);
-        }
-        (void)close(1);
-        (void)close(2);
-        if (execv(SENDMAIL_CMD, margs) == -1)
+		}
+		(void)close(1);
+		(void)close(2);
+		if (execv(SENDMAIL_CMD, margs) == -1)
 			exit(1);
+	}
+	if (mcpid == -1) {/* Error on fork */
+		log_err(errno, __func__, "fork failed\n");
+		(void)close(mfds[0]);
+		exit(1);
 	}
 
 	/* parent (not the real server though) will write body of message on pipe */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* There is no error message logged on mail fork fail. If the failure happens it is difficult to determine why the mail wasn't sent.
* Steps to reproduce: Let the server occupy so much memory that the fork() cannot be done successfully and run a job with '-m b'.

#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* The fork fail is already handled but no error message is logged.

#### Solution Description
* I added logging error message on fork fail. This error message is consistent with the others fork fail messages in the code.

* I also fixed the align of the sendmail code.

* test log: [mail_fork-ptl_output_smoketest.txt](https://github.com/PBSPro/pbspro/files/1893872/mail_fork-ptl_output_smoketest.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
