### PR TITLE
sched crashes while reordering nodes

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2643,6 +2643,7 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	static	int svr_knows_me = 0;
 	int	err;
 	struct	attropl	*attribs, *patt;
+	struct batch_status *all_ss = NULL; /* all scheduler objects */
 	struct batch_status *ss = NULL;
 	char sched_host[PBS_MAXHOSTNAME + 1];
 
@@ -2654,18 +2655,19 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 		return 1;
 
 	/* Stat the scheduler to get details of sched */
-	ss = pbs_statsched(connector, NULL, NULL);
-	ss = bs_find(ss, sc_name);
+	all_ss = pbs_statsched(connector, NULL, NULL);
+	ss = bs_find(all_ss, sc_name);
 
 	if (ss == NULL) {
 		sprintf(log_buffer, "Unable to retrieve the scheduler attributes from server");
 		log_err(-1, __func__, log_buffer);
+		pbs_statfree(all_ss);
 		return 0;
 	}
 	if (!sched_settings_frm_svr(ss))
 		return 0;
 
-	pbs_statfree(ss);
+	pbs_statfree(all_ss);
 
 	/* update the sched with new values */
 	attribs = calloc(4, sizeof(struct attropl));

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -241,6 +241,12 @@ query_nodes(int pbs_sd, server_info *sinfo)
 		cur_node = cur_node->next;
 	}
 	ninfo_arr[nidx] = NULL;
+	if (nidx == 0) {
+		snprintf(log_buffer, sizeof(log_buffer), "No nodes found in partitions serviced by scheduler");
+		schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SERVER, LOG_INFO, __func__, log_buffer);
+		free(ninfo_arr);
+		return NULL;
+	}
 
 	if (update_mom_resources(ninfo_arr) == 0) {
 		pbs_statfree(nodes);
@@ -4745,8 +4751,8 @@ reorder_nodes(node_info **nodes, resource_resv *resresv)
 	nptr = node_array;
 
 
-	if (last_node_name[0] == '\0')
-		strcpy(last_node_name, nodes[0]->name);
+	if (last_node_name[0] == '\0' && nodes[0] != NULL)
+		snprintf(last_node_name, sizeof(last_node_name), "%s", nodes[0]->name);
 
 	if (resresv != NULL) {
 		if (resresv->is_resv && resresv->resv != NULL && resresv->resv->check_alternate_nodes) {

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -965,16 +965,33 @@ resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resr
 
 	pass_flags = flags|UNSET_RES_ZERO;
 
-	/* Check 1: is there at least 1 node in the free state */
-	if (!(flags & COMPARE_TOTAL) && np->free_nodes == 0) {
-		set_schd_error_codes(err, NOT_RUN, NO_FREE_NODES);
-		if ((flags & RETURN_ALL_ERR)) {
-			can_fit = 0;
-			err->next = new_schd_error();
-			prev_err = err;
-			err = err->next;
-		} else
-			return 0;
+	/* Check 1: Based on the flag check if there are any nodes available or if
+	 * they are free.
+	 */
+	if (flags & COMPARE_TOTAL) {
+		/* Check that node partition must have one or more nodes inside it */
+		if (np->tot_nodes == 0) {
+			set_schd_error_codes(err, NEVER_RUN, NO_TOTAL_NODES);
+			if ((flags & RETURN_ALL_ERR)) {
+				can_fit = 0;
+				err->next = new_schd_error();
+				prev_err = err;
+				err = err->next;
+			} else
+				return 0;
+		}
+	} else {
+		/* Check is there at least 1 node in the free state */
+		if (np->free_nodes == 0) {
+			set_schd_error_codes(err, NOT_RUN, NO_FREE_NODES);
+			if ((flags & RETURN_ALL_ERR)) {
+				can_fit = 0;
+				err->next = new_schd_error();
+				prev_err = err;
+				err = err->next;
+			} else
+				return 0;
+		}
 	}
 
 	/* Check 2: v/scatter - If we're scattering or requesting exclusive nodes

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -173,7 +173,8 @@ server_info *
 query_server(status *pol, int pbs_sd)
 {
 	struct batch_status *server;	/* info about the server */
-	struct batch_status *sched;	/* info about the server's scheduler object */
+	struct batch_status *all_sched;	/* info about all server's scheduler objects */
+	struct batch_status *sched;	/* info about the this scheduler object */
 	struct batch_status *bs_resvs = NULL;	/* batch status of the reservations */
 	server_info *sinfo;		/* scheduler internal form of server info */
 	queue_info **qinfo;		/* array of queues on the server */
@@ -224,8 +225,8 @@ query_server(status *pol, int pbs_sd)
 		return NULL;
 	}
 
-	sched = pbs_statsched(pbs_sd, NULL, NULL);
-	sched = bs_find(sched, sc_name);
+	all_sched = pbs_statsched(pbs_sd, NULL, NULL);
+	sched = bs_find(all_sched, sc_name);
 
 	if (sched == NULL) {
 		errmsg = pbs_geterrmsg(pbs_sd);
@@ -235,12 +236,13 @@ query_server(status *pol, int pbs_sd)
 		schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SERVER, LOG_NOTICE, "server_info",
 			log_buffer);
 		pbs_statfree(server);
+		pbs_statfree(all_sched);
 		sinfo->fairshare = NULL;
 		free_server(sinfo, 0);
 		return NULL;
 	}
 	query_sched_obj(policy, sched, sinfo);
-	pbs_statfree(sched);
+	pbs_statfree(all_sched);
 
 	if (!dflt_sched && (sinfo->partitions == NULL)) {
 		snprintf(log_buffer, sizeof(log_buffer), "Scheduler does not contain a partition");


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Scheduler crashes while reordering nodes when a job is submitted to the partition it serves and there are no nodes associated to the partition.
Here is the backtrace - 
Core was generated by `/opt/pbs/sbin/pbs_sched'.
Program terminated with signal 6, Aborted.
#0  0x00007fc0146695f7 in raise () from /lib64/libc.so.6
Missing separate debuginfos, use: debuginfo-install pbspro-server-14.2.3.20170714092614-0.el7.x86_64
(gdb) where
#0  0x00007fc0146695f7 in raise () from /lib64/libc.so.6
#1  0x00007fc01466ace8 in abort () from /lib64/libc.so.6
#2  0x0000000000438927 in on_segv (sig=<optimized out>) at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/pbs_sched.c:164
#3  <signal handler called>
**#4  0x000000000044a872 in reorder_nodes (nodes=nodes@entry=0x1036480, resresv=resresv@entry=0x1033010)**
    at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/node_info.c:4369
#5  0x000000000044eb80 in eval_placement (policy=policy@entry=0x1037300, spec=spec@entry=0x1033160, ninfo_arr=ninfo_arr@entry=0x1036480, pl=pl@entry=0x103a660, 
    resresv=resresv@entry=0x1033010, flags=flags@entry=0, nspec_arr=nspec_arr@entry=0x7ffe55f85268, err=err@entry=0x10355d0)
    at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/node_info.c:2252
#6  0x00000000004502da in eval_selspec (policy=0x1037300, spec=0x1033160, placespec=0x103a660, ninfo_arr=0x1036480, nodepart=0x0, resresv=resresv@entry=0x1033010, 
    flags=flags@entry=0, nspec_arr=nspec_arr@entry=0x7ffe55f85268, err=err@entry=0x10355d0) at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/node_info.c:2089
#7  0x00000000004652e1 in check_nodes (policy=policy@entry=0x1037300, resresv=resresv@entry=0x1033010, ninfo_arr=<optimized out>, nodepart=<optimized out>, 
    flags=flags@entry=0, err=err@entry=0x10355d0) at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/check.c:1509
#8  0x000000000046606d in is_ok_to_run (policy=0x1037300, pbs_sd=pbs_sd@entry=-1, sinfo=sinfo@entry=0x103dbf0, qinfo=0x1032290, resresv=resresv@entry=0x1033010, 
    flags=flags@entry=0, perr=perr@entry=0x10355d0) at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/check.c:1043
#9  0x00000000004634a2 in calc_run_time (name=<optimized out>, sinfo=sinfo@entry=0x103dbf0, flags=flags@entry=2)
    at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/simulate.c:696
#10 0x000000000043a5fb in add_job_to_calendar (pbs_sd=pbs_sd@entry=0, policy=policy@entry=0x1028f10, sinfo=sinfo@entry=0x1035d60, topjob=topjob@entry=0x1039970)
    at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/fifo.c:1870
#11 0x000000000043b832 in main_sched_loop (policy=policy@entry=0x1028f10, sd=sd@entry=0, sinfo=sinfo@entry=0x1035d60, rerr=rerr@entry=0x7ffe55f868b8)
    at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/fifo.c:889
#12 0x000000000043baba in scheduling_cycle (sd=sd@entry=0, jobid=jobid@entry=0x0) at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/fifo.c:668
#13 0x000000000043bd3e in intermediate_schedule (sd=0, jobid=0x0) at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/fifo.c:549
#14 0x0000000000437f83 in main (argc=<optimized out>, argv=0x7ffe55f876b8) at /home/pbsbuild/ramdisk/workspace/build/pbspro/src/scheduler/pbs_sched.c:1448

#### Affected Platform(s)
All

#### Cause / Analysis / Design
The cause of crash was that there was no null check before dereferencing the pointer.
In addition to that when there are no nodes available in the partition, ideally, scheduler should not even have tried to add such a job to calendar (where it crashed). This happened because scheduler's check to find out whether the job can never run was not checking for total resources when the jobs is submitted with placement as 'pack'.

#### Solution Description
Added a null check in reorder_nodes() function. Changed resresv_can_fit_nodepart to check for total nodes in the node partition. Added a check in query_server to find that if there are no nodes in the partition then there is no point in running the cycle.

I've also addressed memory leak in scheduler in this PR which occurs in case of multisched where where scheduler does not free up all the batch_status structures. This leak happens in every scheduling cycle and at the very least (depends on number of scheduler objects) it leaks about 34 bytes every cycle.

#### Testing logs/output
[sched_leak_after_fix.txt](https://github.com/PBSPro/pbspro/files/2420888/sched_leak_after_fix.txt)

I'm not adding a PTL test for testing the crash as I do not see any recurring benefit of having the test.
Steps to reproduce the core:
- Create a new scheduler object.
- Assign it a partition
- Assign a queue the same partition
- Set backfill_depth to 1 in server object, set strict ordering true for the new scheduler object
- start the new scheuler 
- submit a job to the queue this scheduler serves to. Scheduler will not be able to run the job and crash (without the change). After the change in place, it will just skip the cycle after finding out that there are no nodes associated to the partition.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
