### PR TITLE
TestCgroupsHook not skipping if cpuset subsystem is there but memory is not 

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -151,8 +151,8 @@ class TestCgroupsHook(TestFunctional):
                               'use -p moms=<mom1>:<mom2>')
         self.serverA = self.servers.values()[0].name
         self.paths = self.get_paths()
-        if not self.paths['cpuset']:
-            self.skipTest('cpuset cgroup not mounted')
+        if not (self.paths['cpuset'] and self.paths['memory']):
+            self.skipTest('cpuset or memory cgroup subsystem not mounted')
         self.swapctl = is_memsw_enabled(self.paths['memsw'])
         self.server.set_op_mode(PTL_CLI)
         self.server.cleanup_jobs(extend='force')


### PR DESCRIPTION
#### Bug/feature Description
* *Bugs: TestCgroupsHook is not skipping if cpuset subsystem is there but memory is not*

#### Affected Platform(s)
* *Platform (All that has cpuset but no memory cgroup)*

#### Cause / Analysis / Design

* *Bugs: Test is only checking for cpuset and skipping however it should also check if memory cgroup is also not present*

#### Solution Description
* *updated the skip check to also look for memory cgroup subsystem*

#### Testing logs/output
* *
[cgroups_cpu_mem.txt](https://github.com/PBSPro/pbspro/files/2333910/cgroups_cpu_mem.txt)
[cgroups_cpu_nomem.txt](https://github.com/PBSPro/pbspro/files/2333911/cgroups_cpu_nomem.txt)
[cgroups_nocpu_nomem.txt](https://github.com/PBSPro/pbspro/files/2333912/cgroups_nocpu_nomem.txt)

*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
