### PR TITLE
Scheduler reports preempted job as Can Never Run for one cycle (recurrence)

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3265,7 +3265,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 			pjob->job->resreleased = create_res_released_array(npolicy, pjob);
 			pjob->job->resreq_rel = create_resreq_rel_list(npolicy, pjob);
 
-			update_universe_on_end(policy, pjob,  "S", NO_ALLPART);
+			update_universe_on_end(npolicy, pjob,  "S", NO_ALLPART);
 			if ( nsinfo->calendar != NULL ) {
 				te = find_timed_event(nsinfo->calendar->events, pjob->name, TIMED_END_EVENT, 0);
 				if (te != NULL) {
@@ -3335,7 +3335,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 
 				schdlog(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG, njob->name,
 					"Simulation: Preempted enough work to run job");
-				rc = sim_run_update_resresv(policy, njob, ns_arr, NO_ALLPART);
+				rc = sim_run_update_resresv(npolicy, njob, ns_arr, NO_ALLPART);
 				break;
 			}
 
@@ -3423,7 +3423,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 			clear_schd_error(err);
 			if (preemption_similarity(njob, pjobs[j], full_err) == 0) {
 				remove_job = 1;
-			} else if ((ns_arr = is_ok_to_run(policy, nsinfo,
+			} else if ((ns_arr = is_ok_to_run(npolicy, nsinfo,
 				pjobs[j]->job->queue, pjobs[j], NO_ALLPART, err)) != NULL) {
 				remove_job = 1;
 				sim_run_update_resresv(npolicy, pjobs[j], ns_arr, NO_ALLPART);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* The node-bucket check-in (#711) accidentally re-introduced the bug that was fixed by #630 

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* #711 unintentionally reverted the bugfix by passing "update_universe_on_end" the original policy object instead of the dup'd object.

#### Solution Description
* Reverting back the accidental reversal of the original fix (sorry, no better way to describe this)

#### Testing logs/output
[test_preempted_never_run_after_fix.log](https://github.com/PBSPro/pbspro/files/2177974/test_preempted_never_run_after_fix.log)


[test_preempted_never_run_before_fix.log](https://github.com/PBSPro/pbspro/files/2161568/test_preempted_never_run_before_fix.log)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
