### PR TITLE
PP-1222: Add skip test for the case when server and mom are on the same host

### DIFF
--- a/test/tests/functional/pbs_provisioning.py
+++ b/test/tests/functional/pbs_provisioning.py
@@ -85,10 +85,16 @@ class TestProvisioningJob(TestFunctional):
     def setUp(self):
         TestFunctional.setUp(self)
         self.momA = self.moms.values()[0]
+        serverA = (self.servers.values()[0]).shortname
+        self.hostA = self.momA.shortname
+        msg = ("Server and Mom can't be on the same host. "
+               "Provide a mom not present on server host "
+               "while invoking the test: -p moms=<m1>")
+        if serverA == self.hostA:
+            self.skipTest(msg)
         self.momA.delete_vnode_defs()
         self.logger.info(self.momA.shortname)
 
-        self.hostA = self.momA.shortname
         self.server.manager(
             MGR_CMD_DELETE, NODE, None, "", runas=ROOT_USER)
 


### PR DESCRIPTION
PP-1222: Add skip test for the case when server and mom are on the same host

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug Description
*  TestProvisioningJob test suite failed with error "Cannot set provisioning attribute on host running PBS server and scheduler"
* Issue ID: [PP-1222](https://pbspro.atlassian.net/browse/PP-1222)

#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* Provisioning can't be done on a mom which is present on the same host as server. If we run the test case without providing a mom (using -p moms = mom1) which is present on a different host than server, the server host is also considered as mom host and we get the error "Cannot set provisioning attribute on host running PBS server and scheduler" .

#### Solution Description
* Added a check to skip the test case if server and mom host are the same

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
