### PR TITLE
TestPartition is failing due to unknown node error

### DIFF
--- a/test/tests/interfaces/pbs_partition.py
+++ b/test/tests/interfaces/pbs_partition.py
@@ -42,7 +42,6 @@ class TestPartition(TestInterfaces):
     """
     Test suite to test partition attr
     """
-    host_name = socket.gethostname()
 
     def partition_attr(self, mgr_cmd=MGR_CMD_SET,
                        obj_name="QUEUE", q_type=None,
@@ -104,7 +103,7 @@ class TestPartition(TestInterfaces):
                 self.assertTrue(False, msg)
         elif obj_name is "NODE":
             if name is "Q1":
-                name = self.host_name
+                name = self.server.shortname
             attr = {'partition': partition}
             if mgr_cmd == MGR_CMD_SET:
                 self.server.manager(MGR_CMD_SET, NODE, attr,
@@ -157,8 +156,10 @@ class TestPartition(TestInterfaces):
         """
         Test to check the set of partition attribute on routing queue
         """
-        msg1 = "Can not assign a partition to route queue"
-        msg2 = "checking the qmgr error message"
+        msg0 = "Route queues are incompatible with the "\
+               "partition attribute enabled"
+        msg1 = "Cannot assign a partition to route queue"
+        msg2 = "Qmgr error message do not match"
         try:
             self.partition_attr(
                 mgr_cmd=MGR_CMD_CREATE,
@@ -169,7 +170,7 @@ class TestPartition(TestInterfaces):
             # self.assertEquals(e.rc, 15217)
             # The above code has to be uncommented when the PTL framework
             # bug PP-881 gets fixed
-            self.assertTrue(msg1 in e.msg[0], msg2)
+            self.assertTrue(msg0 in e.msg[0], msg2)
         self.server.manager(
             MGR_CMD_CREATE, QUEUE, {
                 'queue_type': 'route'}, id='Q1')
@@ -255,7 +256,8 @@ class TestPartition(TestInterfaces):
             partition="P2")
         self.partition_attr(mgr_cmd=MGR_CMD_UNSET, obj_name="NODE")
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': "Q2"}, id=self.host_name, expect=True)
+                            'queue': "Q2"}, id=self.server.shortname,
+                            expect=True)
         self.partition_attr(obj_name="NODE", partition="P2")
 
     def test_mismatch_of_partition_on_node_and_queue(self):
@@ -277,7 +279,7 @@ class TestPartition(TestInterfaces):
         try:
             self.server.manager(MGR_CMD_SET,
                                 NODE, {'queue': "Q1"},
-                                id=self.host_name)
+                                id=self.server.shortname)
         except PbsManagerError as e:
             # self.assertEquals(e.rc, 15220)
             # The above code has to be uncommented when the PTL framework


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Test cases are failing because of server name and log error mismatch
* *[PP-1091](https://pbspro.atlassian.net/browse/PP-1091)*

#### Affected Platform(s)
* ALL

#### Cause / Analysis / Design
* Some test cases were failing because of hostname(FQDN) and one test case was failed because of error message

#### Solution Description
* I have changed the hostname(FQDN) to hostname(shortname) and changed the error message with the appropriate one.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
