### PR TITLE
 pbs_snapshot captures backup accounting logs

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -890,6 +890,11 @@ quit()
                 self.__copy_dir_with_core(host, item_src_path, item_dest_path,
                                           core_dir, except_list, only_core)
             else:
+                # PBS log files are named YYYYMMDD, skip log files as
+                # they get captured separately
+                if len(item) == 8 and item.isdigit():
+                    continue
+
                 # Copy the file over
                 item_src_path = prefix + item_src_path
                 try:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* If there's a backup of accounting logs inside server_priv, pbs_snapshot captures it whole, without respecting --accounting-logs filter

#### Affected Platform(s)
* All Linux

#### Cause / Analysis / Design
* pbs_snapshot copies everything from server_priv as is, except the accounting directory. That one it filters out logs from based on the value from --accounting-logs option.
* so, if a user has a backup accounting directory called, say, accounting.backup, inside server_priv, then pbs_snapshot will copy it as is, thinking that it's just a normal directory.

#### Solution Description
* Added a check inside __capture_dir_with_core() to ignore files with numerical names that are 8 characters long. Inside $PBS_HOME, I've only ever seen PBSPro's log files have names of that kind, so hopefully this is a sane check to add.

#### Testing logs/output
* No good way to test this. I manually tested this by creating a copy of the accounting directory by a different name and pbs_snapshot didn't capture any log files inside that directory.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
