### PR TITLE
Add deepcopy support to pbs.size type

### DIFF
--- a/src/modules/python/pbs/v1/_base_types.py
+++ b/src/modules/python/pbs/v1/_base_types.py
@@ -533,6 +533,9 @@ class size(_size):
 	# and not in _size's richcompare.
         return size(s.__sub__(o))
 
+    def __deepcopy__(self, mem):
+        return size(str(self))
+
 class duration(int):
     """
     Represents an interval or elapsed time object in number of seconds. This is

--- a/test/tests/functional/pbs_types.py
+++ b/test/tests/functional/pbs_types.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class Test_pbs_types(TestFunctional):
+    """
+    This test suite tests pbs python types and their related functions
+    """
+    def test_pbs_size_deepcopy(self):
+        """
+        Test that deepcopy works for pbs.size type
+        """
+        hook_content = ("""
+import pbs
+import copy
+a = pbs.size(1000)
+b = copy.deepcopy(a)
+c = a
+pbs.logmsg(pbs.EVENT_DEBUG, 'a=%s, b=%s, c=%s' % (a, b, c))
+d = pbs.size('1m')
+e = copy.deepcopy(d)
+f = d
+pbs.logmsg(pbs.EVENT_DEBUG, 'd=%s, e=%s, f=%s' % (d, e, f))
+""")
+        hook_name = 'deepcopy'
+        hook_attr = {'enabled': 'true', 'event': 'queuejob'}
+        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+
+        j = Job(TEST_USER)
+        self.server.submit(j)
+        self.server.log_match("a=1000b, b=1000b, c=1000b")
+        self.server.log_match("d=1mb, e=1mb, f=1mb")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
`pbs.size` type does not support deep copy. So if we do this:
```
import pbs
import copy
a = pbs.size(1000)
b = copy.deepcopy(a)
```
`b` will be ` 0` instead of `1000b`

#### Affected Platform(s)
All

#### Solution Description
Implement `__deepcopy__` method of `pbs.size` type. In this case it is pretty straightforward. The method simply creates and returns a new `pbs.size` object with the same value. 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__


#### Test Log
[PTL test log.txt](https://github.com/PBSPro/pbspro/files/1904937/PTL.test.log.txt)
