### PR TITLE
Add missing space in variable name

### DIFF
--- a/src/cmds/scripts/pbs_postinstall.in
+++ b/src/cmds/scripts/pbs_postinstall.in
@@ -310,7 +310,7 @@ perform_checks() {
 		echo "*** one of the following actions:"
 		echo "*** 1. Update PBS_HOME in $conf"
 		echo "*** 2. mv $oldpbs_home $PBS_HOME"
-		echo "*** 3. ln -s $oldpbshome $PBS_HOME"
+		echo "*** 3. ln -s $oldpbs_home $PBS_HOME"
 		echo "***"
 	fi
 


### PR DESCRIPTION
$oldpbshome -> $oldpbs_home

Signed-off-by: Egbert Eich <eich@suse.com>

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* While eyeballing the `pbs_postinstall.in` script this stared back ;) Since there is no other occurrence `$oldpbshome` but plenty of `$old_pbshome` I figured this was mistyped.


#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* N/A

#### Solution Description
* Replaced `$oldpbshome` by `$oldpbs_home`

#### Testing logs/output
* N/A

#### Checklist:
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.

