### PR TITLE
Fix prologue hook execute twice on pbsdsh request

### DIFF
--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -3465,36 +3465,6 @@ join_err:
 				sprintf(log_buffer, "SPAWN_TASK read of envp array");
 				goto err;
 			}
-			/*
-			 ** do the spawn
-			 */
-
-			if (GET_NEXT(pjob->ji_tasks) == NULL) {
-				mom_hook_input_init(&hook_input);
-				hook_input.pjob = pjob;
-
-				mom_hook_output_init(&hook_output);
-				hook_output.reject_errcode = &hook_errcode;
-				hook_output.last_phook = &last_phook;
-				hook_output.fail_action = &hook_fail_action;
-				switch (mom_process_hooks(HOOK_EVENT_EXECJOB_PROLOGUE,
-						PBS_MOM_SERVICE_NAME, mom_host, &hook_input,
-						&hook_output, hook_msg, sizeof(hook_msg), 1)) {
-					case 0: /* explicit reject */
-						SEND_ERR2(hook_errcode, (char *)hook_msg);
-						arrayfree(argv);
-						arrayfree(envp);
-						goto done;
-					case 1: /* explicit accept */
-						break;
-					case 2:/* no hook script executed - go ahead and accept event*/
-						break;
-					default:
-						log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_HOOK,
-							LOG_INFO, "",
-							"execjob_prologue event: accept req by default");
-				}
-			}
 
 			ret = DIS_SUCCESS;
 			if ((ptask = momtask_create(pjob)) == NULL) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
execjob_prologue hook executes twice on pbsdsh request

#### Affected Platform(s)
all

#### Cause / Analysis / Design
It's caused by left over code in `im_request` function of `mom_comm.c`

#### Solution Description
Remove the leftover code

#### Testing logs/output
- [pbs_hook_execjob_prologue_output.txt](https://github.com/PBSPro/pbspro/files/1948709/pbs_hook_execjob_prologue_output.txt)
- [pbs_accumulate_resc_used_output.txt](https://github.com/PBSPro/pbspro/files/1948927/pbs_accumulate_resc_used_output.txt)
- [pbs_hook_execjob_prologue_new_testcase.txt](https://github.com/PBSPro/pbspro/files/1988995/pbs_hook_execjob_prologue_new_testcase.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
