### PR TITLE
Fix server memory leaks and remove wrong suppressions

### DIFF
--- a/src/lib/Libtpp/tpp_dis.c
+++ b/src/lib/Libtpp/tpp_dis.c
@@ -857,6 +857,7 @@ set_tpp_config(struct pbs_config *pbs_conf,
 			strcat(formatted_names, ",");
 			strcat(formatted_names, nm);
 		}
+		free(nm);
 
 		len += hlen + 2;
 

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -1592,6 +1592,7 @@ tpp_get_addresses(char *names, int *count)
 					tot_count++;
 				}
 			}
+			free(addrs_tmp);
 		}
 
 		token = strtok_r(NULL, ",", &saveptr);

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -549,38 +549,12 @@
    fun:main
 }
 {
-   From PBSPro (server) - Suppress intentional unfreed memory from tpp_get_addresses 
-   Memcheck:Leak
-   match-leak-kinds: definite
-   fun:malloc
-   fun:tpp_lookup_addr_cache
-   fun:tpp_sock_resolve_host
-   fun:tpp_get_addresses
-   fun:*
-}
-{
-   From PBSPro (server) - Suppress intentional unfreed memory from tpp_get_addresses 
-   Memcheck:Leak
-   fun:calloc
-   fun:tpp_sock_resolve_host
-   fun:tpp_get_addresses
-   fun:*
-}
-{
    From PBSPro (server) - Suppress intentional unfreed memory from hook_recov 
    Memcheck:Leak
    fun:malloc
    fun:strdup
    fun:hook_recov
    fun:pbsd_init
-   fun:main
-}
-{
-   From PBSPro (server) - Suppress intentional unfreed memory from set_tpp_config 
-   Memcheck:Leak
-   fun:malloc
-   fun:mk_hostname
-   fun:set_tpp_config
    fun:main
 }
 {
@@ -610,21 +584,6 @@
    fun:hook_recov
    fun:pbsd_init
    fun:main
-}
-{
-   From PBSPro (comm) - Suppress intentional unfreed memory from find_key
-   Memcheck:Leak
-   fun:calloc
-   fun:get_avl_tls
-   fun:avl_find_key
-   fun:*
-}
-{
-   From PBSPro (comm) - Suppress intentional unfreed memory from get_tls
-   Memcheck:Leak
-   fun:calloc
-   fun:tpp_get_tls
-   fun:*
 }
 {
    From PBSPro (all deamons) - Suppress memory allocated for log mutex


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
A few memory leaks are fixed and wrong valgrind suppressions are removed.
1. ==62331== 101 bytes in 5 blocks are definitely lost in loss record 834 of 1,772
==62331== at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==62331== by 0x5787D7: mk_hostname (tpp_util.c:1050)
==62331== by 0x572EDF: set_tpp_config (tpp_dis.c:836)
==62331== by 0x48681B: main (pbsd_main.c:1844)

Solution: Freed memory.

2. ==50217== 120 bytes in 6 blocks are definitely lost in loss record 1,427 of 2,412
==50217== at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==50217== by 0x578BD4: tpp_lookup_addr_cache (tpp_util.c:1608)
==50217== by 0x579963: tpp_sock_resolve_host (tpp_platform.c:721)
==50217== by 0x578EB5: tpp_get_addresses (tpp_util.c:1722)
==50217== by 0x56BECA: tpp_open (tpp_client.c:833)
==50217== by 0x472794: mom_ping_need (node_manager.c:1098)
==50217== by 0x472D29: ping_a_mom_mcast (node_manager.c:1309)
==50217== by 0x474D84: ping_nodes (node_manager.c:2765)
==50217== by 0x501FF4: dispatch_task (work_task.c:142)
==50217== by 0x50237C: default_next_task (work_task.c:316)
==50217== by 0x48778B: next_task (pbsd_main.c:2364)
==50217== by 0x486F65: main (pbsd_main.c:2043)

Solution: Fixed the leak by freeing the right memory address and removed the earlier wrongly added supressions to the valgrind.supp file.

3. Wrong valrgind suppression added. 
{
   From PBSPro (comm) - Suppress intentional unfreed memory from find_key
   Memcheck:Leak
   fun:calloc
   fun:get_avl_tls
   fun:avl_find_key
   fun:*
}

Solution: This is removed now, since the code was already fixed in mainline by pull request #508 

#### Affected Platform(s)
* *Platform (for example CentOS 7.2)*


#### Testing logs/output
* *
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
