### PR TITLE
Fix test_preemption race condition

### DIFF
--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -1528,7 +1528,9 @@ else:
              'enabled': 't', 'priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
 
-        (jid1, jid2) = self.submit_jobs(2)
+        (jid1, ) = self.submit_jobs(1)
+        time.sleep(1)
+        (jid2, ) = self.submit_jobs(1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
`test_preemption` of `TestEquivClass` fails but not consistently. 
This test submits jobs in the following order:

> job1 - workq - ncpus:1
> job2 - workq - ncpus:1
> job3 - expressq - ncpus:3

Total available ncpus is 4
After submitting job3, job  should get suspended but when the test fails, `qstat -f` output shows that job2 is in 'S' state. 

#### Affected Platform(s)
Linux

#### Cause / Analysis / Design
Quote from Bhroam:

> The scheduler will pick jobs for preemption which have most recently been started.  The race condition is how quick the jobs start.  If both jid1 and jid2 start in the same second, then jid1 is chosen.  If the second flips over and jid1 and jid2 are submitted a second apart, jid2 is chosen.

#### Solution Description
Add a `sleep(1)` between the submission of job1 and job2 to force job2 to be started later than job1. 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__


#### PTL test log
[test_equiv_class_output.txt](https://github.com/PBSPro/pbspro/files/1917534/test_equiv_class_output.txt)
