### PR TITLE
test_cgroup_cpuset is failing intermittently on certain platform

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -232,6 +232,7 @@ else
     jobnum=${PBS_JOBID%%.*}
     base="$cpuset_base/pbspro.slice/pbspro-${jobnum}.*.slice"
 fi
+echo "cpuset base path is $base"
 if [ -d $base ]; then
     cpupath1=$base/cpuset.cpus
     cpupath2=$base/cpus
@@ -1260,11 +1261,13 @@ for i in 1 2 3 4; do while : ; do : ; done & done
         # Read the output files
         tmp_file1 = filename1.split(':')[1]
         tmp_out1 = self.wait_and_read_file(filename=tmp_file1, host=self.hostA)
+        self.logger.info("test output for job1: %s" % (tmp_out1))
         self.assertTrue(
             jid1 in tmp_out1, '%s not found in output on host %s'
             % (jid1, self.hostA))
         tmp_file2 = filename2.split(':')[1]
         tmp_out2 = self.wait_and_read_file(filename=tmp_file2, host=self.hostA)
+        self.logger.info("test output for job2: %s" % (tmp_out2))
         self.assertTrue(
             jid2 in tmp_out2, '%s not found in output on host %s'
             % (jid2, self.hostA))
@@ -1282,6 +1285,7 @@ for i in 1 2 3 4; do while : ; do : ; done & done
                 cpuid2 = kv
                 break
         self.assertNotEqual(cpuid2, None, 'Could not read second CPU ID.')
+        self.logger.info("cpuid1 = %s and cpuid2 = %s" % (cpuid1, cpuid2))
         self.assertNotEqual(cpuid1, cpuid2,
                             'Processes should be assigned to different CPUs')
         self.logger.info('CpuIDs check passed')


### PR DESCRIPTION
#### Bug/feature Description
* *Bugs: test_cgroup_cpuset is failing intermittently on certain platform*


#### Affected Platform(s)
* *RHEL7*

#### Cause / Analysis / Design
* *Bugs: test fails while comparing the assigned cpus for each job by cgroups. I looked at the mom logs and cgroups hook working okay. There is some other race condition somewhere hence adding these log messages to help debugging*

#### Solution Description
* *Adding more log messages to help debugging the issue in future.*

#### Testing logs/output
* *Please attach your test log output from running the test you added (or from existing tests that cover your changes)
[test_cgroup_cpuset.txt](https://github.com/PBSPro/pbspro/files/2269210/test_cgroup_cpuset.txt)

*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__