### PR TITLE
Refactor qsub.c

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -162,207 +162,179 @@
 
 #define MAX_QSUB_PREFIX_LEN 32
 #define QSUB_DMN_TIMEOUT_LONG 60  /* timeout for qsub background process */
-#define QSUB_DMN_TIMEOUT_SHORT 5  
+#define QSUB_DMN_TIMEOUT_SHORT 5
 
-static char PBS_DPREFIX_DEFAULT[] = "#PBS";
 
-/* globals */
+/* extern global variables */
 #ifdef NAS /* localmod 005 */
 extern void set_attr_resc(struct attrl **attrib, char *attrib_name, char *attrib_resc, char *attrib_value);
 #endif /* localmod 005 */
 extern char *msg_force_qsub_update;
-int comm_sock;
 
-/* Socket for x11 communication */
-int X11_comm_sock;
+/*
+ * The following variables are file static (ie. global in this file).
+ */
+static char PBS_DPREFIX_DEFAULT[] = "#PBS";
+static char	const pbs_o_env[] = "PBS_O_"; /* prefix for environment variables created by qsub */
 
-/* Max size of buffer to store Xauth cookie length */
-#define XAUTH_LEN   512
-
-/* Max size of buffer to store port information as string */
-#define X11_PORT_LEN 8
-
-/* redirection string used for xauth command */
-static char xauth_err_redirection[] = "2>&1";
-
-/* offset of the redirection clause */
-#define X11_MSG_OFFSET sizeof(xauth_err_redirection)
-
-#ifndef WIN32
-struct termios oldtio;
-struct winsize wsz;
-#else
-static CRITICAL_SECTION continuethread_cs;
-#endif
-
-/* global var to hold the message that background qsub process will send */
-char retmsg[MAXPATHLEN];
-
-
-/* global var to pass cwd to background qsub */
-char qsub_cwd[MAXPATHLEN + 1];
-
-/* new functions for the background qsub process */
-static int dosend(void *s, char *buf, int bufsize);
-static int dorecv(void *s, char *buf, int bufsize);
-static int send_opts(void *s);
-static int recv_opts(void *s);
-static int send_attrl(void *s, struct attrl *attrib);
-static int recv_attrl(void *s, struct attrl **attrib);
-static int send_string(void *s, char *str);
-static int recv_string(void *s, char *str);
-
-static int do_submit(char *retmsg);
-static int do_submit2(char *rmsg);
-static void get_comm_filename(char *fl);
-static char * get_conf_path();
-static void free_attrl(struct attrl *attrib);
-static struct attrl *dup_attrl(struct attrl *attrib);
-static int do_connect(char *server_out, char *retmsg);
+/* Warning/Error messages */
 #ifdef WIN32
-static void do_daemon_stuff(char *server, char *handle, char *file);
-#else
-static void do_daemon_stuff(void);
-static int check_qsub_daemon(char *fl);
-static int fork_and_stay(void);
+static char const intergui_warn[] = "qsub: only interactive jobs can have GUI\n";
 #endif
-
-static char *copy_env_value(char *dest, char *pv, int quote_flg);
-
-
-struct attrl *attrib = NULL;
-struct attrl *attrib_o = NULL;
-char *new_jobname = NULL;                  /* return from submit request */
-char dir_prefix[MAX_QSUB_PREFIX_LEN+1];
-char destination[PBS_MAXDEST];
-static char server_out[PBS_MAXSERVERNAME+PBS_MAXPORTNUM+2];
-struct batch_status *ss = NULL;
-char *dfltqsubargs = NULL;
-int sd_svr;                        /* return from pbs_connect */
-char script_tmp[MAXPATHLEN+1] = "";      /* name of script file copy */
-char   fl[2*MAXPATHLEN+1];	/* the filename used as the pipe name */
-#define BUFSIZE 1024		/* windows default pipe buffer size */
-#define PIPE_TIMEOUT 0		/* default windows pipe timeout */
-char *pbs_hostvar = NULL;
-int pbs_o_hostsize = sizeof(",PBS_O_HOST=") + 1;
-char *display;
-/* state booleans for protecting already-set options */
-int a_opt = FALSE;
-int c_opt = FALSE;
-int e_opt = FALSE;
-int h_opt = FALSE;
-int j_opt = FALSE;
-int k_opt = FALSE;
-int l_opt = FALSE;
-int m_opt = FALSE;
-int o_opt = FALSE;
-int p_opt = FALSE;
-int q_opt = FALSE;
-int r_opt = FALSE;
-int R_opt = FALSE;
-int u_opt = FALSE;
-int v_opt = FALSE;
-int z_opt = FALSE;
-int A_opt = FALSE;
-int P_opt = FALSE;
-int C_opt = FALSE;
-int J_opt = FALSE;
-int M_opt = FALSE;
-int N_opt = FALSE;
-int S_opt = FALSE;
-int V_opt = FALSE;
-int Depend_opt    = FALSE;
-int Interact_opt  = FALSE;
-int Stagein_opt   = FALSE;
-int Stageout_opt  = FALSE;
-int Sandbox_opt   = FALSE;
-int Grouplist_opt = FALSE;
-int Forwardx11_opt = FALSE;
-#ifdef WIN32
-int gui_opt = FALSE;
-#endif
-int Resvstart_opt = FALSE;
-int Resvend_opt = FALSE;
-int pwd_opt = FALSE;
-int cred_opt = FALSE;
-int block_opt = FALSE;
-int relnodes_on_stageout_opt = FALSE;
-int roptarg_inter = FALSE;
-#ifndef WIN32
-int x11_disp = FALSE;
-#endif
-char *v_value = NULL;
-char *v_value_o = NULL;
-char *basic_envlist = NULL;
-char *qsub_envlist = NULL;
-
-/* for saving option booleans */
-int a_opt_o = FALSE;
-int c_opt_o = FALSE;
-int e_opt_o = FALSE;
-int h_opt_o = FALSE;
-int j_opt_o = FALSE;
-int k_opt_o = FALSE;
-int l_opt_o = FALSE;
-int m_opt_o = FALSE;
-int o_opt_o = FALSE;
-int p_opt_o = FALSE;
-int q_opt_o = FALSE;
-int r_opt_o = FALSE;
-int u_opt_o = FALSE;
-int v_opt_o = FALSE;
-int z_opt_o = FALSE;
-int A_opt_o = FALSE;
-int C_opt_o = FALSE;
-int J_opt_o = FALSE;
-int M_opt_o = FALSE;
-int N_opt_o = FALSE;
-int S_opt_o = FALSE;
-int V_opt_o = FALSE;
-int Depend_opt_o = FALSE;
-int Interact_opt_o = FALSE;
-int Stagein_opt_o = FALSE;
-int Stageout_opt_o = FALSE;
-int Sandbox_opt_o = FALSE;
-int Grouplist_opt_o = FALSE;
-int Forwardx11_opt_o = FALSE;
-#ifdef WIN32
-int gui_opt_o = FALSE;
-#endif
-int Resvstart_opt_o = FALSE;
-int Resvend_opt_o = FALSE;
-int pwd_opt_o = FALSE;
-int cred_opt_o = FALSE;
-int block_opt_o = FALSE;
-int relnodes_on_stageout_opt_o = FALSE;
-int P_opt_o = FALSE;
-
-int no_background = 0;
-
-char  roptarg = 'y';
-
-char cred_name[32];	/* space to hold small credential name */
-#ifdef WIN32
-char intergui_warn[] = "qsub: only interactive jobs can have GUI\n";
-#endif
-char interblock_warn[] = "qsub (Warning) : setting \"block\" attribute as \"true\""
+static char const interblock_warn[] = "qsub (Warning) : setting \"block\" attribute as \"true\""
 	" for an interactive job will not return job's exit status\n";
-char interarray[] = "qsub: interactive and array job submission cannot be used together\n";
-char norerunarray[] = "qsub:  cannot submit non-rerunable Array Job\n";
-char reruninteract[] = "qsub (Warning): Interactive jobs will be treated as not rerunnable\n";
-char badw[] = "qsub: illegal -W value\n";
+static char const interarray[] = "qsub: interactive and array job submission cannot be used together\n";
+static char const norerunarray[] = "qsub:  cannot submit non-rerunable Array Job\n";
+static char const reruninteract[] = "qsub (Warning): Interactive jobs will be treated as not rerunnable\n";
+static char const badw[] = "qsub: illegal -W value\n";
 
+/* Security library variables */
 static int	cs_init = 0;	/*1==security library initialized, 0==not initialized*/
-
 static int 	cred_type = -1;
 static size_t	cred_len = 0;
 static char	*cred_buf = NULL;
+static char cred_name[32];	/* space to hold small credential name */
 #if defined(PBS_PASS_CREDENTIALS)
 static char	passwd_buf[PBS_MAXPWLEN] = {'\0'};
 #endif
-static char	pbs_o_env[] = "PBS_O_";
-static char	*tmpdir = NULL;
 
+static char	*tmpdir = NULL; /* Path of temp directory in which to put the job script */
+
+/* variables for Interactive mode */
+static int comm_sock; /* Socket for interactive and block job */
+static int X11_comm_sock; /* Socket for x11 communication */
+
+#define XAUTH_LEN   512 /* Max size of buffer to store Xauth cookie length */
+#define X11_PORT_LEN 8  /* Max size of buffer to store port information as string */
+static char xauth_err_redirection[] = "2>&1"; /* redirection string used for xauth command */
+#define X11_MSG_OFFSET sizeof(xauth_err_redirection) /* offset of the redirection clause */
+
+#ifdef WIN32 /* Windows */
+static CRITICAL_SECTION continuethread_cs;
+#else /* Unix */
+static struct termios oldtio; /* Terminal info */
+static struct winsize wsz; /* Window size */
+#endif
+
+
+static char retmsg[MAXPATHLEN]; /* global var to hold the message that background qsub process will send */
+static char qsub_cwd[MAXPATHLEN + 1]; /* global var to pass cwd to background qsub */
+
+
+static struct attrl *attrib = NULL; /* Attribute list */
+static struct attrl *attrib_o = NULL; /* Original attribute list, before applying default_qsub_arguments */
+static char *new_jobname = NULL;                  /* return from submit request */
+static char dir_prefix[MAX_QSUB_PREFIX_LEN+1]; /* Directive Prefix, specified by C opt */
+static char destination[PBS_MAXDEST]; /* Destination of the batch job, specified by q opt */
+static char server_out[PBS_MAXSERVERNAME+PBS_MAXPORTNUM+2]; /* Destination server, parsed from destination[] */
+static struct batch_status *ss = NULL;
+static char *dfltqsubargs = NULL; /* Default qsub arguments */
+static int sd_svr;                        /* return from pbs_connect */
+static char script_tmp[MAXPATHLEN+1] = "";      /* name of script file copy */
+static char   fl[2*MAXPATHLEN+1];	/* the filename used as the pipe name */
+#define BUFSIZE 1024		/* windows default pipe buffer size */
+#define PIPE_TIMEOUT 0		/* default windows pipe timeout */
+static char *pbs_hostvar = NULL; /* buffer containing ",PBS_O_HOST=" and host name */
+static int pbs_o_hostsize = sizeof(",PBS_O_HOST=") + 1; /* size of prefix for hostvar */
+static char *display; /* environment variable DISPLAY */
+
+static int no_background = 0; /* flag to disable backgrounding */
+static char  roptarg = 'y'; /* whether the job is rerunnable */
+static char *v_value = NULL; /* expanded variable list from v opt */
+static char *v_value_o = NULL; /* copy of v_value before set_job_env() */
+static char *basic_envlist = NULL; /* basic comma-separated environment variables list string */
+static char *qsub_envlist = NULL; /* comma-separated variables list string */
+#ifndef WIN32
+static int x11_disp = FALSE; /* whether DISPLAY environment variable is available */
+#endif
+
+/* state booleans for protecting already-set options */
+static int a_opt = FALSE;
+static int c_opt = FALSE;
+static int e_opt = FALSE;
+static int h_opt = FALSE;
+static int j_opt = FALSE;
+static int k_opt = FALSE;
+static int l_opt = FALSE;
+static int m_opt = FALSE;
+static int o_opt = FALSE;
+static int p_opt = FALSE;
+static int q_opt = FALSE;
+static int r_opt = FALSE;
+static int u_opt = FALSE;
+static int v_opt = FALSE;
+static int z_opt = FALSE;
+static int A_opt = FALSE;
+static int C_opt = FALSE;
+static int J_opt = FALSE;
+static int M_opt = FALSE;
+static int N_opt = FALSE;
+static int P_opt = FALSE;
+static int R_opt = FALSE;
+static int S_opt = FALSE;
+static int V_opt = FALSE;
+static int Depend_opt    = FALSE;
+static int Interact_opt  = FALSE;
+static int Stagein_opt   = FALSE;
+static int Stageout_opt  = FALSE;
+static int Sandbox_opt   = FALSE;
+static int Grouplist_opt = FALSE;
+static int Forwardx11_opt = FALSE;
+#ifdef WIN32
+static int gui_opt = FALSE;
+#endif
+static int Resvstart_opt = FALSE;
+static int Resvend_opt = FALSE;
+static int pwd_opt = FALSE;
+static int cred_opt = FALSE;
+static int block_opt = FALSE;
+static int relnodes_on_stageout_opt = FALSE;
+static int roptarg_inter = FALSE;
+
+/* for saving option booleans */
+static int a_opt_o = FALSE;
+static int c_opt_o = FALSE;
+static int e_opt_o = FALSE;
+static int h_opt_o = FALSE;
+static int j_opt_o = FALSE;
+static int k_opt_o = FALSE;
+static int l_opt_o = FALSE;
+static int m_opt_o = FALSE;
+static int o_opt_o = FALSE;
+static int p_opt_o = FALSE;
+static int q_opt_o = FALSE;
+static int r_opt_o = FALSE;
+static int u_opt_o = FALSE;
+static int v_opt_o = FALSE;
+static int z_opt_o = FALSE;
+static int A_opt_o = FALSE;
+static int C_opt_o = FALSE;
+static int J_opt_o = FALSE;
+static int M_opt_o = FALSE;
+static int N_opt_o = FALSE;
+static int P_opt_o = FALSE;
+static int S_opt_o = FALSE;
+static int V_opt_o = FALSE;
+static int Depend_opt_o = FALSE;
+static int Interact_opt_o = FALSE;
+static int Stagein_opt_o = FALSE;
+static int Stageout_opt_o = FALSE;
+static int Sandbox_opt_o = FALSE;
+static int Grouplist_opt_o = FALSE;
+#ifdef WIN32
+static int gui_opt_o = FALSE;
+#endif
+static int Resvstart_opt_o = FALSE;
+static int Resvend_opt_o = FALSE;
+static int pwd_opt_o = FALSE;
+static int cred_opt_o = FALSE;
+static int block_opt_o = FALSE;
+static int relnodes_on_stageout_opt_o = FALSE;
+
+
+/*
+ * The following bunch of functions are "Utility" functions.
+ */
 
 /**
  * @brief
@@ -373,7 +345,7 @@ static char	*tmpdir = NULL;
  * @return Void
  *
  */
-void
+static void
 log_cmds_portfw_msg(char *msg)
 {
 	fprintf(stderr, "%s\n", msg);
@@ -391,8 +363,8 @@ log_cmds_portfw_msg(char *msg)
  * @param[in]	msg - string to be logged
  *
  */
-void
-log_syslog(char *msg)
+static void
+log_syslog(char const * const msg)
 {
 	openlog("qsub", LOG_PID | LOG_CONS | LOG_NOWAIT, LOG_USER);
 	syslog(LOG_ERR, "%s", msg);
@@ -409,7 +381,7 @@ log_syslog(char *msg)
  * @retval	NULL	no more tokens
  *
  */
-char *
+static char *
 comma_token(char *str)
 {
 	static	char	*p = NULL;
@@ -453,6 +425,103 @@ comma_token(char *str)
 
 /**
  * @brief
+ *      Copy an environment variable to a specified location
+ *
+ * @param[in]	dest	- The destination address
+ * @param[in]   pv	- The source address
+ * @param[in]   quote_flg - Whether quote characters should be escaped
+ *
+ * @return      char*
+ * @retval	NULL - Failure
+ * @retval      !NULL - Success - Pointer to pv parameter
+ */
+static char *
+copy_env_value(char *dest, /* destination  */
+	char *pv, /* value string */
+	int quote_flg) /* non-zero then assume single word (quoting on) */
+{
+	int   go = 1;
+	int   q_ch = 0;
+	int   is_func = 0;
+	char  *dest_full = dest;
+
+	while (*dest)
+		++dest;
+
+	is_func = ((*pv == '(') && (*(pv+1) == ')') && (*(pv+2) == ' ') && (*(pv+3) == '{'));
+
+	/*
+	 * Keep the list of special characters consistent with encode_arst_bs()
+	 * and parse_comma_string_bs().
+	 */
+
+	while (go && *pv) {
+		switch (*pv) {
+			case '"':
+			case '\'':
+				if (q_ch) {	/* local quoting is in progress */
+					if (q_ch == (int)*pv) {
+						q_ch = 0;	/* end quote */
+					} else {
+						*dest++ = ESC_CHAR;	/* escape quote */
+						*dest++ = *pv;
+					}
+				} else if (quote_flg) {	  /* global quoting is on */
+					*dest++ = ESC_CHAR;	  /* escape quote */
+					*dest++ = *pv;
+				} else {
+					q_ch = (int)*pv;  /* turn local quoting on */
+				}
+				break;
+
+			case ESC_CHAR:			/* backslash in value, escape it */
+				*dest++ = *pv;
+				if (*(pv+1) != ',') /* do not escape if ESC_CHAR already escapes */
+					*dest++ = *pv;
+				break;
+
+			case ',':
+				if (q_ch || quote_flg) {
+					*dest++ = ESC_CHAR;
+					*dest++ = *pv;
+				} else if (dest_full != dest && *(dest-1) == ESC_CHAR) { /* the comma is escaped, not finished yet */
+					*dest++ = *pv;
+				} else {
+					go = 0;		/* end of value string */
+				}
+				break;
+
+			case ';':
+				*dest++ = *pv;
+				if (is_func && (*(pv+1) == '\n'))
+					pv++;
+				break;
+
+			case '\n':
+				if (is_func) {
+					*dest++ = ';';
+					*dest++ = ' ';
+				} else {
+					*dest++ = *pv;
+				}
+				break;
+
+			default:
+				*dest++ = *pv;
+				break;
+		}
+		pv++;
+	}
+
+	*dest = '\0';
+	if (q_ch)
+		return NULL;	/* error-unterminated quote */
+	else
+		return (pv);
+}
+
+/**
+ * @brief
  *	Given a comma-separated list of "variable" or "variable=value"
  *	entries, return a new variable list with those "variable" entries
  *	expanded to contain their values obtained from the current
@@ -465,7 +534,7 @@ comma_token(char *str)
  *	NULL if any error encountered.
  *
  */
-char *
+static char *
 expand_varlist(char *varlist)
 {
 	char	*v_value1 = NULL;
@@ -507,7 +576,7 @@ expand_varlist(char *varlist)
 		goto expand_varlist_err;
 	}
 
-	p1=comma_token(v_value2);
+	p1 = comma_token(v_value2);
 	while (p1 != NULL) {
 		vn = p1;
 		vv = NULL;
@@ -515,15 +584,13 @@ expand_varlist(char *varlist)
 			*p2 = '\0';
 			vv = p2+1;
 		}
-		if ((vv == NULL) && (strncmp(vn, pbs_o_env,
-			sizeof(pbs_o_env)-1) !=  0)) {
+		if ((vv == NULL) && (strncmp(vn, pbs_o_env, sizeof(pbs_o_env)-1) !=  0)) {
 			/* do not add PBS_O_* env variables, as these */
 			/* are set by qsub */
 
 			ev = getenv(vn);
 			if (ev == NULL) {
-				fprintf(stderr,
-					"qsub: cannot send environment with the job\n");
+				fprintf(stderr, "qsub: cannot send environment with the job\n");
 				goto expand_varlist_err;
 			}
 
@@ -540,8 +607,7 @@ expand_varlist(char *varlist)
 			strcat(v_value1, "=");
 
 			if (copy_env_value(v_value1, ev, 1) == NULL) {
-				fprintf(stderr,
-					"qsub: cannot send environment with the job\n");
+				fprintf(stderr, "qsub: cannot send environment with the job\n");
 				goto expand_varlist_err;
 			}
 		} else if (vv != NULL) {
@@ -551,26 +617,22 @@ expand_varlist(char *varlist)
 			strcat(v_value1, vn);
 			strcat(v_value1, "=");
 			if (copy_env_value(v_value1, vv, 0) == NULL) {
-				fprintf(stderr,
-					"qsub: cannot send environment with the job\n");
+				fprintf(stderr, "qsub: cannot send environment with the job\n");
 				goto expand_varlist_err;
 			}
 		}
 
 		p1 = comma_token(NULL);
 	}
-	if (v_value2 != NULL) {
+	if (v_value2 != NULL)
 		free(v_value2);
-	}
 	return (v_value1);
 
 expand_varlist_err:
-	if (v_value1 != NULL) {
+	if (v_value1 != NULL)
 		free(v_value1);
-	}
-	if (v_value2 != NULL) {
+	if (v_value2 != NULL)
 		free(v_value2);
-	}
 	return NULL;
 }
 
@@ -672,33 +734,29 @@ x11_get_authstring(void)
 			return NULL;
 		}
 	}
-	strncpy(command, line, strlen(line) - X11_MSG_OFFSET);
+	strncpy(command, line, strlen(line) - X11_MSG_OFFSET); /* safe because strlen(line) <= sizeof(command) */
 
 	if (p != NULL)
 		p = strchr(p, '.');
 
-	if (p != NULL)
-		strncpy(screen, p + 1, sizeof(screen));
+	if (p != NULL) {
+		snprintf(screen, sizeof(screen), "%s", p+1);
+	}
 	else
-		strcpy(screen, "0");
+		strcpy(screen, "0"); /* safe as long as XAUTH_LEN >= 2 */
 
 #ifdef DEBUG
 	fprintf(stderr, "x11_get_authstring: %s\n", line);
 #endif
 	f = popen(line, "r");
 	if (f == NULL) {
-		fprintf(stderr, "execution of '%s' failed, errno=%d \n",
-			command,
-			errno);
+		fprintf(stderr, "execution of '%s' failed, errno=%d \n", command, errno);
 	} else if (fgets(line, sizeof(line), f) == 0) {
-		fprintf(stderr, "cannot read data from '%s', errno=%d \n",
-			command,
-			errno);
+		fprintf(stderr, "cannot read data from '%s', errno=%d \n", command, errno);
 	} else if (sscanf(line, format,
 		protocol,
 		hexdata) != 2) {
-		fprintf(stderr, "cannot parse output from '%s'\n",
-			command);
+		fprintf(stderr, "cannot parse output from '%s'\n", command);
 	} else {
 		/* SUCCESS */
 		got_data = 1;
@@ -717,10 +775,9 @@ x11_get_authstring(void)
 		}
 	}
 
-	if (!got_data) {
+	if (!got_data)
 		/* FAILURE */
 		return NULL;
-	}
 
 	/**
 	 *  Allocate 4 additional bytes for the terminating NULL character for
@@ -756,16 +813,12 @@ static void
 exit_qsub(int exitstatus)
 {
 #ifdef WIN32
-	/*
-	 * A thread that makes qsub exit, should try and acquire the Critical Section.
-	 */
+	/* A thread that makes qsub exit, should try and acquire the Critical Section. */
 	EnterCriticalSection(&continuethread_cs);
 #endif
-	if (cs_init == 1) {
-
-		/*cleanup security library initializations before exiting*/
+	if (cs_init == 1)
+		/* Cleanup security library initializations before exiting */
 		CS_close_app();
-	}
 
 #ifdef BACKTRACE_SIZE
 	if (exitstatus != 0) {
@@ -790,12 +843,3438 @@ exit_qsub(int exitstatus)
 	exit(exitstatus);
 }
 
+/**
+ * @brief
+ *	strdup_esc_commas - duplicate a string escaping commas
+ *	The string is duplicated with all commas in the original string
+ *	escaped by preceeding black slash
+ *
+ * @param[in] str_to_dup - string to be duplicated
+ *
+ * @return
+ * @retval string Succes
+ * @retval NULL   Failure
+ *
+ */
+static char *
+strdup_esc_commas(char *str_to_dup)
+{
+	char *roaming = str_to_dup;
+	char *endstr, *returnstr;
+
+	if (str_to_dup == NULL)
+		return NULL;
+
+	returnstr = endstr = malloc(strlen(str_to_dup)*2 + 2);
+	/* even for an all-comma string, this should suffice */
+	if (returnstr == NULL)
+		return (returnstr); /* just return null on malloc failure */
+	while (*roaming != '\0') {
+		while (*roaming != '\0' && *roaming != ',')
+			*(endstr++) = *(roaming++);
+		if (*roaming==',') {
+			*(endstr++) = ESC_CHAR;
+			*(endstr++) = ',';
+			roaming++;
+		}
+	}
+	*endstr = '\0';
+	return (returnstr);
+}
+
+/**
+ * @brief
+ *	prints the usage format for qsub
+ *
+ */
+static void
+print_usage()
+{
+#ifdef WIN32
+	static char usag2[]="       qsub --version\n";
+	static char usage[]=
+		"usage: qsub [-a date_time] [-A account_string] [-c interval]\n"
+	"\t[-C directive_prefix] [-e path] [-f ] [-G] [-h ] [-j oe|eo] [-J X-Y[:Z]]\n"
+	"\t[-k keep] [-l resource_list] [-m mail_options] [-M user_list]\n"
+	"\t[-N jobname] [-o path] [-p priority] [-P project] [-q queue] [-r y|n]\n"
+	"\t[-R o|e|oe] [-S path] [-u user_list] [-W otherattributes=value...]\n"
+	"\t[-v variable_list] [-V ] [-z] [script | -- command [arg1 ...]]\n";
+#else
+	static char usag2[]="       qsub --version\n";
+	static char usage[]=
+		"usage: qsub [-a date_time] [-A account_string] [-c interval]\n"
+	"\t[-C directive_prefix] [-e path] [-f ] [-h ] [-I [-X]] [-j oe|eo] [-J X-Y[:Z]]\n"
+	"\t[-k keep] [-l resource_list] [-m mail_options] [-M user_list]\n"
+	"\t[-N jobname] [-o path] [-p priority] [-P project] [-q queue] [-r y|n]\n"
+	"\t[-R o|e|oe] [-S path] [-u user_list] [-W otherattributes=value...]\n"
+	"\t[-S path] [-u user_list] [-W otherattributes=value...]\n"
+	"\t[-v variable_list] [-V ] [-z] [script | -- command [arg1 ...]]\n";
+#endif
+	fprintf(stderr, "%s", usage);
+	fprintf(stderr, "%s", usag2);
+}
+
+/* End of "Utility" functions. */
+
+/*
+ * The following bunch of functions support the "Interactive Job"
+ * capability of PBS.
+ */
+
+/**
+ * @brief
+ * 	interactive_port - get a socket to listen to for "interactive" job
+ *	When the "interactive" job is run, its standard in, out, and error
+ *	will be connected to this socket.
+ *
+ * @return string
+ * @retval portstring holding port info
+ * exits from program on failure
+ *
+ */
+static char *
+interactive_port()
+{
+	pbs_socklen_t namelen;
+	static char portstring[8];
+	struct sockaddr_in myaddr;
+	unsigned short port;
+
+	if ((isatty(0) == 0) || (isatty(1) == 0)) {
+		fprintf(stderr, "qsub:\tstandard input and output must be a "
+			"terminal for\n\tinteractive job submission\n");
+		exit_qsub(1);
+	}
+	comm_sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (comm_sock < 0) {
+		perror("qsub: unable to obtain socket");
+		exit_qsub(1);
+	}
+	myaddr.sin_family = AF_INET;
+	myaddr.sin_addr.s_addr = INADDR_ANY;
+	myaddr.sin_port = 0;
+	if (bind(comm_sock, (struct sockaddr *)&myaddr, sizeof(myaddr)) < 0) {
+		perror("qsub: unable to bind to socket");
+		exit_qsub(1);
+	}
+
+	/* get port number assigned */
+
+	namelen = sizeof(myaddr);
+	if (getsockname(comm_sock, (struct sockaddr *)&myaddr, &namelen) < 0) {
+		perror("qsub: unable to get port number");
+		exit_qsub(1);
+	}
+	port = ntohs(myaddr.sin_port);
+	(void)sprintf(portstring, "%u", (unsigned int)port);
+	if (listen(comm_sock, 1) < 0) {
+		perror("qsub: listen on interactive socket");
+		exit_qsub(1);
+	}
+
+	return (portstring);
+}
+
+#ifndef WIN32
+/**
+ * @brief
+ *	This function creates a socket to listen for "X11" data
+ *	and returns a port number where its listening for X data.
+ *
+ * @return	char*
+ * @retval	portstring	success
+ *
+ * @par Side Effects
+ *		If this function fails, it will exit the qsub process.
+ *
+ */
+static char*
+port_X11(void)
+{
+	pbs_socklen_t namelen;
+	struct sockaddr_in myaddr;
+	static char X11_port_str[X11_PORT_LEN];
+	unsigned short X11_port;
+
+	X11_comm_sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (X11_comm_sock < 0) {
+		perror("qsub: unable to create socket");
+		exit_qsub(1);
+	}
+	myaddr.sin_family = AF_INET;
+	myaddr.sin_addr.s_addr = INADDR_ANY;
+	myaddr.sin_port = 0;
+
+	if (bind(X11_comm_sock, (struct sockaddr *) &myaddr,
+		sizeof(myaddr)) < 0) {
+		perror("qsub: unable to bind to socket");
+		exit_qsub(1);
+	}
+	/* get port number assigned */
+	namelen = sizeof(myaddr);
+	if (getsockname(X11_comm_sock, (struct sockaddr *) &myaddr,
+		&namelen) < 0) {
+		perror("qsub: unable to get port number");
+		exit_qsub(1);
+	}
+	X11_port = ntohs(myaddr.sin_port);
+	(void) sprintf(X11_port_str, "%u", (unsigned int) X11_port);
+	if (listen(X11_comm_sock, 1) < 0) {
+		perror("qsub: listening on X11 socket failed");
+		exit_qsub(1);
+	}
+	return (X11_port_str);
+}
+
+/**
+ * @brief
+ * 	settermraw - set terminal into "raw" mode
+ *
+ * @param[in] ptio - pointer to termios structure
+ *
+ * @return None
+ * @retval Void
+ *
+ */
+static void
+settermraw(struct termios *ptio)
+{
+	struct termios tio;
+
+	tio = *ptio;
+
+	tio.c_lflag &= ~(ICANON|ISIG|ECHO|ECHOE|ECHOK);
+	tio.c_iflag &= ~(IGNBRK|INLCR|ICRNL|IXON|IXOFF);
+	tio.c_oflag = 0;
+	tio.c_oflag |= (OPOST); /* TAB3 */
+	tio.c_cc[VMIN] = 1;
+	tio.c_cc[VTIME] = 0;
+
+#if defined(TABDLY) && defined(TAB3)
+	if ((tio.c_oflag & TABDLY) == TAB3)
+		tio.c_oflag &= ~TABDLY;
+#endif
+	tio.c_cc[VKILL]  = -1;
+	tio.c_cc[VERASE] = -1;
+
+	if (tcsetattr(0, TCSANOW, &tio) < 0)
+		perror("qsub: set terminal mode");
+}
+
+/**
+ * @brief
+ * 	stopme - suspend process on ~^Z or ~^Y
+ *	on suspend, reset terminal to normal "cooked" mode;
+ *	when resumed, again set terminal to raw.
+ *
+ * @param[in] p - process id
+ *
+ * @return None
+ * @retval Void
+ *
+ */
+static void
+stopme(pid_t p)
+{
+	(void)tcsetattr(0, TCSANOW, &oldtio); /* reset terminal */
+	kill(p, SIGTSTP);
+	(void)settermraw(&oldtio);            /* back to raw when we resume */
+}
+
+/**
+ * @brief
+ *	Interactive Reader process: reads from the remote socket,
+ *	and writes that out to the stdout
+ *
+ * @param[in] s - socket (file descriptor)
+ *
+ * @return   Error code
+ * @retval  -1  Failure
+ * @retval   0   Success
+ *
+ */
+static int
+reader(int s)
+{
+	char buf[4096];
+	int  c;
+	char *p;
+	int  wc;
+
+	/* read from the socket, and write to stdout */
+	while (1) {
+		c = CS_read(s, buf, sizeof(buf));
+		if (c > 0) {
+			p = buf;
+			while (c) {
+				if ((wc = write(1, p, c)) < 0) {
+					if (errno == EINTR) {
+						continue;
+					} else {
+						perror("qsub: write error");
+						return (-1);
+					}
+				}
+				c -= wc;
+				p += wc;
+			}
+		} else if (c == 0) {
+			return (0);		/* EOF - all done */
+		} else {
+			if (errno == EINTR)
+				continue;
+			else {
+				perror("qsub: read error");
+				return (-1);
+			}
+		}
+	}
+}
+
+/**
+ * @brief       This is a reader function which reads from the remote socket
+ *              when X forwarding is enabled and writes it back to stdout.
+ *
+ * @param[in] s - socket descriptor from where data is to be read.
+ *
+ * @return	int
+ * @retval	 0	Success
+ * @retval	-1	Failure
+ * @retval      -2      Peer Closed connection
+ *
+ */
+static int
+reader_Xjob(int s)
+{
+	static char buf[PF_BUF_SIZE];
+	int c = 0;
+	char *p;
+	int wc;
+	int d = fileno(stdout);
+
+	/* read from the socket and write to stdout */
+	c = CS_read(s, buf, sizeof(buf));
+	if (c > 0) {
+		p = buf;
+		while (c) {
+			/*write data back to stdout*/
+			if ((wc = write(d, p, c)) < 0) {
+				if (errno == EINTR) {
+					continue;
+				} else {
+					perror("qsub: write error");
+					return (-1);
+				}
+			}
+			c -= wc;
+			p += wc;
+		}
+	} else if (c == 0) {
+		/*
+		 * If control reaches here, then it means peer has closed the
+		 * connection.
+		 */
+		return (-2);
+	} else if (errno == EINTR) {
+		return (0);
+	} else {
+		perror("qsub: read error");
+		return (-1);
+	}
+
+	return (0);
+}
+
+
+/**
+ * @brief
+ * 	Writer process: reads from stdin, and writes
+ * 	data out to the rem socket
+ *
+ * @param[in] s - file descriptor
+ *
+ * @return Void
+ *
+ */
+static void
+writer(int s)
+{
+	char c;
+	int i;
+	int newline = 1;
+	char tilda = '~';
+	int wi;
+
+	/* read from stdin, and write to the socket */
+
+	while (1) {
+		i = read(0, &c, 1);
+		if (i > 0) {		/* read data */
+			if (newline) {
+				if (c == tilda) {	/* maybe escape character */
+
+					/* read next character to check */
+
+					while ((i = read(0, &c, 1)) != 1) {
+						if ((i == -1) && (errno == EINTR))
+							continue;
+						else
+							break;
+					}
+					if (i != 1)
+						break;
+					if (c == '.')	/* termination character */
+						break;
+					else if (c == oldtio.c_cc[VSUSP]) {
+						stopme(0);	/* ^Z suspend all */
+						continue;
+#ifdef VDSUSP
+					} else if (c == oldtio.c_cc[VDSUSP]) {
+						stopme(getpid());
+						continue;
+#endif	/* VDSUSP */
+					} else {	/* not escape, write out tilda */
+						while ((wi = CS_write(s, &tilda, 1)) != 1) {
+							if ((wi == -1) && (errno == EINTR))
+								continue;
+							else
+								break;
+						}
+						if (wi != 1)
+							break;
+					}
+				}
+				newline = 0;   /* no longer at start of line */
+			} else {
+				/* reset to newline if \n \r kill or interrupt */
+				newline = (c == '\n') ||
+					(c == oldtio.c_cc[VKILL]) ||
+				(c == oldtio.c_cc[VINTR]) ||
+				(c == '\r') ;
+			}
+			while ((wi = CS_write(s, &c, 1)) != 1) {   /* write out character */
+				if ((wi == -1) && (errno == EINTR))
+					continue;
+				else
+					break;
+			}
+			if (wi != 1)
+				break;
+
+		} else if (i == 0) {	/* EOF */
+			break;
+		} else if (i < 0) {	/* error */
+			if (errno == EINTR)
+				continue;
+			else {
+				perror("qsub: read error");
+				return;
+			}
+		}
+	}
+	return;
+}
+
+/**
+ * @brief
+ *	getwinsize - get the current window size
+ *
+ * @param[in] pwsz - pointer to winsize structure
+ *
+ * @return   Error code
+ * @retval  -1    Failure
+ * @retval   0    Success
+ *
+ */
+static int
+getwinsize(struct winsize *pwsz)
+{
+	if (ioctl(0, TIOCGWINSZ, &wsz) < 0) {
+		perror("qsub: unable to get window size");
+		return (-1);
+	}
+	return (0);
+}
+
+/**
+ * @brief
+ *	send_winsize = send the current tty's window size
+ *
+ * @param[in] sock - file descriptor
+ *
+ * @return Void
+ *
+ */
+static void
+send_winsize(int sock)
+{
+	char  buf[PBS_TERM_BUF_SZ];
+
+	(void)sprintf(buf, "WINSIZE %hu,%hu,%hu,%hu", wsz.ws_row, wsz.ws_col,
+		wsz.ws_xpixel, wsz.ws_ypixel);
+	(void)CS_write(sock, buf, PBS_TERM_BUF_SZ);
+	return;
+}
+
+/**
+ * @brief
+ * 	send_term - send the current TERM type and certain control characters
+ *
+ * @param[in] sock - file descriptor
+ *
+ * @return Void
+ *
+ */
+static void
+send_term(int sock)
+{
+	char  buf[PBS_TERM_BUF_SZ];
+	char *term;
+	char  cc_array[PBS_TERM_CCA];
+
+	term = getenv("TERM");
+	term = strdup_esc_commas(term);
+	if (term == NULL)
+		snprintf(buf, sizeof(buf), "TERM=unknown");
+	else {
+		snprintf(buf, sizeof(buf), "TERM=%s", term);
+		free(term);
+	}
+	(void)CS_write(sock, buf, PBS_TERM_BUF_SZ);
+
+	cc_array[0] = oldtio.c_cc[VINTR];
+	cc_array[1] = oldtio.c_cc[VQUIT];
+	cc_array[2] = oldtio.c_cc[VERASE];
+	cc_array[3] = oldtio.c_cc[VKILL];
+	cc_array[4] = oldtio.c_cc[VEOF];
+	cc_array[5] = oldtio.c_cc[VSUSP];
+	CS_write(sock, cc_array, PBS_TERM_CCA);
+}
+
+
+/**
+ * @brief
+ *	catchchild = signal handler for Death of Child
+ *
+ * @param[in] sig - signal number
+ *
+ * @return Void
+ *
+ */
+static void
+catchchild(int sig)
+{
+	int status;
+	int pid;
+
+	while (1) {
+		pid = waitpid(-1, &status, WNOHANG|WUNTRACED);
+		if (pid == 0)
+			return;
+		if ((pid > 0) && (WIFSTOPPED(status) == 0))
+			break;
+		if ((pid == -1) && (errno != EINTR)) {
+			perror("qsub: bad status in catchchild: ");
+			return;
+		}
+	}
+
+	/* reset terminal to cooked mode */
+
+	(void)tcsetattr(0, TCSANOW, &oldtio);
+	exit_qsub(0);
+}
+
+/**
+ * @brief
+ *	prints can't suspend qsub process on arrival of signal causing suspension
+ *
+ * @param[in] sig - signal number
+ *
+ * @return Void
+ *
+ */
+static void
+no_suspend(int sig)
+{
+	printf("Sorry, you cannot suspend qsub until the job is started\n");
+	fflush(stdout);
+}
+#endif	/* ! WIN32 */
+
+/**
+ * @brief
+ *	Close a socket for both windows and unix.
+ *
+ * @return	void
+ * @param	sock	file descriptor
+ *
+ * @return Void
+ *
+ */
+static void
+close_sock(int sock)
+{
+	shutdown(sock, 2);
+#ifdef WIN32
+	closesocket(sock);
+#else
+	close(sock);
+#endif	/* WIN32 */
+}
+
+/**
+ * @brief
+ * 	send delete job request, disconnect with server and exit qsub
+ *
+ * @param[in]	ret	qsub exit code
+ *
+ * @return      void
+ *
+ */
+static void
+bailout(int ret)
+{
+	int	c;
+
+	close_sock(comm_sock);
+	printf("Job %s is being deleted\n", new_jobname);
+	c = cnt2server(server_out);
+	if (c <= 0) {
+		fprintf(stderr,
+			"qsub: cannot connect to server %s (errno=%d)\n",
+			pbs_server, pbs_errno);
+		exit_qsub(1);
+	}
+	(void)pbs_deljob(c, new_jobname, NULL);
+	pbs_disconnect(c);
+	exit_qsub(ret);
+}
+
+/**
+ * @brief
+ *  Enable X11 Forwarding (on Unix) or GUI (on Windows) if specified.
+ */
+static void
+enable_gui(void)
+{
+#ifndef WIN32 /* Unix */
+	char *x11authstr = NULL;
+	if (Forwardx11_opt) {
+		if (!Interact_opt) {
+			fprintf(stderr, "qsub: X11 Forwarding possible only for interactive jobs\n");
+			exit_qsub(1);
+		}
+		/* get the DISPLAY's auth protocol, hexdata, and screen number */
+		if ((x11authstr = x11_get_authstring()) != NULL) {
+			set_attr(&attrib, ATTR_X11_cookie, x11authstr);
+			set_attr(&attrib, ATTR_X11_port, port_X11());
+#ifdef DEBUG
+			fprintf(stderr, "x11auth string: %s\n", x11authstr);
+#endif
+		} else {
+			exit_qsub(1);
+		}
+	}
+#else /* Windows */
+	if (gui_opt) {
+		if (!Interact_opt) {
+			fprintf(stderr, "qsub: only interactive jobs can have GUI display\n");
+			exit_qsub(1);
+		}
+		set_attr(&attrib, ATTR_GUI, "TRUE");
+	}
+#endif
+}
+
+#ifndef WIN32
+/**
+ * @brief
+ *	signal handler for timeout scenario
+ *
+ * @param[in] sig - signal number
+ *
+ * @return Void
+ *
+ */
+static void
+toolong(int sig)
+{
+	printf("Timeout -- deleting job\n");
+	bailout(0);
+}
+
+/**
+ * @brief
+ *	signal handler function for interrupt signal
+ *
+ * @param[in] sig - signal number
+ *
+ * @return Void
+ *
+ */
+static void
+catchint(int sig)
+{
+	int c;
+
+	printf("Do you wish to terminate the job and exit (y|[n])? ");
+	fflush(stdout);
+	while (1) {
+		alarm(60);	/* give a minute to think about it */
+		c = getchar();
+
+		if ((c == 'n') || (c == 'N') || (c == '\n'))
+			break;
+		else if ((c == 'y') || (c == 'Y') || (c == EOF)) {
+			bailout(0);
+		} else {
+			printf("yes or no please\n");
+			while ((c != '\n') && (c != EOF))
+				c = getchar();
+		}
+	}
+	alarm(0);		/* reset alarm */
+	while ((c != '\n') && (c != EOF))
+		c = getchar();
+	return;
+}
+
+/**
+ * @brief
+ *	This function initializes pfwdsock structure and eventually
+ *	calls port_forwarder.
+ *
+ * @param[in]	X_data_socket - socket descriptor used to read X data from mom
+ *				port forwarders.
+ * @param[in]	interactive_reader_socket - socket descriptor used to read
+ *				interactive job data coming from mom writer.
+ * @return	void
+ *
+ * @par Side Effects
+ * 	On failure, the function will cause the qsub process to exit.
+ *
+ */
+static void
+x11handler(int X_data_socket, int interactive_reader_socket)
+{
+	int n;
+	struct pfwdsock *socks;
+	socks = calloc(sizeof(struct pfwdsock), NUM_SOCKS);
+	if (!socks) {
+		fprintf(stderr, "Calloc failed : out of memory\n");
+		exit_qsub(1);
+	}
+	for (n = 0; n < NUM_SOCKS; n++) {
+		(socks + n)->active = 0;
+	}
+	(socks + 0)->sock = X_data_socket;
+	(socks + 0)->active = 1;
+	(socks + 0)->listening = 1;
+
+	/* Try to open a socket for the local X server. */
+
+	port_forwarder(socks, x11_connect_display, display, 0,
+		interactive_reader_socket, reader_Xjob, log_cmds_portfw_msg);
+}
+
+/**
+ * @brief
+ *	interactive - set up for interactive communication with job
+ *
+ * @return      void
+ *
+ * @par Side Effects
+ *	On failure, the function will cause the qsub process to exit.
+ *
+ */
+static void
+interactive(void)
+{
+	int  amt;
+	char cur_server[PBS_MAXSERVERNAME+PBS_MAXPORTNUM+2];
+	pbs_socklen_t  fromlen;
+	char momjobid[PBS_MAXSVRJOBID+1];
+	int  news;
+	int  nsel;
+	char *pc;
+	fd_set selset;
+
+	struct sigaction act;
+	struct sockaddr_in from;
+	struct timeval timeout;
+	struct winsize wsz;
+	int child;
+	int	ret;
+
+	/* disallow ^Z which hangs up MOM starting an interactive job */
+
+	sigemptyset(&act.sa_mask);
+	act.sa_handler = no_suspend;
+	act.sa_flags   = 0;
+	if (sigaction(SIGTSTP, &act, NULL) < 0) {
+		perror("sigaction(SIGTSTP)");
+		exit_qsub(1);
+	}
+
+	/* Catch SIGINT and SIGTERM, and */
+	/* setup to catch Death of child */
+
+	act.sa_handler = catchint;
+	if ((sigaction(SIGINT, &act, NULL) < 0) ||
+		(sigaction(SIGTERM, &act, NULL) < 0)) {
+		perror("unable to catch signals");
+		exit_qsub(1);
+	}
+	act.sa_handler = toolong;
+	if ((sigaction(SIGALRM, &act, NULL) < 0)) {
+		perror("cannot catch alarm");
+		exit_qsub(2);
+	}
+
+	/* save the old terminal setting */
+
+	if (tcgetattr(0, &oldtio) < 0) {
+		perror("qsub: unable to get terminal settings");
+		exit_qsub  (1);
+	}
+
+	/* Get the current window size, to be sent to MOM later */
+
+	if (getwinsize(&wsz)) {
+		wsz.ws_row = 20;	/* unable to get actual values	*/
+		wsz.ws_col = 80;	/* set defaults			*/
+		wsz.ws_xpixel = 0;
+		wsz.ws_ypixel = 0;
+	}
+
+	printf("qsub: waiting for job %s to start\n", new_jobname);
+
+	/* Accept connection on socket set up earlier */
+
+	nsel = 0;
+	while (nsel == 0) {
+		FD_ZERO(&selset);
+		FD_SET(comm_sock, &selset);
+		timeout.tv_usec = 0;
+		timeout.tv_sec  = 30;
+		nsel = select(FD_SETSIZE, &selset, NULL, NULL, &timeout);
+		if (nsel == -1) {
+			if (errno == EINTR)
+				nsel = 0;
+			else {
+				perror("qsub: select failed");
+				exit_qsub(1);
+			}
+		}
+		if (nsel == 0) {
+			/* connect to server, status job to see if still there */
+			if (! locate_job(new_jobname, server_out, cur_server)) {
+				fprintf(stderr, "qsub: job %s apparently deleted\n", new_jobname);
+				exit_qsub(1);
+			}
+		}
+
+	}
+
+	/* apparently someone is attempting to connect to us */
+
+retry:
+	fromlen = sizeof(from);
+	if ((news = accept(comm_sock, (struct sockaddr *)&from, &fromlen)) < 0) {
+		perror("qsub: accept error from Interactive socket ");
+		exit_qsub(1);
+	}
+
+	/* When Mom connects we expect:
+	 *
+	 * first, to engage in an authentication activity
+	 * second, mom sends the job id for us to verify
+	 */
+
+	ret = CS_client_auth(news);
+
+	if ((ret != CS_SUCCESS) && (ret != CS_AUTH_USE_IFF)) {
+		fprintf(stderr, "qsub: failed authentication with execution host\n");
+		shutdown(news, 2);
+		exit_qsub  (1);
+	}
+
+	/* now verify the value of job id */
+
+	amt = PBS_MAXSVRJOBID+1;
+	pc = momjobid;
+	while (amt > 0) {
+		int	len = CS_read(news, pc, amt);
+		if (len <= 0)
+			break;
+		pc += len;
+		if (*(pc-1) == '\0')
+			break;
+		amt -= len;
+	}
+	if (pc == momjobid) {	/* no data read */
+		shutdown(news, 2);
+		close(news);
+		goto retry;
+	}
+
+	if (strncmp(momjobid, new_jobname, PBS_MAXSVRJOBID) != 0) {
+		fprintf(stderr, "qsub: invalid job name from execution server\n");
+		shutdown(news, 2);
+		exit_qsub  (1);
+	}
+
+	/*
+	 * got the right job, send:
+	 *		terminal type as "TERM=xxxx"
+	 *		window size as   "WINSIZE=r,c,x,y"
+	 */
+	send_term(news);
+	send_winsize(news);
+
+	printf("qsub: job %s ready\n\n", new_jobname);
+
+	/* set SIGINT, SIGTERM processing to default */
+
+	act.sa_handler = SIG_DFL;
+	if ((sigaction(SIGINT, &act, NULL) < 0)  ||
+		(sigaction(SIGTERM, &act, NULL) < 0) ||
+		(sigaction(SIGALRM, &act, NULL) < 0) ||
+		(sigaction(SIGTSTP, &act, NULL) < 0)) {
+		perror("unable to reset signals");
+		exit_qsub(1);
+	}
+
+	child = fork();
+	if (child == 0) {
+		/*
+		 * child process - start the reader function
+		 *                 set terminal into raw mode
+		 */
+
+		settermraw(&oldtio);
+
+		if (Forwardx11_opt) {
+			/*
+			 * if forwardx11_opt is set call x11handler which
+			 * will act as a reader as well as a port forwarder
+			 */
+			x11handler(X11_comm_sock, news);
+		} else {
+			/*call interactive job's reader*/
+			(void) reader(news);
+		}
+		/* reset terminal */
+		tcsetattr(0, TCSANOW, &oldtio);
+		printf("\nqsub: job %s completed\n", new_jobname);
+		exit_qsub(0);
+
+	} else if (child > 0) {
+		/*
+		 * parent - start the writer function
+		 */
+
+		act.sa_handler = catchchild;
+		if (sigaction(SIGCHLD, &act, NULL) < 0)
+			exit_qsub(1);
+
+		writer(news);
+
+		/* all done - make sure the child is gone and reset the terminal */
+
+		kill(child, SIGTERM);
+		shutdown(comm_sock, SHUT_RDWR);
+		close(comm_sock);
+
+		tcsetattr(0, TCSANOW, &oldtio);
+		printf("\nqsub: job %s completed\n", new_jobname);
+		exit_qsub(0);
+	} else {
+		perror("qsub: unable to fork");
+		exit_qsub(1);
+	}
+}
+
+#else /* end of ! WIN32 code */
+/**
+ * @brief
+ *	interactive - set up for interactive communication with job
+ *
+ * @return      void
+ *
+ * @par Side Effects
+ *	On failure, the function will cause the qsub process to exit.
+ *
+ */
+static void
+interactive(void)
+{
+	int			amt = 0;
+	char			cur_server[PBS_MAXSERVERNAME+PBS_MAXPORTNUM+2] = {0};
+	pbs_socklen_t		fromlen = 0;
+	int			news = 0;
+	int			nsel = 0;
+	char			*pc = NULL;
+	fd_set			selset;
+	struct sockaddr_in	from;
+	struct timeval		timeout;
+	int			ret = 0;
+	char			remote_ip[INET_ADDR_STRLEN + 1] = {'\0'};
+	char			momjobid[PBS_MAXSVRJOBID + 1] = {'\0'};
+	int			is_mom_local = 0;
+	STARTUPINFO             si_rdp = { 0 };
+	PROCESS_INFORMATION     pi_rdp = { 0 };
+	HANDLE			hjob_remotesession = INVALID_HANDLE_VALUE;
+
+	printf("qsub: waiting for job %s to start\n", new_jobname);
+
+	/* Accept connection on socket set up earlier */
+	nsel = 0;
+	while (nsel == 0) {
+		FD_ZERO(&selset);
+		FD_SET(comm_sock, &selset);
+		timeout.tv_usec = 0;
+		timeout.tv_sec  = 30;
+		nsel = select(FD_SETSIZE, &selset, NULL, NULL, &timeout);
+		if (nsel == -1) {
+			int err_no = WSAGetLastError();
+			if (err_no == WSAEINTR)
+				nsel = 0;
+			else {
+				perror("qsub: select failed");
+				closesocket(comm_sock);
+				exit_qsub(1);
+			}
+		}
+		if (nsel == 0) {
+			/*
+			 * Check if no signal handler thread is invoked.
+			 * Acquire the critical section before locate_job().
+			 */
+			EnterCriticalSection(&continuethread_cs);
+			/* connect to server, status job to see if still there */
+			if (! locate_job(new_jobname, server_out, cur_server)) {
+				fprintf(stderr, "qsub: job %s apparently deleted\n",
+					new_jobname);
+				closesocket(comm_sock);
+				exit_qsub(1);
+			}
+			LeaveCriticalSection(&continuethread_cs);
+		}
+
+	}
+
+	/* apparently someone is attempting to connect to us */
+
+	fromlen = sizeof(from);
+	/*
+	 * Guarded this with critical section in order to ensure
+	 * that accept() is not called after SIGNIT occurs.
+	 */
+	EnterCriticalSection(&continuethread_cs);
+	if ((news = accept(comm_sock, (struct sockaddr *)&from, &fromlen)) < 0) {
+		perror("qsub: accept error from Interactive socket ");
+		closesocket(comm_sock);
+		exit_qsub(1);
+	}
+	LeaveCriticalSection(&continuethread_cs);
+	strncpy(remote_ip, inet_ntoa(from.sin_addr), INET_ADDR_STRLEN); /* safe because remote_ip was initialized with zeroes */
+	if (remote_ip == NULL) {
+		perror("qsub: Failed to get IP address of execution host ");
+		closesocket(comm_sock);
+		exit_qsub(1);
+	}
+
+	/* When Mom connects we expect:
+	 *
+	 * first, to engage in an authentication activity
+	 * second, mom sends the job id for us to verify
+	 */
+
+	ret = CS_client_auth(news);
+
+	if ((ret != CS_SUCCESS) && (ret != CS_AUTH_USE_IFF)) {
+		fprintf(stderr, "qsub: failed authentication with execution host\n");
+		shutdown(news, 2);
+		exit_qsub  (1);
+	}
+
+	/* now verify the value of job id */
+
+	amt = PBS_MAXSVRJOBID+1;
+	pc = momjobid;
+	while (amt > 0) {
+		fromlen = recv(news, pc, amt, 0);
+		if (fromlen <= 0)
+			break;
+		pc += fromlen;
+		if (*(pc-1) == '\0')
+			break;
+		amt -= fromlen;
+	}
+	if (strncmp(momjobid, new_jobname, PBS_MAXSVRJOBID) != 0) {
+		fprintf(stderr, "qsub: invalid job name from execution server\n");
+		shutdown(news, 2);
+		exit_qsub  (1);
+	}
+	/*
+	 * Guarded this with critical section in order to ensure
+	 * that job ready message and ignoring the signal, happens atomically
+	 */
+	EnterCriticalSection(&continuethread_cs);
+	printf("qsub: job %s ready\n\n", new_jobname);
+	/* Ignore SIGINT */
+	signal(SIGINT, SIG_IGN);
+	LeaveCriticalSection(&continuethread_cs);
+
+	/*
+	 * If it is a GUI job, a configured remote viewer client should be launched if submission host and execution host are not the same.
+	 * If no remote viewer is configured in pbs.conf, use Windows native remote desktop for remote viewing of GUI jobs.
+	 */
+	if(gui_opt != FALSE)
+	{
+		char		rdp_command[PBS_CMDLINE_LENGTH] = {'\0'};
+		int		flags = CREATE_NO_WINDOW | CREATE_SUSPENDED;
+		int		rc = 0;
+		struct hostent	*hp = NULL;
+		char		hname[PBS_MAXHOSTNAME + 1] = {'\0'};
+		int		i = 0;
+
+		/* Check whether the Mom host is same as submission host */
+		(void)gethostname(hname, PBS_MAXHOSTNAME);
+		hp = gethostbyname(hname);
+		for (i=0; hp->h_addr_list[i]; i++) {
+			/* Compare with Mom host IP address to know whether the Mom host is same as submission host */
+			if(memcmp(&(from.sin_addr), hp->h_addr_list[i], hp->h_length) == 0) {
+				is_mom_local = 1;
+				break;
+			}
+		}
+		/* Invoke remote viewer client only if the execution host is not same as submission host */
+		if(is_mom_local == 0) {
+			pbs_loadconf(0);
+			if(pbs_conf.pbs_conf_remote_viewer)
+				/* Invoke remote viewer client configured */
+				snprintf(rdp_command, PBS_CMDLINE_LENGTH -1, "%s %s", pbs_conf.pbs_conf_remote_viewer, remote_ip);
+			else
+				/* No remote viewer client configured, invoke native remote desktop client */
+				snprintf(rdp_command, PBS_CMDLINE_LENGTH -1, "mstsc /v %s", remote_ip);
+
+			hjob_remotesession = CreateJobObject(NULL, NULL);
+			si_rdp.lpDesktop = NULL;
+			si_rdp.dwFlags = STARTF_USESHOWWINDOW;
+			si_rdp.wShowWindow = SW_HIDE;
+			rc = CreateProcess(NULL, rdp_command,
+				NULL, NULL, TRUE, flags, NULL, NULL, &si_rdp, &pi_rdp);
+			if (!rc) {
+				fprintf(stderr, "qsub: failed to launch remote viewer client. CreateProcess %s failed: error=%d\n",
+					rdp_command, GetLastError());
+				printf("\nqsub: job %s completed\n", new_jobname);
+				close_valid_handle(&(pi_rdp.hThread));
+				close_valid_handle(&(pi_rdp.hProcess));
+				close_valid_handle(&hjob_remotesession);
+				exit_qsub(1);
+			}
+			/* Attach the remote viewer session to the job object */
+			rc = AssignProcessToJobObject(hjob_remotesession, pi_rdp.hProcess);
+			if (!rc) {
+				fprintf(stderr, "qsub: failed to attach remote viewer client. \
+						Please close manually after job completion.\nAssignProcessToJobObject() failed: error=%d\n",
+					GetLastError());
+			}
+			(void)ResumeThread(pi_rdp.hThread);
+		}
+	}
+	/* Run remote command shell. Also redirect stdin */
+	if (remote_shell_command(remote_ip, momjobid, 1) == -1)
+		printf("\nqsub: failed to run remote interactive shell\n", new_jobname);
+	printf("\nqsub: job %s completed\n", new_jobname);
+	/* If it is a GUI job and the submission host and execution host are different, terminate remote viewer session */
+	if(gui_opt != FALSE && (is_mom_local == 0)) {
+		int rc = 0;
+		rc = TerminateJobObject(hjob_remotesession, 0);
+		if (!rc) {
+			fprintf(stderr, "qsub: failed to close remote viewer client. \
+					Please close manually.\nTerminateJobObject() failed: error=%d\n",
+				GetLastError());
+		}
+	}
+	close_valid_handle(&(pi_rdp.hThread));
+	close_valid_handle(&(pi_rdp.hProcess));
+	close_valid_handle(&hjob_remotesession);
+	exit_qsub(0);
+}
+#endif
+/*
+ * End of "Interactive Job" functions.
+ */
+
+/*
+ * The following bunch of functions support the "Block Job"
+ * capability of PBS.
+ */
+
+/**
+ * @brief
+ *	creates a socket and blocks the port
+ *
+ * @return char *
+ * @retval portstring string holding port info
+ *
+ */
+static char *
+block_port()
+{
+	pbs_socklen_t  namelen;
+	static char portstring[8];
+	struct sockaddr_in myaddr;
+	unsigned short port;
+
+	comm_sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (comm_sock < 0) {
+		perror("qsub: unable to obtain socket");
+		exit_qsub(1);
+	}
+	myaddr.sin_family = AF_INET;
+	myaddr.sin_addr.s_addr = INADDR_ANY;
+	myaddr.sin_port = 0;
+	if (bind(comm_sock, (struct sockaddr *)&myaddr, sizeof(myaddr)) < 0) {
+		perror("qsub: unable to bind to socket");
+		exit_qsub(1);
+	}
+
+	/* get port number assigned */
+
+	namelen = sizeof(myaddr);
+	if (getsockname(comm_sock, (struct sockaddr *)&myaddr, &namelen) < 0) {
+		perror("qsub: unable to get port number");
+		exit_qsub(1);
+	}
+	port = ntohs(myaddr.sin_port);
+	(void)sprintf(portstring, "%u", (unsigned int)port);
+#ifdef NAS /* localmod 004 */
+	DBPRT((stderr, "block_port: %s\n", portstring))
+#else
+	DBPRT(("block_port: %s\n", portstring))
+#endif /* localmod 004 */
+
+	if (listen(comm_sock, 1) < 0) {
+		perror("qsub: listen on block socket");
+		exit_qsub(1);
+	}
+
+	return (portstring);
+}
+
+static int	sig_happened = 0;
+
+#ifdef WIN32
+/**
+ * @brief
+ *	signal handler to avoid race condition
+ *
+ * @param[in] sig - signal number
+ *
+ * @return Void
+ *
+ */
+static void
+win_blockint(int sig)
+{
+	/*
+	 * Try and acquire the critical Section. This is to avoid a race condition when
+	 * due to an interrupt, the signal handler is invoked, which gets called in a separate thread,
+	 * this thread runs in parallel with main thread. This can yield unwanted results:
+	 * e.g. while the signal handler thread is trying to delete a job, the main thread exits
+	 * OR a socket(comm_sock) closed by signal handler thread, gets used in select() and accept().
+	 * inside main thread.
+	 */
+	EnterCriticalSection(&continuethread_cs);
+	sig_happened = sig;
+
+
+	if (sig == SIGINT || sig == SIGBREAK) {
+
+		if (new_jobname == NULL)
+			exit(2);
+
+		fprintf(stderr, "qsub: wait for job %s "
+			"interrupted by signal %d\n",
+			new_jobname, sig_happened);
+		bailout(2);
+	}
+	LeaveCriticalSection(&continuethread_cs);
+
+}
+#else
+/**
+ * @brief
+ *	signal handler to avoid race condition
+ *
+ * @param[in] sig - signal number
+ *
+ * @return Void
+ *
+ */
+static void
+blockint(int sig)
+{
+	sig_happened = sig;
+}
+
+/**
+ * @brief
+ *	Signal handler for SIGPIPE
+ * @param[in]	sig - signal number
+ * @return	void
+ *
+ */
+static void
+exit_on_sigpipe(int sig)
+{
+	perror("qsub: SIGPIPE received, job submission interrupted.");
+	exit_qsub(1);
+}
+#endif
+
+/**
+ * @brief
+ *  Set the signal handlers.
+ */
+static void
+set_sig_handlers(void)
+{
+#ifdef WIN32
+	signal(SIGINT, win_blockint);
+	signal(SIGBREAK, win_blockint);
+	signal(SIGTERM, win_blockint);
+
+	winsock_init();
+	InitializeCriticalSection(&continuethread_cs);
+#else
+	/* Catch SIGPIPE on write() failures. */
+	struct sigaction act;
+	sigemptyset(&act.sa_mask);
+	act.sa_handler = exit_on_sigpipe;
+	act.sa_flags   = 0;
+	if (sigaction(SIGPIPE, &act, NULL) < 0) {
+		perror("qsub: unable to catch SIGPIPE");
+		exit_qsub(1);
+	}
+#endif
+}
+
+#define BAIL(message) \
+	if (ret != DIS_SUCCESS) { \
+		fail = message; \
+		goto err; \
+	}
+
+/**
+ * @brief
+ *	block - set up to wait for a job to end.
+ *
+ * @return Void
+ * Exits on failre
+ *
+ */
+static void
+block()
+{
+	struct sockaddr_in	from;
+	pbs_socklen_t		fromlen;
+	char			*jobid = "none";
+	char			*message = NULL;
+	char			*fail = NULL;
+	int			news;
+	int			ret;
+	int			version;
+	int			exitval;
+
+#ifndef WIN32
+	struct sigaction	act;
+
+	/* Catch SIGHUP, SIGINT, SIGQUIT and SIGTERM */
+
+	sigemptyset(&act.sa_mask);
+	act.sa_handler = blockint;
+	act.sa_flags   = 0;
+	if ((sigaction(SIGHUP, &act, NULL) < 0) ||
+		(sigaction(SIGINT, &act, NULL) < 0) ||
+		(sigaction(SIGQUIT, &act, NULL) < 0) ||
+		(sigaction(SIGTERM, &act, NULL) < 0)) {
+		perror("qsub: unable to catch signals");
+		exit_qsub(1);
+	}
+#endif
+
+retry:
+	fromlen = sizeof(from);
+	if ((news = accept(comm_sock, (struct sockaddr *)&from,
+		&fromlen)) < 0) {
+#ifdef WIN32
+		if (errno == WSAEINTR)
+#else
+		if (errno == EINTR)
+#endif
+		{
+			fprintf(stderr, "qsub: wait for job %s "
+				"interrupted by signal %d\n",
+				new_jobname, sig_happened);
+			bailout(2);
+		}
+		perror("qsub: accept error");
+		exit_qsub  (1);
+	}
+#ifdef NAS /* localmod 004 */
+	DBPRT((stderr, "got connection from %s:%d\n", inet_ntoa(from.sin_addr),
+		(int)ntohs(from.sin_port)))
+#else
+	DBPRT(("got connection from %s:%d\n", inet_ntoa(from.sin_addr),
+		(int)ntohs(from.sin_port)))
+#endif /* localmod 004 */
+
+	/*
+	 * if SIGINT or SIGBREAK interrupt is raised, then child thread win_blockint()
+	 * does job deletion and other related stuff. So main thread can exit now.
+	 */
+
+#ifdef WIN32
+	if ((sig_happened == SIGINT) || (sig_happened == SIGBREAK))
+		exit_qsub(3);
+#endif
+
+	/* When Mom connects back, the first thing that needs
+	 * to happen is to engage in an authentication activity.
+	 * Any return value other than CS_SUCCESS or CS_AUTH_USE_IFF
+	 * means the authentication failed.
+	 */
+	ret = CS_client_auth(news);
+
+	if ((ret != CS_SUCCESS) && (ret != CS_AUTH_USE_IFF)) {
+		fprintf(stderr, "qsub: failed authentication with execution host\n");
+		close_sock(news);
+		goto retry;
+	}
+
+	DIS_tcp_setup(news);
+	version = disrsi(news, &ret);
+	if (ret != DIS_SUCCESS) {
+		/*
+		 * We couldn't read data so try again if it is a port scan.
+		 */
+		close_sock(news);
+		goto retry;
+	}
+	if (version != 1) {
+		fprintf(stderr, "qsub: unknown protocol version %d\n", version);
+		close_sock(news);
+		goto retry;
+	}
+
+	jobid = disrst(news, &ret);
+	if ((ret != DIS_SUCCESS) || (strcmp(jobid, new_jobname) != 0)) {
+		fprintf(stderr, "qsub: Unknown Job Identifier %s\n", jobid);
+		close_sock(news);
+		goto retry;
+	}
+
+	/* after getting the correct jobid, give up on error */
+	message = disrst(news, &ret);
+	BAIL("message")
+	if (message != NULL && *message != '\0') {	/* non-null message */
+		fprintf(stderr, "qsub: %s %s\n", jobid, message);
+		exit_qsub(3);
+	}
+	exitval = disrsi(news, &ret);
+	BAIL("exitval");
+	exit_qsub(exitval);
+
+err:
+	fprintf(stderr, "qsub: Bad Request Protocol, %s\n",
+			((fail != NULL) && (*fail != '\0')) ? fail : "unknown error");
+	exit_qsub(3);
+}
+
+/*
+ ** End of "Block Job" functions.
+ */
+
+/*
+ * The following bunch of functions support the "Kerberos Authentication"
+ * capability of PBS.
+ */
+
+#ifdef	PBS_CRED_DCE_KRB5
+
+/* helper function: convert flags to necessary KDC options */
+#define flags2options(flags) (flags & KDC_TKT_COMMON_MASK)
+#define		TKTLIFE		32659200	/* about a year */
+
+static time_t	now;
+
+/**
+ * @brief
+ *	gets the service ticket from cache
+ * @param[in] context - library context
+ * @param[in] cc      - credential cache handler
+ * @param[in] creds   - request credentials
+ * @param[in] addrs   - address to be placed in ticket
+ * @param[out] pcreds  - the service ticket
+ *
+ * @return krb5_error_code
+ * @retval 0 	Success
+ * @retval krb5_error_code 	Failure
+ *
+ */
+static krb5_error_code
+get_cred_from_cache(krb5_context context, krb5_ccache    cc, krb5_creds *creds,
+			krb5_address **addrs, krb5_creds **pcreds)
+{
+	krb5_error_code		retval;
+	krb5_creds		tgt;
+	krb5_flags		kdcoptions;
+	krb5_flags		kflags;
+	krb5_cc_cursor		kursor;
+	int			i;
+
+	kflags = TKT_FLG_FORWARDABLE|TKT_FLG_RENEWABLE;
+	memset((char *)&tgt, 0, sizeof(tgt));
+
+	retval = krb5_cc_start_seq_get(context, cc, &kursor);
+	if (retval)
+		return retval;
+
+	for (i=0;; i++) {
+		krb5_free_cred_contents(context, &tgt);
+		retval = krb5_cc_next_cred(context, cc, &kursor, &tgt);
+		if (retval) {
+			if (retval != KRB5_CC_END)
+				return retval;
+			retval = krb5_cc_end_seq_get(context, cc, &kursor);
+			if (retval)
+				return retval;
+			return KRB5_CC_END;
+		}
+
+		/* tgt.client must be equal to creds.client */
+		if (!krb5_principal_compare(context,
+			tgt.client, creds->client))
+			continue;
+		if (!tgt.ticket.length)
+			continue;
+		if ((tgt.ticket_flags & kflags) != kflags)
+			continue;
+		if (tgt.times.endtime <= now)
+			continue;
+
+		break;
+	}
+
+	kdcoptions = flags2options(tgt.ticket_flags)|
+		KDC_OPT_FORWARDED;
+
+	retval = krb5_get_cred_via_tkt(context, &tgt, kdcoptions, addrs, creds, pcreds);
+done:
+	krb5_free_cred_contents(context, &tgt);
+	return retval;
+}
+
+/**
+ * @brief
+ * 	Get a TGT for use at the remote host
+ *
+ * @param[in] context - library context
+ * @param[in] auth_context - authentication context
+ * @param[in] client - principal to be copied
+ * @param[in] server - principal to be copied
+ * @param[in] cc     - credential cache handler
+ * @param[out] outbuf - encoded credentials
+ *
+ * @return krb5_error_code
+ * @retval 0 	Success
+ * @retval krb5_error_code 	Failure
+ *
+ */
+static krb5_error_code
+fwd_tgt_creds(krb5_context context, krb5_auth_context auth_context, krb5_principal client,
+		krb5_principal server, krb5_ccache cc,  krb5_data *outbuf)
+{
+	krb5_replay_data	replaydata;
+	krb5_data		*scratch = 0;
+	krb5_address		**addrs = 0;
+	krb5_error_code		retval;
+	krb5_creds		creds, tgt;
+	krb5_creds		*pcreds;
+	int			free_rhost = 0;
+	char			*rhost;
+
+	memset((char *)&creds, 0, sizeof(creds));
+	memset((char *)&tgt, 0, sizeof(creds));
+
+	if (krb5_princ_type(context, server) != KRB5_NT_SRV_HST)
+		return KRB5_FWD_BAD_PRINCIPAL;
+
+	if (krb5_princ_size(context, server) < 2)
+		return KRB5_CC_BADNAME;
+
+	rhost = malloc(server->data[1].length+1);
+	if (!rhost)
+		return ENOMEM;
+	free_rhost = 1;
+	memcpy(rhost, server->data[1].data, server->data[1].length);
+	rhost[server->data[1].length] = '\0';
+
+	retval = krb5_os_hostaddr(context, rhost, &addrs);
+	if (retval)
+		goto errout;
+
+	if ((retval = krb5_copy_principal(context, client, &creds.client)))
+		goto errout;
+
+	if ((retval = krb5_build_principal_ext(context, &creds.server,
+		client->realm.length,
+		client->realm.data,
+		KRB5_TGS_NAME_SIZE,
+		KRB5_TGS_NAME,
+		client->realm.length,
+		client->realm.data,
+		0)))
+		goto errout;
+
+	/* fetch tgt directly from cache */
+	retval = get_cred_from_cache(context, cc, &creds, addrs, &pcreds);
+
+	if (retval) {
+		goto errout;
+#if 0	/* don't prompt for password */
+		krb5_get_init_creds_opt		options;
+		int				i;
+
+		com_err(__func__, retval, ": get_cred_from_cache");
+
+		krb5_get_init_creds_opt_init(&options);
+		krb5_get_init_creds_opt_set_tkt_life(&options, TKTLIFE);
+		krb5_get_init_creds_opt_set_renew_life(&options, TKTLIFE);
+		krb5_get_init_creds_opt_set_forwardable(&options, 1);
+
+		clearerr(stdin);
+		for (i=0; i<3; i++) {
+			retval = krb5_get_init_creds_password(context, &tgt,
+				client, NULL, krb5_prompter_posix,
+				NULL, 0, NULL, &options);
+			if (retval == 0)
+				break;
+			com_err(__func__, retval, ": krb5_get_init_creds_password");
+		}
+		if (retval)
+			goto errout;
+
+		retval = krb5_cc_store_cred(context, cc, &tgt);
+		if (retval)
+			goto errout;
+
+		printf("credentials stored\n");
+		krb5_free_cred_contents(context, &tgt);
+
+		/* try again ... it should now work */
+		retval = get_cred_from_cache(context, cc, &creds,
+			addrs, &pcreds);
+		if (retval)
+			goto errout;
+#endif
+	}
+
+	retval = krb5_mk_1cred(context, auth_context, pcreds,
+		&scratch, &replaydata);
+	krb5_free_creds(context, pcreds);
+
+	if (retval) {
+		if (scratch)
+			krb5_free_data(context, scratch);
+	}
+	else {
+		*outbuf = *scratch;
+		free(scratch);
+	}
+
+errout:
+	if (addrs)
+		krb5_free_addresses(context, addrs);
+	if (free_rhost)
+		free(rhost);
+	krb5_free_cred_contents(context, &creds);
+	return retval;
+}
+#endif	/* PBS_CRED_DCE_KRB5 */
+
+/**
+ * @brief
+ *	Get a kerberos ticket.
+ * @param[in] remote - server name
+ *
+ * @return   Error code
+ * @retval  -1  Failure
+ * @retval   0  Success
+ *
+ */
+static int
+get_krb5_ticket(char *remote)
+{
+	int			ret = -1;
+#ifdef	PBS_CRED_DCE_KRB5
+	krb5_error_code		err;
+	int			got_auth = 0;
+	char			server_name[512];
+	const char		*ccdefault;
+	krb5_context		ktext = 0;
+	krb5_auth_context	kauth = 0;
+	krb5_ccache		kache = 0;
+	krb5_principal		client = 0;
+	krb5_principal		server = 0;
+	krb5_data		forw_creds;
+	krb5_data		packet;
+
+	now = time(0) + 600;	/* current time + 10 mins */
+
+	memset(&forw_creds, 0, sizeof(forw_creds));
+	memset(&packet, 0, sizeof(packet));
+
+	if ((err = krb5_init_context(&ktext)) != 0) {
+		com_err(__func__, err, ": krb5_init_context");
+		return -1;
+	}
+
+	if ((err = krb5_auth_con_init(ktext, &kauth)) != 0) {
+		com_err(__func__, err, ": krb5_auth_con_init");
+		return -1;
+	}
+	got_auth = 1;
+
+	krb5_auth_con_setflags(ktext, kauth, KRB5_AUTH_CONTEXT_RET_TIME);
+
+	ccdefault = krb5_cc_default_name(ktext);
+	if ((err = krb5_cc_resolve(ktext, ccdefault, &kache)) != 0) {
+		com_err(__func__, err, ": krb5_cc_resolve");
+		goto done;
+	}
+
+	if ((err = krb5_cc_get_principal(ktext, kache, &client)) != 0) {
+		if (pbs_current_user == NULL) {
+			com_err(__func__, err, "(ticket cache %s)", ccdefault);
+			goto done;
+		}
+		if ((err = krb5_parse_name(ktext, pbs_current_user,
+			&client)) != 0) {
+			com_err(__func__, err, ": krb5_parse_name: %s",
+				pbs_current_user);
+			goto done;
+		}
+		if ((err = krb5_cc_initialize(ktext, kache, client)) != 0) {
+			com_err(__func__, err, ": krb5_cc_initialize");
+			goto done;
+		}
+	}
+
+	snprintf(server_name, sizeof(server_name), "host/%s@%s", remote, client->realm.data);
+	krb5_parse_name(ktext, server_name, &server);
+	server->type = KRB5_NT_SRV_HST;
+
+	if ((err = fwd_tgt_creds(ktext, kauth,
+		client, server, kache, &forw_creds)) != 0) {
+		com_err(__func__, err, ": fwd_tgt_creds");
+		goto done;
+	}
+
+	cred_len = forw_creds.length;
+	cred_buf = forw_creds.data;
+	cred_type = PBS_CREDTYPE_DCE_KRB5;
+	ret = 0;
+
+done:
+	if (forw_creds.data && cred_buf != forw_creds.data)
+		free(forw_creds.data);
+	if (client)
+		krb5_free_principal(ktext, client);
+	if (server)
+		krb5_free_principal(ktext, server);
+	if (got_auth)
+		krb5_auth_con_free(ktext, kauth);
+	krb5_free_context(ktext);
+	if (ret) {
+		fprintf(stderr, "qsub: could not get a forwardable, "
+			"renewable kerberos ticket\n"
+			"Try 'kinit -f -r 10d' to get one.\n");
+	}
+#else	/* PBS_CRED_DCE_KRB5 */
+	fprintf(stderr, "qsub: kerberos is not supported.\n");
+#endif	/* PBS_CRED_DCE_KRB5 */
+	return ret;
+}
+
+/**
+ * @brief
+ *	Get a grid proxy.
+ *
+ * @return   Error code
+ * @retval  -1  Failure
+ * @retval   0  Success
+ *
+ */
+static int
+get_grid_proxy()
+{
+	int			ret = -1;
+#ifdef	PBS_CRED_GRIDPROXY
+	proxy_cred_desc		*pcd = NULL;
+	char			*proxy_file = NULL;
+	char			*subject;
+	char			*principal;
+	char			*type;
+	char			*sp, *pp;
+	int			cname = 0;
+	time_t			time_limit, time_now, time_diff;
+	ASN1_UTCTIME		*asn1_time = NULL;
+	int			keylen;
+	int			fd = -1;
+	struct stat		sbuf;
+
+	pcd = proxy_cred_desc_new();
+	if (pcd == NULL) {
+		fprintf(stderr, "%s: could not initialize\n", __func__);
+		goto done;
+	}
+	proxy_get_filenames(pcd, 1, NULL, NULL, &proxy_file, NULL, NULL);
+	if (proxy_file == NULL) {
+		fprintf(stderr, "%s: could not get proxy file name\n", __func__);
+		goto done;
+	}
+#ifdef NAS /* localmod 004 */
+	DBPRT((stderr, "%s: proxy file:\t%s\n", __func__, proxy_file))
+#else
+	DBPRT(("%s: proxy file:\t%s\n", __func__, proxy_file))
+#endif /* localmod 004 */
+
+	pcd->type=CRED_TYPE_PROXY;
+	if (proxy_load_user_cert(pcd, proxy_file, NULL, NULL)) {
+		fprintf(stderr, "%s: unable to load proxy\n", __func__);
+		goto done;
+	}
+	if ((pcd->upkey = X509_get_pubkey(pcd->ucert)) == NULL) {
+		fprintf(stderr, "%s: unable to load public key from proxy\n", __func__);
+		goto done;
+	}
+	subject = X509_NAME_oneline(X509_get_subject_name(pcd->ucert), NULL, 0);
+	principal = (char *)malloc(strlen(subject));
+	assert(principal != NULL);
+
+	for (sp=subject, pp=principal; *sp;) {
+		if (strncmp(sp, "/CN=", 4) == 0) {
+			if (cname == 0) {
+				cname++;
+				*pp++ = *sp++;
+				continue;
+			}
+
+			type = sp+4;
+			for (sp=type; *sp; sp++) {
+				if (*sp == '/') {
+					*sp++ = '\0';
+					*pp++ = '/';
+					break;
+				}
+			}
+			continue;
+		}
+
+		*pp++ = *sp++;
+	}
+	*pp = '\0';
+
+	asn1_time = ASN1_UTCTIME_new();
+	X509_gmtime_adj(asn1_time, 0);
+	time_now = ASN1_UTCTIME_mktime(asn1_time);
+	time_limit = ASN1_UTCTIME_mktime(X509_get_notAfter(pcd->ucert));
+	if (time_limit < time_now)
+		time_diff = 0;
+	else
+		time_diff = time_limit - time_now;
+
+	keylen = 8 * 8 * EVP_PKEY_size(pcd->upkey);
+
+#ifdef NAS /* localmod 004 */
+	DBPRT((stderr, "principal:\t%s\ntime:\t%ld\ntype:\t%s\nkeylen:\t%d\n",
+		principal, time_diff, type, keylen))
+#else
+	DBPRT(("principal:\t%s\ntime:\t%ld\ntype:\t%s\nkeylen:\t%d\n",
+		principal, time_diff, type, keylen))
+#endif /* localmod 004 */
+
+	set_attr(&attrib, ATTR_gridname, principal);
+	free(subject);
+	free(principal);
+
+	if (time_diff < 600) {		/* less than 10 minutes of life */
+		fprintf(stderr, "%s: proxy has %s life left\n", __func__,
+			time_diff == 0 ? "no" : "very little");
+		goto cleanup;
+	}
+
+	if ((fd = open(proxy_file, O_RDONLY)) == -1) {
+		perror(proxy_file);
+		goto cleanup;
+	}
+	if (fstat(fd, &sbuf) == -1) {
+		perror(proxy_file);
+		goto cleanup;
+	}
+
+	cred_len = sbuf.st_size;
+	cred_buf = malloc(cred_len);
+	assert(cred_buf != NULL);
+	if (read(fd, cred_buf, cred_len) != cred_len) {
+		fprintf(stderr, "%s: grid proxy read failed for %s\n", __func__, proxy_file);
+		goto cleanup;
+	}
+	cred_type = PBS_CREDTYPE_GRIDPROXY;
+	ret = 0;
+
+cleanup:
+	proxy_cred_desc_free(pcd);
+	if (proxy_file)
+		free(proxy_file);
+	if (fd != -1)
+		close(fd);
+
+done:
+	if (ret) {
+		fprintf(stderr, "qsub: could not get grid proxy\n"
+			"Try 'grid-proxy-init -hours 200' to get one\n");
+	}
+#else	/* PBS_CRED_GRIDPROXY */
+	fprintf(stderr, "qsub: grid proxy is not supported.\n");
+#endif	/* PBS_CRED_GRIDPROXY */
+	return ret;
+}
+
+/**
+ * @brief
+ *	gets the des password and encrypts
+ *
+ * @return int
+ * @retval 0  Success
+ *a@retval -1 Failure
+ *
+ */
+static int
+get_passwd()
+{
+	int	ret = -1;
+#if	defined(PBS_PASS_CREDENTIALS)
+	int	err;
+	int	i;
+	char	passwdbuf[256];
+
+	for (i=0; i<3; i++) {
+		err = EVP_read_pw_string(passwdbuf, strlen(passwdbuf),
+			"Enter job's password: ", 1);
+		if (err == 0) {
+			ret = 0;
+			break;
+		}
+	}
+	if (err == 0) {
+		pbs_encrypt_pwd(passwdbuf, &cred_type, &cred_buf, &cred_len);
+		ret = 0;
+	}
+	if (ret)
+		fprintf(stderr, "qsub: could not get password\n");
+#else
+	fprintf(stderr, "qsub: DES is not supported.\n");
+#endif
+	return ret;
+}
+
+/*
+ * End of "Kerberos Authentication" functions.
+ */
+
+/*
+ * The following bunch of functions support the "Options Processing"
+ * functionality of qsub.
+ */
+
+/**
+ * @brief
+ *  	This function processes all the options specified while submitting a job. It
+ *  	validates all these options and sets their corresponding flags.
+ *
+ * @param[in] argc  Number of options present in argv.
+ * @param[in] argv  An array containing all the options and their values.
+ * @param[in] passet The value that will be used to set the options. It can have
+ *                   value as CMDLINE (for command line options), CMDLINE-1 (for
+ *                   job script options), CMDLINE-2 (server default options).
+ *
+ * @return int - It returns number of erroneous options processed.
+ *
+ */
+static int
+process_opts(int argc, char **argv, int passet)
+{
+	int i;
+	int c;
+	char *erp;
+	int errflg = 0;
+	time_t after;
+	char a_value[512];
+	char *keyword;
+	char *valuewd;
+	char *pc;
+	struct attrl *pattr = NULL;
+	size_t N_len = 0;
+#ifdef WIN32
+	struct attrl *ap = NULL;
+	short int nSizeofHostName = 0;
+	char *orig_apvalue = NULL;
+	char *temp_apvalue = NULL;
+#endif
+	int ddash_index = -1;
+
+#ifdef WIN32
+#define GETOPT_ARGS_ORIG "a:A:c:C:e:fGhIj:J:k:l:m:M:N:o:p:q:r:R:S:u:v:VW:zP:"
+#else
+#if !defined(PBS_NO_POSIX_VIOLATION)
+#define GETOPT_ARGS_ORIG "a:A:c:C:e:fhIj:J:k:l:m:M:N:o:p:q:r:R:S:u:v:VW:XzP:"
+#else
+#define GETOPT_ARGS_ORIG "a:A:c:C:e:fhj:J:k:l:m:M:N:o:p:q:r:R:S:u:v:VW:zP:"
+#endif    /* PBS_NO_POSIX_VIOLATION */
+#endif	  /* WIN32 */
+
+#ifdef	PBS_GNU_GETOPTS
+#define	GETOPT_ARGS "+"GETOPT_ARGS_ORIG
+#else
+#define	GETOPT_ARGS GETOPT_ARGS_ORIG
+#endif	/* PBS_GNU_GETOPTS */
+
+	/* The following macro, together the value of passet is used	*/
+	/* to enforce the following rules: 1. option on the command line take	*/
+	/* precedence over those in script directives.   2. With in the command	*/
+	/* line or within the script, the last occurance of an option takes	*/
+	/* precedence over the earlier occurance.				*/
+
+	/*
+	 ** The passet value is saved in the opt register.  The option will
+	 ** only be set if the value of passet is greater then or equal to the
+	 ** opt regiester.
+	 */
+#define if_cmd_line(x) if (x <= passet)
+
+	if (passet != CMDLINE) {
+#if defined(linux) || defined(WIN32)
+		optind = 0;  /* prime getopt's starting point */
+#else
+		optind = 1;  /* prime getopt's starting point */
+#endif
+	}
+	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF) {
+		/*
+		 * qsub uses "--" to specify the executable to run for a job,
+		 * so, if "--" is used as a value, we need to make sure that
+		 * there is another "--" for providing the executable name (if any).
+		 */
+		if (optarg && (strcmp(optarg, "--") == 0))
+			ddash_index = optind - 1;
+
+		switch (c) {
+			case 'a':
+				if_cmd_line(a_opt) {
+					a_opt = passet;
+					if ((after = cvtdate(optarg)) < 0) {
+						fprintf(stderr, "qsub: illegal -a value\n");
+						errflg++;
+						break;
+					}
+					sprintf(a_value, "%ld", (long)after);
+					set_attr(&attrib, ATTR_a, a_value);
+				}
+				break;
+			case 'A':
+				if_cmd_line(A_opt) {
+					A_opt = passet;
+					set_attr(&attrib, ATTR_A, optarg);
+				}
+				break;
+			case 'P':
+				if_cmd_line(P_opt) {
+					P_opt = passet;
+					set_attr(&attrib, ATTR_project, optarg);
+				}
+				break;
+			case 'c':
+				if_cmd_line(c_opt) {
+					c_opt = passet;
+					while (isspace((int)*optarg)) optarg++;
+					pc = optarg;
+					if (strlen(optarg) == 1) {
+						if (*pc == 'u') {
+							fprintf(stderr, "qsub: illegal -c value\n");
+							errflg++;
+							break;
+						}
+					}
+					set_attr(&attrib, ATTR_c, optarg);
+				}
+				break;
+			case 'C':
+				if_cmd_line(C_opt) {
+					C_opt = passet;
+					snprintf(dir_prefix, sizeof(dir_prefix), "%s", optarg);
+				}
+				break;
+			case 'e':
+				if_cmd_line(e_opt) {
+					e_opt = passet;
+					set_attr(&attrib, ATTR_e, optarg);
+				}
+				break;
+			case 'h':
+				if_cmd_line(h_opt) {
+					h_opt = passet;
+					set_attr(&attrib, ATTR_h, "u");
+				}
+				break;
+			case 'f':
+				no_background = 1;
+				break;
+#if !defined(PBS_NO_POSIX_VIOLATION)
+			case 'I':
+				if (J_opt != 0) {
+					fprintf(stderr, "%s", interarray);
+					errflg++;
+					break;
+				}
+				if_cmd_line(Interact_opt) {
+					Interact_opt = passet;
+					if (block_opt != FALSE) {
+						fprintf(stderr, "%s", interblock_warn);
+						block_opt = FALSE;
+					}
+					if (roptarg_inter == TRUE) {
+						fprintf(stderr, "%s", reruninteract);
+					}
+					set_attr(&attrib, ATTR_inter, interactive_port());
+				}
+				break;
+#endif	/* PBS_NO_POSIX_VIOLATION */
+			case 'j':
+				if_cmd_line(j_opt) {
+					j_opt = passet;
+					set_attr(&attrib, ATTR_j, optarg);
+				}
+				break;
+			case 'J':
+				if (Interact_opt != FALSE) {
+					fprintf(stderr, "%s", interarray);
+					errflg++;
+					break;
+				}
+				if (roptarg != 'y') {
+					fprintf(stderr, "%s", norerunarray);
+					errflg++;
+					break;
+				}
+				if_cmd_line(J_opt) {
+					J_opt = passet;
+					set_attr(&attrib, ATTR_J, optarg);
+				}
+				break;
+			case 'k':
+				if_cmd_line(k_opt) {
+					k_opt = passet;
+					set_attr(&attrib, ATTR_k, optarg);
+				}
+				break;
+			case 'l':
+				l_opt = passet;
+				if ((i=set_resources(&attrib, optarg, (passet==CMDLINE), &erp))) {
+					if (i > 1) {
+						pbs_prt_parse_err("qsub: illegal -l value\n", optarg,
+							(int)(erp-optarg), i);
+					} else
+						fprintf(stderr, "qsub: illegal -l value\n");
+					errflg++;
+				}
+				break;
+			case 'm':
+				if_cmd_line(m_opt) {
+					m_opt = passet;
+					while (isspace((int)*optarg)) optarg++;
+					set_attr(&attrib, ATTR_m, optarg);
+				}
+				break;
+			case 'M':
+				if_cmd_line(M_opt) {
+					M_opt = passet;
+					set_attr(&attrib, ATTR_M, optarg);
+				}
+				break;
+			case 'N':
+				if_cmd_line(N_opt) {
+					N_opt = passet;
+					/* If ATTR_N is not set previously */
+					if (get_attr(attrib, ATTR_N, NULL) == NULL) {
+						set_attr(&attrib, ATTR_N, optarg);
+					}
+					/* If N_opt is not set previously but if ATTR_N is set
+					 * earlier directly without verification based on the
+					 * job script name and if there is a value for ATTR_N
+					 * after parsing the job script for PBS directives
+					 * replace the earlier value with the current value
+					 * for this attribute
+					 */
+					else {
+						for (pattr = attrib; pattr; pattr = pattr->next) {
+							if (strcmp(pattr->name, ATTR_N) == 0) {
+								N_len = strlen(optarg);
+								if (strlen(pattr->value) < N_len) {
+									pattr->value = (char *) realloc(pattr->value, N_len + 1);
+									if (pattr->value == NULL) {
+										fprintf(stderr, "Out of memory\n");
+										exit(2);
+									}
+								}
+								strcpy(pattr->value, optarg); /* safe because we just allocated enough space */
+							}
+						}
+					}
+				}
+				break;
+			case 'o':
+				if_cmd_line(o_opt) {
+					o_opt = passet;
+					set_attr(&attrib, ATTR_o, optarg);
+				}
+				break;
+			case 'p':
+				if_cmd_line(p_opt) {
+					p_opt = passet;
+					while (isspace((int)*optarg)) optarg++;
+					set_attr(&attrib, ATTR_p, optarg);
+				}
+				break;
+			case 'q':
+				if_cmd_line(q_opt) {
+					q_opt = passet;
+					snprintf(destination, sizeof(destination), "%s", optarg);
+				}
+				break;
+			case 'r':
+				if_cmd_line(r_opt) {
+					r_opt = passet;
+					if (strlen(optarg) != 1) {
+						fprintf(stderr, "qsub: illegal -r value\n");
+						errflg++;
+						break;
+					}
+					if (*optarg != 'y' && *optarg != 'n') {
+						fprintf(stderr, "qsub: illegal -r value\n");
+						errflg++;
+						break;
+					} else if ((*optarg == 'n') && (J_opt != 0)) {
+						fprintf(stderr, "%s", norerunarray);
+						errflg++;
+						break;
+
+					}
+					if ((*optarg=='y')) {
+						roptarg_inter=TRUE;
+						if (Interact_opt)
+							fprintf(stderr, "%s", reruninteract);
+					}
+					roptarg = *optarg;
+					set_attr(&attrib, ATTR_r, optarg);
+				}
+				break;
+			case 'R':
+				if_cmd_line(R_opt) {
+					R_opt = passet;
+					set_attr(&attrib, ATTR_R, optarg);
+				}
+				break;
+			case 'S':
+				if_cmd_line(S_opt) {
+					S_opt = passet;
+					set_attr(&attrib, ATTR_S, optarg);
+				}
+				break;
+			case 'u':
+				if_cmd_line(u_opt) {
+					u_opt = passet;
+					set_attr(&attrib, ATTR_u, optarg);
+				}
+				break;
+			case 'v':
+				if_cmd_line(v_opt) {
+					v_opt = passet;
+					if (v_value != NULL)
+						free(v_value);
+#ifdef	WIN32
+					/*
+					 * Need to change '\' to '/' before expanding the
+					 * environment because '\' is used to protect commas
+					 * inside quoted values.
+					 */
+					back2forward_slash(optarg);
+#endif
+					v_value = expand_varlist(optarg);
+					if (v_value == NULL)
+						exit(1);
+				}
+				break;
+			case 'V':
+				if_cmd_line(V_opt) {
+					V_opt = passet;
+				}
+				break;
+			case 'W':
+				while (isspace((int)*optarg)) optarg++;
+				if (strlen(optarg) == 0) {
+					fprintf(stderr, "%s", badw);
+					errflg++;
+					break;
+				}
+#ifdef WIN32
+				back2forward_slash2(optarg);
+#endif
+				i = parse_equal_string(optarg, &keyword, &valuewd);
+
+#if	defined(PBS_PASS_CREDENTIALS)
+				/*
+				 * Exceptional CASE: All the arguments to option 'W' are
+				 * accepted in the format of -Wattrname=value but in case
+				 * of ATTR_pwd, -Wattrname is accepted without any value.
+				 *
+				 * if parse_equal_string() returns -1 and the optarg is
+				 * is same as ATTR_pwd, then set i = 1, keyword to optarg
+				 * and valuewd to NULL.
+				 */
+				if ((i == -1) && (strcmp(optarg, ATTR_pwd) == 0)) {
+					i = 1;
+					keyword = optarg;
+					valuewd = NULL;
+				}
+#endif
+
+				while (i == 1) {
+					if (strcmp(keyword, ATTR_depend) == 0) {
+						if_cmd_line(Depend_opt) {
+							Depend_opt = passet;
+							set_attr(&attrib, ATTR_depend, valuewd);
+						}
+					} else if (strcmp(keyword, ATTR_stagein) == 0) {
+						if_cmd_line(Stagein_opt) {
+							Stagein_opt = passet;
+							set_attr(&attrib, ATTR_stagein, valuewd);
+						}
+					} else if (strcmp(keyword, ATTR_stageout) == 0) {
+						if_cmd_line(Stageout_opt) {
+							Stageout_opt = passet;
+							set_attr(&attrib, ATTR_stageout, valuewd);
+						}
+					} else if (strcmp(keyword, ATTR_sandbox) == 0) {
+						if_cmd_line(Sandbox_opt) {
+							Sandbox_opt = passet;
+							set_attr(&attrib, ATTR_sandbox, valuewd);
+						}
+					} else if (strcmp(keyword, ATTR_g) == 0) {
+						if_cmd_line(Grouplist_opt) {
+							Grouplist_opt = passet;
+							set_attr(&attrib, ATTR_g, valuewd);
+						}
+					} else if (strcmp(keyword, ATTR_inter) == 0) {
+						if_cmd_line(Interact_opt) {
+							if (J_opt != 0) {
+								fprintf(stderr, "%s", interarray);
+								errflg++;
+								break;
+							}
+							/*
+							 * SPID 232472: can't set interactive attribute to false
+							 * Problem: "qsub -W interactive=false" throws an error
+							 * Cause: There should be check to compare the user value
+							 *   with "false" string and accordingly decide whether it
+							 *   is an interactive job or not.
+							 * Solution: Added additional checks which will not set
+							 *   Interact_opt and will not call set_attr() to create
+							 *   interactive port if user gives a value "false"
+							 */
+							if (!(strcasecmp(valuewd, "true"))) {
+								Interact_opt = passet;
+								set_attr(&attrib, ATTR_inter, interactive_port());
+							} else if (!(strcasecmp(valuewd, "false"))) {
+								/* Do Nothing, let it run as a non-interactive job */
+							} else {
+								/* Any value other than true/false is not acceptable */
+								fprintf(stderr, "%s", badw);
+								errflg++;
+								break;
+							}
+							if (roptarg_inter == TRUE) {
+								fprintf(stderr, "%s", reruninteract);
+							}
+							/* check if both block and interactive are true */
+							if ((block_opt != FALSE) && (Interact_opt)) {
+								fprintf(stderr, "%s", interblock_warn);
+								block_opt = FALSE;
+								break;
+							}
+						}
+					} else if (strcmp(keyword, ATTR_block) == 0) {
+						if_cmd_line(block_opt) {
+							if (!(strcasecmp(valuewd, "true"))) {
+								block_opt = passet;
+							} else if (!(strcasecmp(valuewd, "false"))) {
+								/* Do Nothing, Let it run as a non-blocking job */
+							} else {
+								/* Any value other than true/false is not acceptable */
+								fprintf(stderr, "%s", badw);
+								errflg++;
+								break;
+							}
+							if ((Interact_opt != FALSE) && (block_opt == passet)) {
+								fprintf(stderr, "%s", interblock_warn);
+								block_opt = FALSE;
+								break;
+							}
+						}
+					} else if (strcmp(keyword, ATTR_resv_start) == 0) {
+						if_cmd_line(Resvstart_opt) {
+							Resvstart_opt = passet;
+							if ((after = cvtdate(valuewd)) < 0) {
+								fprintf(stderr, "%s", badw);
+								errflg++;
+								break;
+							}
+							sprintf(a_value, "%ld", (long)after);
+							set_attr(&attrib, ATTR_resv_start, a_value);
+						}
+					} else if (strcmp(keyword, ATTR_resv_end) == 0) {
+						if_cmd_line(Resvend_opt) {
+							Resvend_opt = passet;
+							if ((after = cvtdate(valuewd)) < 0) {
+								fprintf(stderr, "%s", badw);
+								errflg++;
+								break;
+							}
+							sprintf(a_value, "%ld", (long)after);
+							set_attr(&attrib, ATTR_resv_end, a_value);
+						}
+#if	defined(PBS_PASS_CREDENTIALS)
+					} else if (strcmp(keyword, ATTR_pwd) == 0) {
+						if_cmd_line(pwd_opt) {
+							pwd_opt = passet;
+							if (valuewd == NULL || *valuewd == '\0') {
+								int err = 1;
+
+								while (err) {
+									err = EVP_read_pw_string(passwd_buf,
+										sizeof(passwd_buf),
+										"Enter job's password: ", 1);
+								}
+							} else {
+								/*
+								 * Entering password in the qsub command line in
+								 * clear text is a security hole, not supported.
+								 */
+								fprintf(stderr, "%s", badw);
+								errflg++;
+								break;
+							}
+						}
+#endif
+					} else if (strcmp(keyword, ATTR_cred) == 0) {
+						if_cmd_line(cred_opt) {
+							cred_opt = passet;
+							snprintf(cred_name, sizeof(cred_name), "%s", valuewd);
+							set_attr(&attrib, ATTR_cred, valuewd);
+						}
+					} else {
+						set_attr(&attrib, keyword, valuewd);
+					}
+					i = parse_equal_string(NULL, &keyword, &valuewd);
+				}   /* bottom of long while loop */
+				if (i == -1) {
+					fprintf(stderr, "%s", badw);
+					errflg++;
+				}
+				break;
+
+			case 'X':
+				if_cmd_line(Forwardx11_opt) {
+					Forwardx11_opt = passet;
+#if !defined(PBS_NO_POSIX_VIOLATION) && !defined(WIN32)
+					if (!(display = getenv("DISPLAY"))) {
+						fprintf(stderr, "qsub: DISPLAY not set\n");
+						errflg++;
+					}
+#endif
+				}
+				break;
+#ifdef WIN32
+			case 'G':
+				if_cmd_line(gui_opt) {
+					gui_opt = passet;
+					set_attr(&attrib, ATTR_GUI, "TRUE");
+				}
+				break;
+#endif
+			case 'z':
+				if_cmd_line(z_opt) z_opt = passet;
+				break;
+			case '?':
+			default :
+				errflg++;
+		}
+	}
+	if ((block_opt == passet) && (Interact_opt == FALSE))
+		set_attr(&attrib, ATTR_block, block_port());
+	if ((Forwardx11_opt == CMDLINE) && (Interact_opt == FALSE)
+		&& (errflg == 0)) {
+		fprintf(stderr, "qsub: X11 Forwarding possible only for "
+			"interactive jobs\n");
+		exit_qsub(1);
+	}
+#ifdef WIN32
+	if ((gui_opt == CMDLINE) && (Interact_opt == FALSE)) {
+		fprintf(stderr, intergui_warn);
+		gui_opt = FALSE;
+		exit_qsub(1);
+	}
+#endif
+
+	if (errflg == 0 && J_opt == 0 && get_attr(attrib, ATTR_m, NULL) != NULL &&
+		strchr(get_attr(attrib, ATTR_m, NULL), 'j') != NULL) {
+		fprintf(stderr, "qsub: mail option 'j' can not be used without array job\n");
+		exit_qsub(1);
+	}
+
+	/*
+	 * If argv[optind] points to '--' string, then
+	 * decrement optind, so that it would always point
+	 * to first non-command line option.
+	 * And also confirm if "--" was consumed by getopt
+	 * and not used as an argument value.
+	 * If used as an argument value, we cannot use it as
+	 * an indicator that an executable name follows the "--".
+	 */
+	if (strcmp(argv[optind - 1], "--") == 0) {
+		if (ddash_index != optind - 1)
+			optind--;
+		else
+			errflg++;
+	}
+
+	if ((optind != 0) && (argc > 1) && (argv[optind] != NULL)) {
+		/* Now, optind is pointing to first non-command line option */
+		char *s = argv[optind];
+		if ((s[0] == '-') && (s[1] == '-') && (s[2] == '\0')) {
+			/* optind points to '--', it should not be last character */
+			if (optind == (argc - 1))
+				errflg++;
+		} else {
+			/* optind points to 'script-file path' */
+			/* It should be a last argument in command-line options */
+			if (optind != (argc -1))
+				errflg++;
+		}
+	}
+	if (!errflg && passet != CMDLINE) {
+		errflg = (optind != argc);
+	}
+	/* use PBS_SHELL if specified only if -S was not specified */
+	if (S_opt == FALSE) {
+		char* c = getenv("PBS_SHELL");
+		if (c)
+			set_attr(&attrib, ATTR_S, c);
+	}
+
+	if (u_opt && cred_name[0]) {
+		fprintf(stderr, "qsub: credential incompatable with -u\n");
+		errflg++;
+	}
+	return (errflg);
+}
+
+/**
+ * @brief
+ *  Process special arguments.
+ *  The "--" argument indicates an executable and possible arguments to that
+ *  exectuable. qsub will treat that executable and its arguments as the job
+ *  rather than reading from a job script.
+ *
+ * @param[in]  argc         - argument count
+ * @param[in]  argv         - pointer to array of argument variables
+ * @param[out] script       - path of job script
+ * @return     command_flag - indicates whether an executable was specified instead of a job script
+ */
+static int
+process_special_args(int const argc, char ** const argv, char * const script)
+{
+	int command_flag = 0;
+	char *arg_list = NULL;
+	if (optind < argc) {
+		if (strcmp(argv[optind], "--") == 0) {
+			command_flag = 1;
+			/* set executable */
+			set_attr(&attrib, ATTR_executable, argv[optind + 1]);
+			if (argc > (optind + 2)) {
+				/* user has specified arguments to executable as well. */
+				arg_list = encode_xml_arg_list(optind + 2, argc, argv);
+				if (arg_list == NULL) {
+					fprintf(stderr, "qsub: out of memory\n");
+					exit_qsub(2);
+				} else {
+					/* set argument list */
+					set_attr(&attrib, ATTR_Arglist, arg_list);
+					free(arg_list);
+					arg_list = NULL;
+				}
+			}
+			if (!N_opt)	/* '-N' is not set */
+				set_attr(&attrib, ATTR_N, "STDIN");
+		} else {
+			snprintf(script, MAXPATHLEN, "%s", argv[optind]);
+		}
+	}
+	return command_flag;
+}
+
+/**
+ * @brief
+ * 	processes and creates arguments passed for qsub
+ *
+ * @param[in] argc - argument count
+ * @param[in] argv - pointer to array of argument variables
+ * @param[in] line - character pointer for whole line
+ *
+ */
+static void
+make_argv(int *argc, char *argv[], char *line)
+{
+	char *l, *b, *c;
+	char buffer[4096];
+	int len;
+	char quote;
+	int  i;
+
+	*argc = 0;
+	argv[(*argc)++] = "qsub";
+	l = line;
+	b = buffer;
+	while (isspace(*l)) l++;
+	c = l;
+	while (*c != '\0') {
+		if ((*c == '"') || (*c == '\'')) {
+			quote = *c;
+			c++;
+			while ((*c != quote) && *c)
+				*b++ = *c++;
+			if (*c == '\0') {
+				fprintf(stderr, "qsub: unmatched %c\n", *c);
+				exit_qsub(1);
+			}
+			c++;
+		} else if (*c == ESC_CHAR) {
+			c++;
+			*b++ = *c++;
+		} else if (isspace(*c)) {
+			len = c - l;
+			if (argv[*argc] != NULL) free(argv[*argc]);
+			argv[*argc] = (char *) malloc(len + 1);
+			if (argv[*argc] == NULL) {
+				fprintf(stderr, "qsub: out of memory\n");
+				exit_qsub(2);
+			}
+			*b = '\0';
+			strcpy(argv[(*argc)++], buffer);
+			while (isspace(*c)) c++;
+			l = c;
+			b = buffer;
+		} else
+			*b++ = *c++;
+	}
+	if (c != l) {
+		len = c - l;
+		if (argv[*argc] != NULL)
+			free(argv[*argc]);
+		argv[*argc] = (char *) malloc(len + 1);
+		if (argv[*argc] == NULL) {
+			fprintf(stderr, "qsub: out of memory\n");
+			exit_qsub(2);
+		}
+		*b = '\0';
+		strcpy(argv[(*argc)++], buffer);
+	}
+	i = *argc;
+	/* free and null any pointers used for the prior call that are not used  */
+	/* for this line.  Otherwise the argv array would not be null terminated */
+	while (argv[i] != NULL) {
+		free(argv[i]);
+		argv[i++] = NULL;
+	}
+}
+
+/**
+ * @brief
+ *      Create and process qsub argument list from the string 'opts'
+ *
+ * @param[in]	opts     - The qsub options as single parameter.
+ * @param[in]   opt_pass - priority set based on precedence.
+ *
+ * @return      int
+ * @retval	>0 - Failure - Other than PBS directive error.
+ * @retval      -1 - Failure - PBS directive error.
+ * @retval	 0 - Success
+ *
+ */
+static int
+do_dir(char *opts, int opt_pass, char *retmsg, size_t ret_size)
+{
+	int argc;
+	int ret = -1;
+	int index = 0;
+	int len = 0;
+	int nxt_pos = 0;
+	size_t max_size = ret_size - 2 /* 2 deducted for adding newline at end */;
+#define MAX_ARGV_LEN 128
+	static char *vect[MAX_ARGV_LEN+1];
+
+	make_argv(&argc, vect, opts);
+	ret = process_opts(argc, vect, opt_pass);
+	if ((ret != 0) && (opt_pass != CMDLINE)) {
+		nxt_pos = snprintf(retmsg, max_size, "qsub: directive error: ");
+		if (nxt_pos < 0)
+			return (ret);
+		max_size = max_size - nxt_pos;
+		for (index = 1; index<argc; index++) {
+			/* +1 is added to strlen(vect[index]) to reserve space */
+			if ((max_size > 0) && (max_size > strlen(vect[index]) + 1)) {
+				len = snprintf(retmsg + nxt_pos, max_size, "%s ", vect[index]);
+				if (len < 0)
+					break;
+				nxt_pos = nxt_pos + len;
+				max_size = max_size - len;
+			} else {
+				break;
+			}
+		}
+		snprintf(retmsg + nxt_pos, 2, "\n");
+		return (-1);
+	}
+	return (ret);
+}
+
+/*
+ * @brief
+ *	set_opt_defaults - if not already set, set certain job attributes to
+ *	their default value
+ *
+ */
+static void
+set_opt_defaults()
+{
+	if (c_opt == FALSE)
+		set_attr(&attrib, ATTR_c, CHECKPOINT_UNSPECIFIED);
+	if (h_opt == FALSE)
+		set_attr(&attrib, ATTR_h, NO_HOLD);
+	if (j_opt == FALSE)
+		set_attr(&attrib, ATTR_j, NO_JOIN);
+	if (k_opt == FALSE)
+		set_attr(&attrib, ATTR_k, NO_KEEP);
+	if (m_opt == FALSE)
+		set_attr(&attrib, ATTR_m, MAIL_AT_ABORT);
+	if (p_opt == FALSE)
+		set_attr(&attrib, ATTR_p, "0");
+	if (r_opt == FALSE)
+		set_attr(&attrib, ATTR_r, "TRUE");
+}
+
+/*
+ * End of "Options Processing" functions.
+ */
+
+/*
+ * The following bunch of functions support the "Job Script"
+ * functionality of qsub.
+ */
+
+/**
+ * @brief
+ *      Create a temporary file that will house the job script
+ *
+ * @param[in]	file	- Input file pointer
+ * @param[out]  script	- Temp file location
+ * @param[in]   prefix	- Prefix for PBS directives
+ *
+ * @return      int
+ * @retval	-1 - Error processing qsub parameters
+ * @retval      3 - Error writing script file
+ * @retval      4 - Temp file creation failure
+ * @retval      5 - Error reading input file
+ * @retval      6 - Unexpected EOF on read
+ */
+static int
+get_script(FILE *file, char *script, char *prefix)
+{
+	char s[MAX_LINE_LEN+1];
+	char *sopt;
+	int err  = 0;
+	int exec = FALSE;
+	char *cont;
+	char tmp_name[MAXPATHLEN+1];
+	FILE *TMP_FILE;
+	char *in;
+#ifndef WIN32
+	int fds;
+#endif
+	static char tmp_template[] = "pbsscrptXXXXXX";
+
+	/*
+	 * Note: Need to populate script variable as soon as temp file is created so it
+	 * gets cleaned up in case of an error.
+	 */
+
+#ifdef WIN32
+
+	_snprintf(tmp_name, MAXPATHLEN, "%s\\%s", tmpdir, tmp_template);
+	if ((in = _mktemp(tmp_name)) != NULL) {
+		snprintf(script, MAXPATHLEN, "%s", tmp_name);
+		if ((TMP_FILE = fopen(in, "w+")) == NULL)
+			err = 1;
+	} else {
+		err = 1;
+	}
+
+#else	/* not windows */
+
+	snprintf(tmp_name, MAXPATHLEN, "%s/%s", tmpdir, tmp_template);
+	fds = mkstemp(tmp_name);	/* returns file descriptor */
+	if (fds != -1) {
+		snprintf(script, MAXPATHLEN, "%s", tmp_name);
+		if ((TMP_FILE = fdopen(fds, "w+")) == NULL)
+			err = 1;
+	} else {
+		err = 1;
+	}
+
+#endif	/* end windows */
+
+	if (err != 0) {
+		perror("mkstemp");
+		fprintf(stderr, "qsub: could not create/open tmp file %s for script\n", tmp_name);
+		return (4);
+	}
+
+	s[0] = '\0';
+	while ((in = fgets(s, MAX_LINE_LEN, file)) != NULL) {
+		if (!exec && ((sopt = pbs_ispbsdir(s, prefix)) != NULL)) {
+			while ((*(cont = in + strlen(in) - 2) == ESC_CHAR) &&
+				(*(cont+1) == '\n')) {
+				/* next line is continuation of this line */
+				*cont = '\0';	/* clear newline from our copy */
+				if (fputs(in, TMP_FILE) < 0) {
+					perror("fputs");
+					fprintf(stderr,
+						"qsub: error writing copy of script, %s\n", tmp_name);
+					fclose(TMP_FILE);
+					return (3);
+				}
+				in = cont;
+				if ((in = fgets(in, MAX_LINE_LEN-(in - s), file)) == NULL) {
+					perror("fgets");
+					fprintf(stderr, "qsub: unexpected end-of-file "
+						"or read error in script\n");
+					fclose(TMP_FILE);
+					return (6);
+				}
+			}
+			/*
+			 **	Setting options from the job script will not overwrite
+			 **	options set on the command line.  CMDLINE-1 means
+			 **	"one less than CMDLINE priority"
+			 */
+			if (do_dir(sopt, CMDLINE-1, retmsg, MAXPATHLEN) != 0) {
+				fprintf(stderr, "%s", retmsg);
+				return (-1);
+			}
+		} else if (!exec && pbs_isexecutable(s)) {
+			exec = TRUE;
+		}
+		if (fputs(in, TMP_FILE) < 0) {
+			perror("fputs");
+			fprintf(stderr, "qsub: error writing copy of script, %s\n",
+				tmp_name);
+			fclose(TMP_FILE);
+			return (3);
+		}
+	}
+
+#ifdef WIN32
+	if ((s[0] != '\0') && (s[strlen(s)-1] != '\n')) {
+		fputs("\n", TMP_FILE);
+		printf("qsub: added missing newline in job script.\n");
+	}
+#endif
+
+	if (fclose(TMP_FILE) != 0) {
+		perror(" qsub: copy of script to tmp failed on close");
+		return (5);
+	}
+	if (ferror(file)) {
+		fprintf(stderr, "qsub: error reading script file\n");
+		return (5);
+	}
+	return (0);
+}
+
+/**
+ * @brief
+ *	sets directory prefix
+ *
+ * @param[in] prefix - string to be prefixed
+ * @param[in] diropt - boolean value indicating directory prefix to be set or not
+ *
+ * @return String
+ * @retval Success - pbs directory prefix
+ * @retval Failure - NULL
+ *
+ */
+static char *
+set_dir_prefix(char *prefix, int diropt)
+{
+	char *s;
+
+	if (notNULL(prefix))
+		return (prefix);
+	else if (diropt != FALSE)
+		return ("");
+	else if ((s = getenv("PBS_DPREFIX")) != NULL)
+		return (s);
+	else
+		return (PBS_DPREFIX_DEFAULT);
+}
+
+/**
+ * @brief
+ * Read the job script from a file or stdin.
+ *
+ * @param[in] script - path of job script to read from
+ */
+static void
+read_job_script(char * const script)
+{
+	int errflg; /* error code from get_script() */
+	struct stat statbuf;
+	char *bnp;
+	char  basename[PBS_MAXJOBNAME+1]; /* base name of script for job name*/
+	FILE *f; /* FILE pointer to the script */
+
+	/* if script is empty, get standard input */
+	if ((strcmp(script, "") == 0) || (strcmp(script, "-") == 0)) {
+		/* if this is a terminal, print a short info */
+		if (isatty(STDIN_FILENO) && Interact_opt == FALSE) {
+#ifdef WIN32
+			printf("Job script will be read from standard input. Submit with CTRL+Z.\n");
+#else
+			printf("Job script will be read from standard input. Submit with CTRL+D.\n");
+#endif
+		}
+
+		if (! N_opt)
+			set_attr(&attrib, ATTR_N, "STDIN");
+		if (Interact_opt == FALSE) {
+			errflg = get_script(stdin, script_tmp, set_dir_prefix(dir_prefix, C_opt));
+			if (errflg > 0) {
+				(void)unlink(script_tmp);
+				exit_qsub(1);
+			} else if (errflg < 0) {
+				exit_qsub(1);
+			}
+		}
+	} else {  /* non-empty script, read it for directives */
+		if (stat(script, &statbuf) < 0) {
+			perror("qsub: script file:");
+			exit_qsub(1);
+		}
+		if (! S_ISREG(statbuf.st_mode)) {
+			fprintf(stderr, "qsub: script not a file\n");
+			exit_qsub(1);
+		}
+		if ((f = fopen(script, "r")) != NULL) {
+			if (! N_opt) {
+				if ((bnp = strrchr(script, (int)'/')) != NULL)
+					bnp++;
+				else
+					bnp = script;
+
+				snprintf(basename, sizeof(basename), "%s", bnp);
+				/*
+				 * set ATTR_N directly - verification would be done
+				 * by IFL later
+				 */
+				set_attr(&attrib, ATTR_N, basename);
+			}
+			errflg = get_script(f, script_tmp, set_dir_prefix(dir_prefix, C_opt));
+			if (errflg > 0) {
+				(void)unlink(script_tmp);
+				exit_qsub(1);
+			} else if (errflg < 0) {
+				exit_qsub(1);
+			}
+			(void)fclose(f);
+			f = NULL;
+		} else {
+			perror("qsub: opening script file:");
+			exit_qsub(8);
+		}
+	}
+}
+
+/*
+ * End of "Job Script" functions.
+ */
+
+/*
+ * The following bunch of functions supports the "Environment Variables"
+ * feature of qsub.
+ */
+
+/**
+ * @brief
+ *	Constructs the basic comma-separated environment variables
+ *	list string for a PBS job.
+ *
+ * @return	char *
+ * @retval	NULL for failure.
+ * @retval	A comma-separated list of environment variable=value entries.
+ *
+ */
+static char *
+job_env_basic(void)
+{
+	char *job_env = NULL;
+	char *s = NULL;
+	char *c = NULL;
+	char *p = NULL;
+	char *env = NULL;
+#ifdef WIN32
+	OSVERSIONINFO     osInfo;
+#else
+	struct utsname uns;
+#endif
+	int len = 0;
+	char *getcwd();
+
+	/* Calculate how big to make the variable string. */
+	len = 0;
+	env = strdup_esc_commas(getenv("HOME"));
+	if (env != NULL) {len += strlen(env); free(env);}
+	env = strdup_esc_commas(getenv("LANG"));
+	if (env != NULL) {len += strlen(env); free(env);}
+	env = strdup_esc_commas(getenv("LOGNAME"));
+	if (env != NULL) {len += strlen(env); free(env);}
+	env = strdup_esc_commas(getenv("PATH"));
+	if (env != NULL) {len += strlen(env); free(env);}
+	env = strdup_esc_commas(getenv("MAIL"));
+	if (env != NULL) {len += strlen(env); free(env);}
+	env = strdup_esc_commas(getenv("SHELL"));
+	if (env != NULL) {len += strlen(env); free(env);}
+	env = strdup_esc_commas(getenv("TZ"));
+	if (env != NULL) {len += strlen(env); free(env);}
+	len += PBS_MAXHOSTNAME;
+	len += MAXPATHLEN;
+	len += len;     /* Double it for all the commas, etc. */
+
+	if ((job_env = (char *) malloc(len)) == NULL) {
+		fprintf(stderr, "malloc failure (errno %d)\n", errno);
+		return NULL;
+	} else
+		memset(job_env, 0, len);
+
+	/* Send the required variables with the job. */
+	c = strdup_esc_commas(getenv("HOME"));
+#ifdef WIN32
+	back2forward_slash(c);
+#endif
+	strcat(job_env, "PBS_O_HOME=");
+	if (c != NULL) {
+		strcat(job_env, c);
+		free(c);
+	}
+	else
+		strcat(job_env, "/");
+	c = strdup_esc_commas(getenv("LANG"));
+	if (c != NULL) {
+		strcat(job_env, ",PBS_O_LANG=");
+		strcat(job_env, c);
+		free(c);
+
+	}
+	c = strdup_esc_commas(getenv("LOGNAME"));
+	if (c != NULL) {
+		strcat(job_env, ",PBS_O_LOGNAME=");
+		strcat(job_env, c);
+		free(c);
+	}
+	c = strdup_esc_commas(getenv("PATH"));
+#ifdef WIN32
+	back2forward_slash(c);
+#endif
+	if (c != NULL) {
+		strcat(job_env, ",PBS_O_PATH=");
+		strcat(job_env, c);
+		free(c);
+	}
+	c = strdup_esc_commas(getenv("MAIL"));
+#ifdef WIN32
+	back2forward_slash(c);
+#endif
+	if (c != NULL) {
+		strcat(job_env, ",PBS_O_MAIL=");
+		strcat(job_env, c);
+		free(c);
+	}
+	c = strdup_esc_commas(getenv("SHELL"));
+#ifdef WIN32
+	back2forward_slash(c);
+#endif
+	if (c != NULL) {
+		strcat(job_env, ",PBS_O_SHELL=");
+		strcat(job_env, c);
+		free(c);
+	}
+
+	c = strdup_esc_commas(getenv("TZ"));
+	if (c != NULL) {
+		strcat(job_env, ",PBS_O_TZ=");
+		strcat(job_env, c);
+		free(c);
+	}
+
+	/*
+	 * Don't detect the hostname here because it utilizes network services
+	 * that slow everthing down. PBS_O_HOST is set in the daemon later on.
+	 */
+
+	/* get current working directory, use $PWD if available, it is more
+	 * NFS automounter "friendly".  But must double check that is right
+	 */
+	s = job_env + strlen(job_env);
+	strcat(job_env, ",PBS_O_WORKDIR=");
+	c = getenv("PWD");
+	if (c != NULL) {
+		struct stat statbuf;
+		dev_t	dev;
+		ino_t	ino;
+
+		if (stat(c, &statbuf) < 0) {
+			/* cannot stat, cannot trust it */
+			c = NULL;
+		} else {
+			dev = statbuf.st_dev;
+			ino = statbuf.st_ino;
+			if (stat(".", &statbuf) < 0) {
+				perror("qsub: cannot stat current directory: ");
+				return NULL;
+			}
+			/* compare against "." */
+			if ((dev != statbuf.st_dev) || (ino != statbuf.st_ino))
+				/* "." and $PWD is different, cannot trust it */
+				c = NULL;
+		}
+	}
+
+	if (c == NULL) {
+		p = c = job_env + strlen(job_env);
+		if (getcwd(c, MAXPATHLEN) == NULL)
+			c = NULL;
+	} else
+		p = job_env + strlen(job_env);
+
+	if (c != NULL) {
+		char *c_escaped = NULL;
+
+		/* save current working dir for daemon */
+		snprintf(qsub_cwd, sizeof(qsub_cwd), "%s", c);
+#ifdef WIN32
+		/* get UNC path (if available) if it is mapped drive */
+		get_uncpath(c);
+#endif
+		c_escaped = strdup_esc_commas(c);
+		if (c_escaped != NULL) {
+#ifdef WIN32
+			back2forward_slash(c_escaped);
+#endif
+			strncpy(p, c_escaped, strlen(c_escaped));
+			free(c_escaped);
+			c_escaped = NULL;
+		} else
+			*s = '\0';
+	} else
+		*s = '\0';
+
+#ifdef WIN32 /* Windows */
+	osInfo.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+	if (GetVersionEx(&osInfo)) {
+		switch (osInfo.dwPlatformId) {
+			case 0:
+				strcat(job_env, ",PBS_O_SYSTEM=VER_PLATFORM_WIN32s");
+				break;
+			case 1:
+				strcat(job_env, ",PBS_O_SYSTEM=VER_PLATFORM_WIN32_WINDOWS");
+				break;
+			case 2:
+				strcat(job_env, ",PBS_O_SYSTEM=VER_PLATFORM_WIN32_NT");
+				break;
+		}
+	}
+#else /* Unix */
+	if (uname(&uns) != -1) {
+		strcat(job_env, ",PBS_O_SYSTEM=");
+		strcat(job_env, uns.sysname);
+	}
+#endif
+	else {
+		perror("qsub: cannot get uname info:");
+		return NULL;
+	}
+
+	return (job_env);
+}
+
+
+/**
+ * @brief
+ *	Converts an array of environment variable=value strings,
+ *	into a comma-separated variables list string that can be
+ *	exported to a job.
+ *
+ * @par	 NOTE: Variables in the list beginning with "PBS_O" are ignored
+ *	 as these will be preconstructed somewhere else.
+ *
+ * @param[in]	envp - aray of strings making up the current environment.
+ *
+ * @return      char *
+ * @retval      NULL - Failure
+ * @retval      A comma-separated list of environment variables and values.
+ *		The returned string is malloc-ed so it must be freed later.
+ */
+static char *
+env_array_to_varlist(char **envp)
+{
+	char	**evp;
+	int	len;
+	char	*job_env = NULL;
+	char	*s;
+
+	if (envp == NULL) {
+		fprintf(stderr, "env_array_to_varlist: no envp array!\n");
+		return NULL;
+	}
+
+	evp = envp;
+	len = 0;
+	while (notNULL(*evp)) {
+		len += strlen(*evp);
+		evp++;
+	}
+	len += len;     /* Double it for all the commas, etc. */
+
+	if ((job_env = (char *) malloc(len)) == NULL) {
+		fprintf(stderr, "env_array_to_varlist: malloc failure errno=%d", errno);
+		return NULL;
+	}
+
+	*job_env = '\0';
+
+	evp = envp;
+	while (notNULL(*evp)) {
+		s = *evp;
+		while ((*s != '=') && *s)
+			++s;
+		*s = '\0';
+		if (strncmp(*evp, pbs_o_env, sizeof(pbs_o_env)-1) != 0) {
+			/* do not add PBS_O_* env variables, as these are set by qsub */
+			strcat(job_env, ",");
+			strcat(job_env, *evp);
+			strcat(job_env, "=");
+#ifdef WIN32
+			back2forward_slash(s+1);
+#endif
+			(void)copy_env_value(job_env, s+1, 1);
+		}
+		*s = '=';
+		evp++;
+	}
+
+	return (job_env);
+}
+
+/**
+ * @brief
+ *	Adds to the global 'attrib' structure an entry:
+ *
+ *	"-v <basic_vlist>,<v_value>,<current_vlist>
+ *	and this 'attrib' is something that will be passed onto a
+ *	PBS job before submission.
+ *
+ * @param[in]	basic_vlist - the basic variables list string of job.
+ * @param[in]	curent_envlist - the variables list
+ *		string representing the environment where qsub was
+ *		invoked.
+ *
+ * @return	boolean (int)
+ * @retval	TRUE for success.
+ * @retval	FALSE for failure.
+ *
+ */
+static int
+set_job_env(char *basic_vlist, char *current_vlist)
+{
+	char *job_env;
+	int len;
+
+	char *s, *c, *env, l, *pc;
+
+	/* Calculate how big to make the variable string. */
+	len = 0;
+	if (v_opt)
+		len += strlen(v_value);
+
+	if ((basic_vlist == NULL) || (basic_vlist[0] == '\0'))
+		return FALSE;
+
+	len += strlen(basic_vlist);
+
+	if (V_opt && (current_vlist != NULL) && (current_vlist[0] != '\0'))
+		len += strlen(current_vlist);
+
+	len += len;     /* Double it for all the commas, etc. */
+	if ((job_env = (char *) malloc(len)) == NULL) return FALSE;
+	*job_env = '\0';
+
+	strcpy(job_env, basic_vlist);
+
+	/* Send these variables with the job. */
+	/* POSIX requirement: If a variable is given without a value, supply the
+	 value from the environment. */
+	/* MY requirement:    There can be no white space in -v value. */
+	if (v_opt) {
+		c = v_value;
+		state1:         /* Initial state comes here */
+		switch (*c) {
+			case ',':
+			case '=':
+				return FALSE;
+			case '\0':
+				goto final;
+		}
+		s = c;
+		state2:         /* Variable name */
+		switch (*c) {
+			case ',':
+			case '\0':
+				goto state3;
+			case '=':
+				goto state4;
+			default:
+				c++;
+				goto state2;
+		}
+		state3:         /* No value - get it from qsub environment */
+
+		/* From state3, goes back to state1, using 'c' as input */
+		l = *c;
+		*c = '\0';
+		if (strncmp(s, pbs_o_env, sizeof(pbs_o_env)-1) != 0) {
+			/* do not add PBS_O_* env variables, as these are set by qsub */
+
+			env = getenv(s);
+			if (env == NULL) return FALSE;
+
+			strcat(job_env, ",");
+			strcat(job_env, s);
+			strcat(job_env, "=");
+#ifdef WIN32
+			back2forward_slash(env);
+#endif
+			if (copy_env_value(job_env, env, 1) == NULL)
+				return FALSE;
+		}
+
+		if (l == ',')
+			c++;
+		goto state1;
+		state4:         /* Value specified */
+
+		/* From state4, goes back to state1, using 'c' as input */
+		*c++ = '\0';;
+
+#ifndef WIN32
+		if (v_opt && Forwardx11_opt) {
+			if (strcmp(s, "DISPLAY") == 0) {
+				x11_disp = TRUE;
+				return FALSE;
+			}
+		}
+#endif
+		pc = job_env + strlen(job_env);
+		(void)strcat(job_env, ",");
+		(void)strcat(job_env, s);
+		(void)strcat(job_env, "=");
+#ifdef WIN32
+		back2forward_slash(c);
+#endif
+		if ((c = copy_env_value(job_env, c, 0)) == NULL)
+			return FALSE;
+
+		/* Have to undo here, since 'c' was incremented by copy_env_value */
+		if (strncmp(s, pbs_o_env, sizeof(pbs_o_env)-1) == 0)
+			/* ignore PBS_O_ env variables as these are created by qsub */
+			*pc = '\0';
+
+		goto state1;
+	}
+
+final:
+
+	if (V_opt && (current_vlist != NULL) && (current_vlist[0] != '\0'))
+		/* Send every environment variable with the job. */
+		strcat(job_env, current_vlist);
+
+	set_attr(&attrib, ATTR_v, job_env);
+	free(job_env);
+
+	return TRUE;
+}
+
+/*
+ * End of "Environment Variables" functions.
+ */
+
+
+/*
+ * The following bunch of functions support the "Daemon" capability of qsub.
+ */
+
 /*
  * static buffer and length used by various messages for communication
  * between the qsub foreground and background process
  */
 static char *buf = NULL;
 static int buflen = 0;
+
 /**
  * @brief
  *  	This static internal function is used to easily resize a buffer
@@ -980,92 +4459,6 @@ dosend(void *s, char *buf, int bufsize)
 	if (bytes != bufsize)
 		return -1;
 #endif
-	return 0;
-}
-
-/**
- * @brief
- *	Send the cmd opt values for each parameter supported by qsub to the
- *	background qsub process.
- *
- * @param[in]	s - pointer to the windows PIPE or Unix domain socket
- *
- * @return      int
- * @retval	-1 - Failure
- * @retval	 0 - Success
- *
- */
-static int
-send_opts(void *s)
-{
-	/*
-	 * we are allocating a fixed size of 100. This is because we know that
-	 * the list of opts to send is going to fit within 100. Specifically, for each
-	 * opt we need 2 characters, and currently we have 35 opts.
-	 * If a new set of opts are added, the buffer space of 100 allocated here
-	 * needs to be double checked.
-	 */
-	if (resize_buffer(0, 100) != 0)
-		return -1;
-
-	sprintf(buf,
-		"%d %d %d %d %d %d %d %d %d %d "
-		"%d %d %d %d %d %d %d %d %d %d "
-		"%d %d %d %d %d %d %d %d %d %d "
-		"%d %d %d %d %d ",
-		a_opt, c_opt, e_opt, h_opt, j_opt,
-		k_opt, l_opt, m_opt, o_opt, p_opt,
-		q_opt, r_opt, u_opt, v_opt, z_opt,
-		A_opt, C_opt, J_opt, M_opt, N_opt,
-		S_opt, V_opt, Depend_opt, Interact_opt, Stagein_opt,
-		Stageout_opt, Sandbox_opt, Grouplist_opt, Resvstart_opt,
-		Resvend_opt, pwd_opt, cred_opt, block_opt, P_opt,
-					relnodes_on_stageout_opt);
-
-	return (send_string(s, buf));
-}
-
-/**
- * @brief
- *	Recv the cmd opt values for each parameter supported by qsub from the
- *	foreground qsub process.
- *
- * @param[in]	s - pointer to the windows PIPE or Unix domain socket
- *
- * @return      int
- * @retval	-1 - Failure
- * @retval	 0 - Success
- *
- */
-static int
-recv_opts(void *s)
-{
-	/*
-	 * we are allocating a fixed size of 100. This is because we know that
-	 * the list of opts to send is going to fit within 100. Specifically, for each
-	 * opt we need 2 characters, and currently we have 35 opts.
-	 * If a new set of opts are added, the buffer space of 100 allocated here
-	 * needs to be double checked.
-	 */
-	if (resize_buffer(0, 100) != 0)
-		return -1;
-
-	if (recv_string(s, buf) != 0)
-		return -1;
-
-	sscanf(buf,
-		"%d %d %d %d %d %d %d %d %d %d "
-		"%d %d %d %d %d %d %d %d %d %d "
-		"%d %d %d %d %d %d %d %d %d %d "
-		"%d %d %d %d %d ",
-		&a_opt, &c_opt, &e_opt, &h_opt, &j_opt,
-		&k_opt, &l_opt, &m_opt, &o_opt, &p_opt,
-		&q_opt, &r_opt, &u_opt, &v_opt, &z_opt,
-		&A_opt, &C_opt, &J_opt, &M_opt, &N_opt,
-		&S_opt, &V_opt, &Depend_opt, &Interact_opt, &Stagein_opt,
-		&Stageout_opt, &Sandbox_opt, &Grouplist_opt, &Resvstart_opt,
-		&Resvend_opt, &pwd_opt, &cred_opt, &block_opt, &P_opt,
-			&relnodes_on_stageout_opt);
 	return 0;
 }
 
@@ -1288,3320 +4681,89 @@ recv_dyn_string(void *s, char **strp)
 
 /**
  * @brief
- *	strdup_esc_commas - duplicate a string escaping commas
- *	The string is duplicated with all commas in the original string
- *	escaped by preceeding black slash
+ *	Send the cmd opt values for each parameter supported by qsub to the
+ *	background qsub process.
  *
- * @param[in] str_to_dup - string to be duplicated
- *
- * @return
- * @retval string Succes
- * @retval NULL   Failure
- *
- */
-static char *
-strdup_esc_commas(char *str_to_dup)
-{
-	char *roaming = str_to_dup;
-	char *endstr, *returnstr;
-
-	if (str_to_dup == NULL)
-		return NULL;
-
-	returnstr = endstr = malloc(strlen(str_to_dup)*2 + 2);
-	/* even for an all-comma string, this should suffice */
-	if (returnstr == NULL)
-		return (returnstr); /* just return null on malloc failure */
-	while (*roaming != '\0') {
-		while (*roaming != '\0' && *roaming != ',')
-			*(endstr++) = *(roaming++);
-		if (*roaming==',') {
-			*(endstr++) = ESC_CHAR;
-			*(endstr++) = ',';
-			roaming++;
-		}
-	}
-	*endstr = '\0';
-	return (returnstr);
-}
-
-/**
- * @brief
- *	sets directory prefix
- *
- * @param[in] prefix - string to be prefixed
- * @param[in] diropt - boolean value indicating directory prefix to be set or not
- *
- * @return String
- * @retval Success - pbs directory prefix
- * @retval Failure - NULL
- *
- */
-char *
-set_dir_prefix(char *prefix, int diropt)
-{
-	char *s;
-
-	if (notNULL(prefix))
-		return (prefix);
-	else if (diropt != FALSE)
-		return ("");
-	else if ((s = getenv("PBS_DPREFIX")) != NULL)
-		return (s);
-	else
-		return (PBS_DPREFIX_DEFAULT);
-}
-
-/*
- * The following bunch of functions support the "Interactive Job"
- * capability of PBS.
- */
-
-/**
- * @brief
- * 	interactive_port - get a socket to listen to for "interactive" job
- *	When the "interactive" job is run, its standard in, out, and error
- *	will be connected to this socket.
- *
- * @return string
- * @retval portstring holding port info
- * exits from program on failure
- *
- */
-char *
-interactive_port()
-{
-	pbs_socklen_t namelen;
-	static char portstring[8];
-	struct sockaddr_in myaddr;
-	unsigned short port;
-
-	if ((isatty(0) == 0) || (isatty(1) == 0)) {
-		fprintf(stderr, "qsub:\tstandard input and output must be a "
-			"terminal for\n\tinteractive job submission\n");
-		exit_qsub(1);
-	}
-	comm_sock = socket(AF_INET, SOCK_STREAM, 0);
-	if (comm_sock < 0) {
-		perror("qsub: unable to obtain socket");
-		exit_qsub(1);
-	}
-	myaddr.sin_family = AF_INET;
-	myaddr.sin_addr.s_addr = INADDR_ANY;
-	myaddr.sin_port = 0;
-	if (bind(comm_sock, (struct sockaddr *)&myaddr, sizeof(myaddr)) < 0) {
-		perror("qsub: unable to bind to socket");
-		exit_qsub(1);
-	}
-
-	/* get port number assigned */
-
-	namelen = sizeof(myaddr);
-	if (getsockname(comm_sock, (struct sockaddr *)&myaddr, &namelen) < 0) {
-		perror("qsub: unable to get port number");
-		exit_qsub(1);
-	}
-	port = ntohs(myaddr.sin_port);
-	(void)sprintf(portstring, "%u", (unsigned int)port);
-	if (listen(comm_sock, 1) < 0) {
-		perror("qsub: listen on interactive socket");
-		exit_qsub(1);
-	}
-
-	return (portstring);
-}
-
-#ifndef WIN32
-/**
- * @brief
- *	This function creates a socket to listen for "X11" data
- *	and returns a port number where its listening for X data.
- *
- * @return	char*
- * @retval	portstring	success
- *
- * @par Side Effects
- *		If this function fails, it will exit the qsub process.
- *
- */
-char*
-port_X11(void)
-{
-	pbs_socklen_t namelen;
-	struct sockaddr_in myaddr;
-	static char X11_port_str[X11_PORT_LEN];
-	unsigned short X11_port;
-
-	X11_comm_sock = socket(AF_INET, SOCK_STREAM, 0);
-	if (X11_comm_sock < 0) {
-		perror("qsub: unable to create socket");
-		exit_qsub(1);
-	}
-	myaddr.sin_family = AF_INET;
-	myaddr.sin_addr.s_addr = INADDR_ANY;
-	myaddr.sin_port = 0;
-
-	if (bind(X11_comm_sock, (struct sockaddr *) &myaddr,
-		sizeof(myaddr)) < 0) {
-		perror("qsub: unable to bind to socket");
-		exit_qsub(1);
-	}
-	/* get port number assigned */
-	namelen = sizeof(myaddr);
-	if (getsockname(X11_comm_sock, (struct sockaddr *) &myaddr,
-		&namelen) < 0) {
-		perror("qsub: unable to get port number");
-		exit_qsub(1);
-	}
-	X11_port = ntohs(myaddr.sin_port);
-	(void) sprintf(X11_port_str, "%u", (unsigned int) X11_port);
-	if (listen(X11_comm_sock, 1) < 0) {
-		perror("qsub: listening on X11 socket failed");
-		exit_qsub(1);
-	}
-	return (X11_port_str);
-}
-
-/**
- * @brief
- * 	settermraw - set terminal into "raw" mode
- *
- * @param[in] ptio - pointer to termios structure
- *
- * @return None
- * @retval Void
- *
- */
-void
-settermraw(ptio)
-struct termios *ptio;
-{
-	struct termios tio;
-
-	tio = *ptio;
-
-	tio.c_lflag &= ~(ICANON|ISIG|ECHO|ECHOE|ECHOK);
-	tio.c_iflag &= ~(IGNBRK|INLCR|ICRNL|IXON|IXOFF);
-	tio.c_oflag = 0;
-	tio.c_oflag |= (OPOST); /* TAB3 */
-	tio.c_cc[VMIN] = 1;
-	tio.c_cc[VTIME] = 0;
-
-#if defined(TABDLY) && defined(TAB3)
-	if ((tio.c_oflag & TABDLY) == TAB3)
-		tio.c_oflag &= ~TABDLY;
-#endif
-	tio.c_cc[VKILL]  = -1;
-	tio.c_cc[VERASE] = -1;
-
-	if (tcsetattr(0, TCSANOW, &tio) < 0)
-		perror("qsub: set terminal mode");
-}
-
-/**
- * @brief
- * 	stopme - suspend process on ~^Z or ~^Y
- *	on suspend, reset terminal to normal "cooked" mode;
- *	when resumed, again set terminal to raw.
- *
- * @param[in] p - process id
- *
- * @return None
- * @retval Void
- *
- */
-void
-stopme(pid_t p)
-{
-	(void)tcsetattr(0, TCSANOW, &oldtio); /* reset terminal */
-	kill(p, SIGTSTP);
-	(void)settermraw(&oldtio);            /* back to raw when we resume */
-}
-
-/**
- * @brief
- *	Interactive Reader process: reads from the remote socket,
- *	and writes that out to the stdout
- *
- * @param[in] s - socket (file descriptor)
- *
- * @return   Error code
- * @retval  -1  Failure
- * @retval   0   Success
- *
- */
-int
-reader(int s)
-{
-	char buf[4096];
-	int  c;
-	char *p;
-	int  wc;
-
-	/* read from the socket, and write to stdout */
-	while (1) {
-		c = CS_read(s, buf, sizeof(buf));
-		if (c > 0) {
-			p = buf;
-			while (c) {
-				if ((wc = write(1, p, c)) < 0) {
-					if (errno == EINTR) {
-						continue;
-					} else {
-						perror("qsub: write error");
-						return (-1);
-					}
-				}
-				c -= wc;
-				p += wc;
-			}
-		} else if (c == 0) {
-			return (0);		/* EOF - all done */
-		} else {
-			if (errno == EINTR)
-				continue;
-			else {
-				perror("qsub: read error");
-				return (-1);
-			}
-		}
-	}
-}
-
-/**
- * @brief       This is a reader function which reads from the remote socket
- *              when X forwarding is enabled and writes it back to stdout.
- *
- * @param[in] s - socket descriptor from where data is to be read.
- *
- * @return	int
- * @retval	 0	Success
- * @retval	-1	Failure
- * @retval      -2      Peer Closed connection
- *
- */
-int
-reader_Xjob(int s)
-{
-	static char buf[PF_BUF_SIZE];
-	int c = 0;
-	char *p;
-	int wc;
-	int d = fileno(stdout);
-
-	/* read from the socket and write to stdout */
-	c = CS_read(s, buf, sizeof(buf));
-	if (c > 0) {
-		p = buf;
-		while (c) {
-			/*write data back to stdout*/
-			if ((wc = write(d, p, c)) < 0) {
-				if (errno == EINTR) {
-					continue;
-				} else {
-					perror("qsub: write error");
-					return (-1);
-				}
-			}
-			c -= wc;
-			p += wc;
-		}
-	} else if (c == 0) {
-		/*
-		 * If control reaches here, then it means peer has closed the
-		 * connection.
-		 */
-		return (-2);
-	} else if (errno == EINTR) {
-		return (0);
-	} else {
-		perror("qsub: read error");
-		return (-1);
-	}
-
-	return (0);
-}
-
-
-/**
- * @brief
- * 	Writer process: reads from stdin, and writes
- * 	data out to the rem socket
- *
- * @param[in] s - file descriptor
- *
- * @return Void
- *
- */
-void
-writer(int s)
-{
-	char c;
-	int i;
-	int newline = 1;
-	char tilda = '~';
-	int wi;
-
-	/* read from stdin, and write to the socket */
-
-	while (1) {
-		i = read(0, &c, 1);
-		if (i > 0) {		/* read data */
-			if (newline) {
-				if (c == tilda) {	/* maybe escape character */
-
-					/* read next character to check */
-
-					while ((i = read(0, &c, 1)) != 1) {
-						if ((i == -1) && (errno == EINTR))
-							continue;
-						else
-							break;
-					}
-					if (i != 1)
-						break;
-					if (c == '.')	/* termination character */
-						break;
-					else if (c == oldtio.c_cc[VSUSP]) {
-						stopme(0);	/* ^Z suspend all */
-						continue;
-#ifdef VDSUSP
-					} else if (c == oldtio.c_cc[VDSUSP]) {
-						stopme(getpid());
-						continue;
-#endif	/* VDSUSP */
-					} else {	/* not escape, write out tilda */
-						while ((wi = CS_write(s, &tilda, 1)) != 1) {
-							if ((wi == -1) && (errno == EINTR))
-								continue;
-							else
-								break;
-						}
-						if (wi != 1)
-							break;
-					}
-				}
-				newline = 0;   /* no longer at start of line */
-			} else {
-				/* reset to newline if \n \r kill or interrupt */
-				newline = (c == '\n') ||
-					(c == oldtio.c_cc[VKILL]) ||
-				(c == oldtio.c_cc[VINTR]) ||
-				(c == '\r') ;
-			}
-			while ((wi = CS_write(s, &c, 1)) != 1) {   /* write out character */
-				if ((wi == -1) && (errno == EINTR))
-					continue;
-				else
-					break;
-			}
-			if (wi != 1)
-				break;
-
-		} else if (i == 0) {	/* EOF */
-			break;
-		} else if (i < 0) {	/* error */
-			if (errno == EINTR)
-				continue;
-			else {
-				perror("qsub: read error");
-				return;
-			}
-		}
-	}
-	return;
-}
-
-/**
- * @brief
- *	getwinsize - get the current window size
- *
- * @param[in] pwsz - pointer to winsize structure
- *
- * @return   Error code
- * @retval  -1    Failure
- * @retval   0    Success
- *
- */
-int
-getwinsize(struct winsize *pwsz)
-{
-	if (ioctl(0, TIOCGWINSZ, &wsz) < 0) {
-		perror("qsub: unable to get window size");
-		return (-1);
-	}
-	return (0);
-}
-
-/**
- * @brief
- *	send_winsize = send the current tty's window size
- *
- * @param[in] sock - file descriptor
- *
- * @return Void
- *
- */
-void
-send_winsize(int sock)
-{
-	char  buf[PBS_TERM_BUF_SZ];
-
-	(void)sprintf(buf, "WINSIZE %hu,%hu,%hu,%hu", wsz.ws_row, wsz.ws_col,
-		wsz.ws_xpixel, wsz.ws_ypixel);
-	(void)CS_write(sock, buf, PBS_TERM_BUF_SZ);
-	return;
-}
-
-/**
- * @brief
- * 	send_term - send the current TERM type and certain control characters
- *
- * @param[in] sock - file descriptor
- *
- * @return Void
- *
- */
-void
-send_term(int sock)
-{
-	char  buf[PBS_TERM_BUF_SZ];
-	char *term;
-	char  cc_array[PBS_TERM_CCA];
-
-	(void)strcpy(buf, "TERM=");
-	term = getenv("TERM");
-	term = strdup_esc_commas(term);
-	if (term == NULL)
-		(void)strcat(buf, "unknown");
-	else {
-		(void)strncat(buf, term, PBS_TERM_BUF_SZ-5);
-		free(term);
-	}
-	(void)CS_write(sock, buf, PBS_TERM_BUF_SZ);
-
-	cc_array[0] = oldtio.c_cc[VINTR];
-	cc_array[1] = oldtio.c_cc[VQUIT];
-	cc_array[2] = oldtio.c_cc[VERASE];
-	cc_array[3] = oldtio.c_cc[VKILL];
-	cc_array[4] = oldtio.c_cc[VEOF];
-	cc_array[5] = oldtio.c_cc[VSUSP];
-	CS_write(sock, cc_array, PBS_TERM_CCA);
-}
-
-
-/**
- * @brief
- *	catchchild = signal handler for Death of Child
- *
- * @param[in] sig - signal number
- *
- * @return Void
- *
- */
-void
-catchchild(int sig)
-{
-	int status;
-	int pid;
-
-	while (1) {
-		pid = waitpid(-1, &status, WNOHANG|WUNTRACED);
-		if (pid == 0)
-			return;
-		if ((pid > 0) && (WIFSTOPPED(status) == 0))
-			break;
-		if ((pid == -1) && (errno != EINTR)) {
-			perror("qsub: bad status in catchchild: ");
-			return;
-		}
-	}
-
-	/* reset terminal to cooked mode */
-
-	(void)tcsetattr(0, TCSANOW, &oldtio);
-	exit_qsub(0);
-}
-
-/**
- * @brief
- *	prints can't suspend qsub process on arrival of signal causing suspension
- *
- * @param[in] sig - signal number
- *
- * @return Void
- *
- */
-void
-no_suspend(int sig)
-{
-	printf("Sorry, you cannot suspend qsub until the job is started\n");
-	fflush(stdout);
-}
-#endif	/* ! WIN32 */
-
-/**
- * @brief
- *	Close a socket for both windows and unix.
- *
- * @return	void
- * @param	sock	file descriptor
- *
- * @return Void
- *
- */
-void
-close_sock(int sock)
-{
-	shutdown(sock, 2);
-#ifdef WIN32
-	closesocket(sock);
-#else
-	close(sock);
-#endif	/* WIN32 */
-}
-
-/**
- * @brief
- * 	send delete job request, disconnect with server and exit qsub
- *
- * @param[in]	ret	qsub exit code
- *
- * @return      void
- *
- */
-void
-bailout(int ret)
-{
-	int	c;
-
-	close_sock(comm_sock);
-	printf("Job %s is being deleted\n", new_jobname);
-	c = cnt2server(server_out);
-	if (c <= 0) {
-		fprintf(stderr,
-			"qsub: cannot connect to server %s (errno=%d)\n",
-			pbs_server, pbs_errno);
-		exit_qsub(1);
-	}
-	(void)pbs_deljob(c, new_jobname, NULL);
-	pbs_disconnect(c);
-	exit_qsub(ret);
-}
-
-#ifndef WIN32
-/**
- * @brief
- *	signal handler for timeout scenario
- *
- * @param[in] sig - signal number
- *
- * @return Void
- *
- */
-void
-toolong(int sig)
-{
-	printf("Timeout -- deleting job\n");
-	bailout(0);
-}
-
-/**
- * @brief
- *	signal handler function for interrupt signal
- *
- * @param[in] sig - signal number
- *
- * @return Void
- *
- */
-void
-catchint(int sig)
-{
-	int c;
-
-	printf("Do you wish to terminate the job and exit (y|[n])? ");
-	fflush(stdout);
-	while (1) {
-		alarm(60);	/* give a minute to think about it */
-		c = getchar();
-
-		if ((c == 'n') || (c == 'N') || (c == '\n'))
-			break;
-		else if ((c == 'y') || (c == 'Y') || (c == EOF)) {
-			bailout(0);
-		} else {
-			printf("yes or no please\n");
-			while ((c != '\n') && (c != EOF))
-				c = getchar();
-		}
-	}
-	alarm(0);		/* reset alarm */
-	while ((c != '\n') && (c != EOF))
-		c = getchar();
-	return;
-}
-
-/**
- * @brief
- *	This function initializes pfwdsock structure and eventually
- *	calls port_forwarder.
- *
- * @param[in]	X_data_socket - socket descriptor used to read X data from mom
- *				port forwarders.
- * @param[in]	interactive_reader_socket - socket descriptor used to read
- *				interactive job data coming from mom writer.
- * @return	void
- *
- * @par Side Effects
- * 	On failure, the function will cause the qsub process to exit.
- *
- */
-void
-x11handler(int X_data_socket, int interactive_reader_socket)
-{
-	int n;
-	struct pfwdsock *socks;
-	socks = calloc(sizeof(struct pfwdsock), NUM_SOCKS);
-	if (!socks) {
-		fprintf(stderr, "Calloc failed : out of memory\n");
-		exit_qsub(1);
-	}
-	for (n = 0; n < NUM_SOCKS; n++) {
-		(socks + n)->active = 0;
-	}
-	(socks + 0)->sock = X_data_socket;
-	(socks + 0)->active = 1;
-	(socks + 0)->listening = 1;
-
-	/* Try to open a socket for the local X server. */
-
-	port_forwarder(socks, x11_connect_display, display, 0,
-		interactive_reader_socket, reader_Xjob, log_cmds_portfw_msg);
-}
-
-
-/**
- * @brief
- *	interactive - set up for interactive communication with job
- *
- * @return      void
- *
- * @par Side Effects
- *	On failure, the function will cause the qsub process to exit.
- *
- */
-void
-interactive(void)
-{
-	int  amt;
-	char cur_server[PBS_MAXSERVERNAME+PBS_MAXPORTNUM+2];
-	pbs_socklen_t  fromlen;
-	char momjobid[PBS_MAXSVRJOBID+1];
-	int  news;
-	int  nsel;
-	char *pc;
-	fd_set selset;
-
-	struct sigaction act;
-	struct sockaddr_in from;
-	struct timeval timeout;
-	struct winsize wsz;
-	int child;
-	int	ret;
-
-	/* disallow ^Z which hangs up MOM starting an interactive job */
-
-	sigemptyset(&act.sa_mask);
-	act.sa_handler = no_suspend;
-	act.sa_flags   = 0;
-	if (sigaction(SIGTSTP, &act, NULL) < 0) {
-		perror("sigaction(SIGTSTP)");
-		exit_qsub(1);
-	}
-
-	/* Catch SIGINT and SIGTERM, and */
-	/* setup to catch Death of child */
-
-	act.sa_handler = catchint;
-	if ((sigaction(SIGINT, &act, NULL) < 0) ||
-		(sigaction(SIGTERM, &act, NULL) < 0)) {
-		perror("unable to catch signals");
-		exit_qsub(1);
-	}
-	act.sa_handler = toolong;
-	if ((sigaction(SIGALRM, &act, NULL) < 0)) {
-		perror("cannot catch alarm");
-		exit_qsub(2);
-	}
-
-	/* save the old terminal setting */
-
-	if (tcgetattr(0, &oldtio) < 0) {
-		perror("qsub: unable to get terminal settings");
-		exit_qsub  (1);
-	}
-
-	/* Get the current window size, to be sent to MOM later */
-
-	if (getwinsize(&wsz)) {
-		wsz.ws_row = 20;	/* unable to get actual values	*/
-		wsz.ws_col = 80;	/* set defaults			*/
-		wsz.ws_xpixel = 0;
-		wsz.ws_ypixel = 0;
-	}
-
-	printf("qsub: waiting for job %s to start\n", new_jobname);
-
-	/* Accept connection on socket set up earlier */
-
-	nsel = 0;
-	while (nsel == 0) {
-		FD_ZERO(&selset);
-		FD_SET(comm_sock, &selset);
-		timeout.tv_usec = 0;
-		timeout.tv_sec  = 30;
-		nsel = select(FD_SETSIZE, &selset, NULL, NULL, &timeout);
-		if (nsel == -1) {
-			if (errno == EINTR)
-				nsel = 0;
-			else {
-				perror("qsub: select failed");
-				exit_qsub(1);
-			}
-		}
-		if (nsel == 0) {
-			/* connect to server, status job to see if still there */
-			if (! locate_job(new_jobname, server_out, cur_server)) {
-				fprintf(stderr, "qsub: job %s apparently deleted\n",
-					new_jobname);
-				exit_qsub(1);
-			}
-		}
-
-	}
-
-	/* apparently someone is attempting to connect to us */
-
-retry:
-	fromlen = sizeof(from);
-	if ((news = accept(comm_sock, (struct sockaddr *)&from, &fromlen)) < 0) {
-		perror("qsub: accept error from Interactive socket ");
-		exit_qsub(1);
-	}
-
-	/* When Mom connects we expect:
-	 *
-	 * first, to engage in an authentication activity
-	 * second, mom sends the job id for us to verify
-	 */
-
-	ret = CS_client_auth(news);
-
-	if ((ret != CS_SUCCESS) && (ret != CS_AUTH_USE_IFF)) {
-		fprintf(stderr, "qsub: failed authentication with execution host\n");
-		shutdown(news, 2);
-		exit_qsub  (1);
-	}
-
-	/* now verify the value of job id */
-
-	amt = PBS_MAXSVRJOBID+1;
-	pc = momjobid;
-	while (amt > 0) {
-		int	len = CS_read(news, pc, amt);
-		if (len <= 0)
-			break;
-		pc += len;
-		if (*(pc-1) == '\0')
-			break;
-		amt -= len;
-	}
-	if (pc == momjobid) {	/* no data read */
-		shutdown(news, 2);
-		close(news);
-		goto retry;
-	}
-
-	if (strncmp(momjobid, new_jobname, PBS_MAXSVRJOBID) != 0) {
-		fprintf(stderr, "qsub: invalid job name from execution server\n");
-		shutdown(news, 2);
-		exit_qsub  (1);
-	}
-
-	/*
-	 * got the right job, send:
-	 *		terminal type as "TERM=xxxx"
-	 *		window size as   "WINSIZE=r,c,x,y"
-	 */
-	send_term(news);
-	send_winsize(news);
-
-	printf("qsub: job %s ready\n\n", new_jobname);
-
-	/* set SIGINT, SIGTERM processing to default */
-
-	act.sa_handler = SIG_DFL;
-	if ((sigaction(SIGINT, &act, NULL) < 0)  ||
-		(sigaction(SIGTERM, &act, NULL) < 0) ||
-		(sigaction(SIGALRM, &act, NULL) < 0) ||
-		(sigaction(SIGTSTP, &act, NULL) < 0)) {
-		perror("unable to reset signals");
-		exit_qsub(1);
-	}
-
-	child = fork();
-	if (child == 0) {
-		/*
-		 * child process - start the reader function
-		 *                 set terminal into raw mode
-		 */
-
-		settermraw(&oldtio);
-
-		if (Forwardx11_opt) {
-			/*
-			 * if forwardx11_opt is set call x11handler which
-			 * will act as a reader as well as a port forwarder
-			 */
-			x11handler(X11_comm_sock, news);
-		} else {
-			/*call interactive job's reader*/
-			(void) reader(news);
-		}
-		/* reset terminal */
-		tcsetattr(0, TCSANOW, &oldtio);
-		printf("\nqsub: job %s completed\n", new_jobname);
-		exit_qsub(0);
-
-	} else if (child > 0) {
-		/*
-		 * parent - start the writer function
-		 */
-
-		act.sa_handler = catchchild;
-		if (sigaction(SIGCHLD, &act, NULL) < 0)
-			exit_qsub(1);
-
-		writer(news);
-
-		/* all done - make sure the child is gone and reset the terminal */
-
-		kill(child, SIGTERM);
-		shutdown(comm_sock, SHUT_RDWR);
-		close(comm_sock);
-
-		tcsetattr(0, TCSANOW, &oldtio);
-		printf("\nqsub: job %s completed\n", new_jobname);
-		exit_qsub(0);
-	} else {
-		perror("qsub: unable to fork");
-		exit_qsub(1);
-	}
-}
-
-#else /* end of ! WIN32 code */
-/**
- * @brief
- *	interactive - set up for interactive communication with job
- *
- * @return      void
- *
- * @par Side Effects
- *	On failure, the function will cause the qsub process to exit.
- *
- */
-void
-interactive(void)
-{
-	int			amt = 0;
-	char			cur_server[PBS_MAXSERVERNAME+PBS_MAXPORTNUM+2] = {0};
-	pbs_socklen_t		fromlen = 0;
-	int			news = 0;
-	int			nsel = 0;
-	char			*pc = NULL;
-	fd_set			selset;
-	struct sockaddr_in	from;
-	struct timeval		timeout;
-	int			ret = 0;
-	char			remote_ip[INET_ADDR_STRLEN + 1] = {'\0'};
-	char			momjobid[PBS_MAXSVRJOBID + 1] = {'\0'};
-	int			is_mom_local = 0;
-	STARTUPINFO             si_rdp = { 0 };
-	PROCESS_INFORMATION     pi_rdp = { 0 };
-	HANDLE			hjob_remotesession = INVALID_HANDLE_VALUE;
-
-	printf("qsub: waiting for job %s to start\n", new_jobname);
-
-	/* Accept connection on socket set up earlier */
-	nsel = 0;
-	while (nsel == 0) {
-		FD_ZERO(&selset);
-		FD_SET(comm_sock, &selset);
-		timeout.tv_usec = 0;
-		timeout.tv_sec  = 30;
-		nsel = select(FD_SETSIZE, &selset, NULL, NULL, &timeout);
-		if (nsel == -1) {
-			int err_no = WSAGetLastError();
-			if (err_no == WSAEINTR)
-				nsel = 0;
-			else {
-				perror("qsub: select failed");
-				closesocket(comm_sock);
-				exit_qsub(1);
-			}
-		}
-		if (nsel == 0) {
-			/*
-			 * Check if no signal handler thread is invoked.
-			 * Acquire the critical section before locate_job().
-			 */
-			EnterCriticalSection(&continuethread_cs);
-			/* connect to server, status job to see if still there */
-			if (! locate_job(new_jobname, server_out, cur_server)) {
-				fprintf(stderr, "qsub: job %s apparently deleted\n",
-					new_jobname);
-				closesocket(comm_sock);
-				exit_qsub(1);
-			}
-			LeaveCriticalSection(&continuethread_cs);
-		}
-
-	}
-
-	/* apparently someone is attempting to connect to us */
-
-	fromlen = sizeof(from);
-	/*
-	 * Guarded this with critical section in order to ensure
-	 * that accept() is not called after SIGNIT occurs.
-	 */
-	EnterCriticalSection(&continuethread_cs);
-	if ((news = accept(comm_sock, (struct sockaddr *)&from, &fromlen)) < 0) {
-		perror("qsub: accept error from Interactive socket ");
-		closesocket(comm_sock);
-		exit_qsub(1);
-	}
-	LeaveCriticalSection(&continuethread_cs);
-	strncpy(remote_ip, inet_ntoa(from.sin_addr), INET_ADDR_STRLEN);
-	if (remote_ip == NULL) {
-		perror("qsub: Failed to get IP address of execution host ");
-		closesocket(comm_sock);
-		exit_qsub(1);
-	}
-
-	/* When Mom connects we expect:
-	 *
-	 * first, to engage in an authentication activity
-	 * second, mom sends the job id for us to verify
-	 */
-
-	ret = CS_client_auth(news);
-
-	if ((ret != CS_SUCCESS) && (ret != CS_AUTH_USE_IFF)) {
-		fprintf(stderr, "qsub: failed authentication with execution host\n");
-		shutdown(news, 2);
-		exit_qsub  (1);
-	}
-
-	/* now verify the value of job id */
-
-	amt = PBS_MAXSVRJOBID+1;
-	pc = momjobid;
-	while (amt > 0) {
-		fromlen = recv(news, pc, amt, 0);
-		if (fromlen <= 0)
-			break;
-		pc += fromlen;
-		if (*(pc-1) == '\0')
-			break;
-		amt -= fromlen;
-	}
-	if (strncmp(momjobid, new_jobname, PBS_MAXSVRJOBID) != 0) {
-		fprintf(stderr, "qsub: invalid job name from execution server\n");
-		shutdown(news, 2);
-		exit_qsub  (1);
-	}
-	/*
-	 * Guarded this with critical section in order to ensure
-	 * that job ready message and ignoring the signal, happens atomically
-	 */
-	EnterCriticalSection(&continuethread_cs);
-	printf("qsub: job %s ready\n\n", new_jobname);
-	/* Ignore SIGINT */
-	signal(SIGINT, SIG_IGN);
-	LeaveCriticalSection(&continuethread_cs);
-
-	/*
-	 * If it is a GUI job, a configured remote viewer client should be launched if submission host and execution host are not the same.
-	 * If no remote viewer is configured in pbs.conf, use Windows native remote desktop for remote viewing of GUI jobs.
-	 */
-	if(gui_opt != FALSE)
-	{
-		char		rdp_command[PBS_CMDLINE_LENGTH] = {'\0'};
-		int		flags = CREATE_NO_WINDOW | CREATE_SUSPENDED;
-		int		rc = 0;
-		struct hostent	*hp = NULL;
-		char		hname[PBS_MAXHOSTNAME + 1] = {'\0'};
-		int		i = 0;
-
-		/* Check whether the Mom host is same as submission host */
-		(void)gethostname(hname, PBS_MAXHOSTNAME);
-		hp = gethostbyname(hname);
-		for (i=0; hp->h_addr_list[i]; i++) {
-			/* Compare with Mom host IP address to know whether the Mom host is same as submission host */
-			if(memcmp(&(from.sin_addr), hp->h_addr_list[i], hp->h_length) == 0) {
-				is_mom_local = 1;
-				break;
-			}
-		}
-		/* Invoke remote viewer client only if the execution host is not same as submission host */
-		if(is_mom_local == 0) {
-			pbs_loadconf(0);
-			if(pbs_conf.pbs_conf_remote_viewer) { /* Invoke remote viewer client configured */
-				snprintf(rdp_command, PBS_CMDLINE_LENGTH -1, "%s %s", pbs_conf.pbs_conf_remote_viewer, remote_ip);
-			}
-			else { /* No remote viewer client configured, invoke native remote desktop client */
-				snprintf(rdp_command, PBS_CMDLINE_LENGTH -1, "mstsc /v %s", remote_ip);
-			}
-
-			hjob_remotesession = CreateJobObject(NULL, NULL);
-			si_rdp.lpDesktop = NULL;
-			si_rdp.dwFlags = STARTF_USESHOWWINDOW;
-			si_rdp.wShowWindow = SW_HIDE;
-			rc = CreateProcess(NULL, rdp_command,
-				NULL, NULL, TRUE, flags, NULL, NULL, &si_rdp, &pi_rdp);
-			if (!rc) {
-				fprintf(stderr, "qsub: failed to launch remote viewer client. CreateProcess %s failed: error=%d\n",
-					rdp_command, GetLastError());
-				printf("\nqsub: job %s completed\n", new_jobname);
-				close_valid_handle(&(pi_rdp.hThread));
-				close_valid_handle(&(pi_rdp.hProcess));
-				close_valid_handle(&hjob_remotesession);
-				exit_qsub(1);
-			}
-			/* Attach the remote viewer session to the job object */
-			rc = AssignProcessToJobObject(hjob_remotesession, pi_rdp.hProcess);
-			if (!rc) {
-				fprintf(stderr, "qsub: failed to attach remote viewer client. \
-						Please close manually after job completion.\nAssignProcessToJobObject() failed: error=%d\n",
-					GetLastError());
-			}
-			(void)ResumeThread(pi_rdp.hThread);
-		}
-	}
-	/* Run remote command shell. Also redirect stdin */
-	if (remote_shell_command(remote_ip, momjobid, 1) == -1)
-		printf("\nqsub: failed to run remote interactive shell\n", new_jobname);
-	printf("\nqsub: job %s completed\n", new_jobname);
-	/* If it is a GUI job and the submission host and execution host are different, terminate remote viewer session */
-	if(gui_opt != FALSE && (is_mom_local == 0)) {
-		int rc = 0;
-		rc = TerminateJobObject(hjob_remotesession, 0);
-		if (!rc) {
-			fprintf(stderr, "qsub: failed to close remote viewer client. \
-					Please close manually.\nTerminateJobObject() failed: error=%d\n",
-				GetLastError());
-		}
-	}
-	close_valid_handle(&(pi_rdp.hThread));
-	close_valid_handle(&(pi_rdp.hProcess));
-	close_valid_handle(&hjob_remotesession);
-	exit_qsub(0);
-}
-#endif
-/*
- * End of "Interactive Job" functions.
- */
-
-/*
- * The following bunch of functions support the "Block Job"
- * capability of PBS.
- */
-
-/**
- * @brief
- *	creates a socket and blocks the port
- *
- * @return char *
- * @retval portstring string holding port info
- *
- */
-char *
-block_port()
-{
-	pbs_socklen_t  namelen;
-	static char portstring[8];
-	struct sockaddr_in myaddr;
-	unsigned short port;
-
-	comm_sock = socket(AF_INET, SOCK_STREAM, 0);
-	if (comm_sock < 0) {
-		perror("qsub: unable to obtain socket");
-		exit_qsub(1);
-	}
-	myaddr.sin_family = AF_INET;
-	myaddr.sin_addr.s_addr = INADDR_ANY;
-	myaddr.sin_port = 0;
-	if (bind(comm_sock, (struct sockaddr *)&myaddr, sizeof(myaddr)) < 0) {
-		perror("qsub: unable to bind to socket");
-		exit_qsub(1);
-	}
-
-	/* get port number assigned */
-
-	namelen = sizeof(myaddr);
-	if (getsockname(comm_sock, (struct sockaddr *)&myaddr, &namelen) < 0) {
-		perror("qsub: unable to get port number");
-		exit_qsub(1);
-	}
-	port = ntohs(myaddr.sin_port);
-	(void)sprintf(portstring, "%u", (unsigned int)port);
-#ifdef NAS /* localmod 004 */
-	DBPRT((stderr, "block_port: %s\n", portstring))
-#else
-	DBPRT(("block_port: %s\n", portstring))
-#endif /* localmod 004 */
-
-	if (listen(comm_sock, 1) < 0) {
-		perror("qsub: listen on block socket");
-		exit_qsub(1);
-	}
-
-	return (portstring);
-}
-
-int	sig_happened = 0;
-
-#ifdef WIN32
-/**
- * @brief
- *	signal handler to avoid race condition
- *
- * @param[in] sig - signal number
- *
- * @return Void
- *
- */
-void
-win_blockint(int sig)
-{
-	/*
-	 * Try and acquire the critical Section. This is to avoid a race condition when
-	 * due to an interrupt, the signal handler is invoked, which gets called in a separate thread,
-	 * this thread runs in parallel with main thread. This can yield unwanted results:
-	 * e.g. while the signal handler thread is trying to delete a job, the main thread exits
-	 * OR a socket(comm_sock) closed by signal handler thread, gets used in select() and accept().
-	 * inside main thread.
-	 */
-	EnterCriticalSection(&continuethread_cs);
-	sig_happened = sig;
-
-
-	if (sig == SIGINT || sig == SIGBREAK) {
-
-		if (new_jobname == NULL)
-			exit(2);
-
-		fprintf(stderr, "qsub: wait for job %s "
-			"interrupted by signal %d\n",
-			new_jobname, sig_happened);
-		bailout(2);
-	}
-	LeaveCriticalSection(&continuethread_cs);
-
-}
-#else
-/**
- * @brief
- *	signal handler to avoid race condition
- *
- * @param[in] sig - signal number
- *
- * @return Void
- *
- */
-void
-blockint(int sig)
-{
-	sig_happened = sig;
-}
-
-/**
- * @brief
- *	Signal handler for SIGPIPE
- * @param[in]	sig - signal number
- * @return	void
- *
- */
-void
-exit_on_sigpipe(int sig)
-{
-	perror("qsub: SIGPIPE received, job submission interrupted.");
-	exit_qsub(1);
-}
-#endif
-
-#define BAIL(message) \
-	if (ret != DIS_SUCCESS) { \
-		fail = message; \
-		goto err; \
-	}
-
-/**
- * @brief
- *	block - set up to wait for a job to end.
- *
- * @return Void
- * Exits on failre
- *
- */
-void
-block()
-{
-	struct sockaddr_in	from;
-	pbs_socklen_t		fromlen;
-	char			*jobid = "none";
-	char			*message = NULL;
-	char			*fail = NULL;
-	int			news;
-	int			ret;
-	int			version;
-	int			exitval;
-
-#ifndef WIN32
-	struct sigaction	act;
-
-	/* Catch SIGHUP, SIGINT, SIGQUIT and SIGTERM */
-
-	sigemptyset(&act.sa_mask);
-	act.sa_handler = blockint;
-	act.sa_flags   = 0;
-	if ((sigaction(SIGHUP, &act, NULL) < 0) ||
-		(sigaction(SIGINT, &act, NULL) < 0) ||
-		(sigaction(SIGQUIT, &act, NULL) < 0) ||
-		(sigaction(SIGTERM, &act, NULL) < 0)) {
-		perror("qsub: unable to catch signals");
-		exit_qsub(1);
-	}
-#endif
-
-retry:
-	fromlen = sizeof(from);
-	if ((news = accept(comm_sock, (struct sockaddr *)&from,
-		&fromlen)) < 0) {
-#ifdef WIN32
-		if (errno == WSAEINTR)
-#else
-		if (errno == EINTR)
-#endif
-		{
-			fprintf(stderr, "qsub: wait for job %s "
-				"interrupted by signal %d\n",
-				new_jobname, sig_happened);
-			bailout(2);
-		}
-		perror("qsub: accept error");
-		exit_qsub  (1);
-	}
-#ifdef NAS /* localmod 004 */
-	DBPRT((stderr, "got connection from %s:%d\n", inet_ntoa(from.sin_addr),
-		(int)ntohs(from.sin_port)))
-#else
-	DBPRT(("got connection from %s:%d\n", inet_ntoa(from.sin_addr),
-		(int)ntohs(from.sin_port)))
-#endif /* localmod 004 */
-
-	/*
-	 * if SIGINT or SIGBREAK interrupt is raised, then child thread win_blockint()
-	 * does job deletion and other related stuff. So main thread can exit now.
-	 */
-
-#ifdef WIN32
-	if ((sig_happened == SIGINT) || (sig_happened == SIGBREAK)) {
-		exit_qsub(3);
-	}
-#endif
-
-	/* When Mom connects back, the first thing that needs
-	 * to happen is to engage in an authentication activity.
-	 * Any return value other than CS_SUCCESS or CS_AUTH_USE_IFF
-	 * means the authentication failed.
-	 */
-	ret = CS_client_auth(news);
-
-	if ((ret != CS_SUCCESS) && (ret != CS_AUTH_USE_IFF)) {
-		fprintf(stderr, "qsub: failed authentication with execution host\n");
-		close_sock(news);
-		goto retry;
-	}
-
-	DIS_tcp_setup(news);
-	version = disrsi(news, &ret);
-	if (ret != DIS_SUCCESS) {
-		/*
-		 * We couldn't read data so try again if it is a port scan.
-		 */
-		close_sock(news);
-		goto retry;
-	}
-	if (version != 1) {
-		fprintf(stderr, "qsub: unknown protocol version %d\n", version);
-		close_sock(news);
-		goto retry;
-	}
-
-	jobid = disrst(news, &ret);
-	if ((ret != DIS_SUCCESS) || (strcmp(jobid, new_jobname) != 0)) {
-		fprintf(stderr, "qsub: Unknown Job Identifier %s\n", jobid);
-		close_sock(news);
-		goto retry;
-	}
-
-	/* after getting the correct jobid, give up on error */
-	message = disrst(news, &ret);
-	BAIL("message")
-	if (message != NULL && *message != '\0') {	/* non-null message */
-		fprintf(stderr, "qsub: %s %s\n", jobid, message);
-		exit_qsub(3);
-	}
-	exitval = disrsi(news, &ret);
-	BAIL("exitval");
-	exit_qsub(exitval);
-
-err:
-	fprintf(stderr, "qsub: Bad Request Protocol, %s\n",
-			((fail != NULL) && (*fail != '\0')) ? fail : "unknown error");
-	exit_qsub(3);
-}
-
-/*
- ** End of "Block Job" functions.
- */
-
-
-#ifdef	PBS_CRED_DCE_KRB5
-
-/* helper function: convert flags to necessary KDC options */
-#define flags2options(flags) (flags & KDC_TKT_COMMON_MASK)
-#define		TKTLIFE		32659200	/* about a year */
-
-time_t	now;
-
-/**
- * @brief
- *	gets the service ticket from cache
- * @param[in] context - library context
- * @param[in] cc      - credential cache handler
- * @param[in] creds   - request credentials
- * @param[in] addrs   - address to be placed in ticket
- * @param[out] pcreds  - the service ticket
- *
- * @return krb5_error_code
- * @retval 0 	Success
- * @retval krb5_error_code 	Failure
- *
- */
-krb5_error_code
-get_cred_from_cache(krb5_context context, krb5_ccache    cc, krb5_creds *creds,
-			krb5_address **addrs, krb5_creds **pcreds)
-{
-	krb5_error_code		retval;
-	krb5_creds		tgt;
-	krb5_flags		kdcoptions;
-	krb5_flags		kflags;
-	krb5_cc_cursor		kursor;
-	int			i;
-
-	kflags = TKT_FLG_FORWARDABLE|TKT_FLG_RENEWABLE;
-	memset((char *)&tgt, 0, sizeof(tgt));
-
-	retval = krb5_cc_start_seq_get(context, cc, &kursor);
-	if (retval)
-		return retval;
-
-	for (i=0;; i++) {
-		krb5_free_cred_contents(context, &tgt);
-		retval = krb5_cc_next_cred(context, cc, &kursor, &tgt);
-		if (retval) {
-			if (retval != KRB5_CC_END)
-				return retval;
-			retval = krb5_cc_end_seq_get(context, cc, &kursor);
-			if (retval)
-				return retval;
-			return KRB5_CC_END;
-		}
-
-		/* tgt.client must be equal to creds.client */
-		if (!krb5_principal_compare(context,
-			tgt.client, creds->client))
-			continue;
-		if (!tgt.ticket.length)
-			continue;
-		if ((tgt.ticket_flags & kflags) != kflags)
-			continue;
-		if (tgt.times.endtime <= now)
-			continue;
-
-		break;
-	}
-
-	kdcoptions = flags2options(tgt.ticket_flags)|
-		KDC_OPT_FORWARDED;
-
-	retval = krb5_get_cred_via_tkt(context, &tgt, kdcoptions,
-		addrs, creds, pcreds);
-done:
-	krb5_free_cred_contents(context, &tgt);
-	return retval;
-}
-
-/**
- * @brief
- * 	Get a TGT for use at the remote host */
- *
- * @param[in] context - library context
- * @param[in] auth_context - authentication context
- * @param[in] client - principal to be copied
- * @param[in] server - principal to be copied
- * @param[in] cc     - credential cache handler
- * @param[out] outbuf - encoded credentials
- *
- * @return krb5_error_code
- * @retval 0 	Success
- * @retval krb5_error_code 	Failure
- *
- */
-krb5_error_code
-fwd_tgt_creds(krb5_context context, krb5_auth_context auth_context, krb5_principal client,
-		krb5_principal server, krb5_ccache cc,  krb5_data *outbuf)
-{
-	krb5_replay_data	replaydata;
-	krb5_data		*scratch = 0;
-	krb5_address		**addrs = 0;
-	krb5_error_code		retval;
-	krb5_creds		creds, tgt;
-	krb5_creds		*pcreds;
-	int			free_rhost = 0;
-	char			*rhost;
-
-	memset((char *)&creds, 0, sizeof(creds));
-	memset((char *)&tgt, 0, sizeof(creds));
-
-	if (krb5_princ_type(context, server) != KRB5_NT_SRV_HST)
-		return KRB5_FWD_BAD_PRINCIPAL;
-
-	if (krb5_princ_size(context, server) < 2)
-		return KRB5_CC_BADNAME;
-
-	rhost = malloc(server->data[1].length+1);
-	if (!rhost)
-		return ENOMEM;
-	free_rhost = 1;
-	memcpy(rhost, server->data[1].data, server->data[1].length);
-	rhost[server->data[1].length] = '\0';
-
-	retval = krb5_os_hostaddr(context, rhost, &addrs);
-	if (retval)
-		goto errout;
-
-	if ((retval = krb5_copy_principal(context, client, &creds.client)))
-		goto errout;
-
-	if ((retval = krb5_build_principal_ext(context, &creds.server,
-		client->realm.length,
-		client->realm.data,
-		KRB5_TGS_NAME_SIZE,
-		KRB5_TGS_NAME,
-		client->realm.length,
-		client->realm.data,
-		0)))
-		goto errout;
-
-	/* fetch tgt directly from cache */
-	retval = get_cred_from_cache(context, cc, &creds, addrs, &pcreds);
-
-	if (retval) {
-		goto errout;
-#if 0	/* don't prompt for password */
-		krb5_get_init_creds_opt		options;
-		int				i;
-
-		com_err(__func__, retval, ": get_cred_from_cache");
-
-		krb5_get_init_creds_opt_init(&options);
-		krb5_get_init_creds_opt_set_tkt_life(&options, TKTLIFE);
-		krb5_get_init_creds_opt_set_renew_life(&options, TKTLIFE);
-		krb5_get_init_creds_opt_set_forwardable(&options, 1);
-
-		clearerr(stdin);
-		for (i=0; i<3; i++) {
-			retval = krb5_get_init_creds_password(context, &tgt,
-				client, NULL, krb5_prompter_posix,
-				NULL, 0, NULL, &options);
-			if (retval == 0)
-				break;
-			com_err(__func__, retval, ": krb5_get_init_creds_password");
-		}
-		if (retval)
-			goto errout;
-
-		retval = krb5_cc_store_cred(context, cc, &tgt);
-		if (retval)
-			goto errout;
-
-		printf("credentials stored\n");
-		krb5_free_cred_contents(context, &tgt);
-
-		/* try again ... it should now work */
-		retval = get_cred_from_cache(context, cc, &creds,
-			addrs, &pcreds);
-		if (retval)
-			goto errout;
-#endif
-	}
-
-	retval = krb5_mk_1cred(context, auth_context, pcreds,
-		&scratch, &replaydata);
-	krb5_free_creds(context, pcreds);
-
-	if (retval) {
-		if (scratch)
-			krb5_free_data(context, scratch);
-	}
-	else {
-		*outbuf = *scratch;
-		free(scratch);
-	}
-
-errout:
-	if (addrs)
-		krb5_free_addresses(context, addrs);
-	if (free_rhost)
-		free(rhost);
-	krb5_free_cred_contents(context, &creds);
-	return retval;
-}
-#endif	/* PBS_CRED_DCE_KRB5 */
-
-/**
- * @brief
- *	Get a kerberos ticket.
- * @param[in] remote - server name
- *
- * @return   Error code
- * @retval  -1  Failure
- * @retval   0  Success
- *
- */
-int
-get_krb5_ticket(char *remote)
-{
-	int			ret = -1;
-#ifdef	PBS_CRED_DCE_KRB5
-	krb5_error_code		err;
-	int			got_auth = 0;
-	char			server_name[512];
-	const char		*ccdefault;
-	krb5_context		ktext = 0;
-	krb5_auth_context	kauth = 0;
-	krb5_ccache		kache = 0;
-	krb5_principal		client = 0;
-	krb5_principal		server = 0;
-	krb5_data		forw_creds;
-	krb5_data		packet;
-
-	now = time(0) + 600;	/* current time + 10 mins */
-
-	memset(&forw_creds, 0, sizeof(forw_creds));
-	memset(&packet, 0, sizeof(packet));
-
-	if ((err = krb5_init_context(&ktext)) != 0) {
-		com_err(__func__, err, ": krb5_init_context");
-		return -1;
-	}
-
-	if ((err = krb5_auth_con_init(ktext, &kauth)) != 0) {
-		com_err(__func__, err, ": krb5_auth_con_init");
-		return -1;
-	}
-	got_auth = 1;
-
-	krb5_auth_con_setflags(ktext, kauth, KRB5_AUTH_CONTEXT_RET_TIME);
-
-	ccdefault = krb5_cc_default_name(ktext);
-	if ((err = krb5_cc_resolve(ktext, ccdefault, &kache)) != 0) {
-		com_err(__func__, err, ": krb5_cc_resolve");
-		goto done;
-	}
-
-	if ((err = krb5_cc_get_principal(ktext, kache, &client)) != 0) {
-		if (pbs_current_user == NULL) {
-			com_err(__func__, err, "(ticket cache %s)", ccdefault);
-			goto done;
-		}
-		if ((err = krb5_parse_name(ktext, pbs_current_user,
-			&client)) != 0) {
-			com_err(__func__, err, ": krb5_parse_name: %s",
-				pbs_current_user);
-			goto done;
-		}
-		if ((err = krb5_cc_initialize(ktext, kache, client)) != 0) {
-			com_err(__func__, err, ": krb5_cc_initialize");
-			goto done;
-		}
-	}
-
-	snprintf(server_name, sizeof(server_name), "host/%s@", remote);
-	strncat(server_name, client->realm.data, client->realm.length);
-	krb5_parse_name(ktext, server_name, &server);
-	server->type = KRB5_NT_SRV_HST;
-
-	if ((err = fwd_tgt_creds(ktext, kauth,
-		client, server, kache, &forw_creds)) != 0) {
-		com_err(__func__, err, ": fwd_tgt_creds");
-		goto done;
-	}
-
-	cred_len = forw_creds.length;
-	cred_buf = forw_creds.data;
-	cred_type = PBS_CREDTYPE_DCE_KRB5;
-	ret = 0;
-
-done:
-	if (forw_creds.data && cred_buf != forw_creds.data)
-		free(forw_creds.data);
-	if (client)
-		krb5_free_principal(ktext, client);
-	if (server)
-		krb5_free_principal(ktext, server);
-	if (got_auth)
-		krb5_auth_con_free(ktext, kauth);
-	krb5_free_context(ktext);
-	if (ret) {
-		fprintf(stderr, "qsub: could not get a forwardable, "
-			"renewable kerberos ticket\n"
-			"Try 'kinit -f -r 10d' to get one.\n");
-	}
-#else	/* PBS_CRED_DCE_KRB5 */
-	fprintf(stderr, "qsub: kerberos is not supported.\n");
-#endif	/* PBS_CRED_DCE_KRB5 */
-	return ret;
-}
-
-/**
- * @brief
- *	Get a grid proxy.
- *
- * @return   Error code
- * @retval  -1  Failure
- * @retval   0  Success
- *
- */
-int
-get_grid_proxy()
-{
-	int			ret = -1;
-#ifdef	PBS_CRED_GRIDPROXY
-	proxy_cred_desc		*pcd = NULL;
-	char			*proxy_file = NULL;
-	char			*subject;
-	char			*principal;
-	char			*type;
-	char			*sp, *pp;
-	int			cname = 0;
-	time_t			time_limit, time_now, time_diff;
-	ASN1_UTCTIME		*asn1_time = NULL;
-	int			keylen;
-	int			fd = -1;
-	struct stat		sbuf;
-
-	pcd = proxy_cred_desc_new();
-	if (pcd == NULL) {
-		fprintf(stderr, "%s: could not initialize\n", __func__);
-		goto done;
-	}
-	proxy_get_filenames(pcd, 1, NULL, NULL, &proxy_file, NULL, NULL);
-	if (proxy_file == NULL) {
-		fprintf(stderr, "%s: could not get proxy file name\n", __func__);
-		goto done;
-	}
-#ifdef NAS /* localmod 004 */
-	DBPRT((stderr, "%s: proxy file:\t%s\n", __func__, proxy_file))
-#else
-	DBPRT(("%s: proxy file:\t%s\n", __func__, proxy_file))
-#endif /* localmod 004 */
-
-	pcd->type=CRED_TYPE_PROXY;
-	if (proxy_load_user_cert(pcd, proxy_file, NULL, NULL)) {
-		fprintf(stderr, "%s: unable to load proxy\n", __func__);
-		goto done;
-	}
-	if ((pcd->upkey = X509_get_pubkey(pcd->ucert)) == NULL) {
-		fprintf(stderr,
-			"%s: unable to load public key from proxy\n", __func__);
-		goto done;
-	}
-	subject = X509_NAME_oneline(X509_get_subject_name(pcd->ucert),
-		NULL, 0);
-	principal = (char *)malloc(strlen(subject));
-	assert(principal != NULL);
-
-	for (sp=subject, pp=principal; *sp;) {
-		if (strncmp(sp, "/CN=", 4) == 0) {
-			if (cname == 0) {
-				cname++;
-				*pp++ = *sp++;
-				continue;
-			}
-
-			type = sp+4;
-			for (sp=type; *sp; sp++) {
-				if (*sp == '/') {
-					*sp++ = '\0';
-					*pp++ = '/';
-					break;
-				}
-			}
-			continue;
-		}
-
-		*pp++ = *sp++;
-	}
-	*pp = '\0';
-
-	asn1_time = ASN1_UTCTIME_new();
-	X509_gmtime_adj(asn1_time, 0);
-	time_now = ASN1_UTCTIME_mktime(asn1_time);
-	time_limit = ASN1_UTCTIME_mktime(X509_get_notAfter(pcd->ucert));
-	if (time_limit < time_now)
-		time_diff = 0;
-	else
-		time_diff = time_limit - time_now;
-
-	keylen = 8 * 8 * EVP_PKEY_size(pcd->upkey);
-
-#ifdef NAS /* localmod 004 */
-	DBPRT((stderr, "principal:\t%s\ntime:\t%ld\ntype:\t%s\nkeylen:\t%d\n",
-		principal, time_diff, type, keylen))
-#else
-	DBPRT(("principal:\t%s\ntime:\t%ld\ntype:\t%s\nkeylen:\t%d\n",
-		principal, time_diff, type, keylen))
-#endif /* localmod 004 */
-
-	set_attr(&attrib, ATTR_gridname, principal);
-	free(subject);
-	free(principal);
-
-	if (time_diff < 600) {		/* less than 10 minutes of life */
-		fprintf(stderr, "%s: proxy has %s life left\n", __func__,
-			time_diff == 0 ? "no" : "very little");
-		goto cleanup;
-	}
-
-	if ((fd = open(proxy_file, O_RDONLY)) == -1) {
-		perror(proxy_file);
-		goto cleanup;
-	}
-	if (fstat(fd, &sbuf) == -1) {
-		perror(proxy_file);
-		goto cleanup;
-	}
-
-	cred_len = sbuf.st_size;
-	cred_buf = malloc(cred_len);
-	assert(cred_buf != NULL);
-	if (read(fd, cred_buf, cred_len) != cred_len) {
-		fprintf(stderr, "%s: grid proxy read failed for %s\n",
-			__func__, proxy_file);
-		goto cleanup;
-	}
-	cred_type = PBS_CREDTYPE_GRIDPROXY;
-	ret = 0;
-
-cleanup:
-	proxy_cred_desc_free(pcd);
-	if (proxy_file)
-		free(proxy_file);
-	if (fd != -1)
-		close(fd);
-
-done:
-	if (ret) {
-		fprintf(stderr, "qsub: could not get grid proxy\n"
-			"Try 'grid-proxy-init -hours 200' to get one\n");
-	}
-#else	/* PBS_CRED_GRIDPROXY */
-	fprintf(stderr, "qsub: grid proxy is not supported.\n");
-#endif	/* PBS_CRED_GRIDPROXY */
-	return ret;
-}
-/**
- * @brief
- *	gets the des password and encrypts
- *
- * @return int
- * @retval 0  Success
- *a@retval -1 Failure
- *
- */
-int
-get_passwd()
-{
-	int	ret = -1;
-#if	defined(PBS_PASS_CREDENTIALS)
-	int	err;
-	int	i;
-	char	passwdbuf[256];
-
-	for (i=0; i<3; i++) {
-		err = EVP_read_pw_string(passwdbuf, strlen(passwdbuf),
-			"Enter job's password: ", 1);
-		if (err == 0) {
-			ret = 0;
-			break;
-		}
-	}
-	if (err == 0) {
-		pbs_encrypt_pwd(passwdbuf, &cred_type, &cred_buf, &cred_len);
-		ret = 0;
-	}
-	if (ret)
-		fprintf(stderr, "qsub: could not get password\n");
-#else
-	fprintf(stderr, "qsub: DES is not supported.\n");
-#endif
-	return ret;
-}
-
-/**
- * @brief
- *  	This function processes all the options specified while submitting a job. It
- *  	validates all these options and sets their corresponding flags.
- *
- * @param[in] argc  Number of options present in argv.
- * @param[in] argv  An array containing all the options and their values.
- * @param[in] passet The value that will be used to set the options. It can have
- *                   value as CMDLINE (for command line options), CMDLINE-1 (for
- *                   job script options), CMDLINE-2 (server default options).
- *
- * @return int - It returns number of erroneous options processed.
- *
- */
-int
-process_opts(int argc, char **argv, int passet)
-{
-	int i;
-	int c;
-	char *erp;
-	int errflg = 0;
-	time_t after;
-	char a_value[512];
-	char *keyword;
-	char *valuewd;
-	char *pc;
-	struct attrl *pattr = NULL;
-	int N_len = 0;
-#ifdef WIN32
-	struct attrl *ap = NULL;
-	short int nSizeofHostName = 0;
-	char *orig_apvalue = NULL;
-	char *temp_apvalue = NULL;
-#endif
-	int ddash_index = -1;
-
-#ifdef WIN32
-#define GETOPT_ARGS_ORIG "a:A:c:C:e:fGhIj:J:k:l:m:M:N:o:p:q:r:R:S:u:v:VW:zP:"
-#else
-#if !defined(PBS_NO_POSIX_VIOLATION)
-#define GETOPT_ARGS_ORIG "a:A:c:C:e:fhIj:J:k:l:m:M:N:o:p:q:r:R:S:u:v:VW:XzP:"
-#else
-#define GETOPT_ARGS_ORIG "a:A:c:C:e:fhj:J:k:l:m:M:N:o:p:q:r:R:S:u:v:VW:zP:"
-#endif    /* PBS_NO_POSIX_VIOLATION */
-#endif	  /* WIN32 */
-
-#ifdef	PBS_GNU_GETOPTS
-#define	GETOPT_ARGS "+"GETOPT_ARGS_ORIG
-#else
-#define	GETOPT_ARGS GETOPT_ARGS_ORIG
-#endif	/* PBS_GNU_GETOPTS */
-
-	/* The following macro, together the value of passet is used	*/
-	/* to enforce the following rules: 1. option on the command line take	*/
-	/* precedence over those in script directives.   2. With in the command	*/
-	/* line or within the script, the last occurance of an option takes	*/
-	/* precedence over the earlier occurance.				*/
-
-	/*
-	 ** The passet value is saved in the opt register.  The option will
-	 ** only be set if the value of passet is greater then or equal to the
-	 ** opt regiester.
-	 */
-#define if_cmd_line(x) if (x <= passet)
-
-	if (passet != CMDLINE) {
-#if defined(linux) || defined(WIN32)
-		optind = 0;  /* prime getopt's starting point */
-#else
-		optind = 1;  /* prime getopt's starting point */
-#endif
-	}
-	while ((c = getopt(argc, argv, GETOPT_ARGS)) != EOF) {
-		/*
-		 * qsub uses "--" to specify the executable to run for a job,
-		 * so, if "--" is used as a value, we need to make sure that
-		 * there is another "--" for providing the executable name (if any).
-		 */
-		if (optarg && (strcmp(optarg, "--") == 0)) {
-			ddash_index = optind - 1;
-		}
-		switch (c) {
-			case 'a':
-				if_cmd_line(a_opt) {
-					a_opt = passet;
-					if ((after = cvtdate(optarg)) < 0) {
-						fprintf(stderr, "qsub: illegal -a value\n");
-						errflg++;
-						break;
-					}
-					sprintf(a_value, "%ld", (long)after);
-					set_attr(&attrib, ATTR_a, a_value);
-				}
-				break;
-			case 'A':
-				if_cmd_line(A_opt) {
-					A_opt = passet;
-					set_attr(&attrib, ATTR_A, optarg);
-				}
-				break;
-			case 'P':
-				if_cmd_line(P_opt) {
-					P_opt = passet;
-					set_attr(&attrib, ATTR_project, optarg);
-				}
-				break;
-			case 'c':
-				if_cmd_line(c_opt) {
-					c_opt = passet;
-					while (isspace((int)*optarg)) optarg++;
-					pc = optarg;
-					if (strlen(optarg) == 1) {
-						if (*pc == 'u') {
-							fprintf(stderr, "qsub: illegal -c value\n");
-							errflg++;
-							break;
-						}
-					}
-					set_attr(&attrib, ATTR_c, optarg);
-				}
-				break;
-			case 'C':
-				if_cmd_line(C_opt) {
-					C_opt = passet;
-					strcpy(dir_prefix, optarg);
-				}
-				break;
-			case 'e':
-				if_cmd_line(e_opt) {
-					e_opt = passet;
-					set_attr(&attrib, ATTR_e, optarg);
-				}
-				break;
-			case 'h':
-				if_cmd_line(h_opt) {
-					h_opt = passet;
-					set_attr(&attrib, ATTR_h, "u");
-				}
-				break;
-			case 'f':
-				no_background = 1;
-				break;
-#if !defined(PBS_NO_POSIX_VIOLATION)
-			case 'I':
-				if (J_opt != 0) {
-					fprintf(stderr, "%s", interarray);
-					errflg++;
-					break;
-				}
-				if_cmd_line(Interact_opt) {
-					Interact_opt = passet;
-					if (block_opt != FALSE) {
-						fprintf(stderr, "%s", interblock_warn);
-						block_opt = FALSE;
-					}
-					if (roptarg_inter == TRUE) {
-						fprintf(stderr, "%s", reruninteract);
-					}
-					set_attr(&attrib, ATTR_inter, interactive_port());
-				}
-				break;
-#endif	/* PBS_NO_POSIX_VIOLATION */
-			case 'j':
-				if_cmd_line(j_opt) {
-					j_opt = passet;
-					set_attr(&attrib, ATTR_j, optarg);
-				}
-				break;
-			case 'J':
-				if (Interact_opt != FALSE) {
-					fprintf(stderr, "%s", interarray);
-					errflg++;
-					break;
-				}
-				if (roptarg != 'y') {
-					fprintf(stderr, "%s", norerunarray);
-					errflg++;
-					break;
-				}
-				if_cmd_line(J_opt) {
-					J_opt = passet;
-					set_attr(&attrib, ATTR_J, optarg);
-				}
-				break;
-			case 'k':
-				if_cmd_line(k_opt) {
-					k_opt = passet;
-					set_attr(&attrib, ATTR_k, optarg);
-				}
-				break;
-			case 'l':
-				l_opt = passet;
-				if ((i=set_resources(&attrib, optarg, (passet==CMDLINE), &erp))) {
-					if (i > 1) {
-						pbs_prt_parse_err("qsub: illegal -l value\n", optarg,
-							(int)(erp-optarg), i);
-					} else
-						fprintf(stderr, "qsub: illegal -l value\n");
-					errflg++;
-				}
-				break;
-			case 'm':
-				if_cmd_line(m_opt) {
-					m_opt = passet;
-					while (isspace((int)*optarg)) optarg++;
-					set_attr(&attrib, ATTR_m, optarg);
-				}
-				break;
-			case 'M':
-				if_cmd_line(M_opt) {
-					M_opt = passet;
-					set_attr(&attrib, ATTR_M, optarg);
-				}
-				break;
-			case 'N':
-				if_cmd_line(N_opt) {
-					N_opt = passet;
-					/* If ATTR_N is not set previously */
-					if (get_attr(attrib, ATTR_N, NULL) == NULL) {
-						set_attr(&attrib, ATTR_N, optarg);
-					}
-					/* If N_opt is not set previously but if ATTR_N is set
-					 * earlier directly without verification based on the
-					 * job script name and if there is a value for ATTR_N
-					 * after parsing the job script for PBS directives
-					 * replace the earlier value with the current value
-					 * for this attribute
-					 */
-					else {
-						for (pattr = attrib; pattr; pattr = pattr->next) {
-							if (strcmp(pattr->name, ATTR_N) == 0) {
-								N_len = strlen(optarg);
-								if (strlen(pattr->value) < N_len) {
-									pattr->value = (char *) realloc(pattr->value, N_len + 1);
-									if (pattr->value == NULL) {
-										fprintf(stderr, "Out of memory\n");
-										exit(2);
-									}
-								}
-								pattr->value[N_len] = '\0';
-								strncpy(pattr->value, optarg, N_len);
-							}
-						}
-					}
-				}
-				break;
-			case 'o':
-				if_cmd_line(o_opt) {
-					o_opt = passet;
-					set_attr(&attrib, ATTR_o, optarg);
-				}
-				break;
-			case 'p':
-				if_cmd_line(p_opt) {
-					p_opt = passet;
-					while (isspace((int)*optarg)) optarg++;
-					set_attr(&attrib, ATTR_p, optarg);
-				}
-				break;
-			case 'q':
-				if_cmd_line(q_opt) {
-					q_opt = passet;
-					strcpy(destination, optarg);
-				}
-				break;
-			case 'r':
-				if_cmd_line(r_opt) {
-					r_opt = passet;
-					if (strlen(optarg) != 1) {
-						fprintf(stderr, "qsub: illegal -r value\n");
-						errflg++;
-						break;
-					}
-					if (*optarg != 'y' && *optarg != 'n') {
-						fprintf(stderr, "qsub: illegal -r value\n");
-						errflg++;
-						break;
-					} else if ((*optarg == 'n') && (J_opt != 0)) {
-						fprintf(stderr, "%s", norerunarray);
-						errflg++;
-						break;
-
-					}
-					if ((*optarg=='y')) {
-						roptarg_inter=TRUE;
-						if (Interact_opt) {
-							fprintf(stderr, "%s", reruninteract);
-						}
-					}
-					roptarg = *optarg;
-					set_attr(&attrib, ATTR_r, optarg);
-				}
-				break;
-			case 'R':
-				if_cmd_line(R_opt) {
-					R_opt = passet;
-					set_attr(&attrib, ATTR_R, optarg);
-				}
-				break;
-			case 'S':
-				if_cmd_line(S_opt) {
-					S_opt = passet;
-					set_attr(&attrib, ATTR_S, optarg);
-				}
-				break;
-			case 'u':
-				if_cmd_line(u_opt) {
-					u_opt = passet;
-					set_attr(&attrib, ATTR_u, optarg);
-				}
-				break;
-			case 'v':
-				if_cmd_line(v_opt) {
-					v_opt = passet;
-					if (v_value != NULL)
-						free(v_value);
-#ifdef	WIN32
-					/*
-					 * Need to change '\' to '/' before expanding the
-					 * environment because '\' is used to protect commas
-					 * inside quoted values.
-					 */
-					back2forward_slash(optarg);
-#endif
-					v_value = expand_varlist(optarg);
-					if (v_value == NULL) {
-						exit(1);
-					}
-				}
-				break;
-			case 'V':
-				if_cmd_line(V_opt) {
-					V_opt = passet;
-				}
-				break;
-			case 'W':
-				while (isspace((int)*optarg)) optarg++;
-				if (strlen(optarg) == 0) {
-					fprintf(stderr, "%s", badw);
-					errflg++;
-					break;
-				}
-#ifdef WIN32
-				back2forward_slash2(optarg);
-#endif
-				i = parse_equal_string(optarg, &keyword, &valuewd);
-
-#if	defined(PBS_PASS_CREDENTIALS)
-				/*
-				 * Exceptional CASE: All the arguments to option 'W' are
-				 * accepted in the format of -Wattrname=value but in case
-				 * of ATTR_pwd, -Wattrname is accepted without any value.
-				 *
-				 * if parse_equal_string() returns -1 and the optarg is
-				 * is same as ATTR_pwd, then set i = 1, keyword to optarg
-				 * and valuewd to NULL.
-				 */
-				if ((i == -1) && (strcmp(optarg, ATTR_pwd) == 0)) {
-					i = 1;
-					keyword = optarg;
-					valuewd = NULL;
-				}
-#endif
-
-				while (i == 1) {
-					if (strcmp(keyword, ATTR_depend) == 0) {
-						if_cmd_line(Depend_opt) {
-							Depend_opt = passet;
-							set_attr(&attrib, ATTR_depend, valuewd);
-						}
-					} else if (strcmp(keyword, ATTR_stagein) == 0) {
-						if_cmd_line(Stagein_opt) {
-							Stagein_opt = passet;
-							set_attr(&attrib, ATTR_stagein, valuewd);
-						}
-					} else if (strcmp(keyword, ATTR_stageout) == 0) {
-						if_cmd_line(Stageout_opt) {
-							Stageout_opt = passet;
-							set_attr(&attrib, ATTR_stageout, valuewd);
-						}
-					} else if (strcmp(keyword, ATTR_sandbox) == 0) {
-						if_cmd_line(Sandbox_opt) {
-							Sandbox_opt = passet;
-							set_attr(&attrib, ATTR_sandbox, valuewd);
-						}
-					} else if (strcmp(keyword, ATTR_g) == 0) {
-						if_cmd_line(Grouplist_opt) {
-							Grouplist_opt = passet;
-							set_attr(&attrib, ATTR_g, valuewd);
-						}
-					} else if (strcmp(keyword, ATTR_inter) == 0) {
-						if_cmd_line(Interact_opt) {
-							if (J_opt != 0) {
-								fprintf(stderr, "%s", interarray);
-								errflg++;
-								break;
-							}
-							/*
-							 * SPID 232472: can't set interactive attribute to false
-							 * Problem: "qsub -W interactive=false" throws an error
-							 * Cause: There should be check to compare the user value
-							 *   with "false" string and accordingly decide whether it
-							 *   is an interactive job or not.
-							 * Solution: Added additional checks which will not set
-							 *   Interact_opt and will not call set_attr() to create
-							 *   interactive port if user gives a value "false"
-							 */
-							if (!(strcasecmp(valuewd, "true"))) {
-								Interact_opt = passet;
-								set_attr(&attrib, ATTR_inter, interactive_port());
-							} else if (!(strcasecmp(valuewd, "false"))) {
-								/* Do Nothing, let it run as a non-interactive job */
-							} else {
-								/* Any value other than true/false is not acceptable */
-								fprintf(stderr, "%s", badw);
-								errflg++;
-								break;
-							}
-							if (roptarg_inter == TRUE) {
-								fprintf(stderr, "%s", reruninteract);
-							}
-							/* check if both block and interactive are true */
-							if ((block_opt != FALSE) && (Interact_opt)) {
-								fprintf(stderr, "%s", interblock_warn);
-								block_opt = FALSE;
-								break;
-							}
-						}
-					} else if (strcmp(keyword, ATTR_block) == 0) {
-						if_cmd_line(block_opt) {
-							if (!(strcasecmp(valuewd, "true"))) {
-								block_opt = passet;
-							} else if (!(strcasecmp(valuewd, "false"))) {
-								/* Do Nothing, Let it run as a non-blocking job */
-							} else {
-								/* Any value other than true/false is not acceptable */
-								fprintf(stderr, "%s", badw);
-								errflg++;
-								break;
-							}
-							if ((Interact_opt != FALSE) && (block_opt == passet)) {
-								fprintf(stderr, "%s", interblock_warn);
-								block_opt = FALSE;
-								break;
-							}
-						}
-					} else if (strcmp(keyword, ATTR_resv_start) == 0) {
-						if_cmd_line(Resvstart_opt) {
-							Resvstart_opt = passet;
-							if ((after = cvtdate(valuewd)) < 0) {
-								fprintf(stderr, "%s", badw);
-								errflg++;
-								break;
-							}
-							sprintf(a_value, "%ld", (long)after);
-							set_attr(&attrib, ATTR_resv_start, a_value);
-						}
-					} else if (strcmp(keyword, ATTR_resv_end) == 0) {
-						if_cmd_line(Resvend_opt) {
-							Resvend_opt = passet;
-							if ((after = cvtdate(valuewd)) < 0) {
-								fprintf(stderr, "%s", badw);
-								errflg++;
-								break;
-							}
-							sprintf(a_value, "%ld", (long)after);
-							set_attr(&attrib, ATTR_resv_end, a_value);
-						}
-#if	defined(PBS_PASS_CREDENTIALS)
-					} else if (strcmp(keyword, ATTR_pwd) == 0) {
-						if_cmd_line(pwd_opt) {
-							pwd_opt = passet;
-							if (valuewd == NULL || *valuewd == '\0') {
-								int err = 1;
-
-								while (err) {
-									err = EVP_read_pw_string(passwd_buf,
-										sizeof(passwd_buf),
-										"Enter job's password: ", 1);
-								}
-							} else {
-								/*
-								 * Entering password in the qsub command line in
-								 * clear text is a security hole, not supported.
-								 */
-								fprintf(stderr, "%s", badw);
-								errflg++;
-								break;
-							}
-						}
-#endif
-					} else if (strcmp(keyword, ATTR_cred) == 0) {
-						if_cmd_line(cred_opt) {
-							cred_opt = passet;
-							strcpy(cred_name, valuewd);
-							set_attr(&attrib, ATTR_cred, valuewd);
-						}
-					} else {
-						set_attr(&attrib, keyword, valuewd);
-					}
-					i = parse_equal_string(NULL, &keyword, &valuewd);
-				}   /* bottom of long while loop */
-				if (i == -1) {
-					fprintf(stderr, "%s", badw);
-					errflg++;
-				}
-				break;
-
-			case 'X':
-				if_cmd_line(Forwardx11_opt) {
-					Forwardx11_opt = passet;
-#if !defined(PBS_NO_POSIX_VIOLATION) && !defined(WIN32)
-					if (!(display = getenv("DISPLAY"))) {
-						fprintf(stderr, "qsub: DISPLAY not set\n");
-						errflg++;
-					}
-#endif
-				}
-				break;
-#ifdef WIN32
-			case 'G':
-				if_cmd_line(gui_opt) {
-					gui_opt = passet;
-					set_attr(&attrib, ATTR_GUI, "TRUE");
-				}
-				break;
-#endif
-			case 'z':
-				if_cmd_line(z_opt) z_opt = passet;
-				break;
-			case '?':
-			default :
-				errflg++;
-		}
-	}
-	if ((block_opt == passet) && (Interact_opt == FALSE))
-		set_attr(&attrib, ATTR_block, block_port());
-	if ((Forwardx11_opt == CMDLINE) && (Interact_opt == FALSE)
-		&& (errflg == 0)) {
-		fprintf(stderr, "qsub: X11 Forwarding possible only for "
-			"interactive jobs\n");
-		exit_qsub(1);
-	}
-#ifdef WIN32
-	if ((gui_opt == CMDLINE) && (Interact_opt == FALSE)) {
-		fprintf(stderr, intergui_warn);
-		gui_opt = FALSE;
-		exit_qsub(1);
-	}
-#endif
-
-	if (errflg == 0 && J_opt == 0 && get_attr(attrib, ATTR_m, NULL) != NULL &&
-		strchr(get_attr(attrib, ATTR_m, NULL), 'j') != NULL) {
-		fprintf(stderr, "qsub: mail option 'j' can not be used without array job\n");
-		exit_qsub(1);
-	}
-
-	/*
-	 * If argv[optind] points to '--' string, then
-	 * decrement optind, so that it would always point
-	 * to first non-command line option.
-	 * And also confirm if "--" was consumed by getopt
-	 * and not used as an argument value.
-	 * If used as an argument value, we cannot use it as
-	 * an indicator that an executable name follows the "--".
-	 */
-	if (strcmp(argv[optind - 1], "--") == 0) {
-		if (ddash_index != optind - 1) {
-			optind--;
-		} else {
-			errflg++;
-		}
-	}
-
-	if ((optind != 0) && (argc > 1) && (argv[optind] != NULL)) {
-		/* Now, optind is pointing to first non-command line option */
-		char *s = argv[optind];
-		if ((s[0] == '-') && (s[1] == '-') && (s[2] == '\0')) {
-			/* optind points to '--', it should not be last character */
-			if (optind == (argc - 1))
-				errflg++;
-		} else {
-			/* optind points to 'script-file path' */
-			/* It should be a last argument in command-line options */
-			if (optind != (argc -1))
-				errflg++;
-		}
-	}
-	if (!errflg && passet != CMDLINE) {
-		errflg = (optind != argc);
-	}
-	/* use PBS_SHELL if specified only if -S was not specified */
-	if (S_opt == FALSE) {
-		char* c = getenv("PBS_SHELL");
-		if (c)
-			set_attr(&attrib, ATTR_S, c);
-	}
-
-	if (u_opt && cred_name[0]) {
-		fprintf(stderr, "qsub: credential incompatable with -u\n");
-		errflg++;
-	}
-	return (errflg);
-}
-
-/**
- * @brief
- * 	processes and creates arguments passed for qsub
- *
- * @param[in] argc - argument count
- * @param[in] argv - pointer to array of argument variables
- * @param[in] line - charcter pointer for whole line
- *
- */
-void
-make_argv(int *argc, char *argv[], char *line)
-{
-	char *l, *b, *c;
-	char buffer[4096];
-	int len;
-	char quote;
-	int  i;
-
-	*argc = 0;
-	argv[(*argc)++] = "qsub";
-	l = line;
-	b = buffer;
-	while (isspace(*l)) l++;
-	c = l;
-	while (*c != '\0') {
-		if ((*c == '"') || (*c == '\'')) {
-			quote = *c;
-			c++;
-			while ((*c != quote) && *c)
-				*b++ = *c++;
-			if (*c == '\0') {
-				fprintf(stderr, "qsub: unmatched %c\n", *c);
-				exit_qsub(1);
-			}
-			c++;
-		} else if (*c == ESC_CHAR) {
-			c++;
-			*b++ = *c++;
-		} else if (isspace(*c)) {
-			len = c - l;
-			if (argv[*argc] != NULL) free(argv[*argc]);
-			argv[*argc] = (char *) malloc(len + 1);
-			if (argv[*argc] == NULL) {
-				fprintf(stderr, "qsub: out of memory\n");
-				exit_qsub(2);
-			}
-			*b = '\0';
-			strcpy(argv[(*argc)++], buffer);
-			while (isspace(*c)) c++;
-			l = c;
-			b = buffer;
-		} else
-			*b++ = *c++;
-	}
-	if (c != l) {
-		len = c - l;
-		if (argv[*argc] != NULL) free(argv[*argc]);
-		argv[*argc] = (char *) malloc(len + 1);
-		if (argv[*argc] == NULL) {
-			fprintf(stderr, "qsub: out of memory\n");
-			exit_qsub(2);
-		}
-		*b = '\0';
-		strcpy(argv[(*argc)++], buffer);
-	}
-	i = *argc;
-	/* free and null any pointers used for the prior call that are not used  */
-	/* for this line.  Otherwise the argv array would not be null terminated */
-	while (argv[i] != NULL) {
-		free(argv[i]);
-		argv[i++] = NULL;
-	}
-}
-
-/**
- * @brief
- *      Create and process qsub argument list from the string 'opts'
- *
- * @param[in]	opts     - The qsub options as single parameter.
- * @param[in]   opt_pass - priority set based on precedence.
+ * @param[in]	s - pointer to the windows PIPE or Unix domain socket
  *
  * @return      int
- * @retval	>0 - Failure - Other than PBS directive error.
- * @retval      -1 - Failure - PBS directive error.
+ * @retval	-1 - Failure
  * @retval	 0 - Success
  *
  */
-int
-do_dir(char *opts, int opt_pass, char *retmsg, int ret_size)
+static int
+send_opts(void *s)
 {
-	int argc;
-	int ret = -1;
-	int index = 0;
-	int len = 0;
-	int nxt_pos = 0;
-	int max_size = ret_size - 2 /* 2 deducted for adding newline at end */;
-#define MAX_ARGV_LEN 128
-	static char *vect[MAX_ARGV_LEN+1];
+	/*
+	 * we are allocating a fixed size of 100. This is because we know that
+	 * the list of opts to send is going to fit within 100. Specifically, for each
+	 * opt we need 2 characters, and currently we have 35 opts.
+	 * If a new set of opts are added, the buffer space of 100 allocated here
+	 * needs to be double checked.
+	 */
+	if (resize_buffer(0, 100) != 0)
+		return -1;
 
-	make_argv(&argc, vect, opts);
-	ret = process_opts(argc, vect, opt_pass);
-	if ((ret != 0) && (opt_pass != CMDLINE)) {
-		nxt_pos = snprintf(retmsg, max_size, "qsub: directive error: ");
-		if (nxt_pos < 0) {
-			return (ret);
-		}
-		max_size = max_size - nxt_pos;
-		for (index = 1; index<argc; index++) {
-			/* +1 is added to strlen(vect[index]) to reserve space */
-			if ((max_size > 0) && (max_size > strlen(vect[index]) + 1)) {
-				len = snprintf(retmsg + nxt_pos, max_size, "%s ", vect[index]);
-				if (len < 0) {
-					break;
-				}
-				nxt_pos = nxt_pos + len;
-				max_size = max_size - len;
-			} else {
-				break;
-			}
-		}
-		snprintf(retmsg + nxt_pos, 2, "\n");
-		return (-1);
-	}
-	return (ret);
+	sprintf(buf,
+		"%d %d %d %d %d %d %d %d %d %d "
+		"%d %d %d %d %d %d %d %d %d %d "
+		"%d %d %d %d %d %d %d %d %d %d "
+		"%d %d %d %d %d ",
+		a_opt, c_opt, e_opt, h_opt, j_opt,
+		k_opt, l_opt, m_opt, o_opt, p_opt,
+		q_opt, r_opt, u_opt, v_opt, z_opt,
+		A_opt, C_opt, J_opt, M_opt, N_opt,
+		S_opt, V_opt, Depend_opt, Interact_opt, Stagein_opt,
+		Stageout_opt, Sandbox_opt, Grouplist_opt, Resvstart_opt,
+		Resvend_opt, pwd_opt, cred_opt, block_opt, P_opt,
+					relnodes_on_stageout_opt);
+
+	return (send_string(s, buf));
 }
-
 
 /**
  * @brief
- *      Create a temporary file that will house the job script
+ *	Recv the cmd opt values for each parameter supported by qsub from the
+ *	foreground qsub process.
  *
- * @param[in]	file	- Input file pointer
- * @param[out]  script	- Temp file location
- * @param[in]   prefix	- Prefix for PBS directives
+ * @param[in]	s - pointer to the windows PIPE or Unix domain socket
  *
  * @return      int
- * @retval	-1 - Error processing qsub parameters
- * @retval      3 - Error writing script file
- * @retval      4 - Temp file creation failure
- * @retval      5 - Error reading input file
- * @retval      6 - Unexpected EOF on read
+ * @retval	-1 - Failure
+ * @retval	 0 - Success
+ *
  */
-int
-get_script(FILE *file, char *script, char *prefix)
+static int
+recv_opts(void *s)
 {
-	char s[MAX_LINE_LEN+1];
-	char *sopt;
-	int err  = 0;
-	int exec = FALSE;
-	char *cont;
-	char tmp_name[MAXPATHLEN+1];
-	FILE *TMP_FILE;
-	char *in;
-#ifndef WIN32
-	int fds;
-#endif
-	static char tmp_template[] = "pbsscrptXXXXXX";
-
 	/*
-	 * Note: Need to populate script variable as soon as temp file is created so it
-	 * gets cleaned up in case of an error.
+	 * we are allocating a fixed size of 100. This is because we know that
+	 * the list of opts to send is going to fit within 100. Specifically, for each
+	 * opt we need 2 characters, and currently we have 35 opts.
+	 * If a new set of opts are added, the buffer space of 100 allocated here
+	 * needs to be double checked.
 	 */
+	if (resize_buffer(0, 100) != 0)
+		return -1;
 
-#ifdef WIN32
+	if (recv_string(s, buf) != 0)
+		return -1;
 
-	_snprintf(tmp_name, MAXPATHLEN, "%s\\%s", tmpdir, tmp_template);
-	if ((in = _mktemp(tmp_name)) != NULL) {
-		strcpy(script, tmp_name);
-		if ((TMP_FILE = fopen(in, "w+")) == NULL)
-			err = 1;
-	} else {
-		err = 1;
-	}
-
-#else	/* not windows */
-
-	snprintf(tmp_name, MAXPATHLEN, "%s/%s", tmpdir, tmp_template);
-	fds = mkstemp(tmp_name);	/* returns file descriptor */
-	if (fds != -1) {
-		strcpy(script, tmp_name);
-		if ((TMP_FILE = fdopen(fds, "w+")) == NULL)
-			err = 1;
-	} else {
-		err = 1;
-	}
-
-#endif	/* end windows */
-
-	if (err != 0) {
-		perror("mkstemp");
-		fprintf(stderr, "qsub: could not create/open tmp file %s for script\n", tmp_name);
-		return (4);
-	}
-
-	s[0] = '\0';
-	while ((in = fgets(s, MAX_LINE_LEN, file)) != NULL) {
-		if (!exec && ((sopt = pbs_ispbsdir(s, prefix)) != NULL)) {
-			while ((*(cont = in + strlen(in) - 2) == ESC_CHAR) &&
-				(*(cont+1) == '\n')) {
-				/* next line is continuation of this line */
-				*cont = '\0';	/* clear newline from our copy */
-				if (fputs(in, TMP_FILE) < 0) {
-					perror("fputs");
-					fprintf(stderr,
-						"qsub: error writing copy of script, %s\n", tmp_name);
-					fclose(TMP_FILE);
-					return (3);
-				}
-				in = cont;
-				if ((in = fgets(in, MAX_LINE_LEN-(in - s), file)) == NULL) {
-					perror("fgets");
-					fprintf(stderr, "qsub: unexpected end-of-file "
-						"or read error in script\n");
-					fclose(TMP_FILE);
-					return (6);
-				}
-			}
-			/*
-			 **	Setting options from the job script will not overwrite
-			 **	options set on the command line.  CMDLINE-1 means
-			 **	"one less than CMDLINE priority"
-			 */
-			if (do_dir(sopt, CMDLINE-1, retmsg, MAXPATHLEN) != 0) {
-				fprintf(stderr, "%s", retmsg);
-				return (-1);
-			}
-		} else if (!exec && pbs_isexecutable(s)) {
-			exec = TRUE;
-		}
-		if (fputs(in, TMP_FILE) < 0) {
-			perror("fputs");
-			fprintf(stderr, "qsub: error writing copy of script, %s\n",
-				tmp_name);
-			fclose(TMP_FILE);
-			return (3);
-		}
-	}
-
-#ifdef WIN32
-	if ((s[0] != '\0') && (s[strlen(s)-1] != '\n')) {
-		fputs("\n", TMP_FILE);
-		printf("qsub: added missing newline in job script.\n");
-	}
-#endif
-
-	if (fclose(TMP_FILE) != 0) {
-		perror(" qsub: copy of script to tmp failed on close");
-		return (5);
-	}
-	if (ferror(file)) {
-		fprintf(stderr, "qsub: error reading script file\n");
-		return (5);
-	}
-	return (0);
+	sscanf(buf,
+		"%d %d %d %d %d %d %d %d %d %d "
+		"%d %d %d %d %d %d %d %d %d %d "
+		"%d %d %d %d %d %d %d %d %d %d "
+		"%d %d %d %d %d ",
+		&a_opt, &c_opt, &e_opt, &h_opt, &j_opt,
+		&k_opt, &l_opt, &m_opt, &o_opt, &p_opt,
+		&q_opt, &r_opt, &u_opt, &v_opt, &z_opt,
+		&A_opt, &C_opt, &J_opt, &M_opt, &N_opt,
+		&S_opt, &V_opt, &Depend_opt, &Interact_opt, &Stagein_opt,
+		&Stageout_opt, &Sandbox_opt, &Grouplist_opt, &Resvstart_opt,
+		&Resvend_opt, &pwd_opt, &cred_opt, &block_opt, &P_opt,
+			&relnodes_on_stageout_opt);
+	return 0;
 }
-
-/**
- * @brief
- *      Copy an environment variable to a specified location
- *
- * @param[in]	dest	- The destination address
- * @param[in]   pv	- The source address
- * @param[in]   quote_flg - Whether quote characters should be escaped
- *
- * @return      char*
- * @retval	NULL - Failure
- * @retval      !NULL - Success - Pointer to pv parameter
- */
-char *
-copy_env_value(char *dest, /* destination  */
-	char *pv, /* value string */
-	int quote_flg) /* non-zero then assume single word (quoting on) */
-{
-	int   go = 1;
-	int   q_ch = 0;
-	int   is_func = 0;
-	char  *dest_full = dest;
-
-	while (*dest)
-		++dest;
-
-	is_func = ((*pv == '(') && (*(pv+1) == ')') && (*(pv+2) == ' ') && (*(pv+3) == '{'));
-
-	/*
-	 * Keep the list of special characters consistent with encode_arst_bs()
-	 * and parse_comma_string_bs().
-	 */
-
-	while (go && *pv) {
-		switch (*pv) {
-			case '"':
-			case '\'':
-				if (q_ch) {	/* local quoting is in progress */
-					if (q_ch == (int)*pv) {
-						q_ch = 0;	/* end quote */
-					} else {
-						*dest++ = ESC_CHAR;	/* escape quote */
-						*dest++ = *pv;
-					}
-				} else if (quote_flg) {	  /* global quoting is on */
-					*dest++ = ESC_CHAR;	  /* escape quote */
-					*dest++ = *pv;
-				} else {
-					q_ch = (int)*pv;  /* turn local quoting on */
-				}
-				break;
-
-			case ESC_CHAR:			/* backslash in value, escape it */
-				*dest++ = *pv;
-				if (*(pv+1) != ',') /* do not escape if ESC_CHAR already escapes */
-					*dest++ = *pv;
-				break;
-
-			case ',':
-				if (q_ch || quote_flg) {
-					*dest++ = ESC_CHAR;
-					*dest++ = *pv;
-				} else if (dest_full != dest && *(dest-1) == ESC_CHAR) { /* the comma is escaped, not finished yet */
-					*dest++ = *pv;
-				} else {
-					go = 0;		/* end of value string */
-				}
-				break;
-
-			case ';':
-				*dest++ = *pv;
-				if (is_func && (*(pv+1) == '\n'))
-					pv++;
-				break;
-
-			case '\n':
-				if (is_func) {
-					*dest++ = ';';
-					*dest++ = ' ';
-				} else {
-					*dest++ = *pv;
-				}
-				break;
-
-			default:
-				*dest++ = *pv;
-				break;
-		}
-		pv++;
-	}
-
-	*dest = '\0';
-	if (q_ch)
-		return NULL;	/* error-unterminated quote */
-	else
-		return (pv);
-}
-
-/**
- * @brief
- *	Constructs the basic comma-separated environment variables
- *	list string for a PBS job.
- *
- * @return	char *
- * @retval	NULL for failure.
- * @retval	A comma-separated list of environment variable=value entries.
- *
- */
-char *
-job_env_basic(void)
-{
-	char *job_env = NULL;
-	char *s = NULL;
-	char *c = NULL;
-	char *p = NULL;
-	char *env = NULL;
-#ifdef WIN32
-	OSVERSIONINFO     osInfo;
-#else
-	struct utsname uns;
-#endif
-	int len = 0;
-	char *getcwd();
-
-	/* Calculate how big to make the variable string. */
-	len = 0;
-	env = strdup_esc_commas(getenv("HOME"));
-	if (env != NULL) {len += strlen(env); free(env);}
-	env = strdup_esc_commas(getenv("LANG"));
-	if (env != NULL) {len += strlen(env); free(env);}
-	env = strdup_esc_commas(getenv("LOGNAME"));
-	if (env != NULL) {len += strlen(env); free(env);}
-	env = strdup_esc_commas(getenv("PATH"));
-	if (env != NULL) {len += strlen(env); free(env);}
-	env = strdup_esc_commas(getenv("MAIL"));
-	if (env != NULL) {len += strlen(env); free(env);}
-	env = strdup_esc_commas(getenv("SHELL"));
-	if (env != NULL) {len += strlen(env); free(env);}
-	env = strdup_esc_commas(getenv("TZ"));
-	if (env != NULL) {len += strlen(env); free(env);}
-	len += PBS_MAXHOSTNAME;
-	len += MAXPATHLEN;
-	len += len;     /* Double it for all the commas, etc. */
-
-	if ((job_env = (char *) malloc(len)) == NULL) {
-		fprintf(stderr, "malloc failure (errno %d)\n", errno);
-		return NULL;
-	} else
-		memset(job_env, 0, len);
-
-	/* Send the required variables with the job. */
-	c = strdup_esc_commas(getenv("HOME"));
-#ifdef WIN32
-	back2forward_slash(c);
-#endif
-	strcat(job_env, "PBS_O_HOME=");
-	if (c != NULL) {
-		strcat(job_env, c);
-		free(c);
-	}
-	else
-		strcat(job_env, "/");
-	c = strdup_esc_commas(getenv("LANG"));
-	if (c != NULL) {
-		strcat(job_env, ",PBS_O_LANG=");
-		strcat(job_env, c);
-		free(c);
-
-	}
-	c = strdup_esc_commas(getenv("LOGNAME"));
-	if (c != NULL) {
-		strcat(job_env, ",PBS_O_LOGNAME=");
-		strcat(job_env, c);
-		free(c);
-	}
-	c = strdup_esc_commas(getenv("PATH"));
-#ifdef WIN32
-	back2forward_slash(c);
-#endif
-	if (c != NULL) {
-		strcat(job_env, ",PBS_O_PATH=");
-		strcat(job_env, c);
-		free(c);
-	}
-	c = strdup_esc_commas(getenv("MAIL"));
-#ifdef WIN32
-	back2forward_slash(c);
-#endif
-	if (c != NULL) {
-		strcat(job_env, ",PBS_O_MAIL=");
-		strcat(job_env, c);
-		free(c);
-	}
-	c = strdup_esc_commas(getenv("SHELL"));
-#ifdef WIN32
-	back2forward_slash(c);
-#endif
-	if (c != NULL) {
-		strcat(job_env, ",PBS_O_SHELL=");
-		strcat(job_env, c);
-		free(c);
-	}
-
-	c = strdup_esc_commas(getenv("TZ"));
-	if (c != NULL) {
-		strcat(job_env, ",PBS_O_TZ=");
-		strcat(job_env, c);
-		free(c);
-	}
-
-	/*
-	 * Don't detect the hostname here because it utilizes network services
-	 * that slow everthing down. PBS_O_HOST is set in the daemon later on.
-	 */
-
-	/* get current working directory, use $PWD if available, it is more
-	 * NFS automounter "friendly".  But must double check that is right
-	 */
-	s = job_env + strlen(job_env);
-	strcat(job_env, ",PBS_O_WORKDIR=");
-	c = getenv("PWD");
-	if (c != NULL) {
-		struct stat statbuf;
-		dev_t	dev;
-		ino_t	ino;
-
-		if (stat(c, &statbuf) < 0) {
-			/* cannot stat, cannot trust it */
-			c = NULL;
-		} else {
-			dev = statbuf.st_dev;
-			ino = statbuf.st_ino;
-			if (stat(".", &statbuf) < 0) {
-				perror("qsub: cannot stat current directory: ");
-				return NULL;
-			}
-			/* compare against "." */
-			if ((dev != statbuf.st_dev) || (ino != statbuf.st_ino)) {
-				/* "." and $PWD is different, cannot trust it */
-				c = NULL;
-			}
-		}
-	}
-
-	if (c == NULL) {
-		p = c = job_env + strlen(job_env);
-		if (getcwd(c, MAXPATHLEN) == NULL) {
-			c = NULL;
-		}
-	} else
-		p = job_env + strlen(job_env);
-
-	if (c != NULL) {
-		char *c_escaped = NULL;
-
-		/* save current working dir for daemon */
-		strncpy(qsub_cwd, c, strlen(c));
-#ifdef WIN32
-		/* get UNC path (if available) if it is mapped drive */
-		get_uncpath(c);
-#endif
-		c_escaped = strdup_esc_commas(c);
-		if (c_escaped != NULL) {
-#ifdef WIN32
-			back2forward_slash(c_escaped);
-#endif
-			strncpy(p, c_escaped, strlen(c_escaped));
-			free(c_escaped);
-			c_escaped = NULL;
-		} else
-			*s = '\0';
-	} else
-		*s = '\0';
-
-#ifdef WIN32
-	osInfo.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-	if (GetVersionEx(&osInfo)) {
-		switch (osInfo.dwPlatformId) {
-			case 0:
-				strcat(job_env, ",PBS_O_SYSTEM=VER_PLATFORM_WIN32s");
-				break;
-			case 1:
-				strcat(job_env, ",PBS_O_SYSTEM=VER_PLATFORM_WIN32_WINDOWS");
-				break;
-			case 2:
-				strcat(job_env, ",PBS_O_SYSTEM=VER_PLATFORM_WIN32_NT");
-				break;
-		}
-#else
-	if (uname(&uns) != -1) {
-		strcat(job_env, ",PBS_O_SYSTEM=");
-		strcat(job_env, uns.sysname);
-#endif
-	} else {
-		perror("qsub: cannot get uname info:");
-		return NULL;
-	}
-
-	return (job_env);
-
-}
-
-
-/**
- * @brief
- *	Converts an array of environment variable=value strings,
- *	into a comma-separated variables list string that can be
- *	exported to a job.
- *
- * @par	 NOTE: Variables in the list beginning with "PBS_O" are ignored
- *	 as these will be preconstructed somewhere else.
- *
- * @param[in]	envp - aray of strings making up the current environment.
- *
- * @return      char *
- * @retval      NULL - Failure
- * @retval      A comma-separated list of environment variables and values.
- *		The returned string is malloc-ed so it must be freed later.
- */
-
-char *
-env_array_to_varlist(char **envp)
-{
-	char	**evp;
-	int	len;
-	char	*job_env = NULL;
-	char	*s;
-
-	if (envp == NULL) {
-		fprintf(stderr, "env_array_to_varlist: no envp array!\n");
-		return NULL;
-	}
-
-	evp = envp;
-	len = 0;
-	while (notNULL(*evp)) {
-		len += strlen(*evp);
-		evp++;
-	}
-	len += len;     /* Double it for all the commas, etc. */
-
-	if ((job_env = (char *) malloc(len)) == NULL) {
-		fprintf(stderr,
-			"env_array_to_varlist: malloc failure errno=%d", errno);
-		return NULL;
-	}
-
-	*job_env = '\0';
-
-	evp = envp;
-	while (notNULL(*evp)) {
-		s = *evp;
-		while ((*s != '=') && *s)
-			++s;
-		*s = '\0';
-		if (strncmp(*evp, pbs_o_env, sizeof(pbs_o_env)-1) != 0) {
-			/* do not add PBS_O_* env variables, as these are set by qsub */
-			strcat(job_env, ",");
-			strcat(job_env, *evp);
-			strcat(job_env, "=");
-#ifdef WIN32
-			back2forward_slash(s+1);
-#endif
-			(void)copy_env_value(job_env, s+1, 1);
-		}
-		*s = '=';
-		evp++;
-	}
-
-	return (job_env);
-}
-
-/**
- * @brief
- *	Adds to the global 'attrib' structure an entry:
- *
- *	"-v <basic_vlist>,<v_value>,<current_vlist>
- *	and this 'attrib' is something that will be passed onto a
- *	PBS job before submission.
- *
- * @param[in]	basic_vlist - the basic variables list string of job.
- * @param[in]	curent_envlist - the variables list
- *		string representing the environment where qsub was
- *		invoked.
- *
- * @return	boolean (int)
- * @retval	TRUE for success.
- * @retval	FALSE for failure.
- *
- */
-int
-set_job_env(char *basic_vlist, char *current_vlist)
-{
-	char *job_env;
-	int len;
-
-	char *s, *c, *env, l, *pc;
-
-	/* Calculate how big to make the variable string. */
-	len = 0;
-	if (v_opt) {
-		len += strlen(v_value);
-	}
-
-	if ((basic_vlist == NULL) || (basic_vlist[0] == '\0'))
-		return FALSE;
-
-	len += strlen(basic_vlist);
-
-	if (V_opt && (current_vlist != NULL) && (current_vlist[0] != '\0'))
-		len += strlen(current_vlist);
-
-	len += len;     /* Double it for all the commas, etc. */
-	if ((job_env = (char *) malloc(len)) == NULL) return FALSE;
-	*job_env = '\0';
-
-	strcpy(job_env, basic_vlist);
-
-	/* Send these variables with the job. */
-	/* POSIX requirement: If a variable is given without a value, supply the
-	 value from the environment. */
-	/* MY requirement:    There can be no white space in -v value. */
-	if (v_opt) {
-		c = v_value;
-		state1:         /* Initial state comes here */
-		switch (*c) {
-			case ',':
-			case '=':
-				return FALSE;
-			case '\0':
-				goto final;
-		}
-		s = c;
-		state2:         /* Variable name */
-		switch (*c) {
-			case ',':
-			case '\0':
-				goto state3;
-			case '=':
-				goto state4;
-			default:
-				c++;
-				goto state2;
-		}
-		state3:         /* No value - get it from qsub environment */
-
-		/* From state3, goes back to state1, using 'c' as input */
-		l = *c;
-		*c = '\0';
-		if (strncmp(s, pbs_o_env, sizeof(pbs_o_env)-1) != 0) {
-			/* do not add PBS_O_* env variables, as these are set by qsub */
-
-			env = getenv(s);
-			if (env == NULL) return FALSE;
-
-			strcat(job_env, ",");
-			strcat(job_env, s);
-			strcat(job_env, "=");
-#ifdef WIN32
-			back2forward_slash(env);
-#endif
-			if (copy_env_value(job_env, env, 1) == NULL)
-				return FALSE;
-		}
-
-		if (l == ',') c++;
-		goto state1;
-		state4:         /* Value specified */
-
-		/* From state4, goes back to state1, using 'c' as input */
-		*c++ = '\0';;
-
-#ifndef WIN32
-		if (v_opt && Forwardx11_opt) {
-			if (strcmp(s, "DISPLAY") == 0) {
-				x11_disp = TRUE;
-				return FALSE;
-			}
-		}
-#endif
-		pc = job_env + strlen(job_env);
-		(void)strcat(job_env, ",");
-		(void)strcat(job_env, s);
-		(void)strcat(job_env, "=");
-#ifdef WIN32
-		back2forward_slash(c);
-#endif
-		if ((c = copy_env_value(job_env, c, 0)) == NULL) return FALSE;
-
-		/* Have to undo here, since 'c' was incremented by copy_env_value */
-		if (strncmp(s, pbs_o_env, sizeof(pbs_o_env)-1) == 0) {
-			/* ignore PBS_O_ env variables as these are created by qsub */
-			*pc = '\0';
-		}
-
-		goto state1;
-	}
-
-final:
-
-	if (V_opt && (current_vlist != NULL) && (current_vlist[0] != '\0')) {
-		/* Send every environment variable with the job. */
-		strcat(job_env, current_vlist);
-	}
-
-	set_attr(&attrib, ATTR_v, job_env);
-	free(job_env);
-
-	return TRUE;
-}
-
-/*
- * @brief
- *	set_opt_defaults - if not already set, set certain job attributes to
- *	their default value
- *
- */
-void
-set_opt_defaults()
-{
-	if (c_opt == FALSE)
-		set_attr(&attrib, ATTR_c, CHECKPOINT_UNSPECIFIED);
-	if (h_opt == FALSE)
-		set_attr(&attrib, ATTR_h, NO_HOLD);
-	if (j_opt == FALSE)
-		set_attr(&attrib, ATTR_j, NO_JOIN);
-	if (k_opt == FALSE)
-		set_attr(&attrib, ATTR_k, NO_KEEP);
-	if (m_opt == FALSE)
-		set_attr(&attrib, ATTR_m, MAIL_AT_ABORT);
-	if (p_opt == FALSE)
-		set_attr(&attrib, ATTR_p, "0");
-	if (r_opt == FALSE)
-		set_attr(&attrib, ATTR_r, "TRUE");
-}
-
-/**
- * @brief
- *	prints the usage format for qsub
- *
- */
-static void
-print_usage()
-{
-#ifdef WIN32
-	static char usag2[]="       qsub --version\n";
-	static char usage[]=
-		"usage: qsub [-a date_time] [-A account_string] [-c interval]\n"
-	"\t[-C directive_prefix] [-e path] [-f ] [-G] [-h ] [-j oe|eo] [-J X-Y[:Z]]\n"
-	"\t[-k keep] [-l resource_list] [-m mail_options] [-M user_list]\n"
-	"\t[-N jobname] [-o path] [-p priority] [-P project] [-q queue] [-r y|n]\n"
-	"\t[-R o|e|oe] [-S path] [-u user_list] [-W otherattributes=value...]\n"
-	"\t[-v variable_list] [-V ] [-z] [script | -- command [arg1 ...]]\n";
-#else
-	static char usag2[]="       qsub --version\n";
-	static char usage[]=
-		"usage: qsub [-a date_time] [-A account_string] [-c interval]\n"
-	"\t[-C directive_prefix] [-e path] [-f ] [-h ] [-I [-X]] [-j oe|eo] [-J X-Y[:Z]]\n"
-	"\t[-k keep] [-l resource_list] [-m mail_options] [-M user_list]\n"
-	"\t[-N jobname] [-o path] [-p priority] [-P project] [-q queue] [-r y|n]\n"
-	"\t[-R o|e|oe] [-S path] [-u user_list] [-W otherattributes=value...]\n"
-	"\t[-S path] [-u user_list] [-W otherattributes=value...]\n"
-	"\t[-v variable_list] [-V ] [-z] [script | -- command [arg1 ...]]\n";
-#endif
-	fprintf(stderr, "%s", usage);
-	fprintf(stderr, "%s", usag2);
-}
-
 
 /**
  * @brief
@@ -4621,8 +4783,7 @@ print_usage()
  *
  */
 static int
-handle_attribute_errors(struct ecl_attribute_errors *err_list,
-	char *retmsg)
+handle_attribute_errors(struct ecl_attribute_errors *err_list, char *retmsg)
 {
 	struct attropl *attribute;
 	char * opt;
@@ -4703,524 +4864,468 @@ handle_attribute_errors(struct ecl_attribute_errors *err_list,
 	return 0;
 }
 
-
-int
-main(int argc, char **argv, char **envp)   /* qsub */
+/**
+ * @brief
+ *	This functions connects to the pbs_server.
+ *
+ * @param[in] server_out - The target server name, if any, else NULL
+ * @param[out] retmsg	 - Any error string is returned in this parameter
+ *
+ * @return int
+ * @retval 0 - Success
+ * @retval 1/pbs_errno - Failure, retmsg paramter is set
+ *
+ */
+static int
+do_connect(char *server_out, char *retmsg)
 {
-	int errflg;                         /* option error */
-	static char script[MAXPATHLEN+1] = "";   /* name of script file */
-	char  basename[PBS_MAXJOBNAME+1];			/* base name of script for job name*/
-	char *bnp;
-	FILE *f;                            /* FILE pointer to the script */
-	char *q_n_out;                      /* queue part of destination */
-	char *s_n_out;                      /* server part of destination */
-	/* server:port to send request to */
-	struct stat statbuf;
-	char *cmdargs = NULL;
-	int command_flag = 0;
-	char *arg_list = NULL;
-	int rc;
-	char qsub_exe[MAXPATHLEN+1];
-	int do_regular_submit = 1; /* used if daemon based submit fails */
-	char *x11authstr = NULL;
-#ifndef WIN32
-	int daemon_up = 0;
-	int    sock;
-	struct sockaddr_un   s_un;
-	struct sigaction act;
-	sigset_t newsigmask;
-#endif
+	int rc = 0;
+	char host[PBS_MAXHOSTNAME+1];
 
-#ifdef WIN32
-	signal(SIGINT, win_blockint);
-	signal(SIGBREAK, win_blockint);
-	signal(SIGTERM, win_blockint);
+	/* set single threaded mode */
+	pbs_client_thread_set_single_threaded_mode();
 
-	winsock_init();
-	InitializeCriticalSection(&continuethread_cs);
-#else
-	/* Catch SIGPIPE on write() failures. */
-	sigemptyset(&act.sa_mask);
-	act.sa_handler = exit_on_sigpipe;
-	act.sa_flags   = 0;
-	if (sigaction(SIGPIPE, &act, NULL) < 0) {
-		perror("qsub: unable to catch SIGPIPE");
-		exit_qsub(1);
-	}
-#endif
-
-	/*test for real deal or just version and exit*/
-
-	execution_mode(argc, argv);
-
-	/*
-	 * Identify the configured tmpdir without calling pbs_loadconf().
-	 * We do not want to incur the cost of parsing the services DB.
-	 */
-	tmpdir = pbs_get_tmpdir();
-	if (tmpdir == NULL) {
-		fprintf(stderr, "qsub: Failed to load configuration parameters!\n");
-		exit_qsub(2);
-	}
-
-#ifdef WIN32
-	/*
-	 * In windows, the foreground qsub process does a createprocess of the
-	 * same executable (since there is no equivalent of fork). It calls the
-	 * child qsub with parameters "--daemon" as the first parameter. This
-	 * check here ensures that this invocation of qsub was to make it a
-	 * background process and not a user invocation. The --daemon parameter
-	 * is not documented to the user (or part of the syntax printed).
-	 * The parameters that are passed on to the child qsub process:
-	 * 1) --daemon --> Signifying that it is to become a daemon process
-	 * 2) Named Pipe Name --> Name of the named pipe on which to communicate
-	 * 3) Handle to synchronization event
-	 * 4) Name of the target server, if any, else NULL/empty
-	 *
-	 */
-	if ((argc == 4 || argc == 5) && (strcasecmp(argv[1], "--daemon")==0)) {
-		if (argc == 4)
-			do_daemon_stuff(argv[2], argv[3], NULL);
-		else
-			do_daemon_stuff(argv[2], argv[3], argv[4]);
-		exit(0);
-	}
-#endif
-	strcpy(qsub_exe, argv[0]); /* note the name of the qsub executable */
-
-	/*
-	 * If qsub command is submitted with arguments, then capture them and
-	 * encode in XML format using encode_xml_arg_list() and set the
-	 * "Submit_arguments" job attribute.
-	 */
-	if ((argc >= 2) && (cmdargs = encode_xml_arg_list(1, argc, argv))) {
-		set_attr(&attrib, ATTR_submit_arguments, cmdargs);
-		free(cmdargs);
-		cmdargs = NULL;
-	}
-
-	errflg = process_opts(argc, argv, CMDLINE);  /* get cmd-line options */
-
-	if (errflg) {
-		print_usage();
-		exit_qsub  (2);
-	}
-
-	if (optind < argc) {
-		if (strcmp(argv[optind], "--") == 0) {
-			command_flag = 1;
-			/* set executable */
-			set_attr(&attrib, ATTR_executable, argv[optind + 1]);
-			if (argc > (optind + 2)) {
-				/*
-				 * user has specified arguments to executable
-				 * as well.
-				 */
-				arg_list = encode_xml_arg_list(optind + 2,
-					argc, argv);
-				if (arg_list == NULL) {
-					fprintf(stderr, "qsub: out of memory\n");
-					exit_qsub(2);
-				} else {
-					/* set argument list */
-					set_attr(&attrib, ATTR_Arglist,
-						arg_list);
-					free(arg_list);
-					arg_list = NULL;
-				}
-			}
-			if (!N_opt)	/* '-N' is not set */
-				set_attr(&attrib, ATTR_N, "STDIN");
-		} else {
-			strncpy(script, argv[optind], MAXPATHLEN);
-			script[MAXPATHLEN] = '\0';
-		}
-	}
-
-#ifdef WIN32
-	back2forward_slash(script);
-#endif
-
-	if (command_flag == 0) {
-		/* if script is empty, get standard input */
-		if ((strcmp(script, "") == 0) || (strcmp(script, "-") == 0)) {
-			/* if this is a terminal, print a short info */
-			if (isatty(STDIN_FILENO) && Interact_opt == FALSE) {
-#ifdef WIN32
-				printf("Job script will be read from standard input. Submit with CTRL+Z.\n");
-#else
-				printf("Job script will be read from standard input. Submit with CTRL+D.\n");
-#endif
-			}
-
-			if (! N_opt) set_attr(&attrib, ATTR_N, "STDIN");
-			if (Interact_opt == FALSE) {
-				if ((errflg=get_script(stdin, script_tmp,
-					set_dir_prefix(dir_prefix, C_opt))) > 0) {
-					(void)unlink(script_tmp);
-					exit_qsub(1);
-				} else if (errflg < 0) {
-					exit_qsub(1);
-				}
-			}
-		} else {  /* non-empty script, read it for directives */
-			if (stat(script, &statbuf) < 0) {
-				perror("qsub: script file:");
-				exit_qsub(1);
-			}
-			if (! S_ISREG(statbuf.st_mode)) {
-				fprintf(stderr, "qsub: script not a file\n");
-				exit_qsub(1);
-			}
-			if ((f = fopen(script, "r")) != NULL) {
-				if (! N_opt) {
-					if ((bnp = strrchr(script, (int)'/')) != NULL)
-						bnp++;
-					else
-						bnp = script;
-					(void)strncpy(basename, bnp, PBS_MAXJOBNAME);
-					basename[PBS_MAXJOBNAME] = '\0';
-					/*
-					 * set ATTR_N directly - verification would be done
-					 * by IFL later
-					 */
-					set_attr(&attrib, ATTR_N, basename);
-				}
-				if ((errflg=get_script(f, script_tmp,
-					set_dir_prefix(dir_prefix, C_opt))) > 0) {
-					(void)unlink(script_tmp);
-					exit_qsub(1);
-				} else if (errflg < 0) {
-					exit_qsub(1);
-				}
-				(void)fclose(f);
-				f = NULL;
-			} else {
-				perror("qsub: opening script file:");
-				exit_qsub(8);
-			}
-		}
-	}
-#ifndef WIN32
-	if (Forwardx11_opt) {
-		if (!Interact_opt) {
-			fprintf(stderr, "qsub: X11 Forwarding possible only for "
-				"interactive jobs\n");
-			exit_qsub(1);
-		}
-		/* get the DISPLAY's auth protocol, hexdata, and screen number */
-		if ((x11authstr = x11_get_authstring()) != NULL) {
-			set_attr(&attrib, ATTR_X11_cookie, x11authstr);
-			set_attr(&attrib, ATTR_X11_port, port_X11());
-#ifdef DEBUG
-			fprintf(stderr, "x11auth string: %s\n", x11authstr);
-#endif
-		}
-		else {
-			exit_qsub(1);
-		}
-#else
-	if (gui_opt) {
-		if (!Interact_opt) {
-			fprintf(stderr, "qsub: only interactive jobs can have GUI display\n");
-			exit_qsub(1);
-		}
-		set_attr(&attrib, ATTR_GUI, "TRUE");
-#endif
-	}
-	set_opt_defaults();		/* set option default values */
-	server_out[0] = '\0';
-	if (parse_destination_id(destination, &q_n_out, &s_n_out)) {
-		fprintf(stderr, "qsub: illegally formed destination: %s\n",
-			destination);
-		(void)unlink(script_tmp);
-		exit_qsub(2);
+	/*perform needed security library initializations (including none)*/
+	if (CS_client_init() == CS_SUCCESS) {
+		cs_init = 1;
 	} else {
-		if (notNULL(s_n_out)) {
-			strcpy(server_out, s_n_out);
+		sprintf(retmsg, "qsub: unable to initialize security library.\n");
+		return 1;
+	}
+
+	/* Connect to the server */
+	if ((Interact_opt == FALSE) && (block_opt == FALSE))
+		sd_svr = cnt2server_extend(server_out, QSUB_DAEMON);
+	else
+		sd_svr = cnt2server(server_out);
+
+	if (sd_svr <= 0) {
+		sprintf(retmsg, "qsub: cannot connect to server %s (errno=%d)\n",
+			pbs_server, pbs_errno);
+		return (pbs_errno);
+	}
+
+	refresh_dfltqsubargs();
+
+	pbs_hostvar = malloc(pbs_o_hostsize + PBS_MAXHOSTNAME+1);
+	if (!pbs_hostvar) {
+		sprintf(retmsg, "qsub: out of memory\n");
+		return (2);
+	}
+	if ((rc = gethostname(host, (sizeof(host) - 1))) == 0) {
+		if ((rc = get_fullhostname(host, host, (sizeof(host) - 1))) == 0) {
+			strcpy(pbs_hostvar, ",PBS_O_HOST=");
+			strcat(pbs_hostvar, host);
 		}
 	}
-
-	/* Get required environment variables to be sent to the server. */
-	/* Must be done early here, as basic_envlist and qsub_envlist will */
-	/* be sent to the qsub daemon if needed */
-
-	basic_envlist = job_env_basic();
-	if (basic_envlist == NULL) {
-		exit_qsub(3);
-	}
-
-	if (V_opt) {
-		qsub_envlist = env_array_to_varlist(envp);
-        }
-
-	/*
-	 * Disable backgrounding if we are inside another qsub
-	 */
-	if (getenv(ENV_PBS_JOBID) != NULL)
-		no_background = 1;
-
-	/*
-	 * In case of interactive jobs, jobs with block=true, or no_background == 1,
-	 * qsub should fully execute from the foreground.
-	 * It should not fork, neither should it send the data to the background qsub.
-	 */
-	if (Interact_opt || block_opt || no_background)
-		goto regular_submit;
-
-#ifdef WIN32
-	/* determine pipe name */
-	get_comm_filename(fl);
-
-	/*
-	 * we have determined the name of the Named pipe that should be
-	 * used to communicate between the qsub background and foreground
-	 * process. Now try to connect to the background qsub process using this
-	 * named pipe.
-	 *
-	 * If the connection succeeds, it means a background qsub process
-	 * already exists. Send data to the background process and wait for
-	 * result.
-	 *
-	 * If connection fails, create a background qsub process by doing
-	 * a createprocess of the same qsub executable, but with --daemon
-	 * parameter. Now, there could be a race between the background and the
-	 * foreground qsub processes. If the background process is slower to
-	 * startup and listen on the named pipe, the foreground process could
-	 * fail again on trying to connect to it, thus entering a vicious loop.
-	 * To avoid that, create a manual reset event and pass its handle to
-	 * the new child process. The foreground process waits on the event
-	 * object, till the background process is up, sets up the named pipe,
-	 * and signals this event to tell the foreground process to continue
-	 * and  try to connect to it via this new named pipe.
-	 */
-	{
-		HANDLE hFile;
-		SECURITY_ATTRIBUTES sa;
-		STARTUPINFO si = {sizeof(si)};
-		PROCESS_INFORMATION pi;
-		char cmd_line[2*MAXPATHLEN + 1];
-		int created = 0;
-		HANDLE hEvent;
-
-again:
-		hFile = CreateFile(fl, GENERIC_READ | GENERIC_WRITE, 0, NULL,
-			OPEN_EXISTING, 0, NULL);
-		if (hFile == INVALID_HANDLE_VALUE) {
-			if (created == 0) {
-				sa.nLength = sizeof(sa);
-				sa.lpSecurityDescriptor = NULL;
-				sa.bInheritHandle = TRUE;
-
-				/* now create a named event to wait on later */
-				hEvent = CreateEvent(
-					&sa, /* default security attribute */
-					TRUE, /* manual-reset event */
-					FALSE, /* initial state = signaled */
-					NULL); /* unnamed event object */
-				if (hEvent == NULL)
-					goto regular_submit;
-
-				/* launch new qsub process, connect 2 server */
-				sa.bInheritHandle = FALSE;
-				sprintf(cmd_line, "%s --daemon %s %d %s",
-					qsub_exe, fl,
-					hEvent, server_out);
-				if (!CreateProcess(NULL, cmd_line, &sa, &sa,
-					TRUE, CREATE_NO_WINDOW, NULL,
-					NULL, &si, &pi)) {
-					CloseHandle(hEvent);
-					goto regular_submit;
-				}
-
-				/* now wait for single object */
-				/* foreground process wait a max 10 seconds */
-				rc = WaitForSingleObject(hEvent, 10 * 1000);
-				CloseHandle(hEvent);
-
-				if (rc != WAIT_OBJECT_0)
-					goto regular_submit; /* timeout */
-
-				created = 1;
-				goto again;
-			}
-		} else {
-			if ((send_attrl(hFile, attrib) == 0) &&
-				(send_string(hFile, destination) == 0) &&
-				(send_string(hFile, script_tmp) == 0) &&
-				(send_string(hFile, cred_name) == 0) &&
-#if defined(PBS_PASS_CREDENTIALS)
-				(send_string(hFile, passwd_buf) == 0) &&
-#endif
-				(send_string(hFile, v_value?v_value:"") == 0) &&
-				(send_string(hFile, basic_envlist) == 0) &&
-				(send_string(hFile, qsub_envlist?qsub_envlist:"") == 0) &&
-				(send_string(hFile, qsub_cwd) == 0) &&
-				(send_opts(hFile) == 0)) {
-				/*
-				 * we were able to send data to the background qsub.
-				 * Now, even if we fail to read back response from
-				 * background, we do not want to submit again.
-				 */
-				do_regular_submit = 0;
-
-				/* read back response from background qsub */
-				if ((recv_string(hFile, retmsg) != 0) ||
-					(dorecv(hFile, &rc, sizeof(int)) != 0)) {
-
-					/* Something bad happened, either background submitted
-					 * and failed to send us response, or it failed before
-					 * submitting.
-					 */
-					rc = -1;
-					sprintf(retmsg, "Failed to recv data from background qsub\n");
-					/* fall through to print the error message */
-				}
-			}
-			FlushFileBuffers(hFile);
-			CloseHandle(hFile);
-		}
-	}
-
-#else
-again:
-	/*
-	 * In case of Unix, use fork. Foreground checks if connection is
-	 * possible with background daemon. The communication used is unix
-	 * domain sockets. Only the specified user can connect to this socket
-	 * since the domain socket is created with a 0600 permission.
-	 *
-	 * If connection fails, proceed with qsub in the normal flow, and at
-	 * the end fork and stay in the background, while the foreground
-	 * process returns control to the shell. Subsequent qsubs will be able
-	 * to connect to this forked background qsub.
-	 *
-	 */
-	daemon_up = check_qsub_daemon(fl);
-	if (daemon_up == 1) {
-		/* pass information to daemon */
-		/* wait for job-id or error string */
-		if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
-			goto regular_submit;
-
-		s_un.sun_family = AF_UNIX;
-		(void) strncpy(s_un.sun_path, fl, sizeof(s_un.sun_path));
-		if (connect(sock, (const struct sockaddr *) &s_un,  sizeof(s_un)) == -1) {
-			int	refused = (errno == ECONNREFUSED);
-
-			close(sock);
-			if (refused) {
-				/* daemon unavailable, del temp file, restart */
-				if (unlink(fl) != 0)
-					goto regular_submit;
-
-				goto again;
-			}
-			goto regular_submit;
-		}
-
-		/* block SIGPIPE on write() failures. */
-		sigemptyset(&newsigmask);
-		sigaddset(&newsigmask, SIGPIPE);
-		sigprocmask(SIG_BLOCK, &newsigmask, NULL);
-
-		if ((send_attrl(&sock, attrib) == 0) &&
-			(send_string(&sock, destination) == 0) &&
-			(send_string(&sock, script_tmp) == 0) &&
-			(send_string(&sock, cred_name) == 0) &&
-#if defined(PBS_PASS_CREDENTIALS)
-			(send_string(&sock, passwd_buf) == 0) &&
-#endif
-			(send_string(&sock, v_value?v_value:"") == 0) &&
-			(send_string(&sock, basic_envlist) == 0) &&
-			(send_string(&sock, qsub_envlist?qsub_envlist:"") == 0) &&
-			(send_string(&sock, qsub_cwd) == 0) &&
-			(send_opts(&sock) == 0)) {
-
-			/* read back the first error code from the background
-			 * which confirms whether the background received our data
-			 */
-			if (dorecv(&sock, (char *) &rc, sizeof(int)) == 0) {
-				/*
-				 * we were able to send data to the background daemon.
-				 * Now, even if we fail to read back response from
-				 * background, we do not want to submit again.
-				 */
-				do_regular_submit = 0;
-			}
-
-			/* read back response from background daemon */
-			if ((recv_string(&sock, retmsg) != 0) ||
-				dorecv(&sock, (char *) &rc, sizeof(int)) != 0) {
-
-				/* Something bad happened, either background submitted
-				 * and failed to send us response, or it failed before
-				 * submitting.
-				 */
-				rc = -1;
-				sprintf(retmsg, "Failed to recv data from background qsub\n");
-				/* fall through to print the error message */
-			}
-		}
-		/* going down, no need to free stuff */
-		close(sock);
-	}
-#endif
-
-regular_submit:
-	if (do_regular_submit == 1) { /* submission via daemon was not successful, so do regular submit */
-		rc = do_connect(server_out, retmsg);
-		if (rc == 0) {
-			if (sd_svr != -1) {
-#if defined(PBS_PASS_CREDENTIALS)
-				if (passwd_buf[0] != '\0') {
-					pbs_encrypt_pwd(passwd_buf, &cred_type, &cred_buf, &cred_len);
-				}
-#endif
-				rc = do_submit2(retmsg);
-			}
-			else
-				rc = -1;
-		}
-#ifndef WIN32
-		if ((rc == 0) && !(Interact_opt != FALSE || block_opt) && (daemon_up == 0) && (no_background == 0))
-			fork_and_stay();
-#endif
-	}
-
-	(void)unlink(script_tmp);
-
-	if (rc == 0) {
-		new_jobname = retmsg;
-
-		if (!z_opt && Interact_opt == FALSE)
-			printf("%s\n", retmsg); /* print jobid with a \n */
-	} else {
-		/* error, print whatever our daemon gave us back */
-		fprintf(stderr, "%s", retmsg);
-	}
-
 	if (rc != 0) {
-		/* check if the retmsg has "qsub: illegal -" string, if so print usage */
-		if (strstr(retmsg, "qsub: illegal -"))
-			print_usage();
-		exit_qsub(rc);
+		sprintf(retmsg, "qsub: cannot get full local host name\n");
+		return (3);
+	}
+	return 0;
+}
+
+/**
+ * @brief
+ *	This functions does a job submission to the server using the global
+ *	connected server socket sd_svr.
+ *
+ * @param[out] retmsg	 - Any error string is returned in this parameter
+ *
+ * @return int
+ * @retval 0 - Success
+ * @retval 1/-1/pbs_errno - Failure, retmsg paramter is set
+ *
+ */
+static int
+do_submit(char *retmsg)
+{
+	struct ecl_attribute_errors *err_list;
+	char *new_jobname = NULL;
+	int rc;
+	char *errmsg;
+	int retries;
+
+	if (dfltqsubargs != NULL) {
+		/*
+		 * Setting options from the server defaults will not overwrite
+		 * options set from the job script.  CMDLINE-2 means
+		 * "one less than job script priority"
+		 */
+		for (retries = 2; retries > 0; retries--) {
+			rc = do_dir(dfltqsubargs, CMDLINE - 2, retmsg, MAXPATHLEN);
+			if (rc >= 0)
+				break;
+			if (retries == 2)
+				refresh_dfltqsubargs();
+		}
+		if (rc != 0)
+			return (rc);
 	}
 
-	/* is this an interactive job ??? */
-	if (Interact_opt != FALSE)
-		interactive();
-	else if (block_opt) {
-		fflush(stdout);
-		block();
+	/* set_job_env must be done here to pick up -v, -V options passed */
+	/* by default_qsub_arguments */
+	if (! set_job_env(basic_envlist, qsub_envlist)) {
+#ifndef WIN32
+		if (x11_disp)
+			snprintf(retmsg, MAXPATHLEN, "qsub: invalid usage of incompatible option –X with –v DISPLAY\n");
+		else
+			snprintf(retmsg, MAXPATHLEN, "qsub: cannot send environment with the job\n");
+#else
+		snprintf(retmsg, MAXPATHLEN, "qsub: cannot send environment with the job\n");
+#endif
+		return 1;
 	}
 
-	exit_qsub(0);
-	return (0);
+	if (cred_name[0]) {
+		if (strcmp(cred_name, PBS_CREDNAME_DCE_KRB5) == 0 ||
+			strcmp(cred_name, PBS_CREDNAME_KRB5) == 0) {
+			if (get_krb5_ticket(pbs_server))
+				return 1;
+		} else if (strcmp(cred_name, PBS_CREDNAME_AES) == 0) {
+			if (get_passwd())
+				return 1;
+		} else if (strcmp(cred_name, PBS_CREDNAME_GRIDPROXY) == 0) {
+			if (get_grid_proxy())
+				return 1;
+		} else {
+			snprintf(retmsg, MAXPATHLEN, "qsub: unknown credential type\n");
+			return 1;
+		}
+	}
+
+	/* Send submit request to the server. */
+	pbs_errno = 0;
+	if (cred_buf) {
+		/* A credential was obtained, call the credential version of submit */
+		new_jobname = pbs_submit_with_cred(sd_svr, (struct attropl *) attrib,
+			script_tmp, destination, NULL, cred_type,
+			cred_len, cred_buf);
+	} else {
+		new_jobname = pbs_submit(sd_svr, (struct attropl *) attrib,
+			script_tmp, destination, NULL);
+	}
+	if (new_jobname == NULL) {
+
+		if ((err_list = pbs_get_attributes_in_error(sd_svr))) {
+			rc = handle_attribute_errors(err_list, retmsg);
+			if (rc != 0)
+				return rc;
+		}
+
+		errmsg = pbs_geterrmsg(sd_svr);
+		if (errmsg != NULL) {
+			if (strcmp(errmsg, msg_force_qsub_update) == 0)
+				return PBSE_FORCE_QSUB_UPDATE;
+			sprintf(retmsg, "qsub: %s\n", errmsg);
+		} else {
+			sprintf(retmsg, "qsub: Error (%d) submitting job\n", pbs_errno);
+		}
+		return (pbs_errno);
+	} else {
+		sprintf(retmsg, "%s", new_jobname);
+		free(new_jobname);
+	}
+	return 0;
+}
+
+/**
+ * @brief
+ *	Save original values of qsub option variables.
+ *
+ */
+static void
+save_opts()
+{
+	/* save the values */
+	a_opt_o = a_opt;
+	c_opt_o = c_opt;
+	e_opt_o = e_opt;
+	h_opt_o = h_opt;
+	j_opt_o = j_opt;
+	k_opt_o = k_opt;
+	l_opt_o = l_opt;
+	m_opt_o = m_opt;
+	o_opt_o = o_opt;
+	p_opt_o = p_opt;
+	q_opt_o = q_opt;
+	r_opt_o = r_opt;
+	u_opt_o = u_opt;
+	v_opt_o = v_opt;
+	z_opt_o = z_opt;
+	A_opt_o = A_opt;
+	C_opt_o = C_opt;
+	J_opt_o = J_opt;
+	M_opt_o = M_opt;
+	N_opt_o = N_opt;
+	P_opt_o = P_opt;
+	S_opt_o = S_opt;
+	V_opt_o = V_opt;
+	Depend_opt_o = Depend_opt;
+	Interact_opt_o = Interact_opt;
+	Stagein_opt_o = Stagein_opt;
+	Stageout_opt_o = Stageout_opt;
+	Sandbox_opt_o = Sandbox_opt;
+	Grouplist_opt_o = Grouplist_opt;
+#ifdef WIN32
+	gui_opt_o = gui_opt;
+#endif
+	Resvstart_opt_o = Resvstart_opt;
+	Resvend_opt_o = Resvend_opt;
+	pwd_opt_o = pwd_opt;
+	cred_opt_o = cred_opt;
+	block_opt_o = block_opt;
+	relnodes_on_stageout_opt_o = relnodes_on_stageout_opt;
+}
+
+/**
+ * @brief
+ *	Initialize qsub option variables to their original values.
+ *
+ */
+static void
+restore_opts()
+{
+	/* save the values */
+	a_opt = a_opt_o;
+	c_opt = c_opt_o;
+	e_opt = e_opt_o;
+	h_opt = h_opt_o;
+	j_opt = j_opt_o;
+	k_opt = k_opt_o;
+	l_opt = l_opt_o;
+	m_opt = m_opt_o;
+	o_opt = o_opt_o;
+	p_opt = p_opt_o;
+	q_opt = q_opt_o;
+	r_opt = r_opt_o;
+	u_opt = u_opt_o;
+	v_opt = v_opt_o;
+	z_opt = z_opt_o;
+	A_opt = A_opt_o;
+	C_opt = C_opt_o;
+	J_opt = J_opt_o;
+	M_opt = M_opt_o;
+	N_opt = N_opt_o;
+	P_opt = P_opt_o;
+	S_opt = S_opt_o;
+	V_opt = V_opt_o;
+	Depend_opt = Depend_opt_o;
+	Interact_opt = Interact_opt_o;
+	Stagein_opt = Stagein_opt_o;
+	Stageout_opt = Stageout_opt_o;
+	Sandbox_opt = Sandbox_opt_o;
+	Grouplist_opt = Grouplist_opt_o;
+	Resvstart_opt = Resvstart_opt_o;
+	Resvend_opt = Resvend_opt_o;
+	pwd_opt = pwd_opt_o;
+	cred_opt = cred_opt_o;
+	block_opt = block_opt_o;
+	relnodes_on_stageout_opt = relnodes_on_stageout_opt_o;
+}
+
+/**
+ * @brief
+ *	Helper function to free a list of attributes. This is called from
+ *	do_daemon_stuff, since that function loops over for each client request.
+ *	No freeing the list of attributes created would result in a lot of
+ *	memory leak.
+ *
+ * @param[in]	attrib - The list of attributes to free
+ *
+ */
+static void
+free_attrl(struct attrl *attrib)
+{
+	struct attrl *attr;
+
+	while (attrib) {
+		free(attrib->name);
+		if (attrib->resource)
+			free(attrib->resource);
+		free(attrib->value);
+
+		attr = attrib;
+		attrib = attrib->next;
+		free(attr);
+	}
+}
+
+/**
+ * @brief
+ *	Helper function to duplicate the passed attrl structure.
+ *
+ * @param[in]	attrib - The list of attributes to copy
+ *
+ * @return	struct attrl * - the duplicated 'attrib' (malloced).
+ * @retval	non-NULL - success.
+ * @retval	NULL - failure.
+ *
+ */
+static struct attrl *
+dup_attrl(struct attrl *attrib)
+{
+	struct attrl *attr = NULL;
+	struct attrl *attr_new = NULL;
+
+	attr = attrib;
+	while (attr) {
+		if (attr->resource != NULL) {
+			/* strings have null character also in buf */
+			set_attr_resc(&attr_new, attr->name,
+				attr->resource,
+				attr->value);
+		} else {
+			set_attr(&attr_new, attr->name, attr->value);
+		}
+
+		attr=attr->next;
+	}
+
+	return attr_new;
+}
+
+/**
+ * @brief
+ *	Helper function to get the pbs conf file path, and
+ *	convert it to a string, later added to the filename
+ *	(pipe or unix domain socket filename) that is used
+ *	for communications between the front-end and
+ *	background qsub processes.
+ *	The path to the pbs conf file is converted to a string
+ *	by replacing the slashes with underscrore char.
+ *	If PBS_CONF_FILE is not set, then an empty string
+ *	is returned.
+ *
+ * @return - The string representing path to the pbs conf file
+ *
+ */
+static char *
+get_conf_path()
+{
+	char *cnf = getenv("PBS_CONF_FILE");
+	char *dup_cnf_path = "";
+	char *p;
+
+	if (cnf) {
+		p = strdup(cnf);
+		if (p) {
+			dup_cnf_path = p;
+			while (*p) {
+#ifdef WIN32
+				if (*p == '\\' || *p == ':' || *p == ' ' || *p == '.')
+					*p = '_';
+#else
+				if (*p == '/' || *p == ' ' || *p == '.')
+					*p = '_';
+#endif
+				p++;
+			}
+		}
+	}
+	return dup_cnf_path;
+}
+
+/**
+ *
+ * @brief
+ *	The wrapper program to "do_submit()".
+ * @par
+ *	This attempts up to 'retry' times to do_submit(), when this function
+ *	returns PBSE_FORCE_QSUB_UPDATE.
+ *
+ * @param[in]	retmsg - gets filled with the error message.
+ *
+ * @return 	int
+ * @retval	the return code of do_submit().
+ * @retval	if retry time exhausted or any unexpected failure,
+ * 		return PBSE_PROTOCOL
+ *
+ */
+static int
+do_submit2(char *rmsg)
+{
+	int	retry=5;	/* do a retry count to prevent infinite loop */
+	int	rc;
+
+
+	rmsg[0] = '\0';
+	/* save the original job attributes/resources (attrib)	*/
+	/* before 'default_qsub_arguments" was applied. 	*/
+	if (attrib != NULL) {
+		if (attrib_o != NULL)
+			free_attrl(attrib_o);
+		attrib_o = dup_attrl(attrib); /* save attributes list */
+		if (attrib_o == NULL) {
+			snprintf(rmsg, MAXPATHLEN-1,
+				"Failed to duplicate attributes list.\n");
+			return PBSE_PROTOCOL;
+		}
+	}
+
+	/* original v_value also needs to be saved as it gets mangled inside set_job_env() */
+	if (v_value != NULL) {
+		if (v_value_o != NULL)
+			free(v_value_o);
+		v_value_o = strdup(v_value);
+		if (v_value_o == NULL) {
+			snprintf(rmsg, MAXPATHLEN-1,
+				"Failed to duplicate original -v value\n");
+			return PBSE_PROTOCOL;
+		}
+	}
+
+	/* Need to save original values of qsub option variables, */
+	/* as "reset_dfltqsubargs() below could "lose" memory	  */
+	/* of the option variable values. The values are	  */
+	/* needed in case a new "default_qsub_arguments come and  */
+	/* gets reparsed.					  */
+	save_opts();
+
+	rc = do_submit(rmsg);
+	while ((rc == PBSE_FORCE_QSUB_UPDATE) && (retry > 0)) {
+		/* Let's retry with the new "default_qsub_arguments" 	*/
+		refresh_dfltqsubargs();
+
+		/* Use the original attrib value before the previous	*/
+		/* "default_qsub_arguments" was applied.		*/
+		if (attrib_o != NULL) {
+			if (attrib != NULL)
+				free_attrl(attrib);
+			attrib = dup_attrl(attrib_o);
+			if (attrib == NULL) {
+				snprintf(rmsg, MAXPATHLEN-1,
+					"Failed to duplicate attributes list\n");
+				return PBSE_PROTOCOL;
+			}
+		}
+
+		/* use original -v value */
+		if (v_value_o != NULL) {
+			if (v_value != NULL)
+				free(v_value);
+			v_value = strdup(v_value_o);
+			if (v_value == NULL) {
+				snprintf(rmsg, MAXPATHLEN-1,
+					"Failed to duplicate -v value\n");
+				return PBSE_PROTOCOL;
+			}
+		}
+
+		restore_opts();
+
+		rc = do_submit(rmsg);
+		retry--;
+	}
+	if (retry == 0) {
+		snprintf(rmsg, MAXPATHLEN-1,
+			"Retry to submit a job exhausted.\n");
+		rc = PBSE_PROTOCOL;
+	}
+	return (rc);
 }
 
 #ifdef WIN32
-
 /**
  * @brief
  *	Get the filename to be used for communications. This is created by
@@ -5273,7 +5378,7 @@ get_comm_filename(char *fl)
  * @param[in] server - Target server name of NULL in case of default
  *
  */
-void
+static void
 do_daemon_stuff(char *file, char *handle, char *server)
 {
 	HANDLE hPipe;
@@ -5387,9 +5492,8 @@ do_daemon_stuff(char *file, char *handle, char *server)
 			goto error;
 
 #if defined(PBS_PASS_CREDENTIALS)
-		if (passwd_buf[0] != '\0') {
+		if (passwd_buf[0] != '\0')
 			pbs_encrypt_pwd(passwd_buf, &cred_type, &cred_len, &cred_buf);
-		}
 #endif
 		/* set the current work directory by doing a chdir */
 		if (_chdir(qsub_cwd) != 0)
@@ -5460,98 +5564,136 @@ error:
 	exit(1);
 }
 
-#else /* unix */
-
-/**
+/*
  * @brief
- *	Check whether a unix domain socket file is available.
- *	That is an indication that a background qsub might already be running.
+ *  Try to submit job through daemon. On Windows, the daemon would be created
+ *  by calling CreateProcess with the --daemon parameter during a prior
+ *  invocation of the qsub command. The foreground qsub process tries to send
+ *  the job to the daemon using a named pipe.
  *
- * @param[out]	fl - The filename used for the communication pipe/socket for
- *			the communication between background and forground
- *			qsub processes.
- *
- * @return      int
- * @retval	0 - Not available
- * @retval	1 - available
- *
- */
-int
-check_qsub_daemon(char *fl)
-{
-	get_comm_filename(fl);
-	if (access(fl, F_OK) == 0) {
-		/* check if file is usable */
-		return 1;
-	}
-	return 0;
-}
-
-/**
- * @brief
- *	Fork the current process. Call the do_daemon_stuff function in the
- *	child process which starts listening on the unix domain socket etc.
- *	The parent process continues out of this function and eventually
- *	returns back control to the calling shell.
- *
- * @return error code
- * @retval 0 Success
- * exits program on failure
- *
+ * @param[in]  qsub_exe          - Name of the qsub command to pass to CreateProcess
+ * @param[out] do_regular_submit - Indicate whether to do regular submit
+ * @return     rc                - Error code
  */
 static int
-fork_and_stay(void)
+daemon_submit(const char *qsub_exe, int *do_regular_submit)
 {
-	int pid;
+	int rc = 0;
+	HANDLE hFile;
+	SECURITY_ATTRIBUTES sa;
+	STARTUPINFO si = {sizeof(si)};
+	PROCESS_INFORMATION pi;
+	char cmd_line[2*MAXPATHLEN + 1];
+	int created = 0;
+	HANDLE hEvent;
 
-	pid = fork();
-	if (pid == 0) {
+	/* determine pipe name */
+	get_comm_filename(fl);
 
-		/*
-		 * Try to become the session leader.
-		 * If that fails, exit with a syslog message
-		 */
-		if (setsid() == -1) {
-			log_syslog("setsid failed");
-			exit(1);
+	/*
+	 * we have determined the name of the Named pipe that should be
+	 * used to communicate between the qsub background and foreground
+	 * process. Now try to connect to the background qsub process using this
+	 * named pipe.
+	 *
+	 * If the connection succeeds, it means a background qsub process
+	 * already exists. Send data to the background process and wait for
+	 * result.
+	 *
+	 * If connection fails, create a background qsub process by doing
+	 * a createprocess of the same qsub executable, but with --daemon
+	 * parameter. Now, there could be a race between the background and the
+	 * foreground qsub processes. If the background process is slower to
+	 * startup and listen on the named pipe, the foreground process could
+	 * fail again on trying to connect to it, thus entering a vicious loop.
+	 * To avoid that, create a manual reset event and pass its handle to
+	 * the new child process. The foreground process waits on the event
+	 * object, till the background process is up, sets up the named pipe,
+	 * and signals this event to tell the foreground process to continue
+	 * and  try to connect to it via this new named pipe.
+	 */
+
+again:
+	hFile = CreateFile(fl, GENERIC_READ | GENERIC_WRITE, 0, NULL,
+			OPEN_EXISTING, 0, NULL);
+	if (hFile == INVALID_HANDLE_VALUE) {
+		if (created == 0) {
+			sa.nLength = sizeof(sa);
+			sa.lpSecurityDescriptor = NULL;
+			sa.bInheritHandle = TRUE;
+
+			/* now create a named event to wait on later */
+			hEvent = CreateEvent(
+					&sa, /* default security attribute */
+					TRUE, /* manual-reset event */
+					FALSE, /* initial state = signaled */
+					NULL); /* unnamed event object */
+			if (hEvent == NULL)
+				return rc;
+
+			/* launch new qsub process, connect 2 server */
+			sa.bInheritHandle = FALSE;
+			sprintf(cmd_line, "%s --daemon %s %d %s",
+					qsub_exe, fl,
+					hEvent, server_out);
+			if (!CreateProcess(NULL, cmd_line, &sa, &sa,
+						TRUE, CREATE_NO_WINDOW, NULL,
+						NULL, &si, &pi)) {
+				CloseHandle(hEvent);
+				return rc;
+			}
+
+			/* now wait for single object */
+			/* foreground process wait a max 10 seconds */
+			rc = WaitForSingleObject(hEvent, 10 * 1000);
+			CloseHandle(hEvent);
+
+			if (rc != WAIT_OBJECT_0) /* timeout */
+				return rc;
+
+			created = 1;
+			goto again;
 		}
+	} else {
+		if ((send_attrl(hFile, attrib) == 0) &&
+				(send_string(hFile, destination) == 0) &&
+				(send_string(hFile, script_tmp) == 0) &&
+				(send_string(hFile, cred_name) == 0) &&
+#if defined(PBS_PASS_CREDENTIALS)
+				(send_string(hFile, passwd_buf) == 0) &&
+#endif
+				(send_string(hFile, v_value?v_value:"") == 0) &&
+				(send_string(hFile, basic_envlist) == 0) &&
+				(send_string(hFile, qsub_envlist?qsub_envlist:"") == 0) &&
+				(send_string(hFile, qsub_cwd) == 0) &&
+				(send_opts(hFile) == 0)) {
+			/*
+			 * we were able to send data to the background qsub.
+			 * Now, even if we fail to read back response from
+			 * background, we do not want to submit again.
+			 */
+			*do_regular_submit = 0;
 
-		/*
-		 * just close standard files, we don't want to
-		 * be session leader or close all other files
-		 */
-		(void) fclose(stdin);
-		(void) fclose(stdout);
-		(void) fclose(stderr);
+			/* read back response from background qsub */
+			if ((recv_string(hFile, retmsg) != 0) ||
+					(dorecv(hFile, &rc, sizeof(int)) != 0)) {
 
-		/* clear off all the attributes */
-		free_attrl(attrib);
-		attrib = NULL;
-		if (v_value != NULL) {
-			free(v_value);
-			v_value = NULL;
+				/* Something bad happened, either background submitted
+				 * and failed to send us response, or it failed before
+				 * submitting.
+				 */
+				rc = -1;
+				sprintf(retmsg, "Failed to recv data from background qsub\n");
+				/* fall through to print the error message */
+			}
 		}
-		if (basic_envlist != NULL) {
-			free(basic_envlist);
-			basic_envlist = NULL;
-		}
-		if (qsub_envlist != NULL) {
-			free(qsub_envlist);
-			qsub_envlist = NULL;
-		}
-
-		/* set single threaded mode */
-		pbs_client_thread_set_single_threaded_mode();
-
-		do_daemon_stuff();
-		/* control should never reach here */
-		/* still adding an exit, so it does not traverse parent code */
-		exit(1);
+		FlushFileBuffers(hFile);
+		CloseHandle(hFile);
 	}
-	/* parent code */
-	return 0;
+	return rc;
 }
 
+#else /* unix */
 /**
  * @brief
  *	Sets the filename to be used for the unix domain socket based comm.
@@ -5582,10 +5724,35 @@ get_comm_filename(char *fl)
 
 /**
  * @brief
+ *	Check whether a unix domain socket file is available.
+ *	That is an indication that a background qsub might already be running.
+ *
+ * @param[out]	fl - The filename used for the communication pipe/socket for
+ *			the communication between background and forground
+ *			qsub processes.
+ *
+ * @return      int
+ * @retval	0 - Not available
+ * @retval	1 - available
+ *
+ */
+static int
+check_qsub_daemon(char *fl)
+{
+	get_comm_filename(fl);
+	if (access(fl, F_OK) == 0) {
+		/* check if file is usable */
+		return 1;
+	}
+	return 0;
+}
+
+/**
+ * @brief
  *	The do_daemon_stuff Unix counterpart.
  *	It creates a unix domain socket server and starts listening on it.
  *	The umask is set to 077 so that the domain socket file is owned and
- *	accessible by the user exeuting qsub only. Once a client (foreground
+ *	accessible by the user executing qsub only. Once a client (foreground
  *	qsub) connects, it receives all the data from the foreground qsub and
  *	executes do_submit, on the pre-established connection to pbs_server.
  *	The connection to server was estiblished by the caller of this function
@@ -5593,7 +5760,7 @@ get_comm_filename(char *fl)
  *	This function also does a "select" wait on input of data from foreground
  *	qsub processes, and a close notification on the socket with pbs_server.
  *	The select breaks if foreground qsubs connect, the pbs_server dies, or
- *	the timeout of 1 minutes expires. For the later two cases, this function
+ *	the timeout of 1 minutes expires. For the latter two cases, this function
  *	does a silent exit of the background qsub daemon.
  *
  */
@@ -5630,7 +5797,8 @@ do_daemon_stuff(void)
 	}
 
 	s_un.sun_family = AF_UNIX;
-	(void) strncpy(s_un.sun_path, fl, sizeof(s_un.sun_path));
+	snprintf(s_un.sun_path, sizeof(s_un.sun_path), "%s", fl);
+
 	if (bind(bindfd, (const struct sockaddr *) &s_un, sizeof(s_un)) == -1)
 		exit(1); /* dont go to error */
 
@@ -5798,476 +5966,380 @@ error:
 	close(bindfd);
 	exit(1);
 }
-#endif
 
 /**
  * @brief
- *	This functions connects to the pbs_server.
+ *	Fork the current process. Call the do_daemon_stuff function in the
+ *	child process which starts listening on the unix domain socket etc.
+ *	The parent process continues out of this function and eventually
+ *	returns back control to the calling shell.
  *
- * @param[in] server_out - The target server name, if any, else NULL
- * @param[out] retmsg	 - Any error string is returned in this parameter
- *
- * @return int
- * @retval 0 - Success
- * @retval 1/pbs_errno - Failure, retmsg paramter is set
+ * @return error code
+ * @retval 0 Success
+ * exits program on failure
  *
  */
 static int
-do_connect(char *server_out, char *retmsg)
+fork_and_stay(void)
+{
+	int pid;
+
+	pid = fork();
+	if (pid == 0) {
+
+		/*
+		 * Try to become the session leader.
+		 * If that fails, exit with a syslog message
+		 */
+		if (setsid() == -1) {
+			log_syslog("setsid failed");
+			exit(1);
+		}
+
+		/*
+		 * just close standard files, we don't want to
+		 * be session leader or close all other files
+		 */
+		(void) fclose(stdin);
+		(void) fclose(stdout);
+		(void) fclose(stderr);
+
+		/* clear off all the attributes */
+		free_attrl(attrib);
+		attrib = NULL;
+		if (v_value != NULL) {
+			free(v_value);
+			v_value = NULL;
+		}
+		if (basic_envlist != NULL) {
+			free(basic_envlist);
+			basic_envlist = NULL;
+		}
+		if (qsub_envlist != NULL) {
+			free(qsub_envlist);
+			qsub_envlist = NULL;
+		}
+
+		/* set single threaded mode */
+		pbs_client_thread_set_single_threaded_mode();
+
+		do_daemon_stuff();
+		/* control should never reach here */
+		/* still adding an exit, so it does not traverse parent code */
+		exit(1);
+	}
+	/* parent code */
+	return 0;
+}
+
+/*
+ * @brief
+ *  Try to submit job through daemon. On Unix, the daemon would be created by
+ *  forking during a prior invocation of the qsub command. The foregound qsub
+ *  process tries to send the job to the daemon using Unix domain sockets.
+ *
+ * @param[out] daemon_up         - Indicate whether daemon is running
+ * @param[out] do_regular_submit - Indicate whether to do regular submit
+ * @return     rc                - Error code
+ */
+static int
+daemon_submit(int *daemon_up, int *do_regular_submit)
+{
+	int    sock; /* UNIX domain socket for talking to daemon */
+	struct sockaddr_un   s_un;
+	sigset_t newsigmask;
+	int rc = 0;
+again:
+	/*
+	 * In case of Unix, use fork. Foreground checks if connection is
+	 * possible with background daemon. The communication used is unix
+	 * domain sockets. Only the specified user can connect to this socket
+	 * since the domain socket is created with a 0600 permission.
+	 *
+	 * If connection fails, proceed with qsub in the normal flow, and at
+	 * the end fork and stay in the background, while the foreground
+	 * process returns control to the shell. Subsequent qsubs will be able
+	 * to connect to this forked background qsub.
+	 *
+	 */
+	*daemon_up = check_qsub_daemon(fl);
+	if (*daemon_up == 1) {
+		/* pass information to daemon */
+		/* wait for job-id or error string */
+		if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
+			return rc;
+
+		s_un.sun_family = AF_UNIX;
+		snprintf(s_un.sun_path, sizeof(s_un.sun_path), "%s", fl);
+
+		if (connect(sock, (const struct sockaddr *) &s_un,  sizeof(s_un)) == -1) {
+			int	refused = (errno == ECONNREFUSED);
+
+			close(sock);
+			if (refused) {
+				/* daemon unavailable, del temp file, restart */
+				if (unlink(fl) != 0)
+					return rc;
+
+				goto again;
+			}
+			return rc;
+		}
+
+		/* block SIGPIPE on write() failures. */
+		sigemptyset(&newsigmask);
+		sigaddset(&newsigmask, SIGPIPE);
+		sigprocmask(SIG_BLOCK, &newsigmask, NULL);
+
+		if ((send_attrl(&sock, attrib) == 0) &&
+			(send_string(&sock, destination) == 0) &&
+			(send_string(&sock, script_tmp) == 0) &&
+			(send_string(&sock, cred_name) == 0) &&
+#if defined(PBS_PASS_CREDENTIALS)
+			(send_string(&sock, passwd_buf) == 0) &&
+#endif
+			(send_string(&sock, v_value?v_value:"") == 0) &&
+			(send_string(&sock, basic_envlist) == 0) &&
+			(send_string(&sock, qsub_envlist?qsub_envlist:"") == 0) &&
+			(send_string(&sock, qsub_cwd) == 0) &&
+			(send_opts(&sock) == 0)) {
+
+			/* read back the first error code from the background
+			 * which confirms whether the background received our data
+			 */
+			if (dorecv(&sock, (char *) &rc, sizeof(int)) == 0) {
+				/*
+				 * we were able to send data to the background daemon.
+				 * Now, even if we fail to read back response from
+				 * background, we do not want to submit again.
+				 */
+				*do_regular_submit = 0;
+			}
+
+			/* read back response from background daemon */
+			if ((recv_string(&sock, retmsg) != 0) ||
+				dorecv(&sock, (char *) &rc, sizeof(int)) != 0) {
+
+				/* Something bad happened, either background submitted
+				 * and failed to send us response, or it failed before
+				 * submitting.
+				 */
+				rc = -1;
+				sprintf(retmsg, "Failed to recv data from background qsub\n");
+				/* fall through to print the error message */
+			}
+		}
+		/* going down, no need to free stuff */
+		close(sock);
+	}
+	return rc;
+}
+#endif
+
+/*
+ * @brief
+ *  Perform a regular submit, without the daemon.
+ *
+ * @param[in] daemon_up - Indicates whether daemon is running
+ * @return    rc        - Error code
+ */
+static int
+regular_submit(const int daemon_up)
 {
 	int rc = 0;
-	char host[PBS_MAXHOSTNAME+1];
-
-	/* set single threaded mode */
-	pbs_client_thread_set_single_threaded_mode();
-
-	/*perform needed security library initializations (including none)*/
-	if (CS_client_init() == CS_SUCCESS) {
-		cs_init = 1;
-	} else {
-		sprintf(retmsg, "qsub: unable to initialize security library.\n");
-		return 1;
-	}
-
-	/* Connect to the server */
-	if ((Interact_opt == FALSE) && (block_opt == FALSE)) {
-		sd_svr = cnt2server_extend(server_out, QSUB_DAEMON);
-	} else {
-		sd_svr = cnt2server(server_out);
-	}
-
-	if (sd_svr <= 0) {
-		sprintf(retmsg, "qsub: cannot connect to server %s (errno=%d)\n",
-			pbs_server, pbs_errno);
-		return (pbs_errno);
-	}
-
-	refresh_dfltqsubargs();
-
-	pbs_hostvar = malloc(pbs_o_hostsize + PBS_MAXHOSTNAME+1);
-	if (!pbs_hostvar) {
-		sprintf(retmsg, "qsub: out of memory\n");
-		return (2);
-	}
-	if ((rc = gethostname(host, (sizeof(host) - 1))) == 0) {
-		if ((rc = get_fullhostname(host, host, (sizeof(host) - 1))) == 0) {
-			strcpy(pbs_hostvar, ",PBS_O_HOST=");
-			strcat(pbs_hostvar, host);
+	rc = do_connect(server_out, retmsg);
+	if (rc == 0) {
+		if (sd_svr != -1) {
+#if defined(PBS_PASS_CREDENTIALS)
+			if (passwd_buf[0] != '\0')
+				pbs_encrypt_pwd(passwd_buf, &cred_type, &cred_buf, &cred_len);
+#endif
+			rc = do_submit2(retmsg);
 		}
+		else
+			rc = -1;
 	}
-	if (rc != 0) {
-		sprintf(retmsg, "qsub: cannot get full local host name\n");
-		return (3);
-	}
-	return 0;
-}
-
-/**
- * @brief
- *	This functions does a job submission ot the server using the global
- *	connected server socket sd_svr.
- *
- * @param[out] retmsg	 - Any error string is returned in this parameter
- *
- * @return int
- * @retval 0 - Success
- * @retval 1/-1/pbs_errno - Failure, retmsg paramter is set
- *
- */
-static int
-do_submit(char *retmsg)
-{
-	struct ecl_attribute_errors *err_list;
-	char *new_jobname = NULL;
-	int rc;
-	char *errmsg;
-	int retries;
-
-	if (dfltqsubargs != NULL) {
-		/*
-		 * Setting options from the server defaults will not overwrite
-		 * options set from the job script.  CMDLINE-2 means
-		 * "one less than job script priority"
-		 */
-		for (retries = 2; retries > 0; retries--) {
-			rc = do_dir(dfltqsubargs, CMDLINE - 2, retmsg, MAXPATHLEN);
-			if (rc >= 0) {
-				break;
-			}
-			if (retries == 2) {
-				refresh_dfltqsubargs();
-			}
-		}
-		if (rc != 0) {
-			return (rc);
-		}
-	}
-
-	/* set_job_env must be done here to pick up -v, -V options passed */
-	/* by default_qsub_arguments */
-	if (! set_job_env(basic_envlist, qsub_envlist)) {
 #ifndef WIN32
-		if (x11_disp) {
-			snprintf(retmsg, MAXPATHLEN,
-				"qsub: invalid usage of incompatible option –X with –v DISPLAY\n");
-		} else {
-			snprintf(retmsg, MAXPATHLEN, "qsub: cannot send environment with the job\n");
-		}
-#else
-		snprintf(retmsg, MAXPATHLEN,
-			"qsub: cannot send environment with the job\n");
+	if ((rc == 0) && !(Interact_opt != FALSE || block_opt) && (daemon_up == 0) && (no_background == 0))
+		fork_and_stay();
 #endif
-		return 1;
-	}
-
-	if (cred_name[0]) {
-		if (strcmp(cred_name, PBS_CREDNAME_DCE_KRB5) == 0 ||
-			strcmp(cred_name, PBS_CREDNAME_KRB5) == 0) {
-			if (get_krb5_ticket(pbs_server))
-				return 1;
-		} else if (strcmp(cred_name, PBS_CREDNAME_AES) == 0) {
-			if (get_passwd())
-				return 1;
-		} else if (strcmp(cred_name, PBS_CREDNAME_GRIDPROXY) == 0) {
-			if (get_grid_proxy())
-				return 1;
-		} else {
-			strcpy(retmsg, "qsub: unknown credential type\n");
-			return 1;
-		}
-	}
-
-	/* Send submit request to the server. */
-	pbs_errno = 0;
-	if (cred_buf) {
-		/* A credential was obtained, call the credential version of submit */
-		new_jobname = pbs_submit_with_cred(sd_svr, (struct attropl *) attrib,
-			script_tmp, destination, NULL, cred_type,
-			cred_len, cred_buf);
-	} else {
-		new_jobname = pbs_submit(sd_svr, (struct attropl *) attrib,
-			script_tmp, destination, NULL);
-	}
-	if (new_jobname == NULL) {
-
-		if ((err_list = pbs_get_attributes_in_error(sd_svr))) {
-			rc = handle_attribute_errors(err_list, retmsg);
-			if (rc != 0)
-				return rc;
-		}
-
-		errmsg = pbs_geterrmsg(sd_svr);
-		if (errmsg != NULL) {
-			if (strcmp(errmsg, msg_force_qsub_update) == 0)
-				return PBSE_FORCE_QSUB_UPDATE;
-			sprintf(retmsg, "qsub: %s\n", errmsg);
-		} else {
-			sprintf(retmsg, "qsub: Error (%d) submitting job\n", pbs_errno);
-		}
-		return (pbs_errno);
-	} else {
-		sprintf(retmsg, "%s", new_jobname);
-		free(new_jobname);
-	}
-	return 0;
+	return rc;
 }
 
-/**
- * @brief
- *	Save original values of qsub option variables.
- *
+/*
+ * End of "Daemon" functions.
  */
-static void
-save_opts()
+
+int
+main(int argc, char **argv, char **envp)   /* qsub */
 {
-	/* save the values */
-	a_opt_o = a_opt;
-	c_opt_o = c_opt;
-	e_opt_o = e_opt;
-	h_opt_o = h_opt;
-	j_opt_o = j_opt;
-	k_opt_o = k_opt;
-	l_opt_o = l_opt;
-	m_opt_o = m_opt;
-	o_opt_o = o_opt;
-	p_opt_o = p_opt;
-	q_opt_o = q_opt;
-	r_opt_o = r_opt;
-	u_opt_o = u_opt;
-	v_opt_o = v_opt;
-	z_opt_o = z_opt;
-	A_opt_o = A_opt;
-	C_opt_o = C_opt;
-	J_opt_o = J_opt;
-	M_opt_o = M_opt;
-	N_opt_o = N_opt;
-	S_opt_o = S_opt;
-	V_opt_o = V_opt;
-	Depend_opt_o = Depend_opt;
-	Interact_opt_o = Interact_opt;
+	int errflg;                         /* option error */
+	static char script[MAXPATHLEN+1] = "";   /* name of script file */
+	char *q_n_out;                      /* queue part of destination */
+	char *s_n_out;                      /* server part of destination */
+	/* server:port to send request to */
+	char *cmdargs = NULL;
+	int command_flag = 0;
+	int rc = 0; /* error code for submit */
+	int do_regular_submit = 1; /* used if daemon based submit fails */
+#ifdef WIN32 /* Windows */
+	char qsub_exe[MAXPATHLEN+1];
+#endif
+	int daemon_up = 0;
+
+	/* Set signal handlers */
+	set_sig_handlers();
+
+	/*
+	 * Print version info and exit, if specified with --version option.
+	 * Otherwise, proceed normally.
+	 */
+	execution_mode(argc, argv);
+
+	/*
+	 * Identify the configured tmpdir without calling pbs_loadconf().
+	 * We do not want to incur the cost of parsing the services DB.
+	 */
+	tmpdir = pbs_get_tmpdir();
+	if (tmpdir == NULL) {
+		fprintf(stderr, "qsub: Failed to load configuration parameters!\n");
+		exit_qsub(2);
+	}
+
 #ifdef WIN32
-	gui_opt_o = gui_opt;
+	/*
+	 * In windows, the foreground qsub process does a createprocess of the
+	 * same executable (since there is no equivalent of fork). It calls the
+	 * child qsub with parameters "--daemon" as the first parameter. This
+	 * check here ensures that this invocation of qsub was to make it a
+	 * background process and not a user invocation. The --daemon parameter
+	 * is not documented to the user (or part of the syntax printed).
+	 * The parameters that are passed on to the child qsub process:
+	 * 1) --daemon --> Signifying that it is to become a daemon process
+	 * 2) Named Pipe Name --> Name of the named pipe on which to communicate
+	 * 3) Handle to synchronization event
+	 * 4) Name of the target server, if any, else NULL/empty
+	 *
+	 */
+	if ((argc == 4 || argc == 5) && (strcasecmp(argv[1], "--daemon")==0)) {
+		if (argc == 4)
+			do_daemon_stuff(argv[2], argv[3], NULL);
+		else
+			do_daemon_stuff(argv[2], argv[3], argv[4]);
+		exit(0);
+	}
+
+	/* note the name of the qsub executable */
+	if (snprintf(qsub_exe, sizeof(qsub_exe), "%s", argv[0]) != sizeof(qsub_exe)) {
+		fprintf(stderr, "qsub: Name of executable is too long\n");
+		exit_qsub(2);
+	}
 #endif
-	Stagein_opt_o = Stagein_opt;
-	Stageout_opt_o = Stageout_opt;
-	Sandbox_opt_o = Sandbox_opt;
-	Grouplist_opt_o = Grouplist_opt;
-	Resvstart_opt_o = Resvstart_opt;
-	Resvend_opt_o = Resvend_opt;
-	pwd_opt_o = pwd_opt;
-	cred_opt_o = cred_opt;
-	block_opt_o = block_opt;
-	relnodes_on_stageout_opt_o = relnodes_on_stageout_opt;
-	P_opt_o = P_opt;
-
-}
-
-/**
- * @brief
- *	Initialize qsub option variables to their original values.
- *
- */
-static void
-restore_opts()
-{
-	/* save the values */
-	a_opt = a_opt_o;
-	c_opt = c_opt_o;
-	e_opt = e_opt_o;
-	h_opt = h_opt_o;
-	j_opt = j_opt_o;
-	k_opt = k_opt_o;
-	l_opt = l_opt_o;
-	m_opt = m_opt_o;
-	o_opt = o_opt_o;
-	p_opt = p_opt_o;
-	q_opt = q_opt_o;
-	r_opt = r_opt_o;
-	u_opt = u_opt_o;
-	v_opt = v_opt_o;
-	z_opt = z_opt_o;
-	A_opt = A_opt_o;
-	C_opt = C_opt_o;
-	J_opt = J_opt_o;
-	M_opt = M_opt_o;
-	N_opt = N_opt_o;
-	S_opt = S_opt_o;
-	V_opt = V_opt_o;
-	Depend_opt = Depend_opt_o;
-	Interact_opt = Interact_opt_o;
-	Stagein_opt = Stagein_opt_o;
-	Stageout_opt = Stageout_opt_o;
-	Sandbox_opt = Sandbox_opt_o;
-	Grouplist_opt = Grouplist_opt_o;
-	Resvstart_opt = Resvstart_opt_o;
-	Resvend_opt = Resvend_opt_o;
-	pwd_opt = pwd_opt_o;
-	cred_opt = cred_opt_o;
-	block_opt = block_opt_o;
-	relnodes_on_stageout_opt = relnodes_on_stageout_opt_o;
-	P_opt = P_opt_o;
-
-}
-
-/**
- *
- * @brief
- *	The wrapper program to "do_submit()".
- * @par
- *	This attempts up to 'retry' times to do_submit(), when this function
- *	returns PBSE_FORCE_QSUB_UPDATE.
- *
- * @param[in]	retmsg - gets filled with the error message.
- *
- * @return 	int
- * @retval	the return code of do_submit().
- * @retval	if retry time exhausted or any unexpected failure,
- * 		return PBSE_PROTOCOL
- *
- */
-
-static int
-do_submit2(char *rmsg)
-{
-	int	retry=5;	/* do a retry count to prevent infinite loop */
-	int	rc;
 
 
-	rmsg[0] = '\0';
-	/* save the original job attributes/resources (attrib)	*/
-	/* before 'default_qsub_arguments" was applied. 	*/
-	if (attrib != NULL) {
-		if (attrib_o != NULL)
-			free_attrl(attrib_o);
-		attrib_o = dup_attrl(attrib); /* save attributes list */
-		if (attrib_o == NULL) {
-			snprintf(rmsg, MAXPATHLEN-1,
-				"Failed to duplicate attributes list.\n");
-			return PBSE_PROTOCOL;
-		}
+	/*
+	 * If qsub command is submitted with arguments, then capture them and
+	 * encode in XML format using encode_xml_arg_list() and set the
+	 * "Submit_arguments" job attribute.
+	 */
+	if ((argc >= 2) && (cmdargs = encode_xml_arg_list(1, argc, argv))) {
+		set_attr(&attrib, ATTR_submit_arguments, cmdargs);
+		free(cmdargs);
+		cmdargs = NULL;
 	}
 
-	/* original v_value also needs to be saved as it gets mangled */
-	/* inside set_job_env() */
-	if (v_value != NULL) {
-		if (v_value_o != NULL)
-			free(v_value_o);
-		v_value_o = strdup(v_value);
-		if (v_value_o == NULL) {
-			snprintf(rmsg, MAXPATHLEN-1,
-				"Failed to duplicate original -v value\n");
-			return PBSE_PROTOCOL;
-		}
+	/* Process options */
+	errflg = process_opts(argc, argv, CMDLINE);  /* get cmd-line options */
+	if (errflg) {
+		print_usage();
+		exit_qsub  (2);
 	}
+	/* Process special arguments */
+	command_flag = process_special_args(argc, argv, script);
 
-	/* Need to save original values of qsub option variables, */
-	/* as "reset_dfltqsubargs() below could "lose" memory	  */
-	/* of the option variable values. The values are	  */
-	/* needed in case a new "default_qsub_arguments come and  */
-	/* gets reparsed.					  */
-	save_opts();
-
-	rc = do_submit(rmsg);
-	while ((rc == PBSE_FORCE_QSUB_UPDATE) && (retry > 0)) {
-		/* Let's retry with the new "default_qsub_arguments" 	*/
-		refresh_dfltqsubargs();
-
-		/* Use the original attrib value before the previous	*/
-		/* "default_qsub_arguments" was applied.		*/
-		if (attrib_o != NULL) {
-			if (attrib != NULL)
-				free_attrl(attrib);
-			attrib = dup_attrl(attrib_o);
-			if (attrib == NULL) {
-				snprintf(rmsg, MAXPATHLEN-1,
-					"Failed to duplicate attributes list\n");
-				return PBSE_PROTOCOL;
-			}
-		}
-
-		/* use original -v value */
-		if (v_value_o != NULL) {
-			if (v_value != NULL)
-				free(v_value);
-			v_value = strdup(v_value_o);
-			if (v_value == NULL) {
-				snprintf(rmsg, MAXPATHLEN-1,
-					"Failed to duplicate -v value\n");
-				return PBSE_PROTOCOL;
-			}
-		}
-
-		restore_opts();
-
-		rc = do_submit(rmsg);
-		retry--;
-	}
-	if (retry == 0) {
-		snprintf(rmsg, MAXPATHLEN-1,
-			"Retry to submit a job exhausted.\n");
-		rc = PBSE_PROTOCOL;
-	}
-	return (rc);
-}
-
-/**
- * @brief
- *	Helper function to free a list of attributes. This is called from
- *	do_daemon_stuff, since that function loops over for each client request.
- *	No freeing the list of attributes created would result in a lot of
- *	memory leak.
- *
- * @param[in]	attrib - The list of attributes to free
- *
- */
-static void
-free_attrl(struct attrl *attrib)
-{
-	struct attrl *attr;
-
-	while (attrib) {
-		free(attrib->name);
-		if (attrib->resource)
-			free(attrib->resource);
-		free(attrib->value);
-
-		attr = attrib;
-		attrib = attrib->next;
-		free(attr);
-	}
-}
-
-/**
- * @brief
- *	Helper function to duplicate the passed attrl structure.
- *
- * @param[in]	attrib - The list of attributes to copy
- *
- * @return	struct attrl * - the duplicated 'attrib' (malloced).
- * @retval	non-NULL - success.
- * @retval	NULL - failure.
- *
- */
-static struct attrl *
-dup_attrl(struct attrl *attrib)
-{
-	struct attrl *attr = NULL;
-	struct attrl *attr_new = NULL;
-
-	attr = attrib;
-	while (attr) {
-		if (attr->resource != NULL) {
-			/* strings have null character also in buf */
-			set_attr_resc(&attr_new, attr->name,
-				attr->resource,
-				attr->value);
-		} else {
-			set_attr(&attr_new, attr->name, attr->value);
-		}
-
-		attr=attr->next;
-	}
-
-	return attr_new;
-}
-
-/**
- * @brief
- *	Helper function to get the pbs conf file path, and
- *	convert it to a string, later added to the filename
- *	(pipe or unix domain socket filename) that is used
- *	for communications between the front-end and
- *	background qsub processes.
- *	The path to the pbs conf file is converted to a string
- *	by replacing the slashes with underscrore char.
- *	If PBS_CONF_FILE is not set, then an empty string
- *	is returned.
- *
- * @return - The string representing path to the pbs conf file
- *
- */
-static char *
-get_conf_path()
-{
-	char *cnf = getenv("PBS_CONF_FILE");
-	char *dup_cnf_path = "";
-	char *p;
-
-	if (cnf) {
-		p = strdup(cnf);
-		if (p) {
-			dup_cnf_path = p;
-			while (*p) {
 #ifdef WIN32
-				if (*p == '\\' || *p == ':' || *p == ' ' || *p == '.')
-					*p = '_';
-#else
-				if (*p == '/' || *p == ' ' || *p == '.')
-					*p = '_';
+	back2forward_slash(script);
 #endif
-				p++;
-			}
-		}
+
+	if (command_flag == 0)
+		/* Read the job script from a file or stdin */
+		read_job_script(script);
+
+	/* Enable X11 Forwarding (on Unix) or GUI (on Windows) if specified */
+	enable_gui();
+
+	/* Set option default values */
+	set_opt_defaults();
+
+	/* Parse destination string */
+	server_out[0] = '\0';
+	if (parse_destination_id(destination, &q_n_out, &s_n_out)) {
+		fprintf(stderr, "qsub: illegally formed destination: %s\n", destination);
+		(void)unlink(script_tmp);
+		exit_qsub(2);
+	} else if (notNULL(s_n_out)) {
+		snprintf(server_out, sizeof(server_out), "%s", s_n_out);
 	}
-	return dup_cnf_path;
-}
+
+	/* Get required environment variables to be sent to the server. */
+	/* Must be done early here, as basic_envlist and qsub_envlist will */
+	/* be sent to the qsub daemon if needed */
+	basic_envlist = job_env_basic();
+	if (basic_envlist == NULL)
+		exit_qsub(3);
+	if (V_opt)
+		qsub_envlist = env_array_to_varlist(envp);
+
+	/*
+	 * Disable backgrounding if we are inside another qsub
+	 */
+	if (getenv(ENV_PBS_JOBID) != NULL)
+		no_background = 1;
+
+	/*
+	 * In case of interactive jobs, jobs with block=true, or no_background == 1,
+	 * qsub should fully execute from the foreground, so daemon_submit() is not called.
+	 * It should not fork, neither should it send the data to the background qsub.
+	 *
+	 * If all 3 of these options are zero, then try to submit via daemon.
+	 */
+	if ((Interact_opt || block_opt || no_background) == 0) {
+		/* Try to submit jobs using a daemon */
+#ifdef WIN32
+		rc = daemon_submit(qsub_exe, &do_regular_submit);
+#else
+		rc = daemon_submit(&daemon_up, &do_regular_submit);
+#endif
+	}
+
+	if (do_regular_submit == 1)
+		/* submission via daemon was not successful, so do regular submit */
+		rc = regular_submit(daemon_up);
+
+	/* remove temporary job script file */
+	(void)unlink(script_tmp);
+
+	if (rc == 0) { /* submit was successful */
+		new_jobname = retmsg;
+		if (!z_opt && Interact_opt == FALSE)
+			printf("%s\n", retmsg); /* print jobid with a \n */
+	} else {
+		/* error, print whatever our daemon gave us back */
+		fprintf(stderr, "%s", retmsg);
+		/* check if the retmsg has "qsub: illegal -" string, if so print usage */
+		if (strstr(retmsg, "qsub: illegal -"))
+			print_usage();
+		exit_qsub(rc);
+	}
+
+	/* is this an interactive job ??? */
+	if (Interact_opt != FALSE)
+		interactive();
+	else if (block_opt) { /* block until job completes? */
+		fflush(stdout);
+		block();
+	}
+
+	exit_qsub(0);
+	return (0);
+} /* end of main() */


### PR DESCRIPTION
#### Bug/feature Description
* The qsub code is very long (over 4000 lines, not including comments and whitespace), and it is difficult to read, understand, and maintain. This makes it difficult to track down and fix bugs in the qsub code that negatively affect users.
* Additionally, there are numerous instances of unsafe copying of null-terminated strings from user-inputted data into fixed length buffers. Because of this, the qsub program is susceptible to buffer overflow attacks from a negligent or malicious user. 

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* Over the years, adding features in an ad-hoc manner has negatively impacted the structure and organization of the code.
* Buffer overflows can occur when a function such as strcpy() is used to copy data from an arbitrarily long input string (such as user inputted data) into a fixed length buffer. strncpy() prevents an overflow from happening during the copying itself, but it may not include a null terminator, which can cause issues when reading from the buffer. 

#### Solution Description
* Reduced length of main() by 70%, by encapsulating long blocks of code into functions.
* Re-ordered functions according to 8 categories, thus improving overall program organization and eliminating redundant function declarations at the top of the file. The 8 categories are:
  * Utility
  * Interactive Job
  * Block Job
  * Kerberos Authentication
  * Options Processing
  * Job Script
  * Environment Variables
  * Daemon & Submit
* Fixed unsafe copying of strings into fixed length buffers by using snprintf().
* Organized global variables and wrote comments describing them.
* Limited scope of functions and variables by using static keyword.
* Improved consistency of formatting in accordance with the Coding Standards. 
* Fixed some typos.

#### Testing logs/output
[pbs_qsub_direct_write.txt](https://github.com/PBSPro/pbspro/files/2143213/pbs_qsub_direct_write.txt)
[pbs_qsub_performance.txt](https://github.com/PBSPro/pbspro/files/2143214/pbs_qsub_performance.txt)
[pbs_qsub_remove_files.txt](https://github.com/PBSPro/pbspro/files/2143215/pbs_qsub_remove_files.txt)
[pbs_passing_environment_variable.txt](https://github.com/PBSPro/pbspro/files/2143216/pbs_passing_environment_variable.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
