### PR TITLE
Selecting unknown resources results in memory leak.

### DIFF
--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -673,6 +673,10 @@ build_selentry(svrattrl *plist, attribute_def *pdef, int perm, struct select_lis
 
 	resc_access_perm = old_perms;
 	if (rc) {
+		if (rc == PBSE_UNKRESC) {
+			/* The resource was unknown, free the allocated attribute */
+			pdef->at_free(&entry->sl_attr);
+		}
 		(void)free(entry);
 		return (rc);
 	}


### PR DESCRIPTION
#### Bug/feature Description
* `qselect -l <unknown resource>` results in a memory leak

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* A memory leak occurs if a select list is built and one of the entries is an unknown resource. The entry sees an error code and frees the entry without freeing the allocated memory.

#### Solution Description
* When building the entry, if the error code after decoding the attribute is PBS_UNKRESC, then free the attribute.

#### Testing logs/output
* I've attached the output of valgrind after calling the following:
```
qselect -l  cput.eq.600,walltime,mem.eq.1mw
qselect -l strength.eq.weak
```

[after-valgrind.txt](https://github.com/PBSPro/pbspro/files/2402686/after-valgrind.txt)
[before-valgrind.txt](https://github.com/PBSPro/pbspro/files/2402687/before-valgrind.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
