### PR TITLE
Subjob in X state should not be allowed to qdel

### DIFF
--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -407,6 +407,9 @@ req_deletejob(struct batch_request *preq)
 		if ((i == JOB_STATE_EXITING) && (forcedel == 0)) {
 			req_reject(PBSE_BADSTATE, 0, preq);
 			return;
+		} else if (i == JOB_STATE_EXPIRED) {
+			req_reject(PBSE_NOHISTARRAYSUBJOB, 0, preq);
+			return;
 		} else if (i != JOB_STATE_QUEUED && ((pjob = find_job(jid)) != NULL)) {
 			/*
 			 * If the request is to also purge the history of the sub job then set ji_deletehistory to 1


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug Description
* *subjobs in X state getting deleted with qdel command. Bug introduced with merge of [PP-479](https://pbspro.atlassian.net/browse/PP-479)*
* *Bug reproduction:*

1.  Submit an Array job
2.  del an expired subjob using qdel before the complete array finishes.
3.  subjob gets deleted and its job comment appears as "and finished and terminated"

#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
* *With the merge of [PP-479](https://pbspro.atlassian.net/browse/PP-479), the req_deletejob() was not restricted for individual subjob in X state*

#### Solution Description
* *Fixed by rejecting the batch request in req_deletejob() with PBSE_NOHISTARRAYSUBJOB*

#### Test/verification logs
[ptl_test_results_after_squash.zip](https://github.com/PBSPro/pbspro/files/1922922/ptl_test_results_after_squash.zip)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
