### PR TITLE
checkpoint_abort not working when server is shutdown using qterm im…

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -891,6 +891,7 @@ task_find	(job		*pjob,
 #define JOB_SVFLG_ChkptMig 0x100 /* job has migratable checkpoint */
 #define JOB_SVFLG_Suspend  0x200 /* job suspended (signal suspend) */
 #define JOB_SVFLG_StagedIn 0x400 /* job has files that have been staged in */
+#define JOB_SVFLG_HASHOLD  0x800 /* job has a hold request sent to MoM */
 #define JOB_SVFLG_HasNodes 0x1000 /* job has nodes allocated to it */
 #define JOB_SVFLG_RescAssn 0x2000 /* job resources accumulated in server/que */
 #define JOB_SVFLG_SPSwitch 0x2000 /* SP switch loaded for job, SP MOM only */

--- a/src/server/req_holdjob.c
+++ b/src/server/req_holdjob.c
@@ -209,7 +209,7 @@ req_holdjob(struct batch_request *preq)
 			req_reject(rc, 0, preq);
 		} else {
 			pjob->ji_qs.ji_svrflags |=
-				JOB_SVFLG_HASRUN | JOB_SVFLG_CHKPT;
+				(JOB_SVFLG_HASRUN | JOB_SVFLG_CHKPT | JOB_SVFLG_HASHOLD);
 			(void)job_save(pjob, SAVEJOB_QUICK);
 			log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO,
 				pjob->ji_qs.ji_jobid, log_buffer);

--- a/src/server/req_shutdown.c
+++ b/src/server/req_shutdown.c
@@ -323,9 +323,7 @@ shutdown_chkpt(job *pjob)
 		if (pjob->ji_qs.ji_state == JOB_STATE_TRANSIT)
 			svr_setjobstate(pjob, JOB_STATE_RUNNING, JOB_SUBSTATE_RUNNING);
 
-		pjob->ji_qs.ji_substate = JOB_SUBSTATE_RERUN;
-		pjob->ji_qs.ji_svrflags |= JOB_SVFLG_HASRUN;
-		pjob->ji_qs.ji_svrflags |= JOB_SVFLG_CHKPT;
+		pjob->ji_qs.ji_svrflags |= (JOB_SVFLG_HASRUN | JOB_SVFLG_CHKPT | JOB_SVFLG_HASHOLD);
 		pjob->ji_modified = 1;
 		(void)job_save(pjob, SAVEJOB_QUICK);
 		return (0);


### PR DESCRIPTION
…mediate and delay.

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* checkpoint_abort was not working when the server is shutdown using qterm -t immediate (and delay)
* This issue was found by running tests that are being reviewed under [https://github.com/PBSPro/pbspro/pull/749](PR#749)

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* checkpoint_abort was working in other scenarios.
* At the time of shutdown, the server was marking the substate of the job to be rerun before the MoM replied back on the checkpoint request.
* Due to this, in job_obit(), the flow was jumping to the rerun logic, which lead the server to send a delete job request.
#### Solution Description
* To not set the substate to rerun, the new state and substate will be evaluated and set in job_obit().

#### Testing logs/output
* Same 4 PTL test cases being reviewed in PR#749 were run. All test cases passed.
[ptl_0724.txt](https://github.com/PBSPro/pbspro/files/2224169/ptl_0724.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
