### PR TITLE
PP-973: PTL is not reverting the managers and operators in setUp

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -855,11 +855,11 @@ class PBSTestSuite(unittest.TestCase):
         server_stat = server.status(SERVER)[0]
         current_user = pwd.getpwuid(os.getuid())[0]
         try:
-            # remove current user's entry from managers list (if any)
-            a = {ATTR_managers: (DECR, current_user + '@*')}
-            server.manager(MGR_CMD_SET, SERVER, a, sudo=True)
-        except:
-            pass
+            # Unset managers list
+            server.manager(MGR_CMD_UNSET, SERVER, 'managers', sudo=True,
+                           expect=True)
+        except PbsManagerError as e:
+            self.logger.error(e.msg)
         a = {ATTR_managers: (INCR, current_user + '@*')}
         server.manager(MGR_CMD_SET, SERVER, a, sudo=True)
         if ((self.revert_to_defaults and self.server_revert_to_defaults) or

--- a/test/tests/selftest/__init__.py
+++ b/test/tests/selftest/__init__.py
@@ -1,0 +1,44 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from ptl.utils.pbs_testsuite import *
+
+
+class TestSelf(PBSTestSuite):
+    """
+    Base test suite for Self tests
+    """

--- a/test/tests/selftest/pbs_managers_operators_ext.py
+++ b/test/tests/selftest/pbs_managers_operators_ext.py
@@ -1,0 +1,62 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.selftest import *
+
+
+class ManagersOperators(TestSelf):
+
+    """
+    This test suite contains tests related to managers and operators
+
+    """
+    def test_managers_unset_setup(self):
+        """
+        Additional managers users, except current user should get unset
+        after test setUp run
+        """
+        runas = ROOT_USER
+        current_usr = pwd.getpwuid(os.getuid())[0]
+        attr = {ATTR_managers: current_usr + '@*'}
+        self.server.expect(SERVER, attrib=attr)
+        mgr_user1 = str(TEST_USER)
+        mgr_user2 = str(TEST_USER1)
+        a = {ATTR_managers: (INCR, mgr_user1 + '@*,' + mgr_user2 + '@*')}
+        self.server.manager(MGR_CMD_SET, SERVER, a, runas=runas)
+        self.logger.info("Calling test setUp:")
+        TestSelf.setUp(self)
+        self.server.expect(SERVER, attrib=attr)


### PR DESCRIPTION

[manager_unset.txt](https://github.com/PBSPro/pbspro/files/1984842/manager_unset.txt)

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* PTL setup does not revert users other than current user added to managers list.
* [PP-973](https://pbspro.atlassian.net/browse/PP-973)

#### Affected Platform(s)
* All platforms

#### Cause / Analysis / Design
* Existing PTL setup only removes current user from managers list, it does not care about the users other than current user.  

#### Solution Description
* Unset the managers instead of removing only current user from managers list inside PTL setup.

#### Testing logs/output
* *Please attach your test log output from running the test you added (or from existing tests that cover your changes)*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
