### PR TITLE
Resolve req_resvSub() memory leak

### DIFF
--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -2749,6 +2749,7 @@ req_resvSub(struct batch_request *preq)
 			!(strcasecmp(psatl->al_resc, MAX_WALLTIME)))) {
 			req_reject(PBSE_NOSTF_RESV, 0, preq);
 			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_REQUEST, LOG_ERR, "",  msg_nostf_resv);
+			resv_free(presv);
 			return;
 		}
 		/* identify the attribute by name */
@@ -2766,6 +2767,7 @@ req_resvSub(struct batch_request *preq)
 			}
 
 			/* didn`t recognize the name */
+			resv_free(presv);
 			reply_badattr(PBSE_NOATTR, 1, psatl, preq);
 			return;
 		}
@@ -2784,7 +2786,7 @@ req_resvSub(struct batch_request *preq)
 					    ATR_DFLAG_Creat;
 		}
 		if ((pdef->at_flags & resc_access_perm) == 0) {
-			(void)resv_purge(presv);
+			resv_free(presv);
 			reply_badattr(PBSE_ATTRRO, 1, psatl, preq);
 			return;
 		}
@@ -2796,7 +2798,7 @@ req_resvSub(struct batch_request *preq)
 
 
 		if (rc != 0) {
-			(void)resv_purge(presv);
+			resv_free(presv);
 			reply_badattr(rc, 1, psatl, preq);
 			return;
 		}
@@ -2815,7 +2817,7 @@ req_resvSub(struct batch_request *preq)
 			rc = pdef->at_action(&presv->ri_wattr[i],
 				presv, ATR_ACTION_NEW);
 			if (rc) {
-				(void)resv_purge(presv);
+				resv_free(presv);
 				req_reject(rc, i, preq);
 				return;
 			}
@@ -2825,7 +2827,7 @@ req_resvSub(struct batch_request *preq)
 	/*"start", "end","duration", and "wall"; derive and check*/
 
 	if (start_end_dur_wall(presv, RESC_RESV_OBJECT)) {
-		(void)resv_purge(presv);
+		resv_free(presv);
 		req_reject(PBSE_BADTSPEC, 0, preq);
 		return;
 	}
@@ -2851,7 +2853,7 @@ req_resvSub(struct batch_request *preq)
 		 * syntax or time problem
 		 */
 		if (rc!=0) {
-			(void)resv_purge(presv);
+			resv_free(presv);
 			req_reject(rc, 0, preq);
 			return;
 		}
@@ -2884,7 +2886,7 @@ req_resvSub(struct batch_request *preq)
 	 */
 
 	if ((rc = set_resc_deflt((void *)presv, RESC_RESV_OBJECT, NULL)) != 0) {
-		(void)resv_purge(presv);
+		resv_free(presv);
 		req_reject(rc, 0, preq);
 		return;
 	}
@@ -2911,7 +2913,7 @@ req_resvSub(struct batch_request *preq)
 				(presv->ri_wattr[(int)RESV_ATR_priority]
 				.at_val.at_long > 1024)) {
 
-				resv_purge(presv);
+				resv_free(presv);
 				req_reject(PBSE_BADATVAL, 0, preq);
 				return;
 			}
@@ -2945,7 +2947,7 @@ req_resvSub(struct batch_request *preq)
 
 		if (act_resv_add_owner(&presv->ri_wattr[(int)RESV_ATR_auth_u],
 			presv, ATR_ACTION_NEW)) {
-			resv_purge(presv);
+			resv_free(presv);
 			req_reject(PBSE_BADATVAL, 0, preq);
 			return;
 		}
@@ -2986,7 +2988,7 @@ req_resvSub(struct batch_request *preq)
 	/* determine values for the "euser" and "egroup" attributes */
 
 	if ((rc = set_objexid((void *)presv, RESC_RESV_OBJECT, presv->ri_wattr))) {
-		resv_purge(presv);
+		resv_free(presv);
 		req_reject(rc, 0, preq);
 		return;
 	}
@@ -3008,7 +3010,7 @@ req_resvSub(struct batch_request *preq)
 #endif
 			ACL_Group) == 0) {
 
-			resv_purge(presv);
+			resv_free(presv);
 			req_reject(PBSE_RESVAUTH_G, 0, preq);
 			return;
 		}
@@ -3028,7 +3030,7 @@ req_resvSub(struct batch_request *preq)
 			buf1,
 			ACL_User) == 0) {
 
-			resv_purge(presv);
+			resv_free(presv);
 			req_reject(PBSE_RESVAUTH_U, 0, preq);
 			return;
 		}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Memory leak during reservation submission with wall time requests*

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* When a reservation is submitted with wall time requests PBS errors out without freeing the memory allocated to hold the reservation information

#### Solution Description
* Free the memory before we send req_reject()

#### Testing logs/output
[reservation.txt](https://github.com/PBSPro/pbspro/files/2442817/reservation.txt)
[resv_start_end.txt](https://github.com/PBSPro/pbspro/files/2442818/resv_start_end.txt)
[smoke.txt](https://github.com/PBSPro/pbspro/files/2442819/smoke.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
