### PR TITLE
Intermittent failures in TestAdminSuspend.test_hook due to fewer attempts to match logs

### DIFF
--- a/test/tests/functional/pbs_admin_suspend.py
+++ b/test/tests/functional/pbs_admin_suspend.py
@@ -820,7 +820,7 @@ pbs.logmsg(pbs.LOG_DEBUG,\
         time.sleep(5)
 
         # look for the log message
-        self.mom.log_match("list of maintenance_jobs are None", max_attempts=5)
+        self.mom.log_match("list of maintenance_jobs are None")
 
         # admin-suspend jobs
         self.server.sigjob(jid1, 'admin-suspend')
@@ -829,7 +829,7 @@ pbs.logmsg(pbs.LOG_DEBUG,\
         # wait for periodic hook and check mom_log
         time.sleep(5)
         self.mom.log_match("list of maintenance_jobs are %s" %
-                           ((jid1 + "," + jid2),), max_attempts=5)
+                           ((jid1 + "," + jid2),))
 
         # admin-resume job1
         self.server.sigjob(jid1, 'admin-resume')
@@ -837,7 +837,7 @@ pbs.logmsg(pbs.LOG_DEBUG,\
         # wait for periodic hook and check mom_log
         time.sleep(5)
         self.mom.log_match(
-            "list of maintenance_jobs are %s" % (jid2,), max_attempts=5)
+            "list of maintenance_jobs are %s" % (jid2,))
 
     def test_offline(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Intermittent failures in test_hook of TestAdminSuspend due to fewer attempts to match logs

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
The value of 'max_attempts'  argument to log_match was insufficient in some slower test bed machines. 

#### Solution Description
Let the test try and match logs with the default number of attempts (60). 

#### Testing logs/output
[afterfix_test_hook.txt](https://github.com/PBSPro/pbspro/files/2497623/afterfix_test_hook.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__