### PR TITLE
Fix clang warning: use of logical OR with constant / if statement always true

### DIFF
--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -1022,7 +1022,7 @@ main(int argc, char *argv[])
 				break;
 
 			case 'S':
-				if (oper == LISTSP || oper == ALL || LISTSPNV)
+				if (oper == LISTSP || oper == ALL || oper == LISTSPNV)
 					prt_summary = 1;
 				else
 					errflg = 1;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
clang (alternative C compiler) warned:

```
pbsnodes.c:1025:39: warning: use of logical '||' with constant operand [-Wconstant-logical-operand]
if (oper == LISTSP || oper == ALL || LISTSPNV)
```

LISTSPNV is 8.  This if statement will always be true.

#### Affected Platform(s)
* ALL

#### Solution Description
Change the last expression to `oper == LISTSPNV`

#### Testing logs/output
* [PTL tests in progress]
* New test: I don't really know how to add a new test for this yet. In case 'S', oper is always either `LISTSP` or `LISTSPNV` so I cannot find a case where `oper` is equal to something else. All I did was testing `qsub -S` to make sure it still works. If you have a good idea on testing this, let me know in the comments. 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__