### PR TITLE
qsub: parameter -v with commas in value is broken

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -4055,6 +4055,7 @@ copy_env_value(char *dest, /* destination  */
 	int   go = 1;
 	int   q_ch = 0;
 	int   is_func = 0;
+	char  *dest_full = dest;
 
 	while (*dest)
 		++dest;
@@ -4087,12 +4088,15 @@ copy_env_value(char *dest, /* destination  */
 
 			case ESC_CHAR:			/* backslash in value, escape it */
 				*dest++ = *pv;
-				*dest++ = *pv;
+				if (*(pv+1) != ',') /* do not escape if ESC_CHAR already escapes */
+					*dest++ = *pv;
 				break;
 
 			case ',':
 				if (q_ch || quote_flg) {
 					*dest++ = ESC_CHAR;
+					*dest++ = *pv;
+				} else if (dest_full != dest && *(dest-1) == ESC_CHAR) { /* the comma is escaped, not finished yet */
 					*dest++ = *pv;
 				} else {
 					go = 0;		/* end of value string */

--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -1,0 +1,68 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class Test_passing_environment_variable_via_qsub(TestFunctional):
+    """
+    Test to check passing environment variables via qsub
+    """
+
+    def test_commas_in_custom_variable(self):
+        """
+        Submit a job with -v "var1='A,B,C,D'" and check that the value
+        is passed correctly
+        """
+        a = {'Resource_List.select': '1:ncpus=1',
+             'Resource_List.walltime': 10}
+        script = ['#PBS -v "var1=\'A,B,C,D\'"']
+        script += ['env | grep var1']
+        j = Job(TEST_USER, attrs=a)
+        j.create_script(body=script)
+        jid = self.server.submit(j)
+
+        qstat = self.server.status(JOB, ATTR_o, id=jid)
+        job_ofile = qstat[0][ATTR_o].split(':')[1]
+
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=10)
+
+        job_output = ""
+        with open(job_ofile, 'r') as f:
+            job_output = f.read().strip()
+
+        self.assertEqual(job_output, "var1=A,B,C,D")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* man qsub says (-v parameter): 
If a variable=value pair contains any commas, the value must be enclosed in single  or double quotes, and the variable=value pair must be enclosed in the kind of quotes not used to enclose the value.  For example:
                      qsub -v "var1='A,B,C,D'" job.sh
* This feature is broken:
```
(JESSIE)vchlum@torque2:~$ qsub -v "var1='A,B,C,D'" job.sh
qsub: cannot send environment with the job
(JESSIE)vchlum@torque2:~$ 
```

#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* copy_env_value() is called twice on the value of the var1. In the first call, the quotes are removed and the commas are escaped. In the second call, the first comma is considered to be the end of the value because the quotes are gone and the value ends with first ESC_CHAR.

#### Solution Description
* In the copy_env_value(), we should ensure that if the comma comes after ESC_CHAR, it is not the end of the value but the value continues. Moreover, we should not escape already escaped comma.

#### Testing logs/output
* Smoketest: [ptl_output_smoketest.txt](https://github.com/PBSPro/pbspro/files/2075019/ptl_output_smoketest.txt)
* New test: [ptl_passing_environment_variable_output.txt](https://github.com/PBSPro/pbspro/files/2075021/ptl_passing_environment_variable_output.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
