### PR TITLE
PBSPro: Labeling/Tag PTL tests as CI, Nightly and Smoke

### DIFF
--- a/test/tests/functional/pbs_cray_smoketest.py
+++ b/test/tests/functional/pbs_cray_smoketest.py
@@ -40,7 +40,7 @@ from ptl.utils.pbs_crayutils import CrayUtils
 import os
 
 
-@tags('cray', 'smoke')
+@tags('cray', 'smoke','CI','tier_two')
 class TestCraySmokeTest(TestFunctional):
 
     """
@@ -96,7 +96,7 @@ class TestCraySmokeTest(TestFunctional):
                     continue
         return found
 
-    @tags('cray', 'smoke')
+    @tags('cray', 'smoke','CI','tier_two')
     def test_cray_login_job(self):
         """
         Submit a simple sleep job that requests to run on a login node
@@ -138,7 +138,7 @@ class TestCraySmokeTest(TestFunctional):
         foundhw = self.find_hw(output_file)
         self.assertEqual(foundhw, 1, msg="Job output file incorrect")
 
-    @tags('cray', 'smoke')
+    @tags('cray', 'smoke','CI','tier_two')
     def test_cray_compute_job(self):
         """
         Submit a simple sleep job that runs on a compute node and

--- a/test/tests/functional/pbs_cray_suspend_resume.py
+++ b/test/tests/functional/pbs_cray_suspend_resume.py
@@ -54,7 +54,7 @@ class TestSuspendResumeOnCray(TestFunctional):
             self.skipTest("Test suite only meant to run on a Cray")
         TestFunctional.setUp(self)
 
-    @tags('cray', 'smoke')
+    @tags('cray', 'smoke','CI','tier_two')
     def test_default_restrict_res_to_release_on_suspend_setting(self):
         """
         Check that on Cray restrict_res_to_release_on_suspend is always set

--- a/test/tests/functional/pbs_cray_vnode_per_numa.py
+++ b/test/tests/functional/pbs_cray_vnode_per_numa.py
@@ -52,7 +52,7 @@ class TestVnodePerNumaNode(TestFunctional):
             self.skipTest("Test suite only meant to run on a Cray")
         TestFunctional.setUp(self)
 
-    @tags('cray', 'smoke')
+    @tags('cray', 'smoke','CI','tier_two')
     def test_settings(self):
         """
         vnode_per_numa_node is unset (defaults to FALSE).

--- a/test/tests/functional/pbs_qstat_json.py
+++ b/test/tests/functional/pbs_qstat_json.py
@@ -57,7 +57,7 @@ class TestQstat_json(PBSTestSuite):
                         self.parse_json(val, qstat_attr)
         return qstat_attr
 
-    @tags('smoke')
+    @tags('smoke','CI','tier_two')
     def test_qstat_json_valid(self):
         """
         Test json output of qstat -f is in valid format when querired as a
@@ -152,7 +152,7 @@ class TestQstat_json(PBSTestSuite):
         except ValueError, e:
             self.assertTrue(False)
 
-    @tags('smoke')
+    @tags('smoke','CI','tier_two')
     def test_qstat_bf_json_valid(self):
         """
         Test json output of qstat -Bf is in valid format and all
@@ -185,7 +185,7 @@ class TestQstat_json(PBSTestSuite):
             if attr not in qstat_attr:
                 self.assertFalse(attr + " is missing")
 
-    @tags('smoke')
+    @tags('smoke','CI','tier_two')
     def test_qstat_qf_json_valid(self):
         """
         Test json output of qstat -Qf is in valid format and all

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -38,7 +38,7 @@
 from ptl.utils.pbs_testsuite import *
 
 
-@tags('smoke')
+@tags('smoke','CI','tier_two')
 class SmokeTest(PBSTestSuite):
 
     """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* We have 3 categories of tests that we run frequently but the PTL tests are not tagged accordingly.
* Issue ID : [PBS-18817](https://jira.prog.altair.com/browse/PBS-18817)

#### Affected Platform(s)
* All platforms

#### Cause / Analysis / Design
* Bugs: Currently there is only single tag, that is 'smoke', in the PTL tests.
* We are sub dividing the smoke test into two parts: Continuous Integration Tests and Nightly Tests.

#### Solution Description
* Changed the tag in PTL tests wherever there is a smoke label. 
* Added CI label for Continuous Integration tests and tier_two label for Nightly tests

#### Testing logs/output
Test Log File: [ptl.txt](https://github.com/PBSPro/pbspro/files/2147849/ptl.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
