### PR TITLE
remove extra destroying of a lock in tpp

### DIFF
--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -1533,7 +1533,7 @@ tpp_shutdown()
 
 	TPP_DBPRT(("from pid = %d", getpid()));
 
-	tpp_mbox_destroy(&app_mbox);
+	tpp_mbox_destroy(&app_mbox, 1);
 
 	tpp_going_down = 1;
 
@@ -1591,7 +1591,7 @@ tpp_terminate()
 
 	tpp_transport_terminate();
 
-	tpp_mbox_destroy(&app_mbox);
+	tpp_mbox_destroy(&app_mbox, 0);
 
 	if (strmarray)
 		free(strmarray);

--- a/src/lib/Libtpp/tpp_common.h
+++ b/src/lib/Libtpp/tpp_common.h
@@ -646,7 +646,7 @@ int tpp_em_wait_win(void *em_ctx, em_event_t **ev_array, int timeout);
  * plain pipes etc.
  */
 int tpp_mbox_init(tpp_mbox_t *mbox);
-void tpp_mbox_destroy(tpp_mbox_t *mbox);
+void tpp_mbox_destroy(tpp_mbox_t *mbox, int destroy_lock);
 int tpp_mbox_monitor(void *em_ctx, tpp_mbox_t *mbox);
 int tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data);
 int tpp_mbox_clear(tpp_mbox_t *mbox, tpp_que_elem_t **n, unsigned int tfd, int *cmdval, void **data);

--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -1425,7 +1425,7 @@ tpp_mbox_getfd(tpp_mbox_t *mbox)
  *
  */
 void
-tpp_mbox_destroy(tpp_mbox_t *mbox)
+tpp_mbox_destroy(tpp_mbox_t *mbox, int destroy_lock)
 {
 #ifdef HAVE_SYS_EVENTFD_H
 	close(mbox->mbox_eventfd);
@@ -1435,7 +1435,8 @@ tpp_mbox_destroy(tpp_mbox_t *mbox)
 	if (mbox->mbox_pipe[1] > -1)
 		tpp_pipe_close(mbox->mbox_pipe[1]);
 #endif
-	tpp_destroy_lock(&mbox->mbox_mutex);
+	if (destroy_lock)
+		tpp_destroy_lock(&mbox->mbox_mutex);
 }
 
 /**

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -1412,7 +1412,7 @@ handle_cmd(thrd_data_t *td, int tfd, int cmd, void *data)
 			}
 		}
 
-		tpp_mbox_destroy(&td->mbox);
+		tpp_mbox_destroy(&td->mbox, 1);
 		tpp_em_destroy(td->em_context);
 		if (td->listen_fd > -1)
 			tpp_sock_close(td->listen_fd);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* The bug is actually mentioned in the tpp_terminate() comment:
	```
	/* Warning: Do not attempt to destroy any lock
	 * This is not required since our library is effectively
	 * not used after a fork. The function tpp_mbox_destroy
	 * calls pthread_mutex_destroy, so don't call them.
	 * Also never log anything from a terminate handler
	 */
	```
* Although the warning is here, the lock is destroyed.
* Destroying of the lock can lead to stuck the main process.
#### Affected Platform(s)
* Linux

#### Solution Description
* New input parametr of tpp_mbox_destroy() can decide whether to call tpp_destroy_lock() or not.

#### Testing logs/output
* [ptl_remove_extra_lock_smoketest.txt](https://github.com/PBSPro/pbspro/files/2022718/ptl_remove_extra_lock_smoketest.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
