### PR TITLE
PP-1285: ical - Replace deprecated icaltime_from_timet

### DIFF
--- a/src/lib/Libutil/pbs_ical.c
+++ b/src/lib/Libutil/pbs_ical.c
@@ -126,7 +126,7 @@ get_num_occurrences(char *rrule, time_t dtstart, char *tz)
 
 	rt = icalrecurrencetype_from_string(rrule);
 
-	start = icaltime_from_timet(dtstart, 0);
+	start = icaltime_from_timet_with_zone(dtstart, 0, NULL);
 	icaltimezone_convert_time(&start, icaltimezone_get_utc_timezone(), localzone);
 
 	itr = (struct icalrecur_iterator_impl*) icalrecur_iterator_new(rt, start);
@@ -207,7 +207,7 @@ get_occurrence(char *rrule, time_t dtstart, char *tz, int idx)
 
 	rt = icalrecurrencetype_from_string(rrule);
 
-	start = icaltime_from_timet(dtstart, 0);
+	start = icaltime_from_timet_with_zone(dtstart, 0, NULL);
 	icaltimezone_convert_time(&start, icaltimezone_get_utc_timezone(), localzone);
 	next = start;
 
@@ -351,7 +351,7 @@ check_rrule(char *rrule, time_t dtstart, time_t dtend, char *tz, int *err_code)
 		return 0;
 	}
 
-	start = icaltime_from_timet(dtstart, 0);
+	start = icaltime_from_timet_with_zone(dtstart, 0, NULL);
 	icaltimezone_convert_time(&start, icaltimezone_get_utc_timezone(), localzone);
 
 	itr = (struct icalrecur_iterator_impl*) icalrecur_iterator_new(rt, start);


### PR DESCRIPTION
Replace deprecated
`icaltime_from_timet(..)`  by  `icaltime_from_timet_with_zone(.., NULL)`.

Signed-off-by: Egbert Eich <eich@suse.com>
___________ 

#### Bug/feature description

The build breaks with newer versions of libical (tested with version 3.0.3): the function
`icaltime_from_timet()` had been deprecated for a while and has been removed now.
The suggested solution is to replace it with `icaltime_from_timet_with_zone()`.

#### Affected Platform(s)
This issue affects builds on openSUSE Tumbleweed and openSUSE Factory.

#### Solution Description
Replace deprecated `icaltime_from_timet(..)`  by  `icaltime_from_timet_with_zone(.., NULL)`.

####  Testing logs/output
From build log:
```
...
gcc -DHAVE_CONFIG_H -I. -I../../../../src/lib/Libutil -I../../../src/include  -I../../../../src/include -I/usr/include/libical   -g -O2 -MT libutil_a-pbs_ical.o -MD -MP -MF .deps/libutil_a-pbs_ical.Tpo -c -o libutil_a-pbs_ical.o `test -f 'pbs_ical.c' || echo '../../../../src/lib/Libutil/' `pbs_ical.c
 ../../../../src/lib/Libutil/pbs_ical.c: In function 'get_num_occurrences':
 ../../../../src/lib/Libutil/pbs_ical.c:129:10: warning: implicit declaration of function 'icaltime_from_timet'; did you mean 'icaltime_as_timet'? [-Wimplicit-function-declaration]
   start = icaltime_from_timet(dtstart, 0);
           ^~~~~~~~~~~~~~~~~~~
           icaltime_as_timet
 ../../../../src/lib/Libutil/pbs_ical.c:129:8: error: incompatible types when assigning to type 'struct icaltimetype' from type 'int'
   start = icaltime_from_timet(dtstart, 0);
         ^
 ../../../../src/lib/Libutil/pbs_ical.c: In function 'get_occurrence':
 ../../../../src/lib/Libutil/pbs_ical.c:210:8: error: incompatible types when assigning to type 'struct icaltimetype' from type 'int'
   start = icaltime_from_timet(dtstart, 0);
         ^
 ../../../../src/lib/Libutil/pbs_ical.c: In function 'check_rrule':
 ../../../../src/lib/Libutil/pbs_ical.c:354:8: error: incompatible types when assigning to type 'struct icaltimetype' from type 'int'
   start = icaltime_from_timet(dtstart, 0);
         ^
 make[3]: *** [Makefile:580: libutil_a-pbs_ical.o] Error 1
...
```
After the patch has been applied:
```
...
gcc -DHAVE_CONFIG_H -I. -I../../../../src/lib/Libutil -I../../../src/include  -I../../../../src/include -I/usr/include/libical   -g -O2 -MT libutil_a-pbs_ical.o -MD -MP -MF .deps/libutil_a-pbs_ical.Tpo -c -o libutil_a-pbs_ical.o `test -f 'pbs_ical.c' || echo '../../../../src/lib/Libutil/'`pbs_ical.c
gcc -DHAVE_CONFIG_H -I. -I../../../../src/lib/Libutil -I../../../src/include  -I../../../../src/include -I/usr/include/libical   -g -O2 -MT libutil_a-misc_utils.o -MD -MP -MF .deps/libutil_a-misc_utils.Tpo -c -o libutil_a-misc_utils.o `test -f 'misc_utils.c' || echo '../../../../src/lib/Libutil/'`misc_utils.c
...
```
Since these are build fixes, no additions to the PLT are required.
#### Checklist:

   - [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
   - [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
   - [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
   - [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
     - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
   - [ ] I have added **new PTL test(s) to my commit.** (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) (or)
     - [ ] I have added **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
   - [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
   - [x] I have attached **test logs to this pull request** as evidence of testing/verification.

**\*\*\*For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).\*\*\***