### PR TITLE
cpuset: When cpuset version >=4 make sure libbitmask is available and used

### DIFF
--- a/m4/enable_cpuset.m4
+++ b/m4/enable_cpuset.m4
@@ -50,8 +50,11 @@ AC_DEFUN([PBS_AC_ENABLE_CPUSET],
     AS_IF([test ! -r /usr/include/cpuset.h],
       AC_MSG_ERROR([Missing cpuset header file]))
     AS_IF([test -r /usr/include/cpumemset.h],
-      [cpuset_flags="-DCPUSET_VERSION=2"],
-      [cpuset_flags="-DCPUSET_VERSION=4"])
+      [cpuset_flags="-DCPUSET_VERSION=2"; cpuset_v4=no],
+      [cpuset_flags="-DCPUSET_VERSION=4"; cpuset_v4=yes])
+      AS_IF([test x$cpuset_v4 = xyes],
+        AS_IF([test ! -r /usr/include/bitmask.h],
+          AC_MSG_ERROR([Missing libbitmask or bitmask.h header file])))
     AS_CASE([$PBS_MACH],
       [irix6*],
         [cpuset_flags="$cpuset_flags -DIRIX6_CPUSET=1"]
@@ -63,5 +66,6 @@ AC_DEFUN([PBS_AC_ENABLE_CPUSET],
   AC_SUBST([cpuset_flags])
   AM_CONDITIONAL([CPUSET_ENABLED], [test x$enable_cpuset = xyes])
   AM_CONDITIONAL([CPUSET_FOR_IRIX6], [test x$cpuset_for_irix6 = xyes])
+  AM_CONDITIONAL([CPUSET_V4], [test x$cpuset_v4 = xyes])
 ])
 

--- a/src/lib/Libutil/pbs_ical.c
+++ b/src/lib/Libutil/pbs_ical.c
@@ -126,7 +126,7 @@ get_num_occurrences(char *rrule, time_t dtstart, char *tz)
 
 	rt = icalrecurrencetype_from_string(rrule);
 
-	start = icaltime_from_timet(dtstart, 0);
+	start = icaltime_from_timet_with_zone(dtstart, 0, NULL);
 	icaltimezone_convert_time(&start, icaltimezone_get_utc_timezone(), localzone);
 
 	itr = (struct icalrecur_iterator_impl*) icalrecur_iterator_new(rt, start);
@@ -207,7 +207,7 @@ get_occurrence(char *rrule, time_t dtstart, char *tz, int idx)
 
 	rt = icalrecurrencetype_from_string(rrule);
 
-	start = icaltime_from_timet(dtstart, 0);
+	start = icaltime_from_timet_with_zone(dtstart, 0, NULL);
 	icaltimezone_convert_time(&start, icaltimezone_get_utc_timezone(), localzone);
 	next = start;
 
@@ -351,7 +351,7 @@ check_rrule(char *rrule, time_t dtstart, time_t dtend, char *tz, int *err_code)
 		return 0;
 	}
 
-	start = icaltime_from_timet(dtstart, 0);
+	start = icaltime_from_timet_with_zone(dtstart, 0, NULL);
 	icaltimezone_convert_time(&start, icaltimezone_get_utc_timezone(), localzone);
 
 	itr = (struct icalrecur_iterator_impl*) icalrecur_iterator_new(rt, start);

--- a/src/resmom/Makefile.am
+++ b/src/resmom/Makefile.am
@@ -105,6 +105,9 @@ endif
 if CPUSET_ENABLED
 pbs_mom_CPPFLAGS += -DMOM_CPUSET=1 @cpuset_flags@
 pbs_mom_LDADD += -lcpuset
+if CPUSET_V4
+pbs_mom_LDADD += -lbitmask
+endif
 if CPUSET_FOR_IRIX6
 pbs_mom_SOURCES += \
 	irix6cpuset/allocnodes.c \


### PR DESCRIPTION
cpuset version 4 requires libbitmask. If this cpuset version is used '-lbitmask'  should be added to the libraries to load.
Furthermore, check for the presence of the header file bitmask.h during configure and fail with an appropriate error message.

Signed-off-by: Egbert Eich <eich@suse.com>
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description

The issue affects users compiling PBSPro themselves when building with cpuset support and using cpuset version 4. This version requires libbitmask to be available and `-lbitmask` added during linking. If it isn't the build will fail.
The user should be notified of the problem when running configure.

Run a build with `configure --enable-cpuset` and cpuset version 4 installed but without libbitmask installed. Then run `make`. The compile will fail:
```
gcc -DHAVE_CONFIG_H -I. -I../../../src/resmom -I../../src/include
-DPBS_MOM -I../../../src/include -I../../../src/resmom/linux -I/usr/include/python2.7  -DMOM_CPUSET=1 -DCPUSET_VERSION=4     -g -O2 -MT pbs_mom-reply_send.o -MD -MP -MF  .deps/pbs_mom-reply_send.Tpo -c -o pbs_mom-reply_send.o `test -f '../../../src/server/reply_send.c' || echo '../../../src/resmom/'`../../../src/server/reply_send.c
 In file included from ../../../src/include/mom_func.h:47,        
                  from ../../../src/server/job_func.c:171:        
 ../../../src/resmom/linux/mom_mach.h:71:10: fatal error: bitmask.h: No such file or directory
 #include <bitmask.h>         
          ^~~~~~~~~~~         
 compilation terminated.        
make[2]: *** [Makefile:872: pbs_mom-job_func.o] Error 1
```
Due to (`src/resmom/linux/mom_mach.h`)
```
#if     (CPUSET_VERSION < 4)
#include        <cpuset.h>
#include        <cpumemsets.h>
#else
[...]
#include        <bitmask.h>
#include        <cpuset.h>
[...]
#endif
```
If libbitmask is available, it isn't added to the linker and thus linking will fail:
```
/usr/lib64/gcc/x86_64-suse-linux/8/../../../../x86_64-suse-linux/bin/ld: pbs_mom-mom_mach.o: undefined reference to symbol 'bitmask_first'
```
The patch will cause `configure --enable-cpuset` fail and warn the user:
```
checking whether Cray ALPS support was requested... no
checking whether native cpuset support was requested... yes
configure: error: Missing libbitmask or bitmask.h header file
```

#### Affected Platform(s)
openSUSE Tumbleweed 

#### Cause / Analysis / Design

`-lbitmask` isn't added to the command line automatically during build when cpuset version 4 is found.

#### Solution Description

To `m4/enable_cpuset.m4` add test for presence of `bitmask.h` when cpuset version 4 is found also add `-lbitmask` to the linker command line.

#### Testing logs/output

See above.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
