### PR TITLE
Add rm.c to libpbs, don't install any static Libraries other than libpbs

### DIFF
--- a/src/lib/Libattr/Makefile.am
+++ b/src/lib/Libattr/Makefile.am
@@ -36,7 +36,7 @@
 # trademark licensing policies.
 #
 
-lib_LIBRARIES = libattr.a
+noinst_LIBRARIES = libattr.a
 
 libattr_a_CPPFLAGS = -I$(top_srcdir)/src/include
 

--- a/src/lib/Liblog/Makefile.am
+++ b/src/lib/Liblog/Makefile.am
@@ -36,7 +36,7 @@
 # trademark licensing policies.
 #
 
-lib_LIBRARIES = liblog.a
+noinst_LIBRARIES = liblog.a
 
 liblog_a_CPPFLAGS = -I$(top_srcdir)/src/include
 

--- a/src/lib/Libnet/Makefile.am
+++ b/src/lib/Libnet/Makefile.am
@@ -36,7 +36,7 @@
 # trademark licensing policies.
 #
 
-lib_LIBRARIES = libnet.a
+noinst_LIBRARIES = libnet.a
 
 libnet_a_CPPFLAGS = -I$(top_srcdir)/src/include -I$(top_srcdir)/src/lib/Libtpp
 

--- a/src/lib/Libpbs/Makefile.am
+++ b/src/lib/Libpbs/Makefile.am
@@ -267,6 +267,7 @@ libpbs_la_SOURCES = \
 	../Libutil/pbs_secrets.c \
 	../Libutil/pbs_aes_encrypt.c \
 	../Libnet/hnls.c \
+	../Libnet/rm.c \
 	ecl_job_attr_def.c \
 	ecl_svr_attr_def.c \
 	ecl_sched_attr_def.c \

--- a/src/lib/Libsite/Makefile.am
+++ b/src/lib/Libsite/Makefile.am
@@ -36,7 +36,7 @@
 # trademark licensing policies.
 #
 
-lib_LIBRARIES = libsite.a
+noinst_LIBRARIES = libsite.a
 
 libsite_a_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \

--- a/src/scheduler/Makefile.am
+++ b/src/scheduler/Makefile.am
@@ -36,7 +36,7 @@
 # trademark licensing policies.
 #
 
-lib_LIBRARIES = libpbs_sched.a
+noinst_LIBRARIES = libpbs_sched.a
 
 libpbs_sched_a_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \


### PR DESCRIPTION
As discussed in issue #771, there is probably no need to install the static libraries other than libpbs: none of the symbols are made available thru the installed header files - except for the symbols from 'rm.h' - which are defined in 'rm.c' which in turn is part of libnet.a. I was not able to locate any symbols required bun `rm.c` which was not available in libpbs or the external libs: therefore instead of shipping libnet.a,  'rm.c' should be included in libpbs - this would remove the need to install any static lib other than libpbs.
Leave it to the CI to determine if this causes any issues that were not anticipated.
Alternatively, libpbs could be left as is by dropping `rm.h` from the installed header. This alternative solution will be tried in a 2nd request. 
#### Bug/feature Description
* Remove unneeded static libraries from installation.
Currently, the following static libraries get installed `libattr.a liblog.a libnet.a libpbs_sched.a libsite.a`. None of them seems to define any symbols declared in any of the installed header files - except for `libnet.a` which provides the symbols from `rm.c` which are declared in the installed header `rm.h`.
To reduce the number of static libs, include `rm.c` in the build of libpbs and eliminate all static libraries from the installation - except for `libpbs.a`.

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* *See above description*

#### Solution Description
* Mark all libraries listed as `noinst` in the respective `Makefile.am`
* Include `rm.c` in the build for `libpbs`.

#### Testing logs/output
* A test build with this change finishes without issues. Any further fallout - if there is any - should be determined by the CI

#### Checklist:
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature]
  *The pull request contains two commits to illustrate the two steps taken, they will be consolidated to a single request.*
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.



