### PR TITLE
memory is not freed when action function fails in mgr_set_attr

### DIFF
--- a/src/lib/Libattr/attr_fn_entlim.c
+++ b/src/lib/Libattr/attr_fn_entlim.c
@@ -848,6 +848,7 @@ set_entlim(attribute *old, attribute *new, enum batch_op op)
 					if (entlim_replace(pkey->key, newptr, oldctx, svr_freeleaf) != 0) {
 						/* failed to add */
 						svr_freeleaf(newptr);
+						free(pkey);
 						return (PBSE_SYSTEM);
 					}
 				}
@@ -912,7 +913,7 @@ set_entlim(attribute *old, attribute *new, enum batch_op op)
 			/* having removed one or more elements from the value tree */
 			/* see if any entries are left or if the value is now null */
 			pkey = NULL;
-			if (entlim_get_next(pkey, oldctx) == NULL) {
+			if ((pkey = entlim_get_next(pkey, oldctx)) == NULL) {
 				/* no entries left set, clear the entire attribute */
 				free_entlim(old);
 				/* set _MODIFY flag so up level functions */
@@ -920,6 +921,7 @@ set_entlim(attribute *old, attribute *new, enum batch_op op)
 				old->at_flags |= ATR_VFLAG_MODIFY;
 				return (0);
 			}
+			free(pkey);
 			break;
 
 		default:	return (PBSE_INTERNAL);

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -878,6 +878,7 @@ mgr_set_attr2(attribute *pattr, attribute_def *pdef, int limit, svrattrl *plist,
 						attr_atomic_kill(new, pdef, limit);
 						attr_atomic_kill(pre_copy, pdef, limit);
 						attr_atomic_kill(attr_save, pdef, limit);
+						free(pkey);
 						return (PBSE_BADATVAL);
 					}
 					pkey = entlim_get_next(pkey,
@@ -942,8 +943,8 @@ mgr_set_attr2(attribute *pattr, attribute_def *pdef, int limit, svrattrl *plist,
 				rc = (pdef+index)->at_action((new+index), parent, mode);
 				if (rc) {
 					*bad = index + 1;
-					free(new);
-					free(pre_copy);
+					attr_atomic_kill(new, pdef, limit);
+					attr_atomic_kill(pre_copy, pdef, limit);
 					attr_atomic_copy(pattr, attr_save, pdef, limit);
 					attr_atomic_kill(attr_save, pdef, limit);
 					return (rc);
@@ -3817,6 +3818,7 @@ is_entity_resource_set(attribute *pattr, char *resc_name)
 		while ((pkey=entlim_get_next(pkey, ctx)) != NULL) {
 			if (entlim_resc_from_key(pkey, resc, PBS_MAX_RESC_NAME) == 0)
 				if (strcmp(resc, resc_name) == 0) {
+					free(pkey);
 					return 1;
 				}
 		}

--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -38,7 +38,7 @@
 from tests.functional import *
 
 
-class TestProvisioningJob(TestFunctional):
+class TestProvisioningJob_Enh(TestFunctional):
     """
     This testsuite tests newly introduced provisioining capabilities.
     With this enhacement, PBS will be able to run job requesting aoe

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -671,3 +671,53 @@
    fun:pbs_python_populate_attributes_to_python_class
    fun:*
 }
+{
+   From PBSPro (server) - Suppress intentional unfreed memory from loading hook script at mgr_hook_import 
+   Memcheck:Leak
+   fun:malloc
+   fun:strdup
+   fun:pbs_python_ext_alloc_python_script
+   fun:mgr_hook_import
+   fun:req_manager
+   fun:dispatch_request
+   fun:process_request
+   fun:wait_request
+   fun:main
+}
+{
+   From PBSPro (server) - Suppress intentional unfreed memory from loading hook script at mgr_hook_import 
+   Memcheck:Leak
+   fun:malloc
+   fun:pbs_python_ext_alloc_python_script
+   fun:mgr_hook_import
+   fun:req_manager
+   fun:dispatch_request
+   fun:process_request
+   fun:wait_request
+   fun:main
+}
+{
+   From PBSPro (server) - Suppress intentional unfreed memory from allocating hook data at mgr_hook_create 
+   Memcheck:Leak
+   fun:malloc
+   fun:hook_alloc
+   fun:mgr_hook_create
+   fun:req_manager
+   fun:dispatch_request
+   fun:process_request
+   fun:wait_request
+   fun:main
+}
+{
+   From PBSPro (server) - Suppress intentional unfreed memory from allocating hook name at mgr_hook_create 
+   Memcheck:Leak
+   fun:malloc
+   fun:strdup
+   fun:set_hook_name
+   fun:mgr_hook_create
+   fun:req_manager
+   fun:dispatch_request
+   fun:process_request
+   fun:wait_request
+   fun:main
+}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* memory is not freed when action function fails in mgr_set_attr
* memory leak in set_entlim

#### Cause / Analysis / Design
* When action function was failing PBS was just freeing the main attribute structure instead of freeing individual elements in the array. 
* memory allocated by entlim_get_next() is not freed.

#### Solution Description
* Freeing each item in the attribute
* Updating a duplicate test suite name
* Adding more hook related memory leaks to suppress file
* fix for memory leak in set_entlim 

#### Testing logs/output
[memleak1 logs.txt](https://github.com/PBSPro/pbspro/files/2351151/memleak1.logs.txt)
[set_entlim.log](https://github.com/PBSPro/pbspro/files/2356591/set_entlim.log)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

CC: @subhasisb , @bayucan 
