### PR TITLE
Change in PTL test to wait longer for alps cancellation

### DIFF
--- a/test/tests/functional/pbs_alps_release_tunables.py
+++ b/test/tests/functional/pbs_alps_release_tunables.py
@@ -79,13 +79,11 @@ class TestCrayAlpsReleaseTunables(TestFunctional):
 
         # Look for a message that confirms that reservation is deleted
         self.mom.log_match("%s;ALPS reservation cancelled" % jid1,
-                           starttime=start_time, max_attempts=5,
-                           interval=2)
+                           starttime=start_time)
         # Now that we know that reservation is cleared we should
         # check for time difference between each cancellation request
         out = self.mom.log_match("%s;Canceling ALPS reservation *" % jid1,
-                                 n='ALL', max_attempts=5, regexp=True,
-                                 allmatch=True)
+                                 n='ALL', regexp=True, allmatch=True)
 
         # We found something, Let's first check there are atleast 2 such
         # log messages, If not then that means reservation was cancelled
@@ -135,13 +133,11 @@ class TestCrayAlpsReleaseTunables(TestFunctional):
 
             # Look for a message that confirms that reservation is deleted
             self.mom.log_match("%s;ALPS reservation cancelled" % jid1,
-                               starttime=start_time, max_attempts=5,
-                               interval=2)
+                               starttime=start_time)
             # Now that we know that reservation is cleared we should
             # check for time difference between each cancellation request
             out = self.mom.log_match("%s;Canceling ALPS reservation *" % jid1,
-                                     n='ALL', max_attempts=2, regexp=True,
-                                     allmatch=True)
+                                     n='ALL', regexp=True, allmatch=True)
 
             # We found something, Let's first check there are atleast 2 such
             # log messages, If not then that means reservation was cancelled


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
While verifying the change in #660 we found out that sometimes mom acts slow to delete a running job and maximum amount of time PTL test waits for the job's alps reservation to be canceled is less. 
To ensure that the test waits long enough for alps reservation to be canceled we need to change the PTL script.

#### Affected Platform(s)
All Cray platforms

#### Cause / Analysis / Design
Job's cancelation time was more than the time PTL script was waiting for.

#### Solution Description
removed max_attempt and interval from log_match. It will now retry 60 times after every half a second.

#### Testing logs/output
No test logs, it can only be tested on Cray.
[test_on_craysim.txt](https://github.com/PBSPro/pbspro/files/1981807/test_on_craysim.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
