### PR TITLE
server retries to run a job more than 20 times

### DIFF
--- a/src/lib/Libecl/ecl_verify_values.c
+++ b/src/lib/Libecl/ecl_verify_values.c
@@ -1105,13 +1105,15 @@ int
 verify_value_zero_or_positive(int batch_request, int parent_object, int cmd,
 	struct attropl *pattr, char **err_msg)
 {
-	long l;
+	long lval;
+	char *end = NULL;
 
 	if ((pattr->value == NULL) || (pattr->value[0] == '\0'))
 		return PBSE_BADATVAL;
 
-	l = atol(pattr->value);
-	if (l < 0)
+	errno = 0;
+	lval = strtol(pattr->value, &end, 10);
+	if ((errno != 0) || (lval < 0))
 		return PBSE_BADATVAL;
 
 	return PBSE_NONE;

--- a/test/tests/functional/pbs_test_run_count.py
+++ b/test/tests/functional/pbs_test_run_count.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class Test_run_count(TestFunctional):
+    """
+    Test suite to test run_count attribute of a job.
+    """
+
+    def create_reject_begin_hook(self):
+        name = "h1"
+        body = ("import pbs\n"
+                "e=pbs.event()\n"
+                "e.reject()\n")
+        attr = {'event': 'execjob_begin'}
+        self.server.create_import_hook(name, attr, body)
+
+        # make sure hook has propogated to mom
+        self.mom.log_match("h1.HK;copy hook-related file request received",
+                           existence=True)
+
+    def test_run_count_overflow(self):
+        """
+        Submit a job that requests run count exceeding 64 bit integer limit
+        and see that such a job gets rejected.
+        """
+        a = {ATTR_W: "run_count=18446744073709551616"}
+        j = Job(TEST_USER, a)
+        try:
+            self.server.submit(j)
+        except PbsSubmitError as e:
+            self.assertTrue("illegal -W value" in e.msg[0])
+
+    def test_large_run_count(self):
+        """
+        Submit a job with a large (>20) but valid run_count value and create
+        an execjob_begin hook that will reject the job. Check run_count to
+        make sure that the job goes to held state just after one rejection.
+        This is so because if run_count is greater than 20 then PBS will hold
+        the job upon the first rejection from mom.
+        """
+
+        # Create an execjob_begin hook that rejects the job
+        self.create_reject_begin_hook()
+
+        a = {ATTR_W: "run_count=184"}
+        j = Job(TEST_USER, a)
+        jid = self.server.submit(j)
+
+        # expect the job to be in held state and run_count to be 1 more than
+        # originally requested
+        self.server.expect(JOB, {'job_state': "H", 'run_count': "185"},
+                           attrop=PTL_AND, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
There are bunch functions in our ecl library which check for the sanity of input provided to IFL layer and one of them is verify_value_zero_or_positive(). It uses atol() to convert the string to a long and then checks for its sanity. atol() has a bunch of issues with it and it can result into undesirable behavior (like it returns 0 for invalid inputs, its behavior is undefined in case of an overflow).

This problem with atol causes run_count to become negative and causes server to keep on retrying until the value reached 20.  This is a bug because ideally, server should not retry more than 20 times at all times..
#### Affected Platform(s)
All

#### Cause / Analysis / Design
Use of atol instead of strtol()

#### Solution Description
Changed code to use strtol() instead.

#### Testing logs/output
[test_runcount.txt](https://github.com/PBSPro/pbspro/files/2229387/test_runcount.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
