### PR TITLE
Bug fix for Scheduler does a reconfigure after restart of pbs service…

### DIFF
--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2007,6 +2007,7 @@ try_db_again:
 	 * and fairshare usage.
 	 */
 	(void)contact_sched(SCH_CONFIGURE, NULL, pbs_scheduler_addr, pbs_scheduler_port);
+	(void)contact_sched(SCH_SCHEDULE_NULL, NULL, pbs_scheduler_addr, pbs_scheduler_port);
 
 
 	/*

--- a/test/tests/functional/pbs_verify_log_output.py
+++ b/test/tests/functional/pbs_verify_log_output.py
@@ -131,3 +131,23 @@ class TestVerifyLogOutput(TestFunctional):
                 starttime=self.server.ctime,
                 max_attempts=5,
                 interval=2)
+
+    def test_auto_sched_cycle_trigger(self):
+        """
+        Test case to verify that scheduling cycle is triggered automatically
+        without any delay  after restart of PBS Services.
+        """
+        started_time = time.time()
+        self.logger.info('Restarting PBS Services')
+        PBSInitServices().restart()
+
+        if self.server.isUp() and self.scheduler.isUp():
+            try:
+                self.scheduler.log_match("Req;;Starting Scheduling Cycle",
+                                         max_attempts=10,
+                                         starttime=started_time)
+                self.scheduler.log_match("Req;;Leaving Scheduling Cycle",
+                                         max_attempts=10,
+                                         starttime=started_time)
+            except PtlLogMatchError:
+                self.assertFalse(True)


### PR DESCRIPTION
…s causing delayed scheduling cycle

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Scheduling cycle is delayed when PBS Services are restarted.

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* As contact_sched() with command SCH_CONFIGURE has been introduced recently which makes scheduler to reread the configuration while server is getting initialized. And after that server calls scheduling_jobs() immediately upon which Scheduler is receiving the SCH_SCHEDULE_FIRST command in its secondary connection instead of its primary connection and hence the issue is happening. 

#### Solution Description
* Introduce one more call to contact_sched with the command SCH_SCHEDULE_NULL immediately after the following contact_sched.
(void)contact_sched(SCH_CONFIGURE, NULL, pbs_scheduler_addr, pbs_scheduler_port);

This will make sure that SCH_SCHEDULE_FIRST command is reached at the primary connection of scheduler.

#### Testing logs/output
* Have written new PTL test case to address the issue. Following are the logs relating to it.
[test_auto_sched_cycle_trigger.log](https://github.com/PBSPro/pbspro/files/2165180/test_auto_sched_cycle_trigger.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
