### PR TITLE
Test "test_mom_down" & "test_reservation" fails while verifying the job attributes

### DIFF
--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -34,7 +34,6 @@
 # Use of Altair’s trademarks, including but not limited to "PBS™",
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
-import time
 from tests.functional import *
 
 
@@ -815,6 +814,7 @@ j.resources_used["stra2"] = '"glad"'
         a = {'Resource_List.select': '3:ncpus=1', ATTR_queue: rname[0]}
         j = Job(TEST_USER)
         j.set_attributes(a)
+        j.set_sleep_time(20)
         jid = self.server.submit(j)
 
         # Verify the resource values
@@ -947,6 +947,7 @@ for jj in e.job_list.keys():
         # Submit a job that can never run
         a = {'Resource_List.select': '5:ncpus=1',
              'Resource_List.place': 'scatter'}
+        j.set_attributes(a)
         jid2 = self.server.submit(j)
 
         # Wait for 10s approx for hook to get executed


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Problem Description
* *Test **"test_mom_down"** of TestPbsAccumulateRescUsed is currently failing while verifying the job 
attributes*
* *Test **"test_reservation"** of TestPbsAccumulateRescUsed is failing while verifying the job attributes* 

#### Affected Platform(s)
* *All*

#### Analysis 
**_test_mom-down:_**
* In the test we are initially submitting a job(jid1) as follows (/opt/pbs/bin/qsub -l place=scatter -l select=3:ncpus=1 – /bin/sleep 100)
* In the next step we are submitting a job (such that it will never run) with below arguments
a ={'Resource_List.select': '5:ncpus=1', 'Resource_List.place': 'scatter'}
* But if we observe the test-logs the second job is submitted with the same attributes such as J1. 

**_test_reservation:_**
* In the test we are submitting a reservation with 30s duration and then submitting a sleep job of 100 s into the reservation.
* In the failed scenario before the job is done,reservation is complete. As a result of this the job is getting deleted and job attributes(that are set via execjob_epilogue hook) are not being set.

#### Solution Description
**_test_mom-down:_**
* The issue is because before submitting the second job we are not applying the job arributes, i.e. the following code "j.set_attributes(a)" is missing before submitting second job *

**_test_reservation:_**
* Submit a job with less sleep time (than reservation duration)

#### Testing logs/output
* [Complete_Latest_Execution_logs_PR769.txt](https://github.com/PBSPro/pbspro/files/2281978/Complete_Latest_Execution_logs_PR279.txt)
* [Execution_logs_PR769_after_fix.txt](https://github.com/PBSPro/pbspro/files/2281979/Execution_logs_PR279_after_fix.txt)
* [Execution_logs_PR769_bfr_fix.txt](https://github.com/PBSPro/pbspro/files/2281980/Execution_logs_PR279_bfr_fix.txt)
* [Latest_Execution_logs_PR769.txt](https://github.com/PBSPro/pbspro/files/2281981/Latest_Execution_logs_PR279.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.

__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
