### PR TITLE
memory debug logs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,9 @@ AC_CHECK_LIB([socket], [socket],
   AC_SUBST(socket_lib),
   [-lnsl]
 )
+AC_CHECK_LIB([c], [malloc_info],
+  AC_DEFINE([HAVE_MALLOC_INFO], [], [Defined when malloc_info is available])
+)
 
 # Check for X Window System
 AC_PATH_XTRA

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -267,6 +267,10 @@ void free_string_array(char **arr);
  */
 char * escape_delimiter(char *str, char *delim, char esc);
 
+#ifdef HAVE_MALLOC_INFO
+char * get_mem_info(void);
+#endif
+
 /* Size of time buffer */
 #define TIMEBUF_SIZE 128
 

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -269,6 +269,7 @@ extern void			unlicense_socket_licensed_nodes(void);
 extern void			set_sched_default(pbs_sched *, int unset_flag);
 extern void			set_attr_svr(attribute *pattr, attribute_def *pdef, char *value);
 extern int			license_sanity_check(void);
+extern void			memory_debug_log(struct work_task *ptask);
 
 #ifdef	__cplusplus
 }

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -82,6 +82,10 @@
 #endif
 #include "pbs_error.h"
 
+#ifdef HAVE_MALLOC_INFO
+#include <malloc.h>
+#endif
+
 #define ISESCAPED(ch) (ch == '\'' || ch == '\"' || ch == ',')
 
 /** @brief conversion array for vnode sharing attribute between str and enum */
@@ -1326,3 +1330,36 @@ starts_with_triple_quotes(char *str)
 	}
 	return (0);
 }
+
+/*
+ * @brief
+ *	Gets malloc_info and returns as a string
+ *
+ * @return char *
+ * @retval NULL - Error
+ * @note
+ * The buffer has to be freed by the caller.
+ *
+ */
+#ifndef WIN32
+#ifdef HAVE_MALLOC_INFO
+char *
+get_mem_info(void) {
+	FILE *stream;
+	char *buf;
+	size_t len;
+	int err = 0;
+
+	stream = open_memstream(&buf, &len);
+	if (stream == NULL)
+		return NULL;
+	err = malloc_info(0, stream);
+	fclose(stream);
+	if (err == -1) {
+		free(buf);
+		return NULL;
+	}
+	return buf;
+}
+#endif /* malloc_info */
+#endif /* WIN32 */

--- a/src/resmom_win/topology.c
+++ b/src/resmom_win/topology.c
@@ -1,5 +1,4 @@
-#include <windows.h>
-#include <malloc.h>    
+#include <windows.h>   
 #include <stdio.h>
 
 #include "pbs_error.h"

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1460,6 +1460,10 @@ pbsd_init(int type)
 	send_rescdef(0);
 	hook_track_save(NULL, -1); /* refresh path_hooks_tracking file */
 
+#ifndef WIN32
+	(void)set_task(WORK_Immed, time_now, memory_debug_log, NULL);
+#endif /* !WIN32 */
+
 	return (0);
 }
 

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -7163,3 +7163,36 @@ set_attr_svr(attribute *pattr, attribute_def *pdef, char *value)
 	}
 	pdef->at_free(&tempat);
 }
+
+
+/**
+ * @brief
+ * 		dumps the memory usage of the heap into server log in every 10 minutes.
+ *
+ * @param[in]	ptask	-	pointer to the work task
+ *
+ * @return	void
+ *
+ * @par MT-Safe: Yes
+ * @par Side Effects: None
+ *
+ */
+#ifndef WIN32
+void memory_debug_log(struct work_task *ptask) {
+
+	if (ptask)
+		(void)set_task(WORK_Timed, time_now+600, memory_debug_log, NULL);
+	if (!will_log_event(PBSEVENT_DEBUG4))
+		return;
+	snprintf(log_buffer, LOG_BUF_SIZE, "MEM_DEBUG: sbrk: %zu", (size_t)sbrk(0));
+	log_event(PBSEVENT_DEBUG4, PBS_EVENTCLASS_SERVER, LOG_DEBUG, msg_daemonname, log_buffer);
+#ifdef HAVE_MALLOC_INFO
+	char *buf;
+	buf = get_mem_info();
+	if (buf) {
+		log_event(PBSEVENT_DEBUG4, PBS_EVENTCLASS_SERVER, LOG_DEBUG, msg_daemonname, buf);
+		free(buf);
+	}
+#endif /* malloc_info */
+}
+#endif /* WIN32 */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Log system break (sbrk) values in PBS logs at higher debug levels
* Track and dump current exact heap usage (from PBS viewpoint) to PBS logs

#### Solution Description
* malloc_info will log how much memory is consumed by malloc routines
* system break value is obtained by sbrk()
* Printing these values every 10 minutes to know more about memory growth pattern.

#### Testing logs/output
* Test steps:
1) qmgr -c 's s log_events=4095'
2) check whether memory debug logs are appearing in server log every 10 minutes.
* *Please attach your test log output from running the test you added (or from existing tests that cover your changes)*
[logs.txt](https://github.com/PBSPro/pbspro/files/2446108/logs.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

CC: @arungrover , @subhasisb 
