### PR TITLE
Scheduler may oversubscribe node while confirming reservation

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -573,6 +573,7 @@ struct node_info
 	int   port;			/* port on which Mom is listening */
 
 	char **jobs;			/* the name of the jobs currently on the node */
+	char **resvs;			/* the name of the reservations currently on the node */
 	resource_resv **job_arr;	/* ptrs to structs of the jobs on the node */
 	resource_resv **run_resvs_arr;	/* ptrs to structs of resvs holding resources on the node */
 

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -741,6 +741,7 @@ update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 	schd_resource *res = NULL;			/* resource from queue */
 	resource_req *req = NULL;			/* resource request from job */
 	counts *cts;					/* update user/group counts */
+	char logbuf[MAX_LOG_SIZE] = {0};
 
 	if (qinfo == NULL || resresv == NULL)
 		return;
@@ -767,9 +768,17 @@ update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 	while (req != NULL) {
 		res = find_resource(qinfo->qres, req->def);
 
-		if (res != NULL)
+		if (res != NULL) {
 			res->assigned -= req->amount;
 
+			if (res->assigned < 0) {
+				snprintf(logbuf, MAX_LOG_SIZE,
+					"%s turned negative %.2lf, setting it to 0", res->name, res->assigned);
+				schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE,
+					LOG_DEBUG, __func__, logbuf);
+				res->assigned = 0;
+			}
+		}
 		req = req->next;
 	}
 

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1421,9 +1421,9 @@ add_resource_list(status *policy, schd_resource *r1, schd_resource *r2, unsigned
 						end_r1 = nres;
 					} else {
 						nres = false_res();
-						nres->name = boolres[i]->name;
 						if (nres == NULL)
 							return 0;
+						nres->name = boolres[i]->name;
 						(void)add_resource_bool(cur_r1, nres);
 					}
 				}
@@ -1782,8 +1782,18 @@ update_server_on_end(status *policy, server_info *sinfo, queue_info *qinfo,
 		while (req != NULL) {
 			res = find_resource(sinfo->res, req->def);
 
-			if (res != NULL)
+			if (res != NULL) {
 				res->assigned -= req->amount;
+
+				if (res->assigned < 0) {
+					char logbuf[MAX_LOG_SIZE] = {0};
+					snprintf(logbuf, MAX_LOG_SIZE,
+						"%s turned negative %.2lf, setting it to 0", res->name, res->assigned);
+					schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER,
+						LOG_DEBUG, __func__, logbuf);
+					res->assigned = 0;
+				}
+			}
 
 			req = req->next;
 		}

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -225,7 +225,7 @@ chk_job_statenum(int istat, char *statelist)
 
 	if (statelist == NULL)
 		return 1;
-	if (istat >= 0 || istat <= 9)
+	if (istat >= 0 && istat <= 9)
 		if (strchr(statelist, (int)(statechars[istat])))
 			return 1;
 	return 0;
@@ -494,6 +494,9 @@ select_job(job *pjob, struct select_list *psel, int dosubjobs, int dohistjobs)
 	else if ((dosubjobs != 2) &&
 		(pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob))
 		return 0;	/* don't bother to look at sub job */
+	else if ((dosubjobs == 2) && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) &&
+		(pjob->ji_qs.ji_state != JOB_STATE_RUNNING)) /* select only running subjobs */
+		return 0;
 
 	while (psel) {
 

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -1,0 +1,103 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+import time
+from tests.functional import *
+
+
+class TestCalendaring(TestFunctional):
+
+    """
+    This test suite tests if PBS scheduler calendars events correctly
+    """
+    def test_topjob_start_time(self):
+        """
+        In this test we test that the top job which gets added to the
+        calendar has estimated start time correctly set for future when
+        job history is enabled and opt_backfill_fuzzy is turned off.
+        """
+
+        self.scheduler.set_sched_config({'strict_ordering': 'true all'})
+        a = {'resources_available.ncpus': 1}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        a = {'backfill_depth': '2', 'job_history_enable': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        # Turn opt_backfill_fuzzy off because we want to check if the job can
+        # run after performing every end event in calendaring code instead
+        # of rounding it off to next time boundary (default it 60 seconds)
+        a = {'opt_backfill_fuzzy': 'off'}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+
+        res_req = {'Resource_List.select': '1:ncpus=1',
+                   'Resource_List.walltime': 10,
+                   'array_indices_submitted': '1-6'}
+        j1 = Job(TEST_USER, attrs=res_req)
+        j1.set_sleep_time(10)
+        jid1 = self.server.submit(j1)
+        j1_sub1 = j1.create_subjob_id(jid1, 1)
+        j1_sub2 = j1.create_subjob_id(jid1, 2)
+
+        res_req = {'Resource_List.select': '1:ncpus=1',
+                   'Resource_List.walltime': 10}
+        j2 = Job(TEST_USER, attrs=res_req)
+        jid2 = self.server.submit(j2)
+
+        self.server.expect(JOB, {'job_state': 'X'}, j1_sub1)
+        self.server.expect(JOB, {'job_state': 'R'}, j1_sub2)
+        self.server.expect(JOB, {'job_state': 'Q'}, jid2)
+        job1 = self.server.status(JOB, id=jid1)
+        job2 = self.server.status(JOB, id=jid2)
+        time_now = int(time.time())
+
+        # get estimated start time of both the jobs
+        self.assertIn('estimated.start_time', job1[0])
+        est_val1 = job1[0]['estimated.start_time']
+        self.assertIn('estimated.start_time', job2[0])
+        est_val2 = job2[0]['estimated.start_time']
+        est1 = time.strptime(est_val1, "%a %b %d %H:%M:%S %Y")
+        est2 = time.strptime(est_val2, "%a %b %d %H:%M:%S %Y")
+        est_epoch1 = int(time.mktime(est1))
+        est_epoch2 = int(time.mktime(est2))
+
+        # since only one subjob of array parent can become topjob
+        # second job must start 10 seconds after that because
+        # walltime of array job is 10 seconds.
+        self.assertEqual(est_epoch2, est_epoch1+10)
+        # Also make sure that since second subjob from array is running
+        # Third subjob should set estimated.start_time in future.
+        self.assertGreater(est_epoch1, time_now)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
It is found that in some cases scheduler may end up oversubscribing the node. Below are the two cases where this can happen:
* If a reservation that is scheduled to start in future is deleted, the server puts the reservation in 'RESV_BEING_DELETED' state and goes on to delete the jobs present in that reservation. Now during this time if the scheduling cycle is triggered, then the scheduler assumes that the reservation must be running and it is going to release resources very soon. This makes scheduler release resources requested by the reservation when it is simulating future. Due to this problem scheduler sometimes end up oversubscribing the node.
* Second problem was introduced in "[PP-479](https://pbspro.atlassian.net/browse/PP-479)". After this change, when scheduler queries server to select all the jobs, it also gets a list of expired sub jobs of job-array. This was not the case before because the server was only reporting array-parent and running sub jobs to the scheduler. Now, upon receiving expired sub jobs scheduler releases more resources during simulation (for top jobs or reservation) and can end up oversubscribing the node.

#### Affected Platform(s)
All

#### Solution Description
It has 3 way fix - 
  - Server now does not report expired sub jobs to the scheduler. It only reports queued array-parent, running sub jobs and other non-finished jobs to the scheduler.
 - Scheduler detects that if it received reservation in being_deleted state or sub jobs in non-running state then it ignores it.
- While simulating, if scheduler ever falls into a case where resources assigned on node/server/queue are turning negative then it sets them to 0.

#### Testing logs/output
[test_est.txt](https://github.com/PBSPro/pbspro/files/2316682/test_est.txt)

[testlogs_node_oversubscription.txt](https://github.com/PBSPro/pbspro/files/2316657/testlogs_node_oversubscription.txt)
[test_array_jobs.txt](https://github.com/PBSPro/pbspro/files/2319437/test_array_jobs.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__



* NOTE: I've added a PTL test to make sure top jobs do not get affected when there are expired subjobs in the system. To test reservation case, I used gdb and that is why there is no automated test  for that scenario.