### PR TITLE
Fixed race condition in the test for matching server log

### DIFF
--- a/test/tests/functional/pbs_periodic_constant.py
+++ b/test/tests/functional/pbs_periodic_constant.py
@@ -63,5 +63,4 @@ if e.type == pbs.PERIODIC:
                                                 overwrite=True)
         self.assertTrue(retval)
 
-        self.server.log_match("This hook is using pbs.PERIODIC",
-                              max_attempts=10)
+        self.server.log_match("This hook is using pbs.PERIODIC")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
The test test_periodic_constant_via_server_log fails sometimes, as there is a race condition in matching a specific message in the server logs
*  [PP-1228](https://pbspro.atlassian.net/browse/PP-1228)

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* The log_match() functions's max_attempt of 10 is not sufficient in some slower test machines

#### Solution Description
* Let log_match() have the default max_attempts of 60 so as to avoid any race condition

#### Testing logs/output
[periodic_constant.log](https://github.com/PBSPro/pbspro/files/1935001/periodic_constant.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__