### PR TITLE
Fix test_passing_shell_function() to fully test the passed function.

### DIFF
--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -89,9 +89,10 @@ class Test_passing_environment_variable_via_qsub(TestFunctional):
         Define a shell function with new line characters and check that
         the function is passed correctly
         """
-        os.environ['foo'] = '"(){if [ /bin/true ];\nthen\necho hello;\nfi};"'
+        os.environ['foo'] = '() { if [ /bin/true ]; then\necho hello;\nfi\n}'
         script = ['#PBS -V']
         script += ['env | grep -A 3 foo\n']
+        script += ['foo\n']
         # Submit a job without hooks in the system
         jid = self.create_and_submit_job(content=script)
         qstat = self.server.status(JOB, ATTR_o, id=jid)
@@ -100,7 +101,7 @@ class Test_passing_environment_variable_via_qsub(TestFunctional):
         job_output = ""
         with open(job_outfile, 'r') as f:
             job_output = f.read().strip()
-        self.assertEqual(job_output,
-                         'foo="(){if [ /bin/true ];\nthen\necho hello;\nfi};"',
+        match = 'foo=() {  if [ /bin/true ]; then\n echo hello;\n fi\n}\nhello'
+        self.assertEqual(job_output, match,
                          msg="Environment variable foo content does "
                          "not match original")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* PTL test Test_passing_environment_variable_via_qsub has a test_passing_shell_function() that doesn't quite pass the shell function correctly to a job's environment, in order for the function to be callable.


#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* There was some missed required spacings as well as an extra line in the 'foo' value.

#### Solution Description
* Add the required spacings and proper newlines when the 'foo' environment function.
* Also added a call to 'foo' to make sure it executes.

#### Testing logs/output
* [ptl.txt](https://github.com/PBSPro/pbspro/files/2246910/ptl.txt)
* [job.o36.txt](https://github.com/PBSPro/pbspro/files/2246915/job.o36.txt)
* [ptl.fail.txt](https://github.com/PBSPro/pbspro/files/2246950/ptl.fail.txt)
* [job.scr.e1.fail.txt](https://github.com/PBSPro/pbspro/files/2246951/job.scr.e1.fail.txt)







#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
