### PR TITLE
prevent using GPUs without user awareness

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -2818,6 +2818,9 @@ class CgroupUtils(object):
         execjob_launch hook
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
+        if 'devices' in self.subsystems:
+            # prevent using GPUs without user awareness
+            pbs.event().env['CUDA_VISIBLE_DEVICES'] = ''
         if 'device_names' in self.assigned_resources:
             names = self.assigned_resources['device_names']
             pbs.logmsg(pbs.EVENT_DEBUG4,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Some programs (e.g. TensorFlow) autodetect GPU devices and use the devices without user awareness. This can lead to unwanted using of GPUs without its allocation in PBS Pro.

#### Affected Platform(s)
* CUDA

#### Cause / Analysis / Design
* This issue is related to the cgroup hook. If the CUDA_VISIBLE_DEVICES env is not set then some programs autodetect GPUs. The programs usually respect CUDA_VISIBLE_DEVICES and we can set the value of the CUDA_VISIBLE_DEVICES to the empty string in order to prevent using the GPUs.

#### Solution Description
* If the 'devices' subsystem is enabled we can simply set the CUDA_VISIBLE_DEVICES to the empty string. If the GPUs are actually requested the correct value will override the empty value.

#### Manual test
* The job requests the GPUs:
```
(JESSIE)vchlum@torque1:~$ qsub -I -l select=vnode=konos5:ngpus=4
qsub: waiting for job 32497.torque1.ics.muni.cz to start
qsub: job 32497.torque1.ics.muni.cz ready
konos5.fav.zcu.cz$ env | grep CUDA
CUDA_VISIBLE_DEVICES=0,1,2,3
konos5.fav.zcu.cz$ 
```

* The job does not request any GPU:
```
(JESSIE)vchlum@torque1:~$ qsub -I -l select=vnode=konos5
qsub: waiting for job 32496.torque1.ics.muni.cz to start
qsub: job 32496.torque1.ics.muni.cz ready
konos5.fav.zcu.cz$ env | grep CUDA
CUDA_VISIBLE_DEVICES=
konos5.fav.zcu.cz$ 
```

#### Testing logs/output
* [ptl_output_pbs_cgroups_hook.txt](https://github.com/PBSPro/pbspro/files/2053323/ptl_output_pbs_cgroups_hook.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
