### PR TITLE
Add test to validate server attributes of "qstat -Bf"

### DIFF
--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -84,7 +84,6 @@ class TestQstat(PBSTestSuite):
         qstat_o['pbs_version'] = self.server.pbs_version
         qstat_o['eligible_time_enable'] = 'False'
         qstat_o['max_concurrent_provision'] = '5'
-        qstat_o['pbs_license_info'] = None
         qstat_o['FLicenses'] = None
         qstat_o['license_count'] = None
         qstat_o['managers'] = None

--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -39,9 +39,10 @@ from ptl.utils.pbs_testsuite import *
 import json
 
 
-class TestQstat_json(PBSTestSuite):
+class TestQstat(PBSTestSuite):
     """
-    Test qstat output can be viewed in json format
+    This test suite validates output of qstat for
+    various options
     """
 
     def parse_json(self, dictitems, qstat_attr):
@@ -56,6 +57,76 @@ class TestQstat_json(PBSTestSuite):
                     if isinstance(val, dict):
                         self.parse_json(val, qstat_attr)
         return qstat_attr
+
+    def validate_el(self, attr_dict, user):
+        """
+        Check if the value of server attributes reported by
+        qstat -Bf matches the expected values.
+        """
+        qstat_o = {}
+        qstat_o['server_state'] = 'Active'
+        qstat_o['server_host'] = self.server.hostname
+        qstat_o['scheduling'] = 'True'
+        qstat_o['total_jobs'] = '0'
+        qstat_o['state_count'] = ['Transit', 'Queued',
+                                  'Held', 'Waiting', 'Running',
+                                  'Exiting', 'Begun']
+        qstat_o['default_queue'] = 'workq'
+        qstat_o['log_events'] = '511'
+        qstat_o['mail_from'] = 'adm'
+        qstat_o['query_other_jobs'] = 'True'
+        qstat_o['resources_default.ncpus'] = '1'
+        qstat_o['default_chunk.ncpus'] = '1'
+        qstat_o['resv_enable'] = 'True'
+        qstat_o['node_fail_requeue'] = '310'
+        qstat_o['max_array_size'] = '10000'
+        qstat_o['pbs_license_linger_time'] = '3600'
+        qstat_o['pbs_version'] = self.server.pbs_version
+        qstat_o['eligible_time_enable'] = 'False'
+        qstat_o['max_concurrent_provision'] = '5'
+        qstat_o['pbs_license_info'] = None
+        qstat_o['FLicenses'] = None
+        qstat_o['license_count'] = None
+        qstat_o['managers'] = None
+        qstat_o['flatuid'] = None
+        qstat_o['id'] = self.server.shortname
+
+        # If test case is run as root, PTL sets acl_roots
+        if os.getuid() == 0:
+            qstat_o['acl_roots'] = None
+
+        if user == ROOT_USER:
+            qstat_o['power_provisioning'] = 'False'
+
+        platform = self.du.get_platform()
+        if platform == 'cray' or platform == 'craysim':
+            qstat_o['restrict_res_to_release_on_suspend'] = 'ncpus'
+
+        for each in attr_dict:
+            self.assertIn(each, qstat_o, "Unexpected attribute \"%s\""
+                          " encountered in output of qstat -Bf" % each)
+            if qstat_o[each] is not None:
+                if "state_count" in each:
+                    out1 = []
+                    out = attr_dict[each].split()
+                    for k in out:
+                        out1.append(k.split(':')[0])
+                    self.assertListEqual(qstat_o[each], out1,
+                                         "Value of server attribute \"%s\""
+                                         " does not match expected"
+                                         " value" % each)
+                else:
+                    self.assertEqual(qstat_o[each], attr_dict[each],
+                                     "Value of server attribute \"%s\""
+                                     " does not match expected value" % each)
+                self.logger.info("Server attribute \"%s\""
+                                 " is validated successfully" % each)
+        value = [k for k in qstat_o.keys() if k not in attr_dict.keys()]
+        self.assertEqual(len(value), 0, "Output of qstat -Bf is missing"
+                                        " some expected attributes - %s"
+                                        % value)
+        self.logger.info(
+            "Server attributes in output of qstat -Bf validated succesfully")
 
     @tags('smoke')
     def test_qstat_json_valid(self):
@@ -228,3 +299,21 @@ class TestQstat_json(PBSTestSuite):
             json.loads(qstat_out)
         except ValueError, e:
             self.assertTrue(False)
+
+    @tags('smoke')
+    def test_qstat_Bf_as_user(self):
+        """
+        Validate output of qstat -Bf when executed as non-root user
+        """
+        ret = self.server.status(runas=TEST_USER)
+        attr_dict = ret[0]
+        self.validate_el(attr_dict, TEST_USER)
+
+    @tags('smoke')
+    def test_qstat_Bf_as_root(self):
+        """
+        Validate output of qstat -Bf when executed as root user
+        """
+        ret = self.server.status(runas=ROOT_USER)
+        attr_dict = ret[0]
+        self.validate_el(attr_dict, ROOT_USER)

--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -58,7 +58,7 @@ class TestQstat(PBSTestSuite):
                         self.parse_json(val, qstat_attr)
         return qstat_attr
 
-    def validate_el(self, attr_dict, user):
+    def validate_attribute(self, attr_dict, user):
         """
         Check if the value of server attributes reported by
         qstat -Bf matches the expected values.
@@ -304,15 +304,13 @@ class TestQstat(PBSTestSuite):
         """
         Validate output of qstat -Bf when executed as non-root user
         """
-        ret = self.server.status(runas=TEST_USER)
-        attr_dict = ret[0]
-        self.validate_el(attr_dict, TEST_USER)
+        attr_dict = self.server.status(runas=TEST_USER)[0]
+        self.validate_attribute(attr_dict, TEST_USER)
 
     @tags('smoke')
     def test_qstat_Bf_as_root(self):
         """
         Validate output of qstat -Bf when executed as root user
         """
-        ret = self.server.status(runas=ROOT_USER)
-        attr_dict = ret[0]
-        self.validate_el(attr_dict, ROOT_USER)
+        attr_dict = self.server.status(runas=ROOT_USER)[0]
+        self.validate_attribute(attr_dict, ROOT_USER)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description

* Add test case to validate server attributes in the output of qstat -Bf, as root and non-root user

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* This test verifies that the values of server attributes reported by qstat -Bf matches the expected default values. 

#### Solution Description
* Value of server attributes reported in qstat -Bf is checked against the expected default value of that attribute. Some attribute values are changes in the setup function of PTL, those attributes are checked against the new values set by PTL.

#### Testing logs/output
* Attached in comments

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [ ] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
