### PR TITLE
TestAcctlogRescUsedWithTwoMomHooks is not skipped appropriately

### DIFF
--- a/test/tests/functional/pbs_two_mom_hooks_resources_used.py
+++ b/test/tests/functional/pbs_two_mom_hooks_resources_used.py
@@ -47,6 +47,9 @@ class TestAcctlogRescUsedWithTwoMomHooks(TestFunctional):
 
     def setUp(self):
         TestFunctional.setUp(self)
+        if len(self.moms) != 2:
+            self.skipTest('Test requires two MoMs as input, '
+                          'use -p moms=<mom1>:<mom2>')
 
         hook_body = "import time\n"
         a = {'event': 'execjob_begin', 'enabled': 'True'}


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
TestAcctlogRescUsedWithTwoMomHooks errors out when required number of moms are not provided via pbs_benchpress command 

#### Affected Platform(s)
All Linux

#### Cause / Analysis / Design
There is no check in the test to see if required number of moms are provided.

#### Solution Description
Test is skipped when required number of moms (2 moms) is not provided.

#### Testing logs/output
[beforefix.txt](https://github.com/PBSPro/pbspro/files/2432678/beforefix.txt)
[afterfix_nomoms.txt](https://github.com/PBSPro/pbspro/files/2432679/afterfix_nomoms.txt)
[afterfix_2moms.txt](https://github.com/PBSPro/pbspro/files/2432680/afterfix_2moms.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__