### PR TITLE
[WIP] PP-756: Upgrading to the latest release fails to start the PBS daemons

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -132,6 +132,7 @@ Requires: bash
 Requires: expat
 Requires: libedit
 Requires: postgresql-server
+Requires: postgresql-upgrade
 Requires: python >= 2.6
 Requires: python < 3.0
 Requires: tcl
@@ -253,14 +254,28 @@ imps=0
 cle_release_version=0
 cle_release_path=/etc/opt/cray/release/cle-release
 if [ -f ${cle_release_path} ]; then
-        cle_release_version=`grep RELEASE ${cle_release_path} | cut -f2 -d= | cut -f1 -d.`
+	cle_release_version=`grep RELEASE ${cle_release_path} | cut -f2 -d= | cut -f1 -d.`
 fi
 [ "${cle_release_version}" -ge 6 ] 2>/dev/null && imps=1
 if [ $imps -eq 0 ]; then
-${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_postinstall server \
-	%{version} ${RPM_INSTALL_PREFIX:=%{pbs_prefix}} %{pbs_home} %{pbs_dbuser}
+	${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_postinstall server \
+		%{version} ${RPM_INSTALL_PREFIX:=%{pbs_prefix}} %{pbs_home} %{pbs_dbuser}
 else
-        install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
+	install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
+fi
+if [ "$1" = "2" ]; then
+	# The %preun section of 14.x unconditially removes /etc/init.d/pbs
+	setsid nohup /bin/bash >/dev/null 2>&1 <<EOF &
+let i=0
+while [ \$i -lt 60 ]; do
+  if [ ! -r /etc/init.d/pbs ]; then
+    install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
+    break
+  fi
+  let i+=1
+  sleep 1
+done
+EOF
 fi
 
 %post %{pbs_execution}
@@ -269,14 +284,28 @@ imps=0
 cle_release_version=0
 cle_release_path=/etc/opt/cray/release/cle-release
 if [ -f ${cle_release_path} ]; then
-        cle_release_version=`grep RELEASE ${cle_release_path} | cut -f2 -d= | cut -f1 -d.`
+	cle_release_version=`grep RELEASE ${cle_release_path} | cut -f2 -d= | cut -f1 -d.`
 fi
 [ "${cle_release_version}" -ge 6 ] 2>/dev/null && imps=1
 if [ $imps -eq 0 ]; then
-${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_postinstall execution \
-	%{version} ${RPM_INSTALL_PREFIX:=%{pbs_prefix}} %{pbs_home}
+	${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_postinstall execution \
+		%{version} ${RPM_INSTALL_PREFIX:=%{pbs_prefix}} %{pbs_home}
 else
-        install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
+	install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
+fi
+if [ "$1" = "2" ]; then
+	# The %preun section of 14.x unconditially removes /etc/init.d/pbs
+	setsid nohup /bin/bash >/dev/null 2>&1 <<EOF &
+let i=0
+while [ \$i -lt 60 ]; do
+  if [ ! -r /etc/init.d/pbs ]; then
+    install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
+    break
+  fi
+  let i+=1
+  sleep 1
+done
+EOF
 fi
 
 %post %{pbs_client}
@@ -285,14 +314,12 @@ imps=0
 cle_release_version=0
 cle_release_path=/etc/opt/cray/release/cle-release
 if [ -f ${cle_release_path} ]; then
-        cle_release_version=`grep RELEASE ${cle_release_path} | cut -f2 -d= | cut -f1 -d.`
+	cle_release_version=`grep RELEASE ${cle_release_path} | cut -f2 -d= | cut -f1 -d.`
 fi
 [ "${cle_release_version}" -ge 6 ] 2>/dev/null && imps=1
 if [ $imps -eq 0 ]; then
-${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_postinstall client \
-	%{version} ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}
-else
-        install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
+	${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_postinstall client \
+		%{version} ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}
 fi
 
 %preun %{pbs_server}

--- a/pbspro.spec
+++ b/pbspro.spec
@@ -132,7 +132,6 @@ Requires: bash
 Requires: expat
 Requires: libedit
 Requires: postgresql-server
-Requires: postgresql-upgrade
 Requires: python >= 2.6
 Requires: python < 3.0
 Requires: tcl
@@ -140,9 +139,11 @@ Requires: tk
 %if %{defined suse_version}
 Requires: smtp_daemon
 Requires: libical1
+Requires: postgresql-contrib
 %else
 Requires: smtpdaemon
 Requires: libical
+Requires: postgresql-upgrade
 %endif
 Autoreq: 1
 

--- a/pbspro.spec
+++ b/pbspro.spec
@@ -264,20 +264,6 @@ if [ $imps -eq 0 ]; then
 else
 	install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
 fi
-if [ "$1" = "2" ]; then
-	# The %preun section of 14.x unconditially removes /etc/init.d/pbs
-	setsid nohup /bin/bash >/dev/null 2>&1 <<EOF &
-let i=0
-while [ \$i -lt 60 ]; do
-  if [ ! -r /etc/init.d/pbs ]; then
-    install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
-    break
-  fi
-  let i+=1
-  sleep 1
-done
-EOF
-fi
 
 %post %{pbs_execution}
 # do not run pbs_postinstall when the CLE is greater than or equal to 6
@@ -293,20 +279,6 @@ if [ $imps -eq 0 ]; then
 		%{version} ${RPM_INSTALL_PREFIX:=%{pbs_prefix}} %{pbs_home}
 else
 	install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
-fi
-if [ "$1" = "2" ]; then
-	# The %preun section of 14.x unconditially removes /etc/init.d/pbs
-	setsid nohup /bin/bash >/dev/null 2>&1 <<EOF &
-let i=0
-while [ \$i -lt 60 ]; do
-  if [ ! -r /etc/init.d/pbs ]; then
-    install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
-    break
-  fi
-  let i+=1
-  sleep 1
-done
-EOF
 fi
 
 %post %{pbs_client}
@@ -400,6 +372,22 @@ if [ "$1" != "1" ]; then
 	echo
 	echo "NOTE: /etc/pbs.conf must be deleted manually"
 	echo
+fi
+
+%posttrans %{pbs_server}
+# The %preun section of 14.x unconditially removes /etc/init.d/pbs
+# because it does not check whether the package is being removed
+# or upgraded. Make sure it exists here.
+if [ -r %{pbs_prefix}/libexec/pbs_init.d ]; then
+    install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
+fi
+
+%posttrans %{pbs_execution}
+# The %preun section of 14.x unconditially removes /etc/init.d/pbs
+# because it does not check whether the package is being removed
+# or upgraded. Make sure it exists here.
+if [ -r %{pbs_prefix}/libexec/pbs_init.d ]; then
+    install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
 fi
 
 %files %{pbs_server}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* [PP-756](https://pbspro.atlassian.net/browse/PP-756): Upgrading from an older version to the latest mainline version fails to start the PBS daemons
* Avoid copying PBS Pro init script for client installs on Cray

#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* The postgresql-upgrade package needs to be installed during a server upgrade
* Due to the order in which the pre/post install/uninstall scripts run when requesting a package be upgraded (rpm -U) the init script was being deleted.

#### Solution Description
* Added postgresql-upgrade to the requirements
* Removed copying of init script on Cray for client install
* Fixed some formatting (spaces->tabs)

#### Testing logs/output
* Must be provided prior to merge

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
