### PR TITLE
Updates pbs_holidays file for 2018 (replaces 2016 holidays file)

### DIFF
--- a/src/scheduler/pbs_holidays
+++ b/src/scheduler/pbs_holidays
@@ -36,7 +36,7 @@
 *
 
 *
-YEAR  2016
+YEAR  2018
 *
 * Prime/Nonprime Table 
 *
@@ -57,21 +57,21 @@ YEAR  2016
 * Jan 1 
     1           Jan 1           New Year's Day
 * Third Monday of Jan
-   18           Jan 18          Martin Luther King Day
+   15           Jan 15          Martin Luther King Day
 * Third Monday in Feb
-   46           Feb 15          President's Day
+   50           Feb 19          President's Day
 * Last Monday in May
-  151           May 30          Memorial Day
+  148           May 28          Memorial Day
 * July 4th
-  186           Jul 4           Independence Day
+  185           Jul 4           Independence Day
 * First Monday in Sept 
-  249           Sep 5           Labor Day
+  246           Sep 3           Labor Day
 * Second Monday in Oct
-  284           Oct 10          Columbus Day
+  281           Oct 8           Columbus Day
 * Nov 11 
-  316           Nov 11          Veterans Day
+  316           Nov 12          Veterans Day
 * Fourth Thursday in Nov
-  329           Nov 24          Thanksgiving
+  326           Nov 22          Thanksgiving
 * Dec 25 
-  360           Dec 25          Christmas Day
+  359           Dec 25          Christmas Day
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* The current pbs_holidays file dates to 2016. Using the 2016 holidays file as of this date (2018-Oct-03) results in a warning message in the scheduler logs, once per scheduling cycle.
* *To reproduce, simply start pbs with the `pbs_holidays` file from the current source tree in place in `$PBS_HOME/sched_priv/holidays`

#### Affected Platform(s)
* *Platform: All (observed on CentOS 7.3)*

#### Cause / Analysis / Design
* *Holidays file, as shipped, is two years out of date*

#### Solution Description
* *Replaces 2016 holidays with 2018 holidays*
* *Will create a 2019 holidays file if this pull is accepted*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__