### PR TITLE
Decouple pbs_benchpress from PBSTestSuite to CommonTestSuite

### DIFF
--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -55,7 +55,7 @@ from ptl.utils.plugins.ptl_test_db import PTLTestDb
 from ptl.utils.plugins.ptl_test_info import PTLTestInfo
 from ptl.utils.plugins.ptl_test_tags import PTLTestTags
 from ptl.utils.plugins.ptl_test_data import PTLTestData
-
+from ptl.utils.common_testsuite import *
 
 # trap SIGINT and SIGPIPE
 def trap_exceptions(etype, value, tb):
@@ -420,7 +420,7 @@ if __name__ == '__main__':
         tests = os.getcwd()
 
     if testsuites is None:
-        testsuites = 'PBSTestSuite'
+        testsuites = 'CommonTestSuite'
         follow = True
 
     if only_info:

--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -57,6 +57,7 @@ from ptl.utils.plugins.ptl_test_tags import PTLTestTags
 from ptl.utils.plugins.ptl_test_data import PTLTestData
 from ptl.utils.common_testsuite import *
 
+
 # trap SIGINT and SIGPIPE
 def trap_exceptions(etype, value, tb):
     sys.excepthook = sys.__excepthook__

--- a/test/fw/ptl/utils/common_testsuite.py
+++ b/test/fw/ptl/utils/common_testsuite.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+import unittest
+
+
+class CommonTestSuite(unittest.TestCase):
+
+    """
+    Generic Class for PTL. Anything that is common
+    with respect to the test framework is desired to go here.
+    """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -52,6 +52,7 @@ from ptl.utils.pbs_dshutils import DshUtils
 from ptl.utils.pbs_cliutils import CliUtils
 from ptl.utils.pbs_procutils import ProcMonitor
 from ptl.lib.pbs_testlib import *
+from ptl.utils.common_testsuite import *
 try:
     from ptl.utils.plugins.ptl_test_tags import tags
 except ImportError:
@@ -302,7 +303,7 @@ class tearDownClassError(Exception):
     pass
 
 
-class PBSTestSuite(unittest.TestCase):
+class PBSTestSuite(CommonTestSuite):
 
     """
     Generic ``setup``, ``teardown``, and ``logging`` functions to

--- a/test/fw/ptl/utils/plugins/ptl_test_info.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_info.py
@@ -41,6 +41,7 @@ from nose.plugins.base import Plugin
 from ptl.utils.pbs_testsuite import PBSTestSuite
 from ptl.utils.plugins.ptl_test_tags import TAGKEY
 from copy import deepcopy
+from ptl.utils.common_testsuite import *
 
 log = logging.getLogger('nose.plugins.PTLTestInfo')
 
@@ -112,9 +113,9 @@ class PTLTestInfo(Plugin):
         """
         Is the class wanted?
         """
-        if not issubclass(cls, PBSTestSuite):
+        if not issubclass(cls, CommonTestSuite):
             return False
-        if cls.__name__ == 'PBSTestSuite':
+        if cls.__name__ == 'CommonTestSuite':
             return False
         self._tree.setdefault(cls.__name__, cls)
         if len(cls.__bases__) > 0:

--- a/test/fw/ptl/utils/plugins/ptl_test_loader.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_loader.py
@@ -40,6 +40,7 @@ import sys
 import logging
 from nose.plugins.base import Plugin
 from ptl.utils.pbs_testsuite import PBSTestSuite
+from ptl.utils.common_testsuite import *
 
 log = logging.getLogger('nose.plugins.PTLTestLoader')
 
@@ -198,10 +199,10 @@ class PTLTestLoader(Plugin):
 
     def check_follow(self, cls, method=None):
         cname = cls.__name__
-        if not issubclass(cls, PBSTestSuite):
+        if not issubclass(cls, CommonTestSuite):
             return False
-        if cname == 'PBSTestSuite':
-            if 'PBSTestSuite' not in self._tests_list[self._only_ts]:
+        if cname == 'CommonTestSuite':
+            if 'CommonTestSuite' not in self._tests_list[self._only_ts]:
                 return False
         if cname in self._excludes_list[self._only_ts]:
             return False

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -63,6 +63,7 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from StringIO import StringIO
+from ptl.utils.common_testsuite import *
 
 log = logging.getLogger('nose.plugins.PTLTestRunner')
 
@@ -532,7 +533,7 @@ class PTLTestRunner(Plugin):
     def startContext(self, context):
         context.param = self.param
         context.start_time = datetime.datetime.now()
-        if isclass(context) and issubclass(context, PBSTestSuite):
+        if isclass(context) and issubclass(context, CommonTestSuite):
             self.result.logger.info(self.result.separator1)
             self.result.logger.info('suite name: ' + context.__name__)
             doc = context.__doc__


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Decouple pbs_benchpress from PBSTestSuite to CommonTestSuite

#### Affected Platform(s)
None

#### Cause / Analysis / Design
As of now pbs_benchpress is tightly coupled with PBSTestsuite, and thus require PBS to be pre-installed for running any test case. The issue is that we have PBS Installation test cases that require overwriting of PBSTestSuite when automated with current design. So we are proposing to decouple pbs_bencpress from PBSTestSuite to CommonTestSuite, so that such kind of test cases that do not require PBS to be pre-installed can be easily automated.

#### Solution Description
* *The solution is to introduce new class "CommonTestSuite" that inherits from "unittest.TestCase" and make PBSTestSuite as subclass of CommonTestSuite.
With this changes pbs_benchpress, ptl_test_info.py, ptl_test_loader.py, ptl_test_runner.py has to be modified accordingly as these scripts look for "PBSTestSuite" for loading and running PTL test cases.*

#### Testing logs/output
Smoke Test logs after making the changes:
[Smoke_Test_CommonTestSuite.log](https://github.com/PBSPro/pbspro/files/2169123/Smoke_Test_CommonTestSuite.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
