### PR TITLE
PP-1026: Stranded array subjobs

### DIFF
--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -259,7 +259,7 @@ check_deletehistoryjob(struct batch_request * preq)
 					char *sjid = mk_subjob_id(histpjob, i);
 					job  *psjob;
 
-					if ((get_subjob_state(histpjob, i) != JOB_STATE_QUEUED) && (psjob = find_job(sjid))) {
+					if ((psjob = find_job(sjid))) {
 						snprintf(log_buffer, sizeof(log_buffer),
 							msg_job_history_delete, preq->rq_user,
 							preq->rq_host);
@@ -412,7 +412,7 @@ req_deletejob(struct batch_request *preq)
 		} else if (i == JOB_STATE_EXPIRED) {
 			req_reject(PBSE_NOHISTARRAYSUBJOB, 0, preq);
 			return;
-		} else if (i != JOB_STATE_QUEUED && ((pjob = find_job(jid)) != NULL)) {
+		} else if ((pjob = find_job(jid)) != NULL) {
 			/*
 			 * If the request is to also purge the history of the sub job then set ji_deletehistory to 1
 			 */
@@ -482,12 +482,12 @@ req_deletejob(struct batch_request *preq)
 		/* and reply will be sent to client when last delete is done */
 		/* If not deleteing running subjobs, delete2 to del parent   */
 
-		if (--preq->rq_refct == 0)
+		if (--preq->rq_refct == 0) {
 			if ((parent = find_job(jid)) != NULL)
 				req_deletejob2(preq, parent);
-		else
-			reply_send(preq);
-		else
+			else
+				reply_send(preq);
+		} else
 			acct_del_write(jid, parent, preq, 0);
 
 		return;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *Sometimes instantiated subjobs can get stranded in queued state due to communication failure with execution node*
* *Not easily reproducible, usually observed during communication hiccups in large clusters using large job arrays*
* *Refer issue ID: [PP-1026](https://pbspro.atlassian.net/browse/PP-1026)*

#### Affected Platform(s)
* *All*

#### Cause
* *Instantiated subjobs in Q state. the subjobs were instantiated when the server first tried to run them, the find_jobs() in req_runjob() finds an entry for them, causing the server to reject them.*

#### Solution Description
* *Purge an instantiated Queued subjob and re-instantiate it afresh during runjob*

#### Testing logs/output
* *PTL test cannot be automated cause there is no way to create a stranded subjob through commands*
* *Hence I devised below manual steps to verify the fix*

1. Manually build the server by commenting out below lines (for force creating an instantiated Q subjob)
https://github.com/PBSPro/pbspro/blob/882f33a732d82736aca098d8ee0a7e493287628c/src/server/req_runjob.c#L677-L681
2. Comment out below line
https://github.com/PBSPro/pbspro/blob/882f33a732d82736aca098d8ee0a7e493287628c/test/tests/functional/pbs_sched_subjob_badstate.py#L77
3. Run PTL testcase
`pbs_benchpress -t TestSchedSubjobBadstate`
4. After the above test completes we can see
 from `/etc/init.d/pbs status` that `pbs_mom` is not running but `pbsnodes -av` shows the node as free
 from `qstat -t`  that all the subjob are in Q state,
5. Manually Q sub some more regular jobs and array jobs. all will get queued. The first subjob of all the array are stranded subjobs.
6. now start the pbs_mom.
7. We should see that the stranded Q subjobs from the PTL test case and step 5 goes to Running
8. Verify the server logs. We should see as seen in the sample attached below
[strandedsubjob_logs.zip](https://github.com/PBSPro/pbspro/files/2315311/strandedsubjob_logs.zip)
PTL test output attached below
[ptl_test_results.zip](https://github.com/PBSPro/pbspro/files/2317518/ptl_test_results.zip)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
