### PR TITLE
analyze_server_log does not return any values if end time is not specified

### DIFF
--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -991,7 +991,7 @@ class PBSServerLog(PBSLogAnalyzer):
             tm = self.logutils.convert_date_time(m.group('datetime'))
             self.record_tm.append(tm)
             if not self.logutils.in_range(tm, start, end):
-                if tm > end:
+                if end and tm > end:
                     return PARSER_OK_STOP
                 return PARSER_OK_CONTINUE
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
When analyze_server_log is called from PTL it return all values as 0 , if start time is specified and end time is not specified .

analyze_server_log(filename=self.server.logfile,start=self.server.ctime)

 {'server': {'num_jobs_run': 0, 'num_jobs_queued': 0, 'node_up_rate': 0, 'job_dequeue_rate': 0, 'pbs_version': '', 'num_jobs_ended': 0, 'job_run_rate': 0, 'job_end_rate': 0, 'job_submit_rate': 0}}

#### Affected Platform(s)
ALL

#### Cause / Analysis / Design
In logutils we check if time is greater than end time and throw error . If end time is None then also error is thrown

#### Solution Description
Add a check if end time exists and only then check if tm > end.

#### Testing logs/output

function call in PTL test : analyze_server_log(filename=self.server.logfile,start=self.server.ctime)
Before fix:
{'server': {'num_jobs_run': 0, 'num_jobs_queued': 0, 'node_up_rate': 0, 'job_dequeue_rate': 0, 'pbs_version': '', 'num_jobs_ended': 0, 'job_run_rate': 0, 'job_end_rate': 0, 'job_submit_rate': 0}}

After fix:
{'server': {'job_run_time_min': '0:00:00', 'job_run_time_mean': '0:00:00', 'num_jobs_run': 1000, 'job_run_time_max': '0:00:02', 'job_run_time_median': '0:00:01', 'num_jobs_queued': 2, 'job_run_time_25p': '0:00:00', 'job_wait_time_75p': '0:00:20', 'job_wait_time_mean': '0:00:20', 'job_wait_time_max': '0:00:20', 'node_up_rate': 0, 'job_run_time_75p': '0:00:01', 'num_jobs_ended': 1000, 'job_run_rate': '50.00/s', 'job_end_rate': '50.00/s', 'job_submit_rate': '2/s', 'job_wait_time_median': '0:00:20', 'job_wait_time_min': '0:00:20', 'pbs_version': '', 'job_wait_time_25p': '0:00:20'}}


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
