### PR TITLE
Server state going to "Scheduling" in Failover setup

### DIFF
--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1452,11 +1452,6 @@ main(int argc, char **argv)
 		/* in case secondary didn't remove the file */
 		/* also tells the secondary to go idle	    */
 		(void)unlink(path_secondaryact);
-		/* 
-		 * Make the scheduler (re)-read the configuration
-		 * and fairshare usage.
-		 */
-		(void)contact_sched(SCH_CONFIGURE, NULL, pbs_scheduler_addr, pbs_scheduler_port); 
 
 	} else {
 		/* we believe we are a secondary server */
@@ -2007,6 +2002,13 @@ try_db_again:
 		return (1);
 	}
 	process_hooks(periodic_req, hook_msg, sizeof(hook_msg), pbs_python_set_interrupt);
+
+	/*
+	 * Make the scheduler (re)-read the configuration
+	 * and fairshare usage.
+	 */
+	(void)contact_sched(SCH_CONFIGURE, NULL, pbs_scheduler_addr, pbs_scheduler_port);
+
 
 	/*
 	 * main loop of server


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* When primary server takes control back from secondary server its state is going to "Scheduling" . During this time if we submit jobs to PBS they are not run and remain in "Queued" state. This continues for the next 10 minutes.
#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* As part of the code changes made for PP-832 a call to contact_sched() has been introduced to make the Scheduler reread the configuration and fairshare usage. This is getting called before Server initializes its network interface due to which the appropriate callback function(which is process_request) is not getting called when Scheduler sends its first update back to server. Due to this Server thinks that it did not get any reply from Scheduler and hence it does not change its state from "Scheduling" to "Active". 

This problem persists for 10 mins. After that Server again talks to Scheduler for scheduling the jobs but by this time since Server has already initialized its network interface this time Server gets the update from Scheduler immediately after the processing of jobs due to which Server marks the scheduler_fd to -1 after which Server state is brought to "Active". But during this 10 mins jobs will not be run due to the "Scheduling" state of server.

**Why only 10 minutes:**
10 mins is because default scheduler iteration is 600 seconds.   

#### Solution Description
* Delay the call to contact_sched() till the Server initializes its network interface.

#### Testing logs/output
* Attached are the logs of unit testing of various scenarios of Failover.
[Scheduler_Failover_Issue_UnitTesting.txt](https://github.com/PBSPro/pbspro/files/2079181/Scheduler_Failover_Issue_UnitTesting.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
