### PR TITLE
Mom crashes whenever server tries to delete a job in EXITING state

### DIFF
--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -685,7 +685,7 @@ remove_stdouterr_files(job *pjob, char *suffix) {
  */
 int direct_write_requested(job *pjob) {
 	char *pj_attrk = NULL;
-	if ((pjob->ji_wattr[(int)JOB_ATR_keep].at_flags & ATR_VFLAG_SET)) {
+	if (pjob && (pjob->ji_wattr[(int)JOB_ATR_keep].at_flags & ATR_VFLAG_SET)) {
 		pj_attrk = pjob->ji_wattr[(int)JOB_ATR_keep].at_val.at_str;
 		if (strchr(pj_attrk, 'd') && (strchr(pj_attrk, 'o') || (strchr(pj_attrk, 'e'))))
 			return 1;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *Mom crashes whenever server tries to delete a job in EXITING state*
* Steps for reproduction:
1. Create a checkpoint_abort script

cat /tmp/test.sh

#!/bin/bash
kill $1
exit 0
2. Update the mom config file
cat config
$clienthost centos
$restrict_user_maxsysid 999
$action checkpoint_abort 30 !/tmp/test.sh %sid

3. You need to change the order preempt_order: "CSR" from the default "SCR" to checkpoint jobs.
4. HUP mom and scheduler to take effect.
5. Create an express_q
qmgr
c q express_q
s q queue_type = Execution
s q Priority = 200
s q enabled = True
s q started = True
6. submit 2 jobs
qsub -- /bin/sleep 100
qsub -q express_q -- /bin/sleep 10
7. Wait for a minute and check the state of job is 'H' after second job finishes.
8. qdel on the checkpointed job in 'H' state and you can see a mom crash.*
* Attaching pbs_checkpoint which can be used to test this. But I cannot checkin the PTL as this behavior is temporary and won't appear after the checkpoint fix.
[pbs_checkpoint.txt](https://github.com/PBSPro/pbspro/files/1959809/pbs_checkpoint.txt)


#### Cause / Analysis / Design
* In req_cpyfile function we call direct_write_requested() without checking if find_job was successful in finding the requested job or not.

#### Solution Description
* In direct_write_requested(), pjob is null checked before accessing elements.

#### Testing logs/output
[PTL test logs.txt](https://github.com/PBSPro/pbspro/files/1959802/PTL.test.logs.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

CC: @arungrover 