### PR TITLE
Fix invalid read of size 1 under parse_at_list():lib/Libcmds/parse_at.c

### DIFF
--- a/src/lib/Libcmds/parse_at.c
+++ b/src/lib/Libcmds/parse_at.c
@@ -148,7 +148,7 @@ parse_at_item(char *at_item, char *at_name, char *host_name)
 int
 parse_at_list(char *list, int use_count, int abs_path)
 {
-	char *b, *c, *s, *l;
+	char *b, *c, *s, *list_dup;
 	int rc = 0;
 	char user[MAXPATHLEN+1];
 	char host[PBS_MAXSERVERNAME];
@@ -161,12 +161,12 @@ parse_at_list(char *list, int use_count, int abs_path)
 	back2forward_slash(list);        /* "\" translate to "/" for path */
 #endif
 
-	if ((l = strdup(list)) == NULL) {
+	if ((list_dup = strdup(list)) == NULL) {
 		fprintf(stderr, "Out of memory.\n");
 		exit(1);
 	}
 
-	for (c = l; *c != '\0'; rc = 0) {
+	for (c = list_dup; *c != '\0'; rc = 0) {
 		rc = 1;
 
 		/* Drop leading white space */
@@ -182,7 +182,7 @@ parse_at_list(char *list, int use_count, int abs_path)
 			;
 
 		/* Drop any trailing blanks */
-		for (b = c - 1; isspace(*b); b--)
+		for (b = c - 1; (b >= list_dup) && isspace(*b); b--)
 			*b = '\0';
 
 		/* Make sure the list does not end with a comma */
@@ -227,7 +227,7 @@ duplicate:
 		free(ph);
 		ph = nh;
 	}
-	free(l);
+	free(list_dup);
 
 	return rc;
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *Fix invalid read of size 1 under parse_at_list():lib/Libcmds/parse_at.c*

#### Cause / Analysis / Design
* *If input 'list' = ",", then l = strdup(list"), then c = l, then s = c = ',', and b gets "c - 1" which is before the first element of strdup-ed 'list'.*

#### Solution Description
* *Added a check to ensure that we are not accessing any element before the first entry in strdup-ed 'list'.*

#### Testing logs/output
Manual testing makes sense as we need to reproduce using valgrind.
[server_after.log](https://github.com/PBSPro/pbspro/files/2467533/server_after.log)
[server_before.log](https://github.com/PBSPro/pbspro/files/2467534/server_before.log)
[make.sh.log](https://github.com/PBSPro/pbspro/files/2467566/make.sh.log)
[parse_at_list.c.txt](https://github.com/PBSPro/pbspro/files/2467567/parse_at_list.c.txt)
[valgrind.sh.txt](https://github.com/PBSPro/pbspro/files/2467568/valgrind.sh.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

CC: @bayucan 
