### PR TITLE
PP-1262: Fix compiler warnings generated with gcc(version 5.4.0) flags = "-g -O2 -Wall -Werror -fPIC -D_LARGEFILE_SOURCE -Wno-unused-result"

### DIFF
--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -370,6 +370,7 @@ log_add_debug_info()
 {
 	char tbuf[LOG_BUF_SIZE];
 	char temp[LOG_BUF_SIZE];
+	char dest[LOG_BUF_SIZE];
 	/* Temporary buffers to create log entry string for leaf name and mom node name */
 	char host[PBS_MAXHOSTNAME+1];
 
@@ -385,23 +386,25 @@ log_add_debug_info()
 
 	/* To add leaf node name, if set */
 	strcpy(temp, "pbs_leaf_name=");
-	if(pbs_conf.pbs_leaf_name){
-		strncat(temp, pbs_conf.pbs_leaf_name, LOG_BUF_SIZE);
-		strncat(temp, ";", LOG_BUF_SIZE);
+	if(pbs_conf.pbs_leaf_name) {
+		snprintf(dest, LOG_BUF_SIZE, "%s%s;", temp, pbs_conf.pbs_leaf_name);
+		strcpy(temp, dest);
 	}
 	else
 		strcat(temp, "N/A;");
-	strncat(tbuf, temp, LOG_BUF_SIZE);
-
+	snprintf(dest, LOG_BUF_SIZE, "%s%s", tbuf, temp);
+	strcpy(tbuf, dest);
 
 	/* To add mom node name, if set */
 	strcpy(temp, "pbs_mom_node_name=");
-	if(pbs_conf.pbs_mom_node_name)
-		strncat(temp, pbs_conf.pbs_mom_node_name, LOG_BUF_SIZE);
+	if(pbs_conf.pbs_mom_node_name) {
+		snprintf(dest, LOG_BUF_SIZE, "%s%s", temp, pbs_conf.pbs_mom_node_name);
+		strcpy(temp, dest);
+	}
 	else
 		strncat(temp, "N/A", LOG_BUF_SIZE);
-	strncat(tbuf, temp, LOG_BUF_SIZE);
-	log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO, msg_daemonname, tbuf);
+	snprintf(dest, LOG_BUF_SIZE, "%s%s", tbuf, temp);
+	log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO, msg_daemonname, dest);
 
 	return;
 
@@ -425,6 +428,7 @@ log_add_if_info()
 	char msg[LOG_BUF_SIZE];
 	char temp[LOG_BUF_SIZE];
 	int i;
+	char dest[LOG_BUF_SIZE];
 	struct log_net_info *ni, *curr;
 
 	memset(msg, '\0', sizeof(msg));
@@ -443,9 +447,9 @@ log_add_if_info()
 			(curr->ifname) ? curr->ifname : "NULL");
 		for (i = 0; curr->ifhostnames[i]; i++) {
 			snprintf(temp, LOG_BUF_SIZE, "%s ", curr->ifhostnames[i]);
-			strncat(tbuf, temp, LOG_BUF_SIZE);
+			snprintf(dest, LOG_BUF_SIZE, "%s%s", tbuf, temp);
 		}
-		log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO, msg_daemonname, tbuf);
+		log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO, msg_daemonname, dest);
 	}
 
 	free_if_info(ni);

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -2844,7 +2844,7 @@ im_request(int stream, int version)
 						char	hook_buf[HOOK_BUF_SIZE];
 						int	vret = 0;
 
-						snprintf(hook_buf,
+						snprintf(log_buffer,
 							sizeof(log_buffer),
 							"1,%s",
 							last_phook->hook_name);

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -1213,7 +1213,7 @@ initialize(void)
 				if ((last_phook != NULL) &&
 				(last_phook->fail_action & \
 					   HOOK_FAIL_ACTION_OFFLINE_VNODES)) {
-					snprintf(hook_buf,
+					snprintf(log_buffer,
 						sizeof(log_buffer),
 						"1,%s", last_phook->hook_name);
 

--- a/src/tools/pbs_upgrade_job.c
+++ b/src/tools/pbs_upgrade_job.c
@@ -313,7 +313,7 @@ upgrade_job_file(int fd)
 		return 1;
 	}
 	tmpfd = fileno(tmp);
-	if (!tmpfd < 0) {
+	if (tmpfd < 0) {
 		fprintf(stderr, "Failed to find temporary file descriptor [%s]\n",
 			errno ? strerror(errno) : "No error");
 		return 1;
@@ -455,7 +455,7 @@ upgrade_task_file(char *taskfile)
 		return 1;
 	}
 	tmpfd = fileno(tmp);
-	if (!tmpfd < 0) {
+	if (tmpfd < 0) {
 		fprintf(stderr, "Failed to find temporary file descriptor [%s]\n",
 			errno ? strerror(errno) : "No error");
 		return 1;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Fix all warnings produced when compiling on ubuntu 16.04(gcc > 5.0) while using gcc flags "-g -O2 -Wall -Werror -fPIC -D_LARGEFILE_SOURCE -Wno-unused-result"
* Issue ID: [PP-1262](https://pbspro.atlassian.net/browse/PP-1262)*

#### Affected Platform(s)
* Ubuntu 16.04

#### Solution Description
* Fixed warnings pertaining to format security and potential buffer overflow which were only sensitive to gcc 5.0 or higher.

#### Testing logs/output
* [build.txt ("-Wall -Werror")](https://github.com/PBSPro/pbspro/files/1936959/build.txt)
* [build_added_flags.txt  ("-g -O2 -Wall -Werror -fPIC -D_LARGEFILE_SOURCE -Wno-unused-result")](https://github.com/PBSPro/pbspro/files/1941049/build_all.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
