### PR TITLE
Scheduler reports preempted job as Can Never Run for one cycle

### DIFF
--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -1,0 +1,88 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestPreemption(TestFunctional):
+    """
+    Contains tests for scheduler's preemption functionality
+    """
+
+    def test_preempted_never_run(self):
+        """
+        Test that a preempted job is not marked as "Job will never run"
+        """
+        # Set ncpus to 2
+        attr = {'resources_available.ncpus': '2'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, self.mom.shortname,
+                            expect=True)
+
+        # Create a high priority queue
+        attr = {"queue_type": "Execution", "Priority": 200, "started": "True",
+                "enabled": "True"}
+        queue_id_h = "highp"
+        self.server.manager(MGR_CMD_CREATE, QUEUE, attr, id=queue_id_h,
+                            logerr=False)
+
+        # Create a low priority queue
+        attr = {"queue_type": "Execution", "Priority": 100, "started": "True",
+                "enabled": "True"}
+        queue_id_l = "lowp"
+        self.server.manager(MGR_CMD_CREATE, QUEUE, attr, id=queue_id_l,
+                            logerr=False)
+
+        # Submit a job to low priority queue
+        attr = {"Resource_List.ncpus": 2,
+                "queue": queue_id_l,
+                "Resource_List.walltime": "00:10:00"}
+        j = Job(TEST_USER, attrs=attr)
+        jidl = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jidl)
+
+        # Submit a job to high priority queue
+        attr["queue"] = queue_id_h
+        j = Job(TEST_USER, attrs=attr)
+        jidh = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jidh)
+
+        # The low priority job should be preempted
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jidl)
+
+        # Check whether scheduler marked the preempted job as "will never run"
+        self.scheduler.log_match(
+            jidl + ";Job will never run", existence=False, max_attempts=5)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* For jobs preempted by suspension or checkpointing in the cycle that they are preempted, the scheduler will report them as "Job will never run". The preempted jobs do get run in the next cycle, but sched_logs end up with the never run log message, which can be confusing.

#### Affected Platform(s)
* All

#### Cause / Analysis
Bhroam helped me debug this. The analysis as as follows:
1) The resources that the scheduler uses for scheduling are the intersection between the sched_config resources line (stored in policy->resdef_to_check) and the resources requested by jobs/resvs in the cycle (stored in the job's select spec)
2) If a job is preempted via suspension or checkpointing, the job should be run on the same vnodes as before. To make this happen, the scheduler adds information about the vnodes from the job's exec_vnode to its select spec so that it seems like the job is requesting to be placed on the vnodes that it ran on previously.
3) Now, the 'vnode' resource needs to be added to the resources that the scheduler uses for scheduling (ref bullet 1). This happens conditionally inside update_universe_on_end(), the condition being that the job's select spec contains a resource that policy->resdef_to_check doesn't.
4) This condition doesn't gets fulfilled in the cycle that the job was preempted because, and this is the code that's buggy, 'vnode' already got added to policy->resdef_to_check for the original policy object when the scheduler was preempting the job. This happens because the original policy object is modified while simulating job end during preemption. So, the resource 'vnode' never gets added the the list of resources that the scheduler uses and while trying to schedule the preempted job, the scheduler sees that the job is requesting 'vnode', but 'vnode' doesn't seem to be a resource available in the system, and it ends up marks the job as Can Never Run.
5) The problem goes away in the next cycle as it recreates the resource list at the beginning of the cycle unconditionally while querying the universe, but the sched logs already got populated in the previous cycle with a log message saying "Job will never run".


#### Solution Description
* Despite the esoteric nature of the bug, the fix is quite simple: we just need to use the dup'd policy object while simulating job ends during preemption so that the original policy object is not touched. This will make update_universe_in_end() update the scheduler's list of resources to use with 'vnode', and the job will not be marked as Can Never run, it will instead correctly log the insufficient resources message.

#### Testing:
[after_fix.log](https://github.com/PBSPro/pbspro/files/1900368/after_fix.log)
[before_fix.log](https://github.com/PBSPro/pbspro/files/1896688/before_fix.log)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
