### PR TITLE
qstat slowdown due to excessive memory allocation (and zeroing) when displaying jobs using qsub -- /command submission style

### DIFF
--- a/src/lib/Libifl/xml_encode_decode.c
+++ b/src/lib/Libifl/xml_encode_decode.c
@@ -392,21 +392,14 @@ extern	int decode_xml_arg_list(char *executable, char *arg_list,
 
 	init_escapechars_maxarg(escape_chars, &arg_max);
 
-	/* Allocate memory to hold encoded argument */
-	arg = calloc(arg_max, sizeof(char));
-	if (arg == NULL)
-		return -1;
-
 	no_of_arguments++;
 	argv = calloc(no_of_arguments + 1, sizeof(char *));
 	if (argv == NULL) {
-		free(arg);
 		return -1;
 	}
 
 	argv[0] = malloc(strlen(*shell) + 1);
 	if (argv[0] == NULL) {
-		free(arg);
 		free(argv);
 		return -1;
 	}
@@ -416,9 +409,16 @@ extern	int decode_xml_arg_list(char *executable, char *arg_list,
 	if (arg_list == NULL) {
 		argv[no_of_arguments] = 0;
 		*argarray = argv;
-		free(arg);
 		return 0;
 	}
+
+	/* Allocate memory to hold decoded argument */
+	arg = malloc(strlen(arg_list) + 1);
+	if (arg == NULL) {
+		free(argv);
+		return -1;
+	}
+	arg[0] = '\0';
 
 	argument_list = strdup(arg_list);
 	if (argument_list == NULL)
@@ -496,7 +496,7 @@ extern	int decode_xml_arg_list_str(char *arg_list,
 	char		*argv;
 	char		*argv_temp;
 	int		first = 1;
-	int		arg_len = 0;
+	size_t		arg_len = 0;
 	char		*escape_chars[PBS_NUM_ESC_CHARS];
 	long		arg_max = -1;
 	char		*saveptr;		/* for use with strtok_r */
@@ -512,10 +512,12 @@ extern	int decode_xml_arg_list_str(char *arg_list,
 
 	init_escapechars_maxarg(escape_chars, &arg_max);
 
-	/* Allocate memory to hold encoded argument */
-	arg = calloc(arg_max, sizeof(char *));
+	/* Allocate memory to hold decoded argument */
+	arg_len = strlen(arg_list) + 1;
+	arg = malloc(arg_len);
 	if (arg == NULL)
 		return -1;
+	arg[0] = '\0';
 
 	argument_list = strdup(arg_list);
 	if (argument_list == NULL) {
@@ -524,7 +526,7 @@ extern	int decode_xml_arg_list_str(char *arg_list,
 	}
 
 	/* Assign memory to hold argument list */
-	argv = malloc(strlen(argument_list) + 1);
+	argv = malloc(arg_len);
 	if (argv == NULL) {
 		free(arg);
 		free(argument_list);


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
When a job is submitted with an executable and a list of arguments, it will encode them into XML.  In qstat, when allocating memory for the argument list, it chooses a very large number (1 << 24).  It calls calloc() which zeros the memory.

#### Cause / Analysis / Design
With 2600 jobs in the queue, qstat -f > /dev/null took around 11 seconds.  82.5% of that time was spent zeroing the argument list buffer.

#### Solution Description
Replacing calloc with malloc

#### Testing logs/output
[after_fix.txt](https://github.com/PBSPro/pbspro/files/2296644/after_fix.txt)
[before_fix.txt](https://github.com/PBSPro/pbspro/files/2296645/before_fix.txt)
PTL is not included as performance test suite being written by @visheshh  will cover it
Test Scenario:
1. Submit 2600 jobs with arguments and check the time for qstat -f
2. Submit 2600 jobs without arguments and check the time for qstat -f
3. There shouldn't be considerable discrepancy between them.



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

CC: @subhasisb , @bhroam 