### PR TITLE
PP-1287: do not purge moved job from history before the job is finished

### DIFF
--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -5304,7 +5304,7 @@ svr_clean_job_history(struct work_task *pwt)
 		/* save the next job */
 		nxpjob = (job *)GET_NEXT(pjob->ji_alljobs);
 
-		if ((pjob->ji_qs.ji_state == JOB_STATE_MOVED) ||
+		if ((pjob->ji_qs.ji_state == JOB_STATE_MOVED && pjob->ji_qs.ji_substate == JOB_SUBSTATE_FINISHED) ||
 			(pjob->ji_qs.ji_state == JOB_STATE_FINISHED) ||
 			(pjob->ji_qs.ji_state == JOB_STATE_EXPIRED)) {
 

--- a/test/tests/functional/pbs_moved_job.py
+++ b/test/tests/functional/pbs_moved_job.py
@@ -1,0 +1,111 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestMovedJob(TestFunctional):
+    """
+    This test suite tests moved jobs between two servers
+    """
+    @timeout(500)
+    def test_moved_job_history(self):
+        """
+        This test suite verifies that moved (M) job preserves in the system
+        at least until the job is really finished on the target server.
+        Supposing the job is finished, this test also checks whether
+        the M job is removed after <job_history_duration>.
+        """
+        # Skip test if number of servers is not equal to two
+        if len(self.servers) != 2:
+            self.skipTest("test requires atleast two servers as input, " +
+                          "use -p servers=<server1:server2>,moms=<server1>")
+
+        second_server = self.servers.keys()[1]
+
+        attr = {'job_history_enable': 'True', 'job_history_duration': 5}
+        self.servers[second_server].manager(MGR_CMD_SET, SERVER, attr)
+
+        attr = {'queue_type': 'execution',
+                'started': 'True', 'enabled': 'True'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, attr, id='p2p')
+        self.servers[second_server].manager(MGR_CMD_CREATE, QUEUE,
+                                            attr, id='p2p')
+
+        attr = {'peer_queue': '\"p2p p2p@' + second_server + '\"'}
+        self.scheduler.set_sched_config(attr)
+
+        attr = {'scheduler_iteration': 5}
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
+        self.server.restart()
+
+        attr = {ATTR_queue: "p2p", ATTR_j: "oe",
+                ATTR_W: "Output_Path=%s:/dev/null" % self.servers.keys()[0],
+                'Resource_List.select': 'host=%s' % self.moms.keys()[0]}
+        j = Job(TEST_USER, attrs=attr)
+        j.set_sleep_time(300)
+        jid = self.servers[second_server].submit(j)
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.servers[second_server].expect(JOB, {'job_state': 'M'},
+                                           id=jid, extend='x')
+
+        # history work task runs every two minutes
+        self.logger.info("Wait for history work task to process...")
+        time.sleep(125)
+
+        # the jid should be still present with state M
+        self.servers[second_server].expect(JOB, {'job_state': 'M'},
+                                           id=jid, extend='x')
+
+        self.server.delete(id=jid, wait=True)
+
+        # history work task runs every two minutes
+        self.logger.info("Wait for history work task to process...")
+        time.sleep(125)
+
+        # the jid should be gone
+        try:
+            qstat = self.servers[second_server].status(JOB, 'status',
+                                                       id=jid,
+                                                       extend='x')
+        except PbsStatusError as err:
+            #  rc = 153 is for 'Unknown Job Id'
+            self.assertEqual(err.rc, 153)
+            qstat = ""
+
+        self.assertEqual(qstat, "")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Moved job is purged after job_history_duration no matter it is still running. I believe the moved job should not be purged before the job is actually finished. Moreovere, this can lead to problems with dependency: Knowing the job is still running, you should be able to add a new dependent job with -W depend=afterok:\<moved jobid\>. If you try to add this dependency after job_history_duration, the \<moved jobid\> is purged and the \<moved jobid\> is unknown to the dependency.
* [PP-1287](https://pbspro.atlassian.net/browse/PP-1287)
* [forum discussion](http://community.pbspro.org/t/pp-1287-do-not-purge-moved-job-from-history-before-the-job-is-finished/1097)

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* All moved jobs are purged after job_history_duration.

#### Solution Description
* Check the moved job to substate JOB_SUBSTATE_FINISHED and do not purge the job in svr_clean_job_history() before this substate.

#### Testing logs/output
* ptl output: [ptl_moved_jobs_history_output_smoketest.txt](https://github.com/PBSPro/pbspro/files/2222712/ptl_moved_jobs_history_output_smoketest.txt)

* Since we need two pbs servers, I will provide the manual test:
```
Setup:
1) first pbs server 'torque1' with node 'torque1' and with the queue 'p2p'

2) torque1: qmgr -c 'set server job_history_duration = 00:00:05'

3) torque1: qmgr -c 'set server job_history_enable = True'

4) second pbs server 'torque3' with node 'torque3' and with the peer queue 'p2p p2p@torque1'

Test:
1) Submit a job: vchlum@torque1:~$ qsub -I -l select=vnode=torque3 -q p2p

2) wait for job to move and start:
(JESSIE)root@torque1:~# qstat -x
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
52814.torque1     STDIN            vchlum                   0 M p2p 
(JESSIE)root@torque1:~/pbspro# date
Tue Jul 24 09:50:05 CEST 2018

3) wait a moment and check that the moved job is still present
(JESSIE)root@torque1:~# date
Tue Jul 24 09:52:34 CEST 2018
(JESSIE)root@torque1:~# qstat -x
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
52814.torque1     STDIN            vchlum                   0 M p2p 

4) finish the job and check that the moved job will disappear
(JESSIE)root@torque1:~# qstat -x
(JESSIE)root@torque1:~# 
```

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
