### PR TITLE
Tests in Test_acl_host_moms fail when acl_hosts is not a FQDN

### DIFF
--- a/test/tests/functional/pbs_acl_host_moms.py
+++ b/test/tests/functional/pbs_acl_host_moms.py
@@ -61,7 +61,8 @@ class Test_acl_host_moms(TestFunctional):
 
         self.hostA = self.momA.shortname
         if not self.du.is_localhost(self.server.client):
-            self.hostB = self.server.client
+            # acl_hosts expects FQDN
+            self.hostB = socket.getfqdn(self.server.client)
         else:
             self.skip_test(usage_string)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Tests in Test_acl_host_moms fail when acl_hosts (input via -p client option in pbs_benchpress) is not a FQDN
*  [PP-1141](https://pbspro.atlassian.net/browse/PP-1141)

#### Affected Platform(s)
* All Linux

#### Cause / Analysis / Design
The server attribute 'acl_hosts' expects a FQDN, as mentioned in the guides.

#### Solution Description
Use getfqdn() function in the test to always pass FQDN to acl_hosts attribute.

#### Testing logs/output
[beforefix.txt](https://github.com/PBSPro/pbspro/files/2474238/beforefix.txt)
[afterfix.txt](https://github.com/PBSPro/pbspro/files/2474240/afterfix.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__