### PR TITLE
 Server allows jobs/resvs to be run/confirmed on down/stale vnodes

### DIFF
--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -259,6 +259,7 @@ extern "C" {
 #define PBSE_STDG_RESV_OCCR_CONFLICT 15179 /* cannot change start time of a non-empty reservation */
 
 #define PBSE_SOFTWT_STF		     15180 /* soft_walltime is incompatible with STF jobs */
+#define PBSE_BAD_NODE_STATE          15181 /* node is in the wrong state for the operation */
 
 /*
  ** 	Resource monitor specific

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -357,7 +357,7 @@ extern	int  act_resv_add_owner(attribute*, void*, int);
 extern	void svr_mailownerResv(resc_resv*, int, int, char*);
 extern	void resv_free(resc_resv*);
 extern	void set_old_subUniverse(resc_resv *);
-extern	int  assign_resv_resc(resc_resv *, char *, int);
+extern	int  assign_resv_resc(resc_resv *, char *, int svr_init); /* Adding svr_init parameter to track whether the server is in init start mode */
 extern	void  resv_exclusive_handler(resc_resv *);
 #ifdef	__cplusplus
 }

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -172,7 +172,6 @@ typedef struct pbsnode_list_ {
 struct resc_resv {
 
 	/* Note: these members, upto ri_qs, are not saved to disk */
-
 	pbs_list_link		ri_allresvs;		/* links this resc_resv into the
 							 * server's global list
 							 */
@@ -358,7 +357,7 @@ extern	int  act_resv_add_owner(attribute*, void*, int);
 extern	void svr_mailownerResv(resc_resv*, int, int, char*);
 extern	void resv_free(resc_resv*);
 extern	void set_old_subUniverse(resc_resv *);
-extern	int  assign_resv_resc(resc_resv *, char *);
+extern	int  assign_resv_resc(resc_resv *, char *, int);
 extern	void  resv_exclusive_handler(resc_resv *);
 #ifdef	__cplusplus
 }

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7140,9 +7140,7 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 					}
 					else {
 						resv_setResvState(presv, RESV_DEGRADED, RESV_DEGRADED);
-						free(phowl);
-						free(execvncopy);
-						return (PBSE_BAD_NODE_STATE);
+						set_resv_retry(presv, time_now+10);
 					}
 				}
                         }

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7125,6 +7125,11 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				return (PBSE_UNKNODE);
 			}
 
+                        if (svr_init == FALSE && (pnode->nd_state & (INUSE_DOWN | INUSE_STALE))) {
+                                   free(phowl);
+                                   free(execvncopy);
+                                   return (PBSE_BAD_NODE_STATE);
+                        }
 
 			if (pjob != NULL) { /* only for jobs do we warn if a mom */
 				/* hook has not been sent */
@@ -8404,8 +8409,10 @@ set_old_subUniverse(resc_resv	*presv)
 		free(sp);
 		return;
 	}
+	int svr_init;
+	svr_init = TRUE;
 	/* set the nodes on the reservation */
-	rc = assign_resv_resc(presv, sp);
+	rc = assign_resv_resc(presv, sp, svr_init);
 	if (rc != PBSE_NONE) {
 		sprintf(log_buffer,
 			"problem assigning resource to reservation %d", rc);

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7125,10 +7125,23 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				return (PBSE_UNKNODE);
 			}
 
-                        if (svr_init == FALSE && (pnode->nd_state & (INUSE_DOWN | INUSE_STALE))) {
+                        if ((pnode->nd_state & (INUSE_DOWN | INUSE_STALE)) && (svr_init == FALSE)) {
+
+				if(objtype == JOB_OBJECT) {
                                    free(phowl);
                                    free(execvncopy);
                                    return (PBSE_BAD_NODE_STATE);
+				} 
+				else {
+					if(presv->ri_qs.ri_state == RESV_UNCONFIRMED) {
+						set_resv_retry(presv, time_now+10);
+						free(phowl);
+                	                	free(execvncopy);
+                        	      		return (PBSE_BAD_NODE_STATE);
+					}
+					else
+						resv_setResvState(presv, RESV_DEGRADED, RESV_DEGRADED);
+				}
                         }
 
 			if (pjob != NULL) { /* only for jobs do we warn if a mom */

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7134,13 +7134,16 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				} 
 				else {
 					if(presv->ri_qs.ri_state == RESV_UNCONFIRMED) {
-						set_resv_retry(presv, time_now+10);
 						free(phowl);
                 	                	free(execvncopy);
                         	      		return (PBSE_BAD_NODE_STATE);
 					}
-					else
+					else {
 						resv_setResvState(presv, RESV_DEGRADED, RESV_DEGRADED);
+						free(phowl);
+						free(execvncopy);
+						return (PBSE_BAD_NODE_STATE);
+					}
 				}
                         }
 
@@ -8422,10 +8425,8 @@ set_old_subUniverse(resc_resv	*presv)
 		free(sp);
 		return;
 	}
-	int svr_init;
-	svr_init = TRUE;
 	/* set the nodes on the reservation */
-	rc = assign_resv_resc(presv, sp, svr_init);
+	rc = assign_resv_resc(presv, sp, TRUE);
 	if (rc != PBSE_NONE) {
 		sprintf(log_buffer,
 			"problem assigning resource to reservation %d", rc);

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -312,6 +312,7 @@ req_confirmresv(struct batch_request *preq)
 	int		is_being_altered = 0;
 	char		*tmp_buf = NULL;
 	size_t		tmp_buf_size = 0;
+	int 		svr_init=FALSE;
 
 	if ((preq->rq_perm & (ATR_DFLAG_MGWR | ATR_DFLAG_OPWR)) == 0) {
 		req_reject(PBSE_PERM, 0, preq);
@@ -583,7 +584,6 @@ req_confirmresv(struct batch_request *preq)
 	 */
 	if (is_being_altered)
 		free_resvNodes(presv);
-	int svr_init;
 	svr_init = FALSE;
 	rc = assign_resv_resc(presv, next_execvnode, svr_init);
 

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -242,7 +242,7 @@ cnvrt_timer_init()
  * @retval	non-zero	: error code if problem occurs
  */
 int
-assign_resv_resc(resc_resv *presv, char *vnodes)
+assign_resv_resc(resc_resv *presv, char *vnodes, int svr_init)
 {
 	int		  ret;
 	char     *node_str = NULL;
@@ -252,7 +252,7 @@ assign_resv_resc(resc_resv *presv, char *vnodes)
 		return (PBSE_BADNODESPEC);
 
 	ret = set_nodes((void *)presv, presv->ri_qs.ri_type, vnodes,
-		&node_str, &host_str, &host_str2, 0, FALSE);
+		&node_str, &host_str, &host_str2, 0, svr_init);
 
 	if (ret == PBSE_NONE) {
 		/*update resc_resv object's RESV_ATR_resv_nodes attribute*/
@@ -583,7 +583,9 @@ req_confirmresv(struct batch_request *preq)
 	 */
 	if (is_being_altered)
 		free_resvNodes(presv);
-	rc = assign_resv_resc(presv, next_execvnode);
+	int svr_init;
+	svr_init = FALSE;
+	rc = assign_resv_resc(presv, next_execvnode, svr_init);
 
 	if (rc != PBSE_NONE) {
 		free(next_execvnode);

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -249,7 +249,7 @@ assign_resv_resc(resc_resv *presv, char *vnodes, int svr_init)
 	char		 *host_str = NULL;	/* used only as arg to set_nodes */
 	char * host_str2 = NULL;
 	struct work_task *pwt;
-        extern void resv_retry_handler(struct work_task *ptask);
+	extern void resv_retry_handler(struct work_task *ptask);
 
 	if ((vnodes == NULL) || (*vnodes == '\0'))
 		return (PBSE_BADNODESPEC);

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -248,6 +248,9 @@ assign_resv_resc(resc_resv *presv, char *vnodes, int svr_init)
 	char     *node_str = NULL;
 	char		 *host_str = NULL;	/* used only as arg to set_nodes */
 	char * host_str2 = NULL;
+	struct work_task *pwt;
+        extern void resv_retry_handler(struct work_task *ptask);
+
 	if ((vnodes == NULL) || (*vnodes == '\0'))
 		return (PBSE_BADNODESPEC);
 
@@ -268,6 +271,18 @@ assign_resv_resc(resc_resv *presv, char *vnodes, int svr_init)
 
 		presv->ri_modified = 1;
 	}
+	else if (ret == PBSE_BAD_NODE_STATE) {
+           /* Set a work task to initiate a scheduling cycle when the time to check
+            * for alternate nodes to assign the reservation comes
+            */
+           if ((pwt = set_task(WORK_Timed, time_now+10, resv_retry_handler, presv)) != NULL) {
+           /* set things so that the reservation going away will result in
+            * any "yet to be processed" work tasks also going away
+            */
+ 	          append_link(&presv->ri_svrtask, &pwt->wt_linkobj, pwt);
+           }
+	}
+
 
 	return (ret);
 }
@@ -312,7 +327,6 @@ req_confirmresv(struct batch_request *preq)
 	int		is_being_altered = 0;
 	char		*tmp_buf = NULL;
 	size_t		tmp_buf_size = 0;
-	int 		svr_init=FALSE;
 
 	if ((preq->rq_perm & (ATR_DFLAG_MGWR | ATR_DFLAG_OPWR)) == 0) {
 		req_reject(PBSE_PERM, 0, preq);
@@ -584,8 +598,7 @@ req_confirmresv(struct batch_request *preq)
 	 */
 	if (is_being_altered)
 		free_resvNodes(presv);
-	svr_init = FALSE;
-	rc = assign_resv_resc(presv, next_execvnode, svr_init);
+	rc = assign_resv_resc(presv, next_execvnode, FALSE);
 
 	if (rc != PBSE_NONE) {
 		free(next_execvnode);

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -3600,7 +3600,9 @@ Time4occurrenceFinish(resc_resv *presv)
 	/* Assign the allocated resources to the reservation
 	 * and the reservation to the associated vnodes
 	 */
-	rc = assign_resv_resc(presv, newxc);
+	int svr_init;
+	svr_init = FALSE;
+	rc = assign_resv_resc(presv, newxc, svr_init);
 	free(newxc);
 
 	if (rc != PBSE_NONE) {

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -3459,7 +3459,6 @@ Time4occurrenceFinish(resc_resv *presv)
 	int			rcount = presv->ri_wattr[RESV_ATR_resv_count].at_val.at_long;
 	char			*rrule = presv->ri_wattr[RESV_ATR_resv_rrule].at_val.at_str;
 	char			*tz = presv->ri_wattr[RESV_ATR_resv_timezone].at_val.at_str;
-	int 			svr_init = FALSE;
 
 	/* the next occurrence returned by get_occurrence is counted from the current
 	 * one which is at index 1. */
@@ -3601,8 +3600,7 @@ Time4occurrenceFinish(resc_resv *presv)
 	/* Assign the allocated resources to the reservation
 	 * and the reservation to the associated vnodes
 	 */
-	svr_init = FALSE;
-	rc = assign_resv_resc(presv, newxc, svr_init);
+	rc = assign_resv_resc(presv, newxc, FALSE);
 	free(newxc);
 
 	if (rc != PBSE_NONE) {

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -3459,6 +3459,7 @@ Time4occurrenceFinish(resc_resv *presv)
 	int			rcount = presv->ri_wattr[RESV_ATR_resv_count].at_val.at_long;
 	char			*rrule = presv->ri_wattr[RESV_ATR_resv_rrule].at_val.at_str;
 	char			*tz = presv->ri_wattr[RESV_ATR_resv_timezone].at_val.at_str;
+	int 			svr_init = FALSE;
 
 	/* the next occurrence returned by get_occurrence is counted from the current
 	 * one which is at index 1. */
@@ -3600,7 +3601,6 @@ Time4occurrenceFinish(resc_resv *presv)
 	/* Assign the allocated resources to the reservation
 	 * and the reservation to the associated vnodes
 	 */
-	int svr_init;
 	svr_init = FALSE;
 	rc = assign_resv_resc(presv, newxc, svr_init);
 	free(newxc);

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -144,34 +144,33 @@ class SmokeTest(PBSTestSuite):
              ATTR_resv_timezone: tzone,
              ATTR_resv_standing: '1',
              'reserve_start': time_now + 8,
-             'reserve_end': time_now + 14, 
+             'reserve_end': time_now + 14,
              'Resource_List.place': 'free'}
         r = Reservation(TEST_USER, a)
-        #Submitting recurring reservation to check the resv status 
+        #Submitting recurring reservation to check the resv status
         #for one of the vnode being stale
         rid = self.server.submit(r)
         #To check the standing resv once confirmed.
         a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
-        #To check the standing resv for Degraded status 
+        #To check the standing resv for Degraded status
         #when one of the vnode becomes down
         a2 = {'reserve_state': (MATCH_RE, "RESV_DEGRADED|10")}
         self.server.expect(RESV, a, id=rid)
         self.server.status(RESV, 'resv_nodes', id=rid)
         resv_node = self.server.reservations[rid].get_vnodes()[0]
-        #To check the status of standing resv in next cycle and also 
+        #To check the status of standing resv in next cycle and also
         #check the down node doesn't exist in resv_nodes.
         a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2"),
-             'resv_nodes': 
+             'resv_nodes':
              (MATCH_RE, '^((?!' + re.escape(resv_node) + ').)*$')}
         b = {'state': 'down'}
         self.server.manager(MGR_CMD_SET, NODE, b, id=resv_node)
         self.server.expect(RESV, a2, id=rid)
-        self.logger.info('testinfo: waiting for recurring reservation,' + 
+        self.logger.info('testinfo: waiting for recurring reservation,' +
                                                 'while expecting status')
         self.server.expect(RESV, a, id=rid, offset=16)
         if _m == PTL_API:
             self.server.set_op_mode(PTL_API)
-
 
     @skipOnCpuSet
     def test_degraded_advance_reservation(self):
@@ -179,7 +178,6 @@ class SmokeTest(PBSTestSuite):
         Make reservations more fault tolerant
         Test for an advance reservation
         """
-
         now = int(time.time())
         a = {'reserve_retry_init': 5, 'reserve_retry_cutoff': 1}
         self.server.manager(MGR_CMD_SET, SERVER, a)

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -122,7 +122,7 @@ class SmokeTest(PBSTestSuite):
     def test_standing_reservation_stale_nodes(self):
         """
         Test to submit a standing reservation for nodes which are stale
-	after scheduling cycle and before set_nodes in server.
+        after scheduling cycle and before set_nodes in server.
         """
         # PBS_TZID environment variable must be set, there is no way to set
         # it through the API call, use CLI instead for this test
@@ -167,7 +167,7 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, NODE, b, id=resv_node)
         self.server.expect(RESV, a2, id=rid)
         self.logger.info('testinfo: waiting for recurring reservation,' +
-                                                'while expecting status')
+                         'while expecting status')
         self.server.expect(RESV, a, id=rid, offset=16)
         if _m == PTL_API:
             self.server.set_op_mode(PTL_API)

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -147,20 +147,20 @@ class SmokeTest(PBSTestSuite):
              'reserve_end': time_now + 14,
              'Resource_List.place': 'free'}
         r = Reservation(TEST_USER, a)
-        #Submitting recurring reservation to check the resv status
-        #for one of the vnode being stale
+        # Submitting recurring reservation to check the resv status
+        # for one of the vnode being stale
         rid = self.server.submit(r)
-        #To check the standing resv once confirmed.
+        # To check the standing resv once confirmed.
         a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
-        #To check the standing resv for Degraded status
-        #when one of the vnode becomes down
+        # To check the standing resv for Degraded status
+        # when one of the vnode becomes down
         a2 = {'reserve_state': (MATCH_RE, "RESV_DEGRADED|10")}
         self.server.expect(RESV, a, id=rid)
         self.server.status(RESV, 'resv_nodes', id=rid)
         resv_node = self.server.reservations[rid].get_vnodes()[0]
-        #To check the status of standing resv in next cycle and also
-        #check the down node doesn't exist in resv_nodes.
-        a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2"),
+        # To check the status of standing resv in next cycle and also
+        # check the down node doesn't exist in resv_nodes.
+        a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2|RESV_RUNNING|5"),
              'resv_nodes':
              (MATCH_RE, '^((?!' + re.escape(resv_node) + ').)*$')}
         b = {'state': 'down'}

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -112,22 +112,20 @@ class SmokeTest(PBSTestSuite):
              'reserve_start': time.time() + 20,
              'reserve_end': time.time() + 30, }
         r = Reservation(TEST_USER, a)
-        nodes = r.get_vnodes(r.exec_vnode)
-        print "NODES:"
-        print nodes
         rid = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
         self.server.expect(RESV, a, id=rid)
         if _m == PTL_API:
             self.server.set_op_mode(PTL_API)
+
     @skipOnCray
     def test_standing_reservation_stale_nodes(self):
         """
-        Test to submit a standing reservation for nodes which are stale after scheduling cycle and before set_nodes in server.
+        Test to submit a standing reservation for nodes which are stale
+	after scheduling cycle and before set_nodes in server.
         """
         # PBS_TZID environment variable must be set, there is no way to set
         # it through the API call, use CLI instead for this test
-
         _m = self.server.get_op_mode()
         if _m != PTL_CLI:
             self.server.set_op_mode(PTL_CLI)
@@ -138,7 +136,6 @@ class SmokeTest(PBSTestSuite):
         else:
             self.logger.info('Missing timezone, using America/Los_Angeles')
             tzone = 'America/Los_Angeles'
-            
         a = {'resources_available.ncpus': 1}
         time_now = int(time.time())
         self.server.create_vnodes('vn', a, num=4, mom=self.mom)
@@ -150,21 +147,27 @@ class SmokeTest(PBSTestSuite):
              'reserve_end': time_now + 14, 
              'Resource_List.place': 'free'}
         r = Reservation(TEST_USER, a)
-        #Submitting recurring reservation to check the resv status for one of the vnode being stale
+        #Submitting recurring reservation to check the resv status 
+        #for one of the vnode being stale
         rid = self.server.submit(r)
         #To check the standing resv once confirmed.
         a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
-        #To check the standing resv for Degraded status when one of the vnode becomes down
+        #To check the standing resv for Degraded status 
+        #when one of the vnode becomes down
         a2 = {'reserve_state': (MATCH_RE, "RESV_DEGRADED|10")}
         self.server.expect(RESV, a, id=rid)
         self.server.status(RESV, 'resv_nodes', id=rid)
         resv_node = self.server.reservations[rid].get_vnodes()[0]
-        #To check the status of standing resv in next cycle and also check the down node doesn't exist in resv_nodes.
-        a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2"),'resv_nodes': (MATCH_RE, '^((?!' + re.escape(resv_node) + ').)*$')}
+        #To check the status of standing resv in next cycle and also 
+        #check the down node doesn't exist in resv_nodes.
+        a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2"),
+             'resv_nodes': 
+             (MATCH_RE, '^((?!' + re.escape(resv_node) + ').)*$')}
         b = {'state': 'down'}
         self.server.manager(MGR_CMD_SET, NODE, b, id=resv_node)
         self.server.expect(RESV, a2, id=rid)
-        self.logger.info('testinfo: waiting for recurring reservation, while expecting status')
+        self.logger.info('testinfo: waiting for recurring reservation,' + 
+                                                'while expecting status')
         self.server.expect(RESV, a, id=rid, offset=16)
         if _m == PTL_API:
             self.server.set_op_mode(PTL_API)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
When a job is run or a reservation is confirmed, the server is sent a list of nodes.  It does not detect if any of these nodes are down or stale and reject the request.

This can happen in the following cases:

When a node goes down/stale after the scheduler has queried it for the cycle.  The scheduler will think it is available for use.

What does this mean:
If a reservation is confirmed on a down or stale vnode, it will go into the RESV_CONFIRMED state.  It will not be degraded unless there is some other event that will cause it to go degraded.
If a job is run on a down node, the server will attempt to connect to the mom (even though it knows its down) and that will fail.
If a job is run on a stale node, it will successfully run on the mom that is no longer reporting that vnode.

One of the way to Reproduce the issue:
We need to use gdb to reproduce the issue.
1. Attach scheduler to one session of gdb and server to another session of gdb.
2. At scheduler we need to put break point after where the scheduler is querying the stats of server.
3. At Server put a break point inside set_nodes function.
4. run qsub <test script>
5. at scheduler it will enter the break point , kill the mom, so all node state goes down.
6. continue the break point at scheduler to allow it to schedule.
7. it comes back to server, check the steps in set_nodes where job is allocated to vnode which is down. newly added checks will put the job into the Queue for reschedule.


#### Affected Platform(s)
All Platforms supported by PBS Professional is affected.
 
#### Cause / Analysis / Design
The function that parses the list of nodes given the server when a job runs or a reservation is confirmed is called set_nodes().  This function is a very generic and highly critical function to the server.  It is the function that sets the node pointers on the jobs/reservations.  After the Scheduler schedules the job to a node, call comes back to set_nodes - here if the node is down after the job is scheduled, there is no check in server, before sending request to mom. which is causing the mom being contacted by server to push the job.

#### Solution Description
Added checks to the set_nodes function to check whether the assigned node is down/stale, if it's down/stale function returns PBSE_BAD_NODE_STATE.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
