### PR TITLE
pbs_snapshot fails to anonymize accounting records

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -587,7 +587,8 @@ class _PBSSnapUtils(object):
         if ret_out:
             return retstr
 
-    def __convert_flag_to_numeric(self, flag):
+    @staticmethod
+    def __convert_flag_to_numeric(flag):
         """
         Convert a resource's flag attribute to its numeric equivalent
 
@@ -630,7 +631,8 @@ class _PBSSnapUtils(object):
                           ATR_DFLAG_MGRD | ATR_DFLAG_MGWR)
         return resc_flag
 
-    def __convert_type_to_numeric(self, attr_type):
+    @staticmethod
+    def __convert_type_to_numeric(attr_type):
         """
         Convert a resource's type attribute to its numeric equivalent
 
@@ -704,6 +706,10 @@ quit()
         :param num_days_logs: Number of days of logs to capture
         :type num_days_logs: int
         """
+
+        if num_days_logs < 1:
+            self.logger.debug("Number of days of logs < 1, skipping")
+            return
 
         end_time = self.server.ctime
         start_time = end_time - ((num_days_logs - 1) * 24 * 60 * 60)
@@ -1524,14 +1530,19 @@ quit()
 
         self.finalized = True
 
-        # Print out obfuscation map
-        if self.anonymize and (self.mapfile is not None):
-            try:
-                with open(self.mapfile, "w") as mapfd:
-                    mapfd.write(str(self.anon_obj))
-            except Exception:
-                self.logger.error("Error writing out the map file " +
-                                  self.mapfile)
+        if self.anonymize:
+            # Print out number of bad accounting records:
+            if self.anon_obj.num_bad_acct_records > 0:
+                self.logger.error("Number of bad accounting records found: " +
+                                  str(self.anon_obj.num_bad_acct_records))
+            if self.mapfile is not None:
+                # Print out obfuscation map
+                try:
+                    with open(self.mapfile, "w") as mapfd:
+                        mapfd.write(str(self.anon_obj))
+                except Exception:
+                    self.logger.error("Error writing out the map file " +
+                                      self.mapfile)
 
         # Record timestamp of the snapshot
         snap_ctimepath = os.path.join(self.snapdir, CTIME_PATH)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* When capturing snapshot with --obfuscate, pbs_snapshot fails with the following error:
Traceback (most recent call last):
  File "pbs_snapshot.py", line 195, in <module>
  File "site-packages/ptl/utils/pbs_snaputils.py", line 1615, in capture_all
  File "site-packages/ptl/utils/pbs_snaputils.py", line 1269, in capture_server
  File "site-packages/ptl/utils/pbs_snaputils.py", line 1121, in __capture_acct_logs
  File "site-packages/ptl/utils/pbs_snaputils.py", line 889, in __capture_logs
  File "site-packages/ptl/utils/pbs_anonutils.py", line 1097, in anonymize_accounting_log
ValueError: need more than 1 value to unpack
Failed to execute script pbs_snapshot


#### Affected Platform(s)
* All Linux

#### Cause / Analysis / Design
* This happens when anonymizing an accounting record which is corrupt (instead of a key=value pair, it has only a single string)

#### Solution Description
* Making the code robust to such bad records so that they get skipped instead
* pbs_snapshot will also print out number of bad records found at the end
* pbs_snapshot -l DEBUG will print out the actual bad records which were found

#### Testing logs/output
* No good way to test this, I just removed the value from 'user' in 2 of the accounting records and took a snapshot with --obfuscate. Attaching snapshot logs here. pbs_snapshot.log is at default log level, at the end you'll see a log line printing the number of bad accounting records found. pbs_snapshot_debug.log was taken with log level set to DEBUG, if you search through it you'll find the log messages for bad accounting records that were found.
[pbs_snapshot_debug.log](https://github.com/PBSPro/pbspro/files/2308158/pbs_snapshot_debug.log)
[pbs_snapshot.log](https://github.com/PBSPro/pbspro/files/2308159/pbs_snapshot.log)

I also ran TestPBSSnapshot:
[testpbssnapshot.log](https://github.com/PBSPro/pbspro/files/2312037/testpbssnapshot.log)




#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
