### PR TITLE
PP-1267: Fix script error in TestReservations.test_sched_cycle_starts…

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -207,7 +207,7 @@ class TestReservations(TestFunctional):
         a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|2')}
         self.server.expect(RESV, a, rid)
 
-        resid = d.split('.')[0]
+        resid = rid.split('.')[0]
         self.server.log_match(resid + ";deleted at request of pbs_server",
                               id=resid, interval=5)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)


### PR DESCRIPTION
…_on_resv_end test

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Test case test_sched_cycle_starts_on_resv_end of TestReservations test suite is failing due to script error. 
File "/home/pbsroot/TEST/tmp/tests/functional/pbs_reservations.py", line 210, in test_sched_cycle_starts_on_resv_end
     resid = d.split('.')[0]
 NameError: global name 'd' is not defined
* *Bugs: [PP-1267](https://pbspro.atlassian.net/browse/PP-1267)*

#### Affected Platform(s)
All

#### Cause / Analysis / Design
Test case failed due to script error which caused test to fail.

#### Solution Description
Test case is throwing error at line resid = d.split('.')[0]. Instead of 'd', it should be 'rid', hence the test case is failing. Fix is to replace d with rid.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
