### PR TITLE
pbs_mom not starting; set_enforcement fails to handle arguments witho…

### DIFF
--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -2490,22 +2490,34 @@ set_enforcement(char *str)
 
 	str = TOKCPY(str, arg);
 	str = skipwhite(str);
-	if (*str == '\0')
-		return HANDLER_FAIL;
 
 	if (strcmp(arg, "delta_percent_over") == 0) {
+		if (*str == '\0')
+			return HANDLER_FAIL;
 		delta_percent_over = atoi(str);
 	} else if (strcmp(arg, "delta_cpufactor") == 0) {
+		if (*str == '\0')
+			return HANDLER_FAIL;
 		delta_cpufactor = atof(str);
 	} else if (strcmp(arg, "delta_weightup") == 0) {
+		if (*str == '\0')
+			return HANDLER_FAIL;
 		delta_weightup = atof(str);
 	} else if (strcmp(arg, "delta_weightdown") == 0) {
+		if (*str == '\0')
+			return HANDLER_FAIL;
 		delta_weightdown = atof(str);
 	} else if (strcmp(arg, "average_percent_over") == 0) {
+		if (*str == '\0')
+			return HANDLER_FAIL;
 		average_percent_over = atoi(str);
 	} else if (strcmp(arg, "average_cpufactor") == 0) {
+		if (*str == '\0')
+			return HANDLER_FAIL;
 		average_cpufactor = atof(str);
 	} else if (strcmp(arg, "average_trialperiod") == 0) {
+		if (*str == '\0')
+			return HANDLER_FAIL;
 		average_trialperiod = atoi(str);
 	} else if (strcmp(arg, "cpuburst") == 0) {
 		cpuburst = on;		/* may be off */

--- a/test/tests/functional/pbs_set_enforcement.py
+++ b/test/tests/functional/pbs_set_enforcement.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestMomEnforcement(TestFunctional):
+    """
+    This test suite tests enforcement on mom
+    """
+
+    def test_set_enforcement(self):
+        """
+        This test suite verifies that mom successfully handle the setting
+        of enforcement in the config file
+        """
+        self.mom.add_config(
+            {'$enforce delta_percent_over': '50',
+             '$enforce delta_cpufactor': '1.5',
+             '$enforce delta_weightup': '0.4',
+             '$enforce delta_weightdown': '0.1',
+             '$enforce average_percent_over': '50',
+             '$enforce average_cpufactor': '1.025',
+             '$enforce average_trialperiod': '120',
+             '$enforce cpuburst': '',
+             '$enforce cpuaverage': '',
+             '$enforce mem': ''})
+
+        error = ""
+        try:
+            self.mom.stop()
+            self.mom.start()
+        except PbsServiceError as err:
+            error = err
+
+        self.assertEqual(error, "")


### PR DESCRIPTION
…ut value

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* If you set enforcement setting without value (some enforcement setting does not need the value) in mom config, the pbs_mom will not start with the following error:
```
# cat /var/spool/pbs/mom_priv/config | grep enforce
$enforce mem
$enforce cpuaverage
$enforce average_trialperiod 3
$enforce average_percent_over 10
$enforce average_cpufactor 1.02
```
```
09/04/2018 09:23:56;0001;pbs_mom;Svr;pbs_mom;parse_config, config[4] command "$enforce mem" failed, aborting
09/04/2018 09:23:56;0001;pbs_mom;Svr;pbs_mom;parse_config, config[5] command "$enforce cpuaverage" failed, aborting
```
#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* PR #767 causes this issue. There is a following fix in mom_main.c:set_enforcement():
```
           str = skipwhite(str);
2490 -     if (str == '\0')
2493 +     if (*str == '\0')
                    return HANDLER_FAIL;
```
The fix is partially correct but it causes that the enforcement item without value returns HANDLER_FAIL because the set_enforcement() always expects three words in the config file.

#### Solution Description
* I have moved the string end check before each imminent value reading.

#### Testing logs/output
* test log: [ptl_output_set_enforcement.txt](https://github.com/PBSPro/pbspro/files/2348088/ptl_output_set_enforcement.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
