### PR TITLE
PP-1310: Tests of TestSchedSubjobBadstate is failing on cpuset platform due to race conditions

### DIFF
--- a/test/tests/functional/pbs_sched_subjob_badstate.py
+++ b/test/tests/functional/pbs_sched_subjob_badstate.py
@@ -40,6 +40,7 @@ from tests.functional import *
 
 class TestSchedSubjobBadstate(TestFunctional):
 
+    @timeout('600')
     def test_sched_badstate_subjob(self):
         """
         This test case tests if scheduler goes into infinite loop
@@ -73,5 +74,5 @@ class TestSchedSubjobBadstate(TestFunctional):
 
         self.scheduler.log_match("Leaving Scheduling Cycle",
                                  starttime=now,
-                                 max_attempts=3, interval=1)
+                                 interval=1)
         self.server.delete(j1id)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
*  *[PP-1310](https://pbspro.atlassian.net/browse/PP-1310)*

#### Cause / Analysis / Design
* The test failed initially due to the timeout issue. After fixing the timeout issue the test failed while verifiying the log msg "Leaving scheduling cycle" in sched-logs. In sched-logs the log-msg appeared after the test failed.

#### Solution Description
* Increase the timeout and remove the parameter "max_attempts" from log_match function

#### Testing logs/output
* [TestSchedSubjobBadstate_with_fix.txt](https://github.com/PBSPro/pbspro/files/2471806/TestSchedSubjobBadstate_with_fix.txt)
* [TestSchedSubjobBadstate_without_fix.txt](https://github.com/PBSPro/pbspro/files/2471807/TestSchedSubjobBadstate_without_fix.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
