### PR TITLE
Addressed server and mom leaks

### DIFF
--- a/src/lib/Libattr/attr_fn_l.c
+++ b/src/lib/Libattr/attr_fn_l.c
@@ -166,6 +166,9 @@ encode_l(attribute *attr, pbs_list_head *phead, char *atname, char *rsname, int 
 	if (rtnl)
 		*rtnl = pal;
 
+	if ((phead == NULL) && (rtnl == NULL))
+		free(pal);
+
 	return (1);
 }
 

--- a/src/lib/Libattr/attr_fn_size.c
+++ b/src/lib/Libattr/attr_fn_size.c
@@ -162,6 +162,8 @@ encode_size(attribute *attr, pbs_list_head *phead, char *atname, char *rsname, i
 		append_link(phead, &pal->al_link, pal);
 	if (rtnl)
 		*rtnl = pal;
+	if ((phead == NULL) && (rtnl == NULL))
+		free(pal);
 
 	return (1);
 }

--- a/src/lib/Libattr/attr_fn_str.c
+++ b/src/lib/Libattr/attr_fn_str.c
@@ -157,6 +157,9 @@ encode_str(attribute *attr, pbs_list_head *phead, char *atname, char *rsname, in
 	if (rtnl)
 		*rtnl = pal;
 
+	if ((phead == NULL) && (rtnl == NULL))
+		free(pal);
+
 	return (1);
 }
 

--- a/src/lib/Libcmds/parse_depend.c
+++ b/src/lib/Libcmds/parse_depend.c
@@ -185,7 +185,6 @@ parse_depend_item(char *depend_list, char **rtn_list, int *rtn_size)
 	return 0;
 }
 
-
 /**
  * @brief
  *	Parse dependency lists with
@@ -240,6 +239,7 @@ parse_depend_list(char *list, char **rtn_list, int rtn_size)
 		/* Parse the individual list item */
 
 		if (parse_depend_item(s, rtn_list, &rtn_size)) {
+			free(lc);	
 			return 1;
 		}
 

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -4822,6 +4822,7 @@ update_vnodes_on_resourcedef_change(char **deleted_resources)
 		}
 	}
 
+	free(attr);
 	if (mod_vnlp) {
 		vnl_free(vnlp);
 		nv->vnl_modtime = time(0);
@@ -5112,7 +5113,7 @@ req_del_hookfile(struct batch_request *preq) /* ptr to the decoded request   */
 				"deleted any hook task entry");
 			/* inside hook_purge() is where the hook control */
 			/* file is deleted */
-			hook_purge(phook, NULL);
+			hook_purge(phook, python_script_free);
 		}
 		reply_ack(preq);
 		return;

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -596,7 +596,10 @@ free_sellist(struct select_list *pslist)
 
 	while (pslist) {
 		next = pslist->sl_next;
-		job_attr_def[pslist->sl_atindx].at_free(&pslist->sl_attr); /* free the attr */
+		if (pslist->sl_atindx == JOB_ATR_state)
+			state_sel.at_free(&pslist->sl_attr);
+		else
+			job_attr_def[pslist->sl_atindx].at_free(&pslist->sl_attr); /* free the attr */
 		(void)free(pslist);			  /* free the entry */
 		pslist = next;
 	}

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -635,3 +635,36 @@
    fun:pbs_python_populate_attributes_to_python_class
    fun:*
 }
+{
+   From PBSPro (server) - Suppress intentional unfreed memory from pbs_python_populate_attributes_to_python_class() that is tracked and freed in a local pbs_list_head
+   Memcheck:Leak
+   fun:malloc
+   fun:attrlist_alloc
+   fun:attrlist_create
+   fun:encode_l
+   fun:encode_resc
+   fun:pbs_python_populate_attributes_to_python_class
+   fun:*
+}
+{
+   From PBSPro (server) - Suppress intentional unfreed memory from pbs_python_populate_attributes_to_python_class() that is tracked and freed in a local pbs_list_head.
+   Memcheck:Leak
+   fun:malloc
+   fun:attrlist_alloc
+   fun:attrlist_create
+   fun:encode_size
+   fun:encode_resc
+   fun:pbs_python_populate_attributes_to_python_class
+   fun:*
+}
+{
+   From PBSPro (server) - Suppress intentional unfreed memory from pbs_python_populate_attributes_to_python_class() that is tracked and freed in a local pbs_list_head.
+   Memcheck:Leak
+   fun:malloc
+   fun:attrlist_alloc
+   fun:attrlist_create
+   fun:encode_str
+   fun:encode_resc
+   fun:pbs_python_populate_attributes_to_python_class
+   fun:*
+}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
This request addresses the following leak-related messages reported by valgrind when running pbs server and mom:
1. SERVER: ==1661== 5 bytes in 1 blocks are definitely lost in loss record 8 of 513
==1661==    at 0x4C2C27B: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==1661==    by 0x4D8078: parse_depend_list (parse_depend.c:217)
==1661==    by 0x4DB222: verify_value_dependlist (ecl_verify_values.c:291)
==1661==    by 0x4DA930: verify_an_attribute (ecl_verify.c:347)
==1661==    by 0x4C9425: pbsv1mod_meth_validate_input (pbs_python_svr_internal.c:7942)
==1661==    by 0x55A2119: PyEval_EvalFrameEx (in /usr/lib64/libpython2.7.so.1.0)
==1661==    by 0x55A7302: PyEval_EvalCodeEx (in /usr/lib64/libpython2.7.so.1.0)
==1661==    by 0x558E5B5: ??? (in /usr/lib64/libpython2.7.so.1.0)
==1661==    by 0x558A40C: PyObject_Call (in /usr/lib64/libpython2.7.so.1.0)
==1661==    by 0x558B170: ??? (in /usr/lib64/libpython2.7.so.1.0)
==1661==    by 0x558A40C: PyObject_Call (in /usr/lib64/libpython2.7.so.1.0)
==1661==    by 0x55994FF: ??? (in /usr/lib64/libpython2.7.so.1.0)
This is reproducible in a hook that sets pbs.event().job.depend to bad value, for example:
        pbs.event().job.depend = pbs.depend("ok:2")
CAUSE/FIX: In lib/Libcmds/parse_depend.c:parse_depend_item(), there was a missed free() call when function returns early due to error.
 
2. SERVER ==2602== 2 bytes in 1 blocks are definitely lost in loss record 3 of 538
==2602==    at 0x4C2C27B: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==2602==    by 0x4978EC: decode_str (attr_fn_str.c:104)
==2602==    by 0x473F4C: req_selectjobs (req_select.c:665)
==2602==    by 0x4AAC74: wait_request (net_server.c:568)
==2602==    by 0x42D916: main (pbsd_main.c:2141)
==2602==
This can be reproduced by submitting a job, let it run, and doing a qselect -s R.
CAUSE/FIX: In req_select.c:free_sellist(), when attribute is JOB_ATR_state, the wrong free call is done (free_null()) as it should be the state_sel.at_free().

3. SERVER ==18192== 640 bytes in 5 blocks are possibly lost in loss record 484 of 792
==18192==    at 0x4C2C27B: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==18192==    by 0x4980D3: attrlist_alloc (attr_func.c:288)
==18192==    by 0x4981BC: attrlist_create (attr_func.c:346)
==18192==    by 0x4977EF: encode_size (attr_fn_size.c:155)
==18192==    by 0x4969D3: encode_resc (attr_fn_resc.c:246)
==18192==    by 0x4BE7AC: pbs_python_populate_attributes_to_python_class (pbs_python_svr_internal.c:2012)
==18192==    by 0x4C1F48: _pps_helper_get_vnode (pbs_python_svr_internal.c:3844)
==18192==    by 0x4C7D96: pbsv1mod_meth_get_vnode (pbs_python_svr_internal.c:6957)
==18192==    by 0x55A2119: PyEval_EvalFrameEx (in /usr/lib64/libpython2.7.so.1.0)
==18192==    by 0x55A433C: PyEval_EvalFrameEx (in /usr/lib64/libpython2.7.so.1.0)
==18192==    by 0x55A75C2: PyEval_EvalCodeEx (in /usr/lib64/libpython2.7.so.1.0)
==18192==    by 0x55D5891: PyEval_EvalCode (in /usr/lib64/libpython2.7.so.1.0)
==18192==
CAUSE/FIX: This is reported as "possibly lost" and investigation verified that the memory malloced is saved in a pbs_list_head that is later freed. However, there's a case in lib/Libattr/attr_fn_size.c:encode_size() where the input parameters 'phead' and 'rtnl' when both NULL (note that this currently does not happen in pbs code) would result in the malloc-ed 'pal' to leak. This has been fixed. However, we still get the "possibly lost" message so that has been added to the valgrind suppression file.

4. SERVER ==18351== 487 bytes in 4 blocks are possibly lost in loss record 451 of 790
==18351==    at 0x4C2C27B: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==18351==    by 0x4980D3: attrlist_alloc (attr_func.c:288)
==18351==    by 0x4981BC: attrlist_create (attr_func.c:346)
==18351==    by 0x496764: encode_l (attr_fn_l.c:158)
==18351==    by 0x4969D3: encode_resc (attr_fn_resc.c:246)
==18351==    by 0x4BE7AC: pbs_python_populate_attributes_to_python_class (pbs_python_svr_internal.c:2012)
==18351==    by 0x4C1853: _pps_helper_get_server (pbs_python_svr_internal.c:3468)
==18351==    by 0x4C2659: _pps_helper_get_job (pbs_python_svr_internal.c:3615)
==18351==    by 0x4C4B56: _pbs_python_event_set (pbs_python_svr_internal.c:5503)
==18351==    by 0x4BA6C7: pbs_python_event_set (pbs_python_svr_external.c:234)
==18351==    by 0x439A8F: server_process_hooks (hook_func.c:4054)
==18351==    by 0x43B864: process_hooks (hook_func.c:3921)
==18351==
CAUSE/FIX: This is reported as "possibly lost" and investigation verified that the memory malloced is saved in a pbs_list_head that is later freed. However, there's a case in lib/Libattr/attr_fn_l.c:encode_l() where the input parameters 'phead' and 'rtnl' when both NULL (note that this currently does not happen in pbs code) would result in the malloc-ed 'pal' to leak. This has been fixed. However, we still get the "possibly lost" message so that has been added to the valgrind suppression file.

5. SERVER ==13900== 248 bytes in 2 blocks are possibly lost in loss record 228 of 749
==13900==    at 0x4C2C27B: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==13900==    by 0x4980D3: attrlist_alloc (attr_func.c:288)
==13900==    by 0x4981BC: attrlist_create (attr_func.c:346)
==13900==    by 0x497A1D: encode_str (attr_fn_str.c:149)
==13900==    by 0x4969D3: encode_resc (attr_fn_resc.c:246)
==13900==    by 0x4BE7AC: pbs_python_populate_attributes_to_python_class (pbs_python_svr_internal.c:2012)
==13900==    by 0x4C2615: _pps_helper_get_job (pbs_python_svr_internal.c:3591)
==13900==    by 0x4C4B56: _pbs_python_event_set (pbs_python_svr_internal.c:5503)
==13900==    by 0x4BA6C7: pbs_python_event_set (pbs_python_svr_external.c:234)
==13900==    by 0x439A8F: server_process_hooks (hook_func.c:4054)
==13900==    by 0x43B864: process_hooks (hook_func.c:3921)
==13900==    by 0x471758: call_to_process_hooks (req_runjob.c:280)
==13900==
CAUSE/FIX: This is reported as "possibly lost" and investigation verified that the memory malloced is saved in a pbs_list_head that is later freed. However, there's a case in lib/Libattr/attr_fn_str.c:encode_size() where the input parameters 'phead' and 'rtnl' when both NULL (note that this currently does not happen in pbs code) would result in the malloc-ed 'pal' to leak. This has been fixed. However, we still get the "possibly lost" message so that has been added to the valgrind suppression file.

6. Mom ==6621== 40 bytes in 1 blocks are definitely lost in loss record 88 of 318
==6621==    at 0x4C2C27B: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==6621==    by 0x452EE1: req_copy_hookfile (requests.c:4794)
==6621==    by 0x44C38F: is_request (mom_server.c:592)
==6621==    by 0x448898: do_rpp (mom_main.c:6072)
==6621==    by 0x4488EB: rpp_request (mom_main.c:6109)
==6621==    by 0x467734: wait_request (net_server.c:568)
==6621==    by 0x421ADA: main (mom_main.c:6375)
==6621==
CAUSE/FIX: This can be reproduced by having an existing mom hook (e.g. epilogue hook), creating 2 dynamic resources using qmgr as in qmgr -c 'c r foo type=string,flag=h' and qmgr -c 'c r foo2 type=string,flag=h', and then later deleting one of the resources: qmgr -c 'd r foo2'. As mom gets a resourcedef file update request due to resource changes, some variable holding temporarily malloced data, does not get freed. This has been fixed.

7. Mom ==6490== 138 bytes in 3 blocks are definitely lost in loss record 110 of 316
==6490==    at 0x4C2C27B: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==6490==    by 0x6622EE1: strdup (in /lib64/libc-2.17.so)
==6490==    by 0x43E6F1: python_script_alloc (mom_hook_func.c:1639)
==6490==    by 0x494BAC: hook_recov (hook.c:3531)
==6490==    by 0x42135A: main (mom_main.c:9259)
==6490==
CAUSE/FIX: This can be reproduced by having a mom hook in the system, and then delete the node that is holding the mom hook: qmgr -c 'd n <node_name>'. This results in the hook being deleted from the system, clearing memory malloced for the hook, but forgetting to remove the malloced area given to the hook script content. This has been fixed.

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* see detailed bug description.

#### Solution Description
* see detailed bug description

#### Testing logs/output
* 
[leak.server.depend.txt](https://github.com/PBSPro/pbspro/files/1969984/leak.server.depend.txt)
[bef_depend_valgrind_server.txt](https://github.com/PBSPro/pbspro/files/1969985/bef_depend_valgrind_server.txt)
[aft_depend_valgrind_server.txt](https://github.com/PBSPro/pbspro/files/1969986/aft_depend_valgrind_server.txt)
[leak.server.select.txt](https://github.com/PBSPro/pbspro/files/1969987/leak.server.select.txt)
[bef_select_valgrind_server.txt](https://github.com/PBSPro/pbspro/files/1969988/bef_select_valgrind_server.txt)
[aft_select_valgrind_server.txt](https://github.com/PBSPro/pbspro/files/1969990/aft_select_valgrind_server.txt)
[leak.mom.update.resourcedef.txt](https://github.com/PBSPro/pbspro/files/1969991/leak.mom.update.resourcedef.txt)
[leak.mom.node.delete.txt](https://github.com/PBSPro/pbspro/files/1969992/leak.mom.node.delete.txt)
[before_valgrind_logs.tar.gz](https://github.com/PBSPro/pbspro/files/1970000/before_valgrind_logs.tar.gz)
[after_valgrind_logs.tar.gz](https://github.com/PBSPro/pbspro/files/1970001/after_valgrind_logs.tar.gz)











#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
