### PR TITLE
orphaned subjobs at job_history_duration expiry and a race scenario

### DIFF
--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -452,7 +452,7 @@ req_deletejob(struct batch_request *preq)
 			sjst = get_subjob_state(parent, i);
 			if ((sjst == JOB_STATE_EXITING) && !forcedel)
 				continue;
-			if ((sjst != JOB_STATE_QUEUED) && (pjob = find_job(mk_subjob_id(parent, i)))) {
+			if ((pjob = find_job(mk_subjob_id(parent, i)))) {
 				if (delhist)
 					pjob->ji_deletehistory = 1;
 				if (pjob->ji_qs.ji_state == JOB_STATE_EXPIRED) {

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -5290,7 +5290,8 @@ svr_clean_job_history(struct work_task *pwt)
 		nxpjob = (job *)GET_NEXT(pjob->ji_alljobs);
 
 		if ((pjob->ji_qs.ji_state == JOB_STATE_MOVED) ||
-			(pjob->ji_qs.ji_state == JOB_STATE_FINISHED)) {
+			(pjob->ji_qs.ji_state == JOB_STATE_FINISHED) ||
+			(pjob->ji_qs.ji_state == JOB_STATE_EXPIRED)) {
 
 			if (!(pjob->ji_wattr[(int) JOB_ATR_history_timestamp].at_flags & ATR_VFLAG_SET)) {
 				if (pjob->ji_qs.ji_state == JOB_STATE_MOVED)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug Description
* *Orphaned subjobs possible when:*
1. job_history_duration expires
2. qdel a job array containing instantiated Q subjob (created due to a race condition)

This makes deletion of subjob and its queue impossible.
* *steps to easily reproduce the problem*

Bug1: 
1. enable history and set job_history_duration (default 2 weeks)
2. submit an Array job to an execution queue and let it finish (do not do a qstat on subjobs)
3. wait for expiry of the set job_history_duration after Array job finishes 

Bug2:
1. submit an Array job to an execution queue
2. now we need to kill the server just immediately after a subjob moves from Q to R and substate becomes JOB_SUBSTATE_PRERUN.  (i.e at time when the server sends a subjob to the mom to run and before the mom replies the confirmation of subjob run)
3. now start the server again and we see the particular subjob is held in Q state

Now for both Bug1 and Bug2:
 Delete the exec queue using qmgr, we get below errors
```
qmgr obj=workq svr=default: Cannot delete busy object
qmgr: Error (15027) returned from server
```
 now if you inspect the job table in database using db tools we can see only the subjobs job db object with missing parent Array job object in the db


#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
* *root cause/analysis of the problem*

Bug1:
Subjob move to X state once they finish, but in the periodic job cleanup function svr_clean_job_history() we were only cleaning up jobs which were in M or F state.

Bug2:
The change introduced in [this PR line diff](https://github.com/PBSPro/pbspro/pull/590/files#diff-c3101b9054e0987316d8a49addb67e38R452), excluded jobpurge() for instantiated subjob obj in Q state leading to the subjob left orphaned when the parent array job was qdeled.


#### Solution Description
Bug1:
added in svr_clean_job_history() to also consider cleaning up of subjob job obj in X state

Bug2:
removed the exclusion of Q subjob in req_deletejob() while deleting the whole array.

#### Testing logs/output
[ptl_test_results.zip](https://github.com/PBSPro/pbspro/files/1973397/ptl_test_results.zip)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
