### PR TITLE
Mem leak fix - happens when user ralter standing resv

### DIFF
--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1043,6 +1043,12 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						 * the required fields.
 						 */
 						release_nodes(nresv_copy);
+						nresv_copy->nspec_arr = parse_execvnode(occr_execvnodes_arr[j],
+							sinfo);
+						nresv_copy->ninfo_arr = create_node_array_from_nspec(
+							nresv_copy->nspec_arr);
+						nresv_copy->resv->resv_nodes = create_resv_nodes(
+							nresv_copy->nspec_arr, sinfo);
 					}
 
 					/* Note that the sequence of occurrence dates and time are determined
@@ -1053,12 +1059,6 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 
 					/* update start time, duration, and execvnodes of the occurrence */
 					nresv_copy->end = nresv_copy->start + nresv_copy->duration ;
-					nresv_copy->nspec_arr = parse_execvnode(occr_execvnodes_arr[j],
-						sinfo);
-					nresv_copy->ninfo_arr = create_node_array_from_nspec(
-						nresv_copy->nspec_arr);
-					nresv_copy->resv->resv_nodes = create_resv_nodes(
-						nresv_copy->nspec_arr, sinfo);
 
 					/* Only add the occurrence to the real universe if we are not
 					 * processing a degraded reservation as otherwise, the resources
@@ -1592,11 +1592,10 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		schdlog(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
 			"Reservation Confirmed");
 
-		/* If handling a degraded reservation, we recreate a new execvnode sequence
-		 * string, so the old should be cleared
+		/* If handling a degraded reservation or while altering a standing reservation
+		 * we recreate a new execvnode sequence string, so the old should be cleared.
 		 */
-		if (nresv_parent->resv->resv_substate == RESV_DEGRADED)
-			free(nresv_parent->resv->execvnodes_seq);
+		free(nresv_parent->resv->execvnodes_seq);
 
 		/* set or update (for reconfirmation) the sequence of execvnodes */
 		nresv_parent->resv->execvnodes_seq = short_xc;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Memory leak in scheduler when user tries to qalter a standing reservation

#### Affected Platform(s)
All

#### Cause / Analysis / Design
There were two leaks in scheduler when we try to ralter a standing reservation.
In one case we were freeing up execvnode sequence of reservations only when they were getting re-confirmed in the degraded state. This use to be true before we had ralter command but now we also re-confirm reservations when they are in being altered state.
The second leak was while checking for the new reservation when the scheduler is able to re-confirm occurrence of standing reservation but it used to leak the memory allocated for storing node-info of the first occurrence.
#### Solution Description
Removed check for degraded reservations in confirm_reservation() and moved the code to create node-info array placeholder only second occurrence and onwards

#### Testing logs/output
Attaching valgrind log and other relevant test results -
[sched_resv_leak.txt](https://github.com/PBSPro/pbspro/files/1990081/sched_resv_leak.txt)
[pbs_ralter.txt](https://github.com/PBSPro/pbspro/files/1990082/pbs_ralter.txt)
[stale_node.txt](https://github.com/PBSPro/pbspro/files/1990083/stale_node.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
