### PR TITLE
fix for mom crash when ALPS returns invalid XML

### DIFF
--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -4952,9 +4952,9 @@ alps_request_parent(int fdin, char *basil_ver)
 			__func__, log_buffer);
 		snprintf(brp->error, BASIL_ERROR_BUFFER_SIZE, ud.message);
 		if (strcmp(BASIL_VAL_PARSER, ud.error_source) == 0) {
-			sprintf(log_buffer, "XML buffer: %s", expatBuffer);
+			log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE, LOG_DEBUG, __func__, "XML buffer: ");
 			log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE,
-				LOG_DEBUG, __func__, log_buffer);
+				LOG_DEBUG, __func__, expatBuffer);
 		}
 	}
 	XML_ParserFree(parser);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
On Cray, if ALPS inventory call returns an invalid XML then pbs_mom may crash

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ff0fd1788ab in __mempcpy_sse2 () from /lib64/libc.so.6
(gdb) bt
#0  0x00007ff0fd1788ab in __mempcpy_sse2 () from /lib64/libc.so.6
#1  0x00007ff0fd16918e in __GI__IO_default_xsputn () from /lib64/libc.so.6
#2  0x00007ff0fd13af42 in vfprintf () from /lib64/libc.so.6
#3  0x00007ff0fd15f31b in vsprintf () from /lib64/libc.so.6
#4  0x00007ff0fd143777 in sprintf () from /lib64/libc.so.6
#5  0x000000000047bb93 in alps_request_parent (fdin=<optimized out>, basil_ver=basil_ver@entry=0x927340 <basilversion_inventory> "1.4") at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/linux/alps.c:4955
#6  0x000000000047c00c in alps_request (msg=0x11d3130 "<?xml version=\"1.0\"?>\n<BasilRequest protocol=\"1.4\" method=\"QUERY\" type=\"INVENTORY\"/>", basil_ver=basil_ver@entry=0x927340 <basilversion_inventory> "1.4")
    at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/linux/alps.c:5063
#7  0x0000000000484b1c in alps_inventory () at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/linux/alps.c:6654
#8  0x000000000044440e in dep_topology () at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/linux/mom_mach.c:4699
#9  0x0000000000447243 in dep_initialize () at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/linux/mom_mach.c:4841
#10 0x000000000045dd2f in initialize () at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/mom_main.c:1167
#11 0x0000000000439d16 in process_hup () at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/mom_main.c:5646
#12 main (argc=<optimized out>, argv=<optimized out>) at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/mom_main.c:9578
```

#### Affected Platform(s)
Cray only 

#### Cause / Analysis / Design
Root cause of this problem is buffer overrun. We try to log the faulty XML of size 64K by copying it into a log_buffer of 4K size.

#### Solution Description
Not using log_buffer to log the XML.

#### Testing logs/output
This test cannot be automated. I was able to reproduce this problem on a cray simulator by modifying the inventory response XML to make it invalid in a debugger and then it makes mom crash.
Attaching the mom logs after the change
[craysim_logs.txt](https://github.com/PBSPro/pbspro/files/2003039/craysim_logs.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
