### PR TITLE
Fix qsub failure on Windows due to return value of _snprintf()

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -6166,8 +6166,9 @@ main(int argc, char **argv, char **envp) /* qsub */
 		exit(0);
 	}
 
-	/* note the name of the qsub executable */
-	if (snprintf(qsub_exe, sizeof(qsub_exe), "%s", argv[0]) != sizeof(qsub_exe)) {
+	strncpy(qsub_exe, argv[0], sizeof(qsub_exe)); /* note the name of the qsub executable */
+	qsub_exe[sizeof(qsub_exe) - 1] = '\0';
+	if (strlen(qsub_exe) != strlen(argv[0])) { /* exit with error instead of silent truncation */
 		fprintf(stderr, "qsub: Name of executable is too long\n");
 		exit_qsub(2);
 	}


### PR DESCRIPTION
#### Bug/feature Description
* Ever since PR #734, qsub has been failing on Windows with the message `qsub: Name of executable is too long`
* This happens every time qsub is run, regardless of how long the executable name is.

#### Affected Platform(s)
* Windows

#### Cause / Analysis / Design
* As part of the daemon functionality, qsub on Windows must take note of its own executable name, so that a background process can be started by calling CreateProcess with the --daemon parameter. Before PR #734, this was done with `strcpy(qsub_exe, argv[0])`, where qsub_exe is a fixed length buffer, locally scoped in main(). This code was very dangerous because a user could cause a buffer overrun by using an executable name larger than the capacity of qsub_exe. 
* The solution in PR #734 was to use snprintf() instead of strcpy(), because it allows for safe truncation of the string if its length exceeds the size parameter. However, it is also undesirable to perform a silent truncation of the string because that would lead to a later failure when calling CreateProcess with an incorrect executable name. Therefore, the error message `qsub: Name of executable is too long` was introduced as a new feature in PR #734. When the return value of snprintf() differs from the size of the fixed length buffer, the string was truncated, so the program prints the error message and exits. 
* Any version of Microsoft Visual C++ (MSVC) compiler from before 2015 only supports C89, and does NOT support the C99 standard (in which snprintf() was introduced). Therefore, these older versions of MSVC do not implement snprintf(), but as a non-standard extension to C89, they provide _snprintf(), which replicates a lot of the functionality of snprintf() but has a different return value.
* The usage of snprintf() in PR #734  does not work because in src/include/win.h, the function snprintf() is aliased to _snprintf() with `#define snprintf _snprintf`. This causes the comparison with sizeof(qsub_exe) to fail, resulting in the error message and program exiting.

#### Solution Description
* Because the C99-compliant snprintf() is not available in older versions of MSVC, this particular invocation of snprintf() which checks the return value has been replaced with strncpy(), which should work on all versions of MSVC.

#### Testing logs/output
* *Please attach your test log output from running the test you added (or from existing tests that cover your changes)*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
