### PR TITLE
Do not install rm.h, don't install any static Libraries other than libpbs

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -39,7 +39,6 @@
 include_HEADERS = \
 	pbs_error.h \
 	pbs_ifl.h \
-	rm.h \
 	tm_.h \
 	tm.h
 
@@ -107,6 +106,7 @@ noinst_HEADERS = \
 	resmon.h \
 	resource.h \
 	resv_node.h \
+	rm.h \
 	rpp.h \
 	sched_cmds.h \
 	pbs_sched.h \

--- a/src/lib/Libattr/Makefile.am
+++ b/src/lib/Libattr/Makefile.am
@@ -36,7 +36,7 @@
 # trademark licensing policies.
 #
 
-lib_LIBRARIES = libattr.a
+noinst_LIBRARIES = libattr.a
 
 libattr_a_CPPFLAGS = -I$(top_srcdir)/src/include
 

--- a/src/lib/Liblog/Makefile.am
+++ b/src/lib/Liblog/Makefile.am
@@ -36,7 +36,7 @@
 # trademark licensing policies.
 #
 
-lib_LIBRARIES = liblog.a
+noinst_LIBRARIES = liblog.a
 
 liblog_a_CPPFLAGS = -I$(top_srcdir)/src/include
 

--- a/src/lib/Libnet/Makefile.am
+++ b/src/lib/Libnet/Makefile.am
@@ -36,7 +36,7 @@
 # trademark licensing policies.
 #
 
-lib_LIBRARIES = libnet.a
+noinst_LIBRARIES = libnet.a
 
 libnet_a_CPPFLAGS = -I$(top_srcdir)/src/include -I$(top_srcdir)/src/lib/Libtpp
 

--- a/src/lib/Libsite/Makefile.am
+++ b/src/lib/Libsite/Makefile.am
@@ -36,7 +36,7 @@
 # trademark licensing policies.
 #
 
-lib_LIBRARIES = libsite.a
+noinst_LIBRARIES = libsite.a
 
 libsite_a_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \

--- a/src/scheduler/Makefile.am
+++ b/src/scheduler/Makefile.am
@@ -36,7 +36,7 @@
 # trademark licensing policies.
 #
 
-lib_LIBRARIES = libpbs_sched.a
+noinst_LIBRARIES = libpbs_sched.a
 
 libpbs_sched_a_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \


### PR DESCRIPTION
This is the alternative propose to reduce the number of static libraries installed - for which no corresponding shared libraries exist as discussed in issue #771. The other alternative can be found in issue #782.
None of the static libraries `libattr.a liblog.a libnet.a libpbs_sched.a libsite.a` define any symbols that are declared in an installed header file. Thus these symbols are not usable by external software. There is one exception: the symbols declared in `rm.h` are provided by `libnet.a` - among many other symbols not available to external software. Since there hasn't been any shared version of libnet, i may be assumed that none of their symbols was meant for use by external software - in which case `rm.h` should not be installed either.

#### Bug/feature Description
*  Remove unneeded static libraries from installation.
Currently, the following static libraries get installed `libattr.a liblog.a libnet.a libpbs_sched.a libsite.a`. None of them seems to define any symbols declared in any of the installed header files - except for `libnet.a` which provides the symbols from `rm.c` which are declared in the installed header `rm.h`.
To reduce the number of static libs, remove  `rm.h` from the list of headers to install.

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* *See above description*

#### Solution Description
* Mark all libraries listed as `noinst` in the respective `Makefile.am`
* Remove `rm.h` from list of headers to install

#### Testing logs/output
* A build with described changes has finished successfully.
* Any unanticipated fallout will hopefully caught by the CI

#### Checklist:
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature]
   *Currently, the pull request contains two commits. This is for illustration purposes and will be consolidated to a single commit.*
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
 *TDB*
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
