### PR TITLE
PP-1254: PBS starts in the background even when started using init script much after the system startup

### DIFF
--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -783,11 +783,27 @@ site_mom_cleanup()
 	fi
 }
 
+# Check whether PBS is registered to start at boot time
+is_registered()
+{
+	if command -v systemctl >/dev/null 2>&1; then
+		systemctl is-enabled pbs > /dev/null 2>&1
+		return $?
+	elif command -v chkconfig; then
+		chkconfig pbs > /dev/null 2>&1
+		return $?
+	fi
+	return 0
+}
+
 # Check whether system is being booted or not 
 # and also update the time in /var/tmp/pbs_boot_check file  
 # return 0 if system is being booted otherwise return 1
 is_boottime()
 {
+	is_registered
+	[ $? -ne 0 ] && return 1
+	
 	PYTHON_EXE=${PBS_EXEC}/python/bin/python
 	if [ -z "${PYTHON_EXE}" -o ! -x "${PYTHON_EXE}" ] ; then
 		return 1
@@ -801,8 +817,8 @@ is_boottime()
 	fi
 	
 	${PYTHON_EXE} ${BOOTPYFILE} ${BOOTCHECKFILE} > /dev/null 2>&1
-        ret=$?
-        return ${ret}
+	ret=$?
+	return ${ret}
 }
 
 pre_start_pbs()

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1517,11 +1517,11 @@ class SmokeTest(PBSTestSuite):
             'sharing', 'last_state_change_time']
         possible_dflt_attrs = {'license': 'l', 'last_used_time': 'arbitrary'}
         self.server.expect(NODE, {'state': 'free'},
-                           id=self.server.shortname, interval=3)
+                           id=self.mom.shortname, interval=3)
         node_attr = []
         for (key, val) in \
                 (self.server.status(NODE,
-                                    id=self.server.shortname)[0].iteritems()):
+                                    id=self.mom.shortname)[0].iteritems()):
             key = key.split('.')[0]
             if str(key) not in attrs_pbsnodes_dflts:
                 self.assertFalse(not ((key in possible_dflt_attrs) and


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *PBS starts in the background even when started using init script much after the system startup*
* *How to reproduce??*
1. PBS is not registered with systemd for auto start up during the boot-time.
2. Restart the machine.
3. Start pbs
It will start in the background.
* *If there is an issue ID, link to it: [PP-1254](https://pbspro.atlassian.net/browse/PP-1254)*

#### Cause / Analysis / Design
PBS check whether boot_time > prev_start_time then it starts in the background.
This assumption is wrong when pbs is not registered to start at system start up.
Then the first start-up of pbs will be in backround even if the admin starts it by running init script.

#### Solution Description
* Checking whether the system is registered using chkconfig and systemctl
* If not returning from the function with false.
* Updated two smoke tests.

#### Testing logs/output
Attached in the Jira ticket.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
