### PR TITLE
PP-1259 : Deleted subjobs get requeued after server restart or failover

### DIFF
--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -422,6 +422,17 @@ chk_array_doneness(job *parent)
 		 */
 		svr_saveorpurge_finjobhist(parent);
 	} else {
+		/* Before we do a full save of parent, recalculate "JOB_ATR_array_indices_remaining" here*/
+		attribute *premain = &parent->ji_wattr[(int)JOB_ATR_array_indices_remaining];
+		if (premain->at_flags & ATR_VFLAG_MODCACHE) {
+			char *pnewstr = cvt_range(parent->ji_ajtrk, JOB_STATE_QUEUED);
+			if (pnewstr == NULL)
+				pnewstr = "-";
+			job_attr_def[JOB_ATR_array_indices_remaining].at_free(premain);
+			job_attr_def[JOB_ATR_array_indices_remaining].at_decode(premain, 0, 0, pnewstr);
+			/* also update value of attribute "array_state_count" */
+			update_subjob_state_ct(parent);
+		}
 		(void)job_save(parent, SAVEJOB_FULL);
 	}
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug Description
* *A deleted Queued subjob gets requeued if the server restarts or failsover. Bug introduced with merge of [PP-479](https://pbspro.atlassian.net/browse/PP-479)*
* *issue ID link : [PP-1259](https://pbspro.atlassian.net/browse/PP-1259)*
* *Bug reproduction steps*

1. Submit an array job
2. Dlete a subjob which is in Q state
3. Kill and restart the server.
4. The deteleted subjob gets back to Q state

#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
* *This is due to stale value of JOB_ATR_array_indices_remaining attribute in db.*

#### Solution Description
* *JOB_ATR_array_indices_remaining is now updated and pushed to db when sub job is deleted*

#### Test or Verification logs
[ptl_test_results_after_squash.zip](https://github.com/PBSPro/pbspro/files/1919079/ptl_test_results_after_squash.zip)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
