### PR TITLE
TestJobArray.test_subjob_comments_with_history is failing due to race condition

### DIFF
--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -326,11 +326,11 @@ class TestJobArray(TestFunctional):
         j_id = self.server.submit(j)
         subjid_1 = j.create_subjob_id(j_id, 1)
         subjid_2 = j.create_subjob_id(j_id, 2)
-        self.server.expect(JOB, {'comment': (
-            MATCH_RE, 'Job run at.*and finished')}, subjid_1, extend='x')
         self.server.delete(subjid_2, extend='force')
         self.server.expect(
             JOB, {'comment': (MATCH_RE, 'terminated')}, subjid_2, extend='x')
+        self.server.expect(JOB, {'comment': (
+            MATCH_RE, 'Job run at.*and finished')}, subjid_1, extend='x')
         self.kill_and_restart_svr()
         self.server.expect(JOB, {'comment': (
             MATCH_RE, 'Job run at.*and finished')}, subjid_1, extend='x',


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* TestJobArray.test_subjob_comments_with_history is failing due to race condition

#### Affected Platform(s)
* ALL

#### Cause / Analysis / Design
* Test case is submitting an job array and checking for the comments, in which waiting for the first job to finish and after that trying to delete the second job but by that time second job finishes.

#### Solution Description
* I have changed the order, so firstly will delete the second job and check for the particular comment. After that will check the comment for the first job and most probably by that time the job would be finished.

#### Testing logs/output
* [ptl_pbs_job_array.txt](https://github.com/PBSPro/pbspro/files/2488528/ptl_pbs_job_array.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
