### PR TITLE
Log match failures in TestPbsHookSetJobEnv

### DIFF
--- a/test/tests/functional/pbs_hook_set_jobenv.py
+++ b/test/tests/functional/pbs_hook_set_jobenv.py
@@ -36,6 +36,7 @@
 # trademark licensing policies.
 import os
 from tests.functional import *
+from ptl.utils.pbs_logutils import PBSLogUtils
 
 
 class TestPbsHookSetJobEnv(TestFunctional):
@@ -162,6 +163,7 @@ class TestPbsHookSetJobEnv(TestFunctional):
         """
         Validate the env variable output in daemon logs
         """
+        logutils = PBSLogUtils()
         logmsg = ["TEST_COMMA=1\,2\,3\,4",
                   "TEST_SEMICOLON=;",
                   "TEST_ENCLOSED=\\'\,\\'",
@@ -180,32 +182,50 @@ class TestPbsHookSetJobEnv(TestFunctional):
                   "TEST_SQUOTE5=music \\'makes \\\"the\\'\\\"people",
                   "TEST_SQUOTE6=loving\\'",
                   "TEST_SPECIAL={}[]()~@#$%^&*!",
-                  "TEST_SPECIAL2=<dumb-test_text>"]
+                  "TEST_SPECIAL2=<dumb-test_text>",
+                  "TEST_RETURN=\\'3\,",
+                  # Cannot add '\n' here because '\n' is not included in
+                  # the items of the list returned by log_lines(), (though
+                  # lines are split by '\n')
+                  "4\,",
+                  "5\\',"]
 
         if (daemon == "mom"):
             self.logger.info("Matching in mom logs")
+            logfile_type = self.mom
         elif (daemon == "server"):
             self.logger.info("Matching in server logs")
+            logfile_type = self.server
         else:
             self.logger.info("Provide a valid daemon name; server or mom")
             return
-
+        lines = None
+        ret_linenum = 0
+        search_msg = 'log match: searching for '
+        nomatch_msg = ' No match for '
         for msg in logmsg:
-            if (daemon == "mom"):
-                # Match the trailing separator (',')
-                self.mom.log_match(msg + ',')
-            elif (daemon == "server"):
-                self.server.log_match(msg, starttime=self.server.ctime)
-
-        # Following lines are commented due to PTL bug PP-1008
-        # if (daemon == "mom"):
-        #    rv = self.mom.log_match(
-        #          msg="TEST_RETURN\=\\\'3\\\,\n4\\\,\n5\\\'", regexp=True)
-        #    self.assertTrue(rv)
-        # else:
-        #    rv = self.server.log_match(
-        #            msg="TEST_RETURN\=\\\'3\\\,\n4\\\,\n5\\\'", regexp=True)
-        #    self.assertTrue(rv)
+            for attempt in range(1, 61):
+                lines = self.server.log_lines(
+                    logfile_type, starttime=self.server.ctime)
+                match = logutils.match_msg(lines, msg=msg)
+                if match:
+                    # Dont want the test to pass if there are
+                    # unwanted matched for "4\," and "5\\'.
+                    if msg == "TEST_RETURN=\\'3\,":
+                        ret_linenum = match[0]
+                    if (msg == "4\," and match[0] != (ret_linenum - 1)) or \
+                       (msg == "5\\'" and match[0] != (ret_linenum - 2)):
+                        pass
+                    else:
+                        self.logger.info(search_msg + msg + ' ... OK')
+                        break
+                else:
+                    self.logger.info(nomatch_msg + msg +
+                                     ' attempt ' + str(attempt))
+                time.sleep(0.5)
+            if match is None:
+                _msg = nomatch_msg + msg
+                raise PtlLogMatchError(rc=1, rv=False, msg=_msg)
 
     def common_validate(self):
         """
@@ -479,9 +499,7 @@ pbs.logmsg(pbs.LOG_DEBUG,"Variable List is %s" % (e.job.Variable_List,))
         self.assertEqual(self.env_hook_exclude['happy'], 'days\n')
         self.common_validate()
 
-        # Validate the output in server_log
-        # Following is blocked on PTL bug PP-1008
-        # self.common_log_match("server")
+        self.common_log_match("server")
 
     def test_execjob_epi(self):
         """
@@ -782,6 +800,7 @@ haa'"""
 
         # match the values in qstat -f Variable_List
         # Following is blocked on PTL bug PP-1008
+
         # self.assertTrue("TEST_COMMA=1\,2\,3\,4" in job_var)
         # self.assertTrue("TEST_SEMICOLON=\;" in job_var)
         # self.assertTrue("TEST_COLON=:" in job_var)
@@ -947,7 +966,7 @@ pbs.logmsg(pbs.LOG_DEBUG,
         # now restart mom
         self.mom.start()
 
-        self.mom.log_match("Restart sent to server", max_attempts=5)
+        self.mom.log_match("Restart sent to server")
 
         # Verify the env variables are seen in logs
         self.common_log_match("mom")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Log match failures occur, when test has job environment variable whose values contain newline (\n) characters.

#### Affected Platform(s)
All Linux

#### Cause / Analysis / Design
A hook in the test writes job’s variable list to server and mom logs.  With two newlines characters in the env var TEST_RETURN, the variable list is broken into 3 lines in the log file; two of them starting with no timestamps.(which otherwise would have been a single variable list line starting with a timestamp)  By default, logutils.match_msg function ignores those lines that don’t have timestamps when called with starttime or endtime specified. Hence the test fails finding no match for the variables that appear in the lines without timestamps . 

#### Solution Description
The problem will be fixed by the following changes in the test suite's common_log_match() function. 
Instead of calling log_match function directly (which causes match_msg to be called with starttime and endtime and hence skipping lines without timestamps)
- Use logutils.log_lines() with starttime as the server’s ctime to fetch the required log lines
- Call logutils.match_msg() without starttime or endtime set,  so the lines without timestamp can also be matched  

#### Testing logs/output
[afterfix.txt](https://github.com/PBSPro/pbspro/files/2473673/afterfix.txt)
[beforefix.txt](https://github.com/PBSPro/pbspro/files/2473684/beforefix.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__