### PR TITLE
PP-1261: Retain previous scheduling cycle's configuration of Multisched as much as necessary

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -294,6 +294,7 @@ struct server_info
 	int num_resvs;			/* number of reservations on the server */
 	int num_preempted;		/* number of jobs currently preempted */
 	long sched_cycle_len;		/* length of cycle in seconds */
+	char **partitions;		/* partitions associated */
 	long opt_backfill_fuzzy_time;	/* time window for fuzzy backfill opt */
 	char **node_group_key;		/* the node grouping resources */
 	state_count sc;			/* number of jobs in each state */

--- a/src/scheduler/globals.c
+++ b/src/scheduler/globals.c
@@ -159,8 +159,6 @@ resdef **boolres = NULL;
 /* AOE name used to compare nodes, free when exit cycle */
 char *cmp_aoename = NULL;
 
-char *partitions = NULL;
-char scheduler_host_name[PBS_MAXHOSTNAME + 1] = "Me";  /* arbitrary string */
 char *sc_name = NULL;
 int sched_port = -1;
 char *logfile = NULL;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -75,8 +75,6 @@ extern resdef **allres;
 extern resdef **consres;
 extern resdef **boolres;
 
-extern char *partitions;
-extern char scheduler_host_name[PBS_MAXHOSTNAME+1];
 extern char *sc_name;
 extern int sched_port;
 extern char *logfile;

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -223,7 +223,7 @@ query_nodes(int pbs_sd, server_info *sinfo)
 		sinfo->nodes_by_NASrank[i] = ninfo;
 #endif /* localmod 049 */
 
-		if (node_in_partition(ninfo)) {
+		if (node_in_partition(ninfo, sinfo->partitions)) {
 			ninfo->rank = get_sched_rank();
 			/* get node info from mom */
 			if (talk_with_mom(ninfo)) {
@@ -5684,6 +5684,7 @@ check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, plac
  *      node_in_partition	-  Tells whether the given node belongs to this scheduler
  *
  * @param[in]	ninfo		-  node information
+ * @param[in]	partitions	-  array of partitions associated to scheduler
  *
  *
  * @return	int
@@ -5691,10 +5692,8 @@ check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, plac
  * @retval	0	: if failure
  */
 int
-node_in_partition(node_info *ninfo)
+node_in_partition(node_info *ninfo, char **partitions)
 {
-	char **my_partitions;
-
 	if (dflt_sched) {
 		if (ninfo->partition == NULL)
 			return 1;
@@ -5704,19 +5703,10 @@ node_in_partition(node_info *ninfo)
 	if (ninfo->partition == NULL)
 		return 0;
 
-	my_partitions = break_comma_list(partitions);
-	if (my_partitions == NULL) {
-		log_err(errno, __func__, "Error parsing partitions");
-		return 0;
-	}
-
-	if (find_string(my_partitions, ninfo->partition)) {
-		free_string_array(my_partitions);
+	if (find_string(partitions, ninfo->partition))
 		return 1;
-	} else {
-		free_string_array(my_partitions);
+	else
 		return 0;
-	}
 }
 
 /**

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -657,7 +657,7 @@ void set_current_eoe(node_info *node, char *eoe);
 /* check nodes for eligibility and mark them ineligible if not */
 void check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, place *pl, schd_error *err);
 
-int node_in_partition(node_info *ninfo);
+int node_in_partition(node_info *ninfo, char **partitions);
 
 
 #ifdef	__cplusplus

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -795,8 +795,6 @@ are_we_primary()
 		log_err(-1, __func__, "Unable to get my host name");
 		return -1;
 	}
-	strncpy(scheduler_host_name, server_host, sizeof(scheduler_host_name));
-	scheduler_host_name[sizeof(scheduler_host_name) - 1] = '\0';
 
 	/* both secondary and primary should be set or neither set */
 	if ((pbs_conf.pbs_secondary == NULL) && (pbs_conf.pbs_primary == NULL))

--- a/src/scheduler/pbs_sched_win.c
+++ b/src/scheduler/pbs_sched_win.c
@@ -769,8 +769,7 @@ are_we_primary()
 			return -1;
 		}
 	}
-	strncpy(scheduler_host_name, server_host, sizeof(scheduler_host_name));
-	scheduler_host_name[sizeof(scheduler_host_name) - 1] = '\0';
+
 	/* both secondary and primary should be set or neither set */
 	if ((pbs_conf.pbs_secondary == NULL) && (pbs_conf.pbs_primary == NULL))
 		return 1;

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -185,7 +185,7 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 			return NULL;
 		}
 
-		if (queue_in_partition(qinfo)) {
+		if (queue_in_partition(qinfo, sinfo->partitions)) {
 			/* check if the queue is a dedicated time queue */
 			if (conf.ded_prefix[0] != '\0')
 				if (!strncmp(qinfo->name, conf.ded_prefix, strlen(conf.ded_prefix))) {
@@ -1042,6 +1042,7 @@ node_queue_cmp(node_info *ninfo, void *arg)
  *      queue_in_partition	-  Tells whether the given node belongs to this scheduler
  *
  * @param[in]	qinfo		-  queue information
+ * @param[in]	partitions	-  array of partitions associated to scheduler
  *
  * @return	a node_info filled with information from node
  *
@@ -1050,10 +1051,8 @@ node_queue_cmp(node_info *ninfo, void *arg)
  * @retval	0	: if failure
  */
 int
-queue_in_partition(queue_info *qinfo)
+queue_in_partition(queue_info *qinfo, char **partitions)
 {
-	char **my_partitions;
-
 	if (dflt_sched) {
 		if (qinfo->partition == NULL)
 			return 1;
@@ -1063,20 +1062,10 @@ queue_in_partition(queue_info *qinfo)
 	if (qinfo->partition == NULL)
 		return 0;
 
-	my_partitions = break_comma_list(partitions);
-	if (my_partitions == NULL) {
-		log_err(errno, __func__, "Error parsing partitions");
-		return 0;
-	}
-
-	if (find_string(my_partitions, qinfo->partition)) {
-		free_string_array(my_partitions);
+	if (find_string(partitions, qinfo->partition))
 		return 1;
-	} else {
-		free_string_array(my_partitions);
+	else
 		return 0;
-	}
-
 }
 
 

--- a/src/scheduler/queue_info.h
+++ b/src/scheduler/queue_info.h
@@ -108,7 +108,7 @@ void
 update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 	char *job_state);
 
-int queue_in_partition(queue_info *qinfo);
+int queue_in_partition(queue_info *qinfo, char **partitions);
 
 
 #ifdef	__cplusplus

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -55,6 +55,7 @@
 #include "pbs_error.h"
 #include "sched_cmds.h"
 #include "server.h"
+#include "svrfunc.h"
 
 extern pbs_db_conn_t *svr_db_conn;
 
@@ -277,7 +278,8 @@ action_sched_priv(attribute *pattr, void *pobj, int actmode)
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
-	set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
+	if (actmode != ATR_ACTION_RECOV)
+		(void)contact_sched(SCH_ATTRS_CONFIGURE, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port);
 	return PBSE_NONE;
 }
 
@@ -317,7 +319,8 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
-	set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
+	if (actmode != ATR_ACTION_RECOV)
+		(void)contact_sched(SCH_ATTRS_CONFIGURE, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port);
 	return PBSE_NONE;
 }
 
@@ -512,6 +515,7 @@ action_sched_partition(attribute *pattr, void *pobj, int actmode)
 			}
 		}
 	}
-	set_scheduler_flag(SCH_ATTRS_CONFIGURE, pin_sched);
+	if (actmode != ATR_ACTION_RECOV)
+		(void)contact_sched(SCH_ATTRS_CONFIGURE, NULL, pin_sched->pbs_scheduler_addr, pin_sched->pbs_scheduler_port);
 	return PBSE_NONE;
 }


### PR DESCRIPTION



<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
This ticket is one of the major user-stories of the following EPIC.
 
[PP-337](https://pbspro.atlassian.net/browse/PP-337) Multiple schedulers servicing the PBS cluster

Currently at the end of each scheduler_iteration or intermediate scheduling cycle Multisched validates its configuration assuming that admins can change its configuration at any point in time i.e. during the intermediate scheduling cycles or before submitting/deleting a job etc. The problem with this approach is we will end up in validating the necessary Multisched configuration for each iteration of the events as described above even though there is no change in its configuration data. The current user-story helps in avoiding this.

#### Affected Platform(s)
* All

#### Cause / Analysis / Design/Solution
Now Multisched maintains some sort of its previous cycle's configuration. This certainly helps in reducing the number of times we perform/validate configuration. We need to do validation only when the configuration is different from its previous cycle. This way Multisched performance is also improved to a better extent.

In addition to the above to achieve this goal we have to separate Multisched configuration change/applying it from the attribute scheduling i.e. configuration change should be applied in real time(immediately when admins change it irrespective of scheduling=true or not).
If scheduling=false then Multisched should apply its configuration but should not trigger scheduling cycle.

I have also fixed the following bug "multi-sched scheduler goes to scheduling=false intermittently" as part of this pull request. Root cause of this bug is as follows.

The system call “open” is failing while opening/writing one of the scheduler’s config files and hence Multisched is thinking that scheduler validation is failed and hence setting its comment to “PBS failed validation checks for sched_priv directory”. And as per the design once validation is failed we set its scheduling to false automatically. “open” system call is actually failing because the number of file descriptors per process are exhausted(which is 1024 in my system). After this no matter even we set scheduling to true any number of times “open” system call fails since it crossed the soft limit of number of fds open which is 1024.

solution to this is make sure that the closing of file happens correctly. Added this as a separate commit for clarity.
Also written all the necessary PTL test cases. Please find the logs given below.

[TestMultipleSchedulers_04122018.log](https://github.com/PBSPro/pbspro/files/1902543/TestMultipleSchedulers_04122018.log)
[TestSchedulerInterface_04122018.log](https://github.com/PBSPro/pbspro/files/1902545/TestSchedulerInterface_04122018.log)


**Latest PTL logs**
[TestMultipleSchedulers_04182018.log](https://github.com/PBSPro/pbspro/files/1927678/TestMultipleSchedulers_04182018.log)
[TestSchedulerInterface_04182018.log](https://github.com/PBSPro/pbspro/files/1927679/TestSchedulerInterface_04182018.log)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
