### PR TITLE
Failure of any server hook event that is combined with server periodic hook event

### DIFF
--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -3917,7 +3917,7 @@ process_hooks(struct batch_request *preq, char *hook_msg, size_t msg_len,
 			continue;
 		}
 
-		if (phook->event & HOOK_EVENT_PERIODIC) {
+		if (hook_event & HOOK_EVENT_PERIODIC) {
 			(void)set_task(WORK_Timed, time_now+phook->freq, run_periodic_hook, phook);
 			num_run++;
 			continue;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Bugs: Server hook fails when any other hook event is combined with periodic hook event
If any existing hook event like queuejob event is combined with periodic event for a single hook, it will fail. Jobs submitted will get rejected with the message "qsub: queuejob event: rejected request" .

#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* We are comparing hooks event value with PERIODIC event every time and when multiple hook events are created, this condition becomes true for all the server side hook events and hook will fail.

#### Solution Description
* Read the hook event based on the batch request

#### Testing logs/output
* Attached in comments

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
