### PR TITLE
Fix syntax gets messed up while exporting shell functions with qsub -V bug

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -490,15 +490,6 @@ copy_env_value(char *dest, char *pv, int quote_flg)
 					pv++;
 				break;
 
-			case '\n':
-				if (is_func) {
-					*dest++ = ';';
-					*dest++ = ' ';
-				} else {
-					*dest++ = *pv;
-				}
-				break;
-
 			default:
 				*dest++ = *pv;
 				break;

--- a/test/tests/functional/pbs_hook_set_jobenv.py
+++ b/test/tests/functional/pbs_hook_set_jobenv.py
@@ -193,7 +193,7 @@ class TestPbsHookSetJobEnv(TestFunctional):
         for msg in logmsg:
             if (daemon == "mom"):
                 # Match the trailing separator (',')
-                self.mom.log_match(msg + ',', max_attempts=3)
+                self.mom.log_match(msg + ',')
             elif (daemon == "server"):
                 self.server.log_match(msg, starttime=self.server.ctime)
 

--- a/test/tests/performance/pbs_qsub_performance.py
+++ b/test/tests/performance/pbs_qsub_performance.py
@@ -48,6 +48,7 @@ class TestQsubPerformance(TestPerformance):
         attr = {'scheduling': 'False'}
         self.server.manager(MGR_CMD_SET, SERVER, attr)
 
+    @timeout(400)
     def test_submit_large_env(self):
         """
         submission of 1000 jobs


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
`qsub -V` adds a semicolon to new line when exporting shell functions 

```
[root@centos ~]# foo()
> { if [ /bin/true ];
> then
> echo true;
> fi };
[root@centos ~]# export -f foo
[root@centos ~]# foo
true
[root@centos ~]# qsub -I -V
qsub: waiting for job 1.rubicon-bl3 to start
qsub: job 1.centos ready
 ** 
-bash: foo: line 1: syntax error: unexpected end of file
-bash: error importing function definition for `BASH_FUNC_foo'
```

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
In `qsub.c`, the `copy_env_value` function adds a semicolon to a new line in shell functions. 

#### Solution Description
Delete case '\n' in `copy_env_value`

#### Testing logs/output
* Test_passing_environment_variable_via_qsub
  - [test_commas_in_custom_variable.txt](https://github.com/PBSPro/pbspro/files/2171468/test_commas_in_custom_variable.txt)
  - [test_passing_shell_function.txt](https://github.com/PBSPro/pbspro/files/2156885/test_passing_shell_function.txt)
  - [test_passing_shell_function_new.txt](https://github.com/PBSPro/pbspro/files/2232908/test_passing_shell_function_new.txt)

* TestPbsHookSetJobEnv
  - [test_que.txt](https://github.com/PBSPro/pbspro/files/2156886/test_que.txt)
  - [test_interactive_no_hook.txt](https://github.com/PBSPro/pbspro/files/2156887/test_interactive_no_hook.txt)
  - [test_no_hook.txt](https://github.com/PBSPro/pbspro/files/2156888/test_no_hook.txt)
  - test_interactive
* TestQsubPerformance
  - [test_submit_large_env.txt](https://github.com/PBSPro/pbspro/files/2168166/test_submit_large_env.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__