### PR TITLE
PBS starts in the background even when the system is up

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -357,6 +357,8 @@ if [ "$1" != "1" ]; then
 	fi
 	rm -f /etc/init.d/pbs
 	rm -f /opt/modulefiles/pbs/%{version}
+	rm -f /var/tmp/pbs_boot_check
+	rm -f /var/tmp/pbs_bootcheck.py
 	%if %{defined have_systemd}
 		systemctl disable pbs
 		rm -f /usr/lib/systemd/system-preset/95-pbs.preset
@@ -378,6 +380,8 @@ if [ "$1" != "1" ]; then
 	fi
 	rm -f /etc/init.d/pbs
 	rm -f /opt/modulefiles/pbs/%{version}
+	rm -f /var/tmp/pbs_boot_check
+	rm -f /var/tmp/pbs_bootcheck.py
 	%if %{defined have_systemd}
 		systemctl disable pbs
 		rm -f /usr/lib/systemd/system-preset/95-pbs.preset
@@ -470,6 +474,7 @@ fi
 %endif
 %exclude %{pbs_prefix}/bin/printjob_svr.bin
 %exclude %{pbs_prefix}/etc/pbs_db_schema.sql
+%exclude %{pbs_prefix}/libexec/pbs_schema_upgrade
 %exclude %{pbs_prefix}/etc/pbs_dedicated
 %exclude %{pbs_prefix}/etc/pbs_holidays*
 %exclude %{pbs_prefix}/etc/pbs_resource_group

--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -357,6 +357,8 @@ if [ "$1" != "1" ]; then
 	fi
 	rm -f /etc/init.d/pbs
 	rm -f /opt/modulefiles/pbs/%{version}
+	rm -f /var/tmp/pbs_boot_check
+	rm -f /var/tmp/pbs_bootcheck.py
 	%if %{defined have_systemd}
 		systemctl disable pbs
 		rm -f /usr/lib/systemd/system-preset/95-pbs.preset
@@ -378,6 +380,8 @@ if [ "$1" != "1" ]; then
 	fi
 	rm -f /etc/init.d/pbs
 	rm -f /opt/modulefiles/pbs/%{version}
+	rm -f /var/tmp/pbs_boot_check
+	rm -f /var/tmp/pbs_bootcheck.py
 	%if %{defined have_systemd}
 		systemctl disable pbs
 		rm -f /usr/lib/systemd/system-preset/95-pbs.preset
@@ -470,6 +474,7 @@ fi
 %endif
 %exclude %{pbs_prefix}/bin/printjob_svr.bin
 %exclude %{pbs_prefix}/etc/pbs_db_schema.sql
+%exclude %{pbs_prefix}/libexec/pbs_schema_upgrade
 %exclude %{pbs_prefix}/etc/pbs_dedicated
 %exclude %{pbs_prefix}/etc/pbs_holidays*
 %exclude %{pbs_prefix}/etc/pbs_resource_group

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -790,7 +790,10 @@ is_boottime()
 	
 	PYTHON_EXE=${PBS_EXEC}/python/bin/python
 	if [ -z "${PYTHON_EXE}" -o ! -x "${PYTHON_EXE}" ] ; then
-		return 1
+		PYTHON_EXE=`type python 2>/dev/null | cut -d' ' -f3`
+		if [ -z "${PYTHON_EXE}" -o ! -x "${PYTHON_EXE}" ] ; then
+			return 1
+		fi
 	fi
 	
 	BOOTPYFILE="/var/tmp/pbs_bootcheck.py"

--- a/src/cmds/scripts/pbs_postinstall.in
+++ b/src/cmds/scripts/pbs_postinstall.in
@@ -401,6 +401,9 @@ install_pbsinitd() {
 			cp ${pbslibdir}/python/pbs_bootcheck.py /var/tmp/pbs_bootcheck.py
 			chmod 0644 /var/tmp/pbs_bootcheck.py
 		fi
+		if [ -f /var/tmp/pbs_boot_check ] ; then
+			rm -f /var/tmp/pbs_boot_check
+		fi
 	fi
 	echo "***"
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* PBS starts in the background even when the system is up. Which is supposed to happen only at boot time.

#### Cause / Analysis / Design
* This is observed mainly in dev systems due to two reasons.
1) pbs_boot_check file which stores the prev_start_time of pbs, is not removed when an RPM is erased. If the user installs a new RPM after a system restart, the residue file still indicates a time before boot, thereby pbs starts in the background.
2) PBS is disabled or removed. Then restarted system and installed pbs using make procedure followed by a post install. The new pbs will refer to the residue pbs_boot_check file and starts in the background.

#### Solution Description
* Removing boot check files as part of uninstallation.
* Correcting the python_exe if PBS uses system python.
* Clearing boot check file if present as part of post install script.

#### Testing logs/output
* Please attach your test log output from running the test you added (or from existing tests that cover your changes)*
[erase_restartsystem_install_and_start.txt](https://github.com/PBSPro/pbspro/files/2419024/erase_restartsystem_install_and_start.txt)

PTL is not included as the testing requires re-boot of the machine.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
