### PR TITLE
PP-1275: Remove max_attempts specified in TestHookSwig test suite

### DIFF
--- a/test/tests/functional/pbs_hookswig.py
+++ b/test/tests/functional/pbs_hookswig.py
@@ -74,7 +74,7 @@ pbs.logjobmsg(jid, "server is %s" % (s.name,))
         except PbsSubmitError:
             pass
         self.server.log_match("Job;%s;server is %s" % (
-            "newjob", self.server.shortname), max_attempts=3)
+            "newjob", self.server.shortname))
 
         self.mom.log_match("Job;%s;server is %s" % (
-            jid, self.server.shortname), max_attempts=3)
+            jid, self.server.shortname))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->


- **[PP-1275](https://pbspro.atlassian.net/browse/PP-1275)**

#### Cause / Analysis / Design
* *Bug: Test "test_hook" from TestHookSwig is failing intermittently during weekend regression. The test is failing while checking for log messages in server and mom logs due to very low max_attempts passed in the log_match function*

#### Solution Description
*Remove the parameter "max_attempts" specified in log_match function. The function will then take the default max_attempts (i.e. 60)*

#### Testing logs/output
**[Execution_logs_PP-1275_1.txt](https://github.com/PBSPro/pbspro/files/1951062/Execution_logs_PP-1275_1.txt)**


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
