### PR TITLE
Fix the typos in the description of pbs_hook_debug_nocrash

### DIFF
--- a/test/tests/functional/pbs_hook_debug_nocrash.py
+++ b/test/tests/functional/pbs_hook_debug_nocrash.py
@@ -45,8 +45,8 @@ class TestHookDebugNoCrash(TestFunctional):
           Hook debug causes file descriptor leak that crashes PBS server
 
     PRE: Have 3 queuejob hooks, qjob1, qjob2, qjob3 with order=1, order=2,
-         order=3 respectively. qjob1 and qjob2 have debug=True while
-         order=3 has debug=False. Try submitting 1000 jobs.
+         order=2 respectively. qjob1 and qjob2 have debug=True while
+         qjob3 has debug=False. Try submitting 1000 jobs.
     POST: On a fixed PBS, this test case will run to completion.
           On a PBS containing the bug, the test could fail on a server crash,
           a failure in qsub with "Invalid credential", or even a qstat


### PR DESCRIPTION
#### Bug/feature Description
* *Bugs: Fix the typos in the description of pbs_hook_debug_nocrash*

#### Affected Platform(s)
* *Platform (None)*

#### Cause / Analysis / Design
* *Bugs: Description of the test was not matching with the actual test*

#### Solution Description
* *Updated the description to be same as the actual configuration*

#### Testing logs/output
* *Please attach your test log output from running the test you added (or from existing tests that cover your changes)*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__