### PR TITLE
Fixed scheduler crash with ASAP reservations

### DIFF
--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -705,6 +705,7 @@ calc_run_time(char *name, server_info *sinfo, int flags)
 	int desc;
 	nspec **ns = NULL;
 	unsigned int ok_flags = NO_ALLPART;
+	queue_info *qinfo = NULL;
 
 	if (name == NULL || sinfo == NULL)
 		return (time_t) -1;
@@ -719,8 +720,10 @@ calc_run_time(char *name, server_info *sinfo, int flags)
 
 	if (flags & USE_BUCKETS)
 		ok_flags |= USE_BUCKETS;
-	if (resresv->is_job)
+	if (resresv->is_job) {
 		ok_flags |= IGNORE_EQUIV_CLASS;
+		qinfo = resresv->job->queue;
+	}
 
 	err = new_schd_error();
 	if(err == NULL)
@@ -734,7 +737,7 @@ calc_run_time(char *name, server_info *sinfo, int flags)
 		desc = describe_simret(ret);
 		if (desc > 0 || (desc == 0 && policy_change_info(sinfo, resresv))) {
 			clear_schd_error(err);
-			ns = is_ok_to_run(sinfo->policy, sinfo, resresv->job->queue, resresv, ok_flags, err);
+			ns = is_ok_to_run(sinfo->policy, sinfo, qinfo, resresv, ok_flags, err);
 		}
 
 		if (ns == NULL) /* event can not run */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Submitting an ASAP reservation will crash the scheduler
* Steps to reproduce:
1. submit job
2. qsub -Wqmove job
3. scheduler crashes

#### Cause / Analysis / Design
* The function which calculates the start time for jobs and reservations(calc_run_time()) was recently refactored.  It works fine for jobs, but will dereference the resresv->job pointer which is only set on jobs.

#### Solution Description
* The is_ok_to_run() function is used for both jobs and reservations.  It takes a queue as a parameter.  It is only used for jobs and should be NULL for reservations.  The crash happened when resresv->job->queue was passed to is_ok_to_run().  The resresv->job pointer was NULL.  Now I only pass resresv->job->queue if the resresv is a job or NULL if it is a reservation.

#### Testing logs/output
* [ptl.log](https://github.com/PBSPro/pbspro/files/2186458/ptl.log)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
