### PR TITLE
PP-993: When PTL starts or restarts mom, after tests, the mom left be…

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14191,10 +14191,8 @@ class PBSInitServices(object):
                 dconf['PBS_START_SCHED'] = 1
             elif daemon == 'comm' and conf.get('PBS_START_COMM', 0) != 0:
                 dconf['PBS_START_COMM'] = 1
-            fn = self.du.create_temp_file(hostname)
-            self.du.set_pbs_config(hostname, fin=conf_file, fout=fn,
-                                   confs=dconf)
-            init_cmd += ['PBS_CONF_FILE=' + fn]
+            for k, v in dconf.items():
+                init_cmd += ["%s=%s" % (k, str(v))]
             _as = True
         else:
             fn = None


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* When we start or restart mom in PTL and then if we try to execute a hook then hook execution fails with the error "pbs_mom;Svr;pbs_mom;run_hook, execv of /opt/pbs/bin/pbs_python resulted in nonzero exit status=1"
* [PP-993](https://pbspro.atlassian.net/browse/PP-993)

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* When we restart individual daemon in PTL, it creates temporary conf file at /tmp location setting 
values for PBS_START_SERVER, PBS_START_MOM, PBS_START_SCHED, PBS_START_COMM in it and 'PBS_CONF_FILE' points to '/tmp/< filename >'. At the end of test execution PTL does cleanup and removes all temp files created, which also includes temporary conf file. Now if we execute a hook then it fails because PBS_CONF_FILE still points to '/tmp/< filename >' location. 

#### Solution Description
* Instead of creating temporary conf file at '/tmp' location for individual daemon start or restart, pass PBS_START_SERVER, PBS_START_MOM, PBS_START_SCHED, PBS_START_COMM variables to the command itself.

#### Testing logs/output
* *Please attach your test log output from running the test you added (or from existing tests that cover your changes)*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
