### PR TITLE
PP-261: Microsecond Logging

### DIFF
--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -233,6 +233,7 @@ struct pbs_config
 	long  pbs_comm_log_events;      /* log_events for pbs_comm process, default 0 */
 	unsigned int pbs_comm_threads;	/* number of threads for router, default 4 */
 	char *pbs_mom_node_name;	/* mom short name used for natural node, default NULL */
+	unsigned int pbs_log_highres_timestamp; /* high resolution logging */
 #ifdef WIN32
 	char *pbs_conf_remote_viewer; /* Remote viewer client executable for PBS GUI jobs, along with launch options */
 #endif
@@ -295,6 +296,7 @@ extern struct pbs_config pbs_conf;
 #define PBS_CONF_AUTH           "PBS_AUTH_METHOD"
 #define PBS_CONF_SCHEDULER_MODIFY_EVENT	"PBS_SCHEDULER_MODIFY_EVENT"
 #define PBS_CONF_MOM_NODE_NAME	"PBS_MOM_NODE_NAME"
+#define PBS_CONF_LOG_HIGHRES_TIMESTAMP	"PBS_LOG_HIGHRES_TIMESTAMP"
 #ifdef WIN32
 #define PBS_CONF_REMOTE_VIEWER "PBS_REMOTE_VIEWER"	/* Executable for remote viewer application alongwith its launch options, for PBS GUI jobs */
 #endif

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -121,9 +121,10 @@ struct pbs_config pbs_conf = {
 	NULL,					/* for router, default communication routers list */
 	0,					/* default comm logevent mask */
 	4,					/* default number of threads */
-	NULL					/* mom short name override */
+	NULL,					/* mom short name override */
+	0					/* high resolution timestamp logging */
 #ifdef WIN32
-	,NULL					/* remote viewer launcher executable alongwith launch options */
+	,NULL					/* remote viewer launcher executable along with launch options */
 #endif
 };
 
@@ -564,6 +565,10 @@ pbs_loadconf(int reload)
 				free(pbs_conf.pbs_mom_node_name);
 				pbs_conf.pbs_mom_node_name = strdup(conf_value);
 			}
+			else if (!strcmp(conf_name, PBS_CONF_LOG_HIGHRES_TIMESTAMP)) {
+				if (sscanf(conf_value, "%u", &uvalue) == 1)
+					pbs_conf.pbs_log_highres_timestamp = ((uvalue > 0) ? 1 : 0);
+			}
 #ifdef WIN32
 			else if (!strcmp(conf_name, PBS_CONF_REMOTE_VIEWER)) {
 				free(pbs_conf.pbs_conf_remote_viewer);
@@ -790,6 +795,10 @@ pbs_loadconf(int reload)
 	if ((gvalue = getenv(PBS_CONF_ENVIRONMENT)) != NULL) {
 		free(pbs_conf.pbs_environment);
 		pbs_conf.pbs_environment = shorten_and_cleanup_path(gvalue);
+	}
+	if ((gvalue = getenv(PBS_CONF_LOG_HIGHRES_TIMESTAMP)) != NULL) {
+		if (sscanf(gvalue, "%u", &uvalue) == 1)
+			pbs_conf.pbs_log_highres_timestamp = ((uvalue > 0) ? 1 : 0);
 	}
 
 #ifdef WIN32

--- a/src/tools/tracejob.h
+++ b/src/tools/tracejob.h
@@ -92,14 +92,15 @@ enum field
 /* A PBS log entry */
 struct log_entry
 {
-	char *date;           /* date of log entry */
-	time_t date_time;     /* number of seconds from the epoch to date */
-	char *event;          /* event type */
-	char *obj;            /* what entity is writing the log */
-	char *type;           /* type of object Job/Svr/etc */
-	char *name;           /* name of object */
-	char *msg;            /* log message */
-	char log_file;        /* What log file */
+	char *date;		/* date of log entry */
+	time_t date_time;	/* number of seconds from the epoch to date */
+	long highres;	  	/* high resolution portion of the log entry (number smaller than seconds) */
+	char *event;		/* event type */
+	char *obj;		/* what entity is writing the log */
+	char *type;		/* type of object Job/Svr/etc */
+	char *name;		/* name of object */
+	char *msg;		/* log message */
+	char log_file;		/* What log file */
 	int lineno;		/* what line in the file.  used to stabilize the sort */
 	unsigned no_print:1;	/* whether or not to print the message */
 	/* A=accounting S=server M=Mom L=Scheduler */
@@ -119,6 +120,9 @@ char *log_path(char *path, int index, int month, int day, int year);
 void alloc_more_space();
 void filter_excess(int threshold);
 int sort_by_message(const void *v1, const void *v2);
+
+/* Macros */
+#define NO_HIGH_RES_TIMESTAMP -1
 
 
 /* used by getopt(3) */

--- a/test/tests/functional/pbs_highreslog.py
+++ b/test/tests/functional/pbs_highreslog.py
@@ -1,0 +1,148 @@
+# coding: utf-8
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestHighResLogging(TestFunctional):
+    """
+    TestSuite for High resolution logging in PBS
+    """
+    tm_micro_re = re.compile(
+        r'(\d{2,2}/\d{2,2}/\d{4,4}\s\d{2,2}:\d{2,2}:\d{2,2}.\d{6,6})')
+
+    def test_disabled(self):
+        """
+        Default High resolution should be disabled (logfile version)
+        """
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+        lines = self.server.log_lines(logtype=self.server,
+                                      starttime=self.server.ctime)
+
+        _msg = 'Found high resolution time stamp in log,' \
+               ' it shouldn\'t be there'
+
+        for line in lines:
+            m = self.tm_micro_re.match(line)
+            self.assertIsNone(m, _msg)
+
+        _msg = self.server.shortname + \
+            ': High resolution time stamp correctly not set in log'
+        self.logger.info(_msg)
+
+    def test_disabled_tracejob(self):
+        """
+        Default High resolution should be disabled (tracejob version)
+        """
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+        lines = self.server.log_lines(logtype='tracejob', id=jid, n='ALL')
+        if len(lines) > 1:
+            # Remove first line as it is not log line
+            lines = lines[1:]
+
+        _msg = 'Found high resolution time stamp in tracejob, ' \
+            'it should not be there'
+
+        for line in lines:
+            m = self.tm_micro_re.match(line)
+            self.assertIsNone(m, _msg)
+
+        _msg = self.server.shortname + \
+            ': High resolution time stamp correctly not set in tracejob output'
+        self.logger.info(_msg)
+
+    def test_basic(self):
+        """
+        Enable High resolution logging, restart server
+        and look for high resolution time stamp in server log
+        """
+        a = {'PBS_LOG_HIGHRES_TIMESTAMP': 1}
+        self.du.set_pbs_config(confs=a, append=True)
+        _msg = 'Failed to restart server: %s' % (self.server.shortname)
+        self.assertTrue(self.server.restart(), _msg)
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+        lines = self.server.log_lines(logtype=self.server, n=20)
+        for line in lines:
+            m = self.tm_micro_re.match(line)
+            _msg = 'Not Found high resolution time stamp in log'
+            self.assertTrue(m, _msg)
+        _msg = self.server.shortname + \
+            ': High resolution time stamp found in log'
+        self.logger.info(_msg)
+
+    def test_basic_tracejob(self):
+        """
+        Enable High resolution logging, restart PBS Daemons
+        and look for high resolution time stamp in tracejob output
+        """
+        a = {'PBS_LOG_HIGHRES_TIMESTAMP': 1}
+        self.du.set_pbs_config(confs=a, append=True)
+        PBSInitServices().restart()
+        self.assertTrue(self.server.isUp(), 'Failed to restart PBS Daemons')
+
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+        lines = self.server.log_lines(logtype='tracejob', id=jid, n='ALL')
+        if len(lines) > 1:
+            # Remove first line as it is not log line
+            lines = lines[1:]
+        for line in lines:
+            m = self.tm_micro_re.match(line)
+            if m is None:
+                # If this is accounting log, ignore it as
+                # Accounting log does not have high res logging
+                line = line.split()
+                _msg = 'Not Found high resolution time stamp in log'
+                self.assertFalse(len(line) >= 3 and
+                                 (line[2].strip() != 'A'), _msg)
+        _msg = self.server.shortname + \
+            ': High resolution time stamp found in log'
+        self.logger.info(_msg)
+
+    def tearDown(self):
+        confs = self.du.parse_pbs_config()
+        if 'PBS_LOG_HIGHRES_TIMESTAMP' in confs:
+            del confs['PBS_LOG_HIGHRES_TIMESTAMP']
+            self.du.set_pbs_config(confs=confs, append=False)
+            PBSInitServices().restart()
+        PBSTestSuite.tearDown(self)

--- a/test/tests/functional/pbs_power_provisioning_sgi.py
+++ b/test/tests/functional/pbs_power_provisioning_sgi.py
@@ -154,8 +154,9 @@ def NodesetDelete( nodeset_name ):
             # will use the SGI functionality.
             mom = self.moms[host]
             if mom is not None:
+                environ = {"PBS_PMINAME": "sgi"}
                 self.server.du.set_pbs_environment(host,
-                                                   vars={"PBS_PMINAME": "sgi"})
+                                                   environ=environ)
                 self.server.du.run_cmd(host, "chown root %s" %
                                        os.path.join(mom.pbs_conf[
                                                     'PBS_HOME'],

--- a/test/tests/selftest/pbs_dshutils_tests.py
+++ b/test/tests/selftest/pbs_dshutils_tests.py
@@ -1,0 +1,85 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.selftest import *
+from ptl.utils.pbs_dshutils import PbsConfigError
+
+
+class TestDshUtils(TestSelf):
+    """
+    Test pbs distributed utilities util pbs_dshutils.py
+    """
+
+    def test_pbs_conf(self):
+        """
+        Test setting a pbs.conf variable and then unsetting it
+        """
+        var = 'PBS_COMM_THREADS'
+        val = '16'
+        self.du.set_pbs_config(confs={var: val})
+        conf = self.du.parse_pbs_config()
+        msg = 'pbs.conf variable not set'
+        self.assertIn(var, conf, msg)
+        self.assertEquals(conf[var], val, msg)
+
+        msg = 'pbs.conf variable not unset'
+        self.du.unset_pbs_config(confs=[var])
+        conf = self.du.parse_pbs_config()
+        self.assertNotIn(var, conf, msg)
+
+        exception_found = False
+        try:
+            self.du.set_pbs_config(confs={'f': 'b'}, fout='/does/not/exist')
+        except PbsConfigError:
+            exception_found = True
+
+        self.assertTrue(exception_found, 'PbsConfigError not thrown')
+
+    def test_pbs_env(self):
+        """
+        Test setting a pbs_environment variable and then unsetting it
+        """
+        self.du.set_pbs_environment(environ={'pbs_foo': 'True'})
+        environ = self.du.parse_pbs_environment()
+        msg = 'pbs environment variable not set'
+        self.assertIn('pbs_foo', environ, msg)
+        self.assertEquals(environ['pbs_foo'], 'True', msg)
+
+        msg = 'pbs environment variable not unset'
+        self.du.unset_pbs_environment(environ=['pbs_foo'])
+        environ = self.du.parse_pbs_environment()
+        self.assertNotIn('pbs_foo', environ, msg)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* This PR implements the RFE for microsecond logging.  
*  [PP-261](https://pbspro.atlassian.net/browse/PP-261)
* PTL bug where the dshutils functions pbs_set_config(), pbs_unset_config(), and pbs_set_environment() would only work if the test was run as root.  Plus there wasn't pbs_unset_environment(), so that was implemented.
* Fixed test pbs_init_script.py to be able to be run as non-root.

#### Cause / Analysis / Design
* Design: https://pbspro.atlassian.net/wiki/spaces/PD/pages/50836942/PP-261+micro-second+time+stamp+for+daemon+logging
* Discussion: http://community.pbspro.org/t/pp-261-micro-second-time-stamp-for-daemon-logging/467

#### Solution Description
* PTL bug: The root cause was that all the functions called an internal function called _set_file().  _set_file() would call run_copy() without sudo=True.  I fixed it by adding a sudo argument to _set_file() which is passed to run_copy().  In all the affected functions, I pass sudo=True.
* Test bug: The test didn't call run_cmd() with sudo=True.  This meant the init script wouldn't be able to stop/start PBS.  Also, the env argument to run_cmd() won't work with the sudo argument.  It will pass the environmental variables to the sudo process which strips them from the real command.  I had to pass the environmental variables on the command line.
#### Testing logs/output
*  [ptl.log](https://github.com/PBSPro/pbspro/files/2033238/ptl.log)
* Other tests that use affected functions:  [ptl2.log](https://github.com/PBSPro/pbspro/files/2011259/ptl2.log)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [X] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [X] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
