### PR TITLE
PP-917: PTL server.create_vnodes() with delall=False not validating c…

### DIFF
--- a/test/tests/selftest/pbs_test_create_vnodes.py
+++ b/test/tests/selftest/pbs_test_create_vnodes.py
@@ -1,0 +1,68 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.selftest import *
+
+
+class Test_create_vnodes(TestSelf):
+    """
+    Tests to test Server().create_vnodes()
+    """
+
+    def test_delall_multi(self):
+        # Skip test if number of mom provided is not equal to two
+        if len(self.moms) != 2:
+            self.skipTest("test requires atleast two MoMs as input, "
+                          "use -p moms=<mom1:mom2>")
+        mom1 = self.moms.values()[0]
+        mom2 = self.moms.values()[1]
+        a = {'resources_available.ncpus': 4}
+        self.server.create_vnodes(mom1.shortname, a, 4, mom1)
+        self.server.create_vnodes(mom2.shortname, a, 5, mom2,
+                                  usenatvnode=True, delall=False)
+        stat = self.server.status(NODE)
+        self.assertEqual(len(stat), 10)
+
+    def test_delall(self):
+        a = {'resources_available.ncpus': 4}
+        self.server.create_vnodes('first', a, 4, self.mom)
+        self.server.create_vnodes('second', a, 5, self.mom,
+                                  usenatvnode=True, delall=False)
+        self.server.create_vnodes('third', a, 5, self.mom,
+                                  delall=False)
+        stat = self.server.status(NODE)
+        self.assertEqual(len(stat), 14)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* In PTL when we try to create vnodes with "delall=False" option, then it fails during vnode attribute verification.
* [PP-917](https://pbspro.atlassian.net/browse/PP-917)

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* There is an issue with the total number of vnodes count. When we pass 'delall=False' then existing vnodes should be preserved and total vnode count should be the existing vnodes count plus the newely created vnodes count. But currently PTL is taking only the newely created vnodes count and during verification it fails as the count doesn't match.

#### Solution Description
* When delall is set to False then first take a count of existing vnodes. While getting the count of existing vnodes, if nodes are not present then create a node temporarily, take a count and delete it.Now calculate the total number of vnodes present as:
n = (existing vnodes count) + (newely created vnodes count)

#### Testing logs/output
* [smoketest_pp-917.txt](https://github.com/PBSPro/pbspro/files/1992097/smoketest_pp-917.txt)
* [test_001.txt](https://github.com/PBSPro/pbspro/files/1992098/test_001.txt)
* [test_002.txt](https://github.com/PBSPro/pbspro/files/1992099/test_002.txt)
* [test_delall.txt](https://github.com/PBSPro/pbspro/files/2000669/test_delall.txt)
* [test_delall_multi.txt](https://github.com/PBSPro/pbspro/files/2000670/test_delall_multi.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
