### PR TITLE
pbs_snapshot fails when run from a hook

### DIFF
--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -107,7 +107,6 @@ if __name__ == '__main__':
     map_file = None
     anonymize = False
     create_tar = True
-
     log_file = "pbs_snapshot.log"
 
     PtlConfig()
@@ -158,9 +157,20 @@ if __name__ == '__main__':
             usage()
             sys.exit(1)
 
+    # -o is a mandatory option, so make sure that it was provided
+    if out_dir is None:
+        sys.stderr.write("-o option not provided")
+        usage()
+        sys.exit(1)
+    elif not os.path.isdir(out_dir):
+        sys.stderr.write("-o path should exist,"
+                         " this is where the snapshot is captured")
+        usage()
+        sys.exit(1)
+
     fmt = '%(asctime)-15s %(levelname)-8s %(message)s'
     level_int = CliUtils.get_logging_level(log_level)
-    log_path = os.path.abspath(log_file)
+    log_path = os.path.join(out_dir, log_file)
     logging.basicConfig(filename=log_path, filemode='w+',
                         level=level_int, format=fmt)
     stream_hdlr = logging.StreamHandler()
@@ -169,12 +179,6 @@ if __name__ == '__main__':
     ptl_logger = logging.getLogger('ptl')
     ptl_logger.addHandler(stream_hdlr)
     ptl_logger.setLevel(level_int)
-
-    # -o is a mandatory option, so make sure that it was provided
-    if out_dir is None:
-        sys.stderr.write("-o option not provided")
-        usage()
-        sys.exit(1)
 
     if anonymize is True:
         # find the parent directory of the snapshot


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* If pbs_snapshot is run from a server hook, it fails with the following error:
Traceback (most recent call last):
  File "/opt/pbs/unsupported/fw/bin/pbs_snapshot.py", line 191, in <module>
    outtar = snap_utils.capture_all()
  File "/opt/pbs/unsupported/fw/ptl/utils/pbs_snaputils.py", line 250, in _exit_
    self.utils_obj.finalize()
  File "/opt/pbs/unsupported/fw/ptl/utils/pbs_snaputils.py", line 1534, in finalize
    self.__add_to_archive(snap_logpath)
  File "/opt/pbs/unsupported/fw/ptl/utils/pbs_snaputils.py", line 963, in __add_to_archive
    self.outtar_fd.add(src_path, arcname=path_in_tar)
  File "/usr/lib64/python2.7/tarfile.py", line 1975, in add
    tarinfo = self.gettarinfo(name, arcname)
  File "/usr/lib64/python2.7/tarfile.py", line 1847, in gettarinfo
    statres = os.lstat(name)
OSError: [Errno 2] No such file or directory: '/var/spool/pbs/server_priv/pbs_snapshot.log'

#### Affected Platform(s)
* All Linux

#### Cause / Analysis / Design
* This happens because server hooks run from inside server_priv, which is one of the directories that's captured by the snapshot. Since the hook runs from server_priv, it runs pbs_snapshot from server_priv, which means it temporarily creates pbs_snapshot.log inside server_priv, which gets copied to the tarball while capturing server_priv and subsequently removed. So, at the end when we try to capture pbs_snapshit.log again, it can't find it as it was previously removed, and the script fails.

#### Solution Description
* Changed default snapshot log path to be inside the -o directory instead of the directory where pbs_snapshot is being run from
* Also added support for creating snapshot inside a directory which will get captured by pbs_snapshot. e.g - if somebody says pbs_snapshot -o /var/spool/pbs/server_priv, where server_priv is a directory which also gets captured by pbs_snapshot, it still will be able to create a snapshot tarball inside server_priv.

#### Testing logs/output
* [pbs_snapshot_unittest.log](https://github.com/PBSPro/pbspro/files/2277238/pbs_snapshot_unittest.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
