### PR TITLE
Increase timeout for test_cgroups_race_condition

### DIFF
--- a/test/tests/performance/pbs_cgroups_stress.py
+++ b/test/tests/performance/pbs_cgroups_stress.py
@@ -190,7 +190,7 @@ class TestCgroupsStress(TestPerformance):
         # Restart MoM to work around PP-993
         self.mom.restart()
 
-    @timeout(600)
+    @timeout(1200)
     def test_cgroups_race_condition(self):
         """
         Test to ensure a cgroups event does not read the cgroups file system


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Insufficient timeout value for TestCgroupsStress.test_cgroups_race_condition causes the test to timeout before completion on test bed machines 

#### Affected Platform(s)
All Linux flavors

#### Cause / Analysis / Design
* The intent of the the test 'test_cgroups_race_condition' is to ensure that a cgroups event does not read the cgroups file system while another event is writing to it.  For this purpose, 1000 jobs are submitted , to simulate a situation where events will collide at least once. The test passes if there are no IOErrors . 
* The test does not bother about the test execution time and does not log any performance numbers.  
* When this test was first added with timeout of 600s, the test was executed in local virtual machine by the test writer and not on a performance test machine. A timeout of 600s was sufficient in the VM. 
* But the timeout of 600s is insufficient for the test to run to completion in test bed machines
* With my recent test runs on test bed machines and history of past test execution for this test,  found that the test takes  approximately 12-17 mins to complete. 
* Hence a timeout 1200s (20m) is proposed as a safer timeout value.

#### Solution Description
Increase the timeout value to 1200s. 


#### Testing logs/output

[test_cgroups_race_condition_beforefix.txt](https://github.com/PBSPro/pbspro/files/2189831/test_cgroups_race_condition_beforefix.txt)
[test_cgroups_race_condition_afterfix.txt](https://github.com/PBSPro/pbspro/files/2189832/test_cgroups_race_condition_afterfix.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__