### PR TITLE
PP-1278: Need a skip decorator in PTL which will skip the test withou…

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -135,6 +135,22 @@ NUMNODES = 'numnodes'
 TIMEOUT_KEY = '__testcase_timeout__'
 
 
+def skip(reason="Skipped test execution"):
+    """
+    Unconditionally skip a test.
+
+    :param reason: Reason for the skip
+    :type reason: str or None
+    """
+    skip_flag = True
+
+    def wrapper(test_item):
+        test_item.__unittest_skip__ = skip_flag
+        test_item.__unittest_skip_why__ = reason
+        return test_item
+    return wrapper
+
+
 def timeout(val):
     """
     Decorator to set timeout value of test case


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Currently in PTL we can not skip the test forcefully using a decorator. 
* [PP-1278](https://pbspro.atlassian.net/browse/PP-1278)

#### Affected Platform(s)
* All platforms

#### Cause / Analysis / Design
* In PTL we don't have an decorator which will skip the test execution without any condition.

#### Solution Description
* Need to implement a decorator which will skip the test with the reason passed irrespective of any condition. It should also skip the setup.  

#### Testing logs/output
* [skip_test_withoutreason.txt](https://github.com/PBSPro/pbspro/files/2123106/skip_test_withoutreason.txt)
* [skip_test_withreason.txt](https://github.com/PBSPro/pbspro/files/2123107/skip_test_withreason.txt)
* [skip_testsuite_withoutreason.txt](https://github.com/PBSPro/pbspro/files/2123108/skip_testsuite_withoutreason.txt)
* [skip_testsuite_withreason.txt](https://github.com/PBSPro/pbspro/files/2123109/skip_testsuite_withreason.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
