### PR TITLE
Job IDs are not unique after a server restart

### DIFF
--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -2437,6 +2437,14 @@ req_commit(struct batch_request *preq)
 		pj->ji_script = NULL;
 	}
 
+	/* save server here as part of the transaction */
+	if (svr_save_db(&server, SVR_SAVE_QUICK) != 0) {
+		job_purge(pj);
+		req_reject(PBSE_SYSTEM, 0, preq);
+		(void) pbs_db_end_trx(conn, PBS_DB_ROLLBACK);
+		return;
+	}
+
 	if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0) {
 		job_purge(pj);
 		req_reject(PBSE_SYSTEM, 0, preq);
@@ -3114,6 +3122,14 @@ req_resvSub(struct batch_request *preq)
 		(void) pbs_db_end_trx(conn, PBS_DB_ROLLBACK);
 		(void)resv_purge(presv);
 		req_reject(PBSE_SAVE_ERR, 0, preq);
+		return;
+	}
+
+	/* save server here as part of the transaction */
+	if (svr_save_db(&server, SVR_SAVE_QUICK) != 0) {
+		(void)resv_purge(presv);
+		req_reject(PBSE_SYSTEM, 0, preq);
+		(void) pbs_db_end_trx(conn, PBS_DB_ROLLBACK);
 		return;
 	}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug Description
* *Job IDs are not unique after a server restart*
* *Steps to easily reproduce the problem;*
1. Submit few jobs (note the last jobid number)
2. Delete all jobs (qdel `qselect` )
3. Kill and restart pbs_server
4. submit another job
5. the jobid number of this new job will be a repeat

#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
https://github.com/PBSPro/pbspro/commit/d40069815cb9a61d90e33d269a637c402573473e#diff-4848154f487e506f0dec13a531dc2960

#### Solution Description
revert https://github.com/PBSPro/pbspro/commit/d40069815cb9a61d90e33d269a637c402573473e#diff-4848154f487e506f0dec13a531dc2960

#### Testing logs/output
[test_log.txt](https://github.com/PBSPro/pbspro/files/1994566/test_log.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
