### PR TITLE
Node stays in state=free with excl resv on server restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ src/tools/printjob.bin
 src/tools/printjob_svr.bin
 src/tools/tracejob
 src/tools/wrap_tcl.sh
+src/tools/pbs_sleep
 src/unsupported/pbs_diag
 src/unsupported/pbs_dtj
 src/unsupported/pbs_rmget

--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -259,7 +259,6 @@ extern "C" {
 #define PBSE_STDG_RESV_OCCR_CONFLICT 15179 /* cannot change start time of a non-empty reservation */
 
 #define PBSE_SOFTWT_STF		     15180 /* soft_walltime is incompatible with STF jobs */
-#define PBSE_BAD_NODE_STATE	     15181 /* node is in the wrong state for the operation */
 
 /*
  ** 	Resource monitor specific

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -414,7 +414,6 @@ char *msg_stdg_resv_occr_conflict = "Requested time(s) will interfere with a lat
 char *msg_alps_switch_err = "Switching ALPS reservation failed";
 
 char *msg_softwt_stf = "soft_walltime is not supported with Shrink to Fit jobs";
-char *msg_bad_node_state = "Node is in the wrong state for operation";
 
 /*
  * The following table connects error numbers with text
@@ -591,7 +590,6 @@ struct pbs_err_to_txt pbs_err_to_txt[] = {
 	{PBSE_STDG_RESV_OCCR_CONFLICT, &msg_stdg_resv_occr_conflict},
 	{PBSE_ALPS_SWITCH_ERR, &msg_alps_switch_err},
 	{PBSE_SOFTWT_STF, &msg_softwt_stf},
-	{PBSE_BAD_NODE_STATE, &msg_bad_node_state},
 	{PBSE_SCHED_OP_NOT_PERMITTED, &msg_sched_op_not_permitted},
 	{PBSE_SCHED_PARTITION_ALREADY_EXISTS, &msg_sched_part_already_used},
 	{ 0, NULL }		/* MUST be the last entry */

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7114,17 +7114,6 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				return (PBSE_UNKNODE);
 			}
 
-			/*
-			 * Initially don't allow allow jobs/resvs to be placed on down or stale nodes.
-			 * If the job is already on a down/stale node and is being recovered from the
-			 * database, allow it back onto that node.  Nodes may not be back up before
-			 * jobs are recovered from the database.
-			 */
-			if (svr_init == FALSE && (pnode->nd_state & (INUSE_DOWN | INUSE_STALE))) {
-				free(phowl);
-				free(execvncopy);
-				return (PBSE_BAD_NODE_STATE);
-			}
 
 			if (pjob != NULL) { /* only for jobs do we warn if a mom */
 				/* hook has not been sent */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* node stays in state=free with excl resv on server restart
* clearly describe the steps to easily reproduce the problem:
1. submit excl reservation
2. restart the server
3. wait till resv starts
4. Node won't be in resv-exclusive state

#### Problem description
* If the server is restarted before an excl reservation starts, the resv nodes stay in state=free (not state=resv-exclusive) after the reservation starts.
#### Cause / Analysis
* When the server starts, the nodes are in the down state.  Before the come up, the server attempts to reassign the nodes to the reservation.  Since they are down, the set_nodes() call is rejected and the reservation has no nodes.
#### Solution description
* Remove the code in set_nodes() which checks for down/stale vnodes.  It caused too many problems with vnodes not being assigned to reservations when the nodes were down or the server was starting up.

#### Testing logs/output
* [ptl.log](https://github.com/PBSPro/pbspro/files/2104484/ptl.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
