### PR TITLE
Removing python-magic dependency from PBS Snapshot

### DIFF
--- a/test/fw/ptl/utils/pbs_anonutils.py
+++ b/test/fw/ptl/utils/pbs_anonutils.py
@@ -854,7 +854,7 @@ class PBSAnonymizer(object):
 
         :returns: a str object containing filename of the anonymized file
         """
-        (fd, fn) = self.du.mkstemp()
+        fn = self.du.create_temp_file()
 
         # qstat outputs sometimes have different names for some attributes
         self.__add_alias_attr(ATTR_euser, "User")
@@ -866,7 +866,7 @@ class PBSAnonymizer(object):
         self.__add_alias_attr(ATTR_NODE_Host, "host")
 
         header = None
-        with open(filename) as f, os.fdopen(fd, "w") as nf:
+        with open(filename) as f, open(fn, "w") as nf:
             # Get the header and the line with '-'s
             # Also write out the header and dash lines to the output file
             line_num = 0
@@ -982,9 +982,9 @@ class PBSAnonymizer(object):
 
         :returns: a str object containing filename of the anonymized file
         """
-        (fd, fn) = self.du.mkstemp()
+        fn = self.du.create_temp_file()
 
-        with open(filename) as f, os.fdopen(fd, "w") as nf:
+        with open(filename) as f, open(fn, "w") as nf:
             delete_line = False
             for line in f:
                 # Check if this is a line extension for an attr being deleted

--- a/test/fw/requirements.txt
+++ b/test/fw/requirements.txt
@@ -1,5 +1,4 @@
 nose
 BeautifulSoup
 pexpect
-python-magic
 defusedxml


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* python-magic was a third-party dependency that was used by pbs_snapshot to determine if a file was a core file or not. Because that's the only reason why that module was used, we decided that it's better to just use the file command to do this and remove an additional 3rd party dependency.

#### Affected Platform(s)
* All Linux

#### Solution Description
* Replaced the use of python-magic module with the file command
* The trace capturing script had a bug, it didn't include the executable which generated it, fixed that.
* #581 had renamed DshUtils' mkstemp to create_temp_file but pbs_snaputils and pbs_anonutils were not updated with the new call, so updated those as well.

#### Testing logs/output
* Since an automated test for this would require the test to generate a core file (and possibly mess around with ulimit), I don't think an automated test is possible. I did manual testing by generating a core file from a dummy program called 'create_core', copied it over to server_priv/ and ran pbs_snapshot. PFB the snapshot that it captured (I had to convert it to a .zip as Github doesn't support tars):
[snapshot_20180420_22_12_40.zip](https://github.com/PBSPro/pbspro/files/1933833/snapshot_20180420_22_12_40.zip)

The stack trace captured is inside core_trace_bt/server_priv/core
* Here's also the output of the pbs_snapshot's existing ptl tests: 
[testpbssnapshot.log](https://github.com/PBSPro/pbspro/files/1930133/testpbssnapshot.log)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
