### PR TITLE
near term excl resvs interfere with longer term resvs

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -720,6 +720,9 @@ remove_node_state(node_info *ninfo, char *state)
 {
 	char errbuf[256];
 
+	if (ninfo == NULL)
+		return 1;
+
 	if (!strcmp(state, ND_down))
 		ninfo->is_down = 0;
 	else if (!strcmp(state, ND_free))
@@ -787,6 +790,9 @@ add_node_state(node_info *ninfo, char *state)
 {
 	char errbuf[256];
 	int set_free = 0;
+
+	if (ninfo == NULL)
+		return 1;
 
 	if (!strcmp(state, ND_down))
 		ninfo->is_down = 1;
@@ -1665,6 +1671,8 @@ update_node_on_run(nspec *ns, resource_resv *resresv, char *job_state)
 			}
 			else {
 				add_node_state(ninfo, ND_job_exclusive);
+				if (ninfo->svr_node != NULL)
+					add_node_state(ninfo->svr_node, ND_job_exclusive);
 			}
 		}
 	}
@@ -1719,12 +1727,12 @@ update_node_on_end(node_info *ninfo, resource_resv *resresv, char *job_state)
 	if (ninfo->is_job_busy)
 		remove_node_state(ninfo, ND_jobbusy);
 	if (is_excl(resresv->place_spec, ninfo->sharing)) {
-		if (resresv->is_resv) {
-			if (ninfo->svr_node != NULL)
-				remove_node_state(ninfo->svr_node, ND_resv_exclusive);
-		}
+		if (resresv->is_resv)
+			remove_node_state(ninfo, ND_resv_exclusive);
 		else {
 			remove_node_state(ninfo, ND_job_exclusive);
+			if (ninfo->svr_node != NULL)
+				remove_node_state(ninfo->svr_node, ND_job_exclusive);
 		}
 	}
 
@@ -1735,7 +1743,7 @@ update_node_on_end(node_info *ninfo, resource_resv *resresv, char *job_state)
 			resreq = ns->resreq;
 			if ((job_state != NULL) && (*job_state == 'S')) {
 				if (resresv->job->resreleased != NULL) {
-					nspec * temp = find_nspec_by_rank(resresv->job->resreleased, ninfo->rank);
+					nspec *temp = find_nspec_by_rank(resresv->job->resreleased, ninfo->rank);
 					if (temp != NULL)
 						resreq = temp->resreq;
 				}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* The nodes assigned to a near term excl reservation will not become free in simulation and will not be available for longer term reservations.  This means longer term reservations can be denied when there are free nodes at that time.
* How to reproduce:
On a single node submit a near term excl reservation and then a longer term reservation.  The near term reservation will be confirmed, but the longer term one will not be.

#### Cause / Analysis / Design
* An excl reservation marks the node in state resv-exclusive.  When the reservation ends in simulation, the resv-exclusive state is not removed from the node.  When it is time to see if the new reservation can be confirmed, the nodes are still in state resv-exclusive and they are not available.
#### Solution Description
* Correctly add and remove the resv-exclusive state.

#### Testing logs/output
* [ptl.log](https://github.com/PBSPro/pbspro/files/2081910/ptl.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
