### PR TITLE
hook fail_action 'offline_vnodes' is not functional

### DIFF
--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -2844,8 +2844,8 @@ im_request(int stream, int version)
 						char	hook_buf[HOOK_BUF_SIZE];
 						int	vret = 0;
 
-						snprintf(log_buffer,
-							sizeof(log_buffer),
+						snprintf(hook_buf,
+							HOOK_BUF_SIZE,
 							"1,%s",
 							last_phook->hook_name);
 						if (vnl_alloc(&tvnl) != NULL) {

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -1213,8 +1213,8 @@ initialize(void)
 				if ((last_phook != NULL) &&
 				(last_phook->fail_action & \
 					   HOOK_FAIL_ACTION_OFFLINE_VNODES)) {
-					snprintf(log_buffer,
-						sizeof(log_buffer),
+					snprintf(hook_buf,
+						HOOK_BUF_SIZE+1,
 						"1,%s", last_phook->hook_name);
 
 					ret = vn_addvnr(vnlp_from_hook,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *commit 57fa19e: PP-1262: Fix compiler warnings generated with gcc(version 5.4.0) flags = '-g -O2 -Wall -Werror -fPIC -D_LARGEFILE_SOURCE -Wno-unused-result', introduced a bug where in snprintf call after mom_process_hook, a variable hook_buf was replaced by log_buffer*


#### Affected Platform(s)
* *All*

#### Solution Description
* *Restore the hook_buf variable wherever necessary*
Cherry pick from master branch.

#### Testing logs/output
* *Test logs*
[hook_log.txt](https://github.com/PBSPro/pbspro/files/1994995/hook_log.txt)
[pbs_smoke.txt](https://github.com/PBSPro/pbspro/files/1994996/pbs_smoke.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
