### PR TITLE
Fix mom crash when deleting job in exiting state.

### DIFF
--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -3423,7 +3423,7 @@ req_cpyfile(struct batch_request *preq)
 		}
 	}
 
-	if (dir == STAGE_DIR_OUT && direct_write_requested(pjob))
+	if ((pjob != NULL) && (dir == STAGE_DIR_OUT) && direct_write_requested(pjob))
 		stage_inout.direct_write = 1;
 	else
 		stage_inout.direct_write = 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Mom crashes whenever server tries to delete a job in EXITING state
* Steps for reproduction:

1. Create a checkpoint_abort script
cat /tmp/test.sh 
#!/bin/bash
kill $1
exit 0
2. Update the mom config file
cat config
$clienthost centos
$restrict_user_maxsysid 999
$action checkpoint_abort 30 !/tmp/test.sh %sid 
3. You need to change the order preempt_order: "CSR" from the default "SCR" to checkpoint jobs.
4. HUP mom and scheduler to take effect.
5. Create an express_q
 qmgr
c q express_q
s q queue_type = Execution
s q Priority = 200
s q enabled = True
 s q started = True
6. submit 2 jobs
qsub -- /bin/sleep 100
qsub -q express_q -- /bin/sleep 10
7. Wait for a minute and check the state of job is 'H' after second job finishes.
8. qdel on the checkpointed job in 'H' state and you can see a mom crash.*

#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* In req_cpyfile function we call direct_write_requested() without checking if find_job was successful in finding the requested job or not.

#### Solution Description
* In resmom/requests.c:req_cpyfile() function, check pjob is not NULL first and is doing STAGE_DIR_OUT before calling direct_write_requested(). This essentially does what is in the existing Windows portion of the code. Note that pjob can be NULL under req_cpyfile() when job is doing STAGE_DIR_IN.

#### Testing logs/output
* PTL test, pbs_checkpoint.py, has been added and here are the results:
[ptl.checkpoint.PASS.txt](https://github.com/PBSPro/pbspro/files/2014928/ptl.checkpoint.PASS.txt)
[ptl.checkpoint.FAIL.txt](https://github.com/PBSPro/pbspro/files/2014929/ptl.checkpoint.FAIL.txt)
* The code fix is in the path of direct_write_requested() so regression test of the direct write feature has been run successfully:
[ptl.direct_write.txt](https://github.com/PBSPro/pbspro/files/2014931/ptl.direct_write.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
Manual test is done as it's not possible to create a PTL test that can reproduce a bug, that is dependent on a buggy checkpoint abort behavior (where job does not get properly checkpointed) that will soon also get fixed. Here is the PTL test that can be run manually but should not be checked-in as it is written in a way that is dependent on existing checkpoint buggy behavior:
[pbs_checkpoint.py.txt](https://github.com/PBSPro/pbspro/files/2028538/pbs_checkpoint.py.txt)
[ptl.pbs_checkpoint.FAIL.2.txt](https://github.com/PBSPro/pbspro/files/2028539/ptl.pbs_checkpoint.FAIL.2.txt)
[ptl.pbs_checkpoint.PASS.2.txt](https://github.com/PBSPro/pbspro/files/2028540/ptl.pbs_checkpoint.PASS.2.txt)

- [] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
