### PR TITLE
misuse of qrun -H crashes server

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -6760,7 +6760,12 @@ build_execvnode(job *pjob, char *nds)
 		pc = parse_plus_spec(NULL, &rc);
 	}
 
-	if (rc)
+       /* 
+        * if the number of nodes defined above in ndarray is not equal
+        * to the number of nodes identified, then skip the below loop
+        */
+
+	if (rc || i != nnodes)
 		goto done;
 
 	/* now loop breaking up the select spec into separate chunks */

--- a/test/tests/functional/pbs_qrun.py
+++ b/test/tests/functional/pbs_qrun.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestQrun(TestFunctional):
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        # set ncpus to a known value, 2 here
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a,
+                            self.mom.shortname, expect=True)
+        self.pbs_exec = self.server.pbs_conf['PBS_EXEC']
+        self.qrun = os.path.join(self.pbs_exec, 'bin', 'qrun')
+
+    def test_misuse_of_qrun(self):
+        j1 = Job(TEST_USER)
+        # submit a multi-chunk job
+        j1 = Job(attrs={'Resource_List.select':
+                        'ncpus=2:host=%s+ncpus=2:host=%s' %
+                 (self.mom.shortname, self.mom.shortname)})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, jid1)
+        cmd = [self.qrun, '-H', '"\'(%s)+(%s)\'"' %
+               (self.mom.shortname, self.mom.shortname), jid1]
+        ret = self.du.run_cmd(self.server.hostname, cmd,
+                              sudo=True, as_script=True)
+        msg = "qrun: Unknown node  \'(%s)+(%s)\'" % \
+            (self.mom.shortname, self.mom.shortname)
+        self.assertIn(msg, ret['err'][-1])
+        j2 = Job(TEST_USER)
+        # submit a sleep job
+        j2 = Job(attrs={'Resource_List.select': 'ncpus=3'})
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, jid2)
+        cmd = [self.qrun, '-H', '"\'(%s)+(%s)\'"' %
+               (self.mom.shortname, self.mom.shortname), jid2]
+        ret = self.du.run_cmd(self.server.hostname, cmd,
+                              sudo=True, as_script=True)
+        self.assertIn(msg, ret['err'][-1])


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* qrun -H call crashes the server when the node list is ill-formed.
* example:  jid=$(echo "sleep 10" | qsub -l select=ncpus=36:host=centos7+ncpus=36:host=centos7)
                   qrun -H "'(centos7)+(centos7)'" $jid
                   qrun: End of File 4.centos7

#### Affected Platform(s)
* All Platforms

#### Cause / Analysis / Design
* parse_plus_spec_r of src/lib/Libifl/grunt_parse.c explicitly skips everything within quotes including the plus sign , whereas build_execvnode of src/server/node_manager.c  disagrees with it about the significance of plus signs within the quoted string.
* Having identified the number of nodes (2 in the above example) in build_execvnode, ndarray is defined (with one node value as NULL) 
* Seg Fault occurs in strlen() call for the above ndarray.

#### Solution Description
* if qrun is used with a bad -H specification, then reject the call with Unknown node error.
* if the number of nodes defined above in ndarray is not equal to the number of nodes identified, then skip the loop of breaking up the select spec into separate chunks.

#### Testing logs/output
* *Please attach your test log output from running the test you added (or from existing tests that cover your changes)*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
