### PR TITLE
Adding backward compatibility to pbs_snapshot

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -1209,16 +1209,19 @@ quit()
                 if sched_name is not None:
                     line = "".join(line.split())
                     if line.startswith("sched_priv="):
-                        sched_details[sched_name]["sched_priv"] = line.split(
-                            "=")[1]
+                        sched_details[sched_name]["sched_priv"] = \
+                            line.split("=")[1]
                     elif line.startswith("sched_log="):
-                        sched_details[sched_name]["sched_log"] = line.split(
-                            "=")[1]
+                        sched_details[sched_name]["sched_log"] = \
+                            line.split("=")[1]
 
             for sched_name in sched_details:
                 # Capture sched_priv for the scheduler
-                pbs_sched_priv = sched_details[sched_name]["sched_priv"]
-                if sched_name == "default":
+                if len(sched_details) == 1:  # For pre-multisched outputs
+                    pbs_sched_priv = os.path.join(self.pbs_home, "sched_priv")
+                else:
+                    pbs_sched_priv = sched_details[sched_name]["sched_priv"]
+                if sched_name == "default" or len(sched_details) == 1:
                     snap_sched_priv = os.path.join(self.snapdir,
                                                    DFLT_SCHED_PRIV_PATH)
                     core_dir = os.path.join(self.snapdir, CORE_SCHED_PATH)
@@ -1234,8 +1237,12 @@ quit()
                                           snap_sched_priv, core_dir)
                 if with_sched_logs and self.num_daemon_logs > 0:
                     # Capture scheduler logs
-                    pbs_sched_log = sched_details[sched_name]["sched_log"]
-                    if sched_name == "default":
+                    if len(sched_details) == 1:  # For pre-multisched outputs
+                        pbs_sched_log = os.path.join(self.pbs_home,
+                                                     "sched_logs")
+                    else:
+                        pbs_sched_log = sched_details[sched_name]["sched_log"]
+                    if sched_name == "default" or len(sched_details) == 1:
                         snap_sched_log = os.path.join(self.snapdir,
                                                       DFLT_SCHED_LOGS_PATH)
                     else:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
pbs_snapshot breaks when run on PBSPro 14.2, it'd be good to make it compatible with older versions of PBSPro

#### Affected Platform(s)
* PBSPro 14.2 (Linux only)

#### Cause / Analysis / Design
* The code inside pbs_snaputils.py (capture_scheduler()) explicitly looks for the "default" scheduler and the "sched_priv" and "sched_log" attributes, which were added as part of one of the multi-sched check-ins.

#### Solution Description
* Added a check in capture_scheduler() for older systems which will have only 1 scheduler named something other than 'default'

#### Testing logs/output
* There's no elegant way to test as we are talking about taking the pbs_snapshot that comes with latest pbspro and running it on an older pbspro. So, I used Pyinstaller (https://pyinstaller.readthedocs.io/en/v3.3.1/index.html) to create a standalone binary of pbs_snapshot and ran it on a system that had pbspro 14.2 installed, here's the snapshot log before fix:
[before_fix.log](https://github.com/PBSPro/pbspro/files/2139287/before_fix.log)
 and here's the snapshot log after the fix: 
[after_fix.log](https://github.com/PBSPro/pbspro/files/2139289/after_fix.log)

Also, here's TestPBSSnapshot logs for the latest code after making these changes: 
[testpbssnapshot.log](https://github.com/PBSPro/pbspro/files/2139320/testpbssnapshot.log)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
