### PR TITLE
fix server memory leak in fix_indirectness involving indirect resources

### DIFF
--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -158,7 +158,7 @@ extern	void	tinsert2(const u_long, const u_long, mominfo_t *, struct tree **);
 extern	void   *tdelete2(const u_long, const u_long, struct tree **);
 extern	void	tfree2(struct tree **rootp);
 #ifdef	_RESOURCE_H
-extern  int  set_clear_target(struct pbsnode *, resource *, int, int);
+extern  int  fix_indirect_resc_targets(struct pbsnode *, resource *, int, int);
 #endif 	/* _RESOURCE_H */
 #endif	/* _PBS_NODES_H */
 

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -742,7 +742,7 @@ unset_indirect(resource *presc, attribute_def *pdef, int limit, char *name, void
 		return;
 
 	pnode = (struct pbsnode *)pobj;
-	(void)set_clear_target(pnode, presc, ND_ATR_ResourceAvail, 0);
+	(void)fix_indirect_resc_targets(pnode, presc, ND_ATR_ResourceAvail, 0);
 	free_str(&presc->rs_value);
 
 	/* Now,  if and only if the above attrbute was "resources_available" */
@@ -760,7 +760,7 @@ unset_indirect(resource *presc, attribute_def *pdef, int limit, char *name, void
 	presc = find_resc_entry(pattr, prdef);
 	if (presc) {
 		if (presc->rs_value.at_flags & ATR_VFLAG_INDIRECT) {
-			(void)set_clear_target(pnode, presc, ND_ATR_ResourceAssn, 0);
+			(void)fix_indirect_resc_targets(pnode, presc, ND_ATR_ResourceAssn, 0);
 			free_str(&presc->rs_value);
 		}
 	}

--- a/test/tests/functional/pbs_indirect_resources.py
+++ b/test/tests/functional/pbs_indirect_resources.py
@@ -1,0 +1,137 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestHostResources(TestFunctional):
+
+    def test_set_direct_on_indirect_resc(self):
+        """
+        Set a direct resource on indirect resource and make sure
+        this change is reflected on resource assigned.
+        """
+        # Create a consumable custom resources 'fooi'
+        self.server.add_resource('fooi', 'long', 'nh')
+        # Create 2 vnodes with individual hosts
+        attr = {'resources_available.ncpus': 1}
+        self.server.create_vnodes('vnode', attr, 2, sharednode=False,
+                                  mom=self.mom)
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'resources_available.fooi': 100}, 'vnode[0]')
+        self.server.manager(MGR_CMD_SET, NODE, {'resources_available.fooi':
+                                                '@vnode[0]'}, 'vnode[1]')
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'resources_available.fooi': 100}, 'vnode[1]')
+        self.server.expect(NODE, {'resources_assigned.fooi': ''},
+                           id='vnode[1]', op=UNSET, max_attempts=1)
+
+    def test_set_direct_on_indirect_resc_busy(self):
+        """
+        Set a direct resource on indirect resource
+        but a busy node and make sure this is failing.
+        """
+        # Create 2 vnodes with individual hosts
+        attr = {'resources_available.ncpus': 1}
+        self.server.create_vnodes('vnode', attr, 2, sharednode=False,
+                                  mom=self.mom)
+        # Create a consumable custom resources 'fooi'
+        self.server.add_resource('fooi', 'long', 'nh')
+        self.scheduler.add_resource("fooi")
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'resources_available.fooi': 100}, 'vnode[0]')
+        self.server.manager(MGR_CMD_SET, NODE, {'resources_available.fooi':
+                                                '@vnode[0]'}, 'vnode[1]')
+        # Submit jobs.
+        a = {'Resource_List.fooi': 50}
+        J = Job(attrs=a)
+        self.server.submit(J)
+        j2 = self.server.submit(J)
+        self.server.expect(JOB, {'job_state': 'R'}, id=j2)
+        self.server.expect(NODE, {'state': 'job-busy'}, id='vnode[1]')
+        try:
+            self.server.manager(MGR_CMD_SET, NODE,
+                                {'resources_available.fooi': 100},
+                                'vnode[1]')
+        except PbsManagerError:
+            pass
+        else:
+            self.server.expect(NODE, {'resources_available.fooi': 100},
+                               id='vnode[1]', op=UNSET, max_attempts=1)
+
+    def test_set_direct_on_target_node(self):
+        """
+        Set a direct resource on target node which should
+        fail with error.
+        A and B are having direct resources.
+        C -> B
+        B -> A should fail as it is alreay a target.
+        """
+        # Create 3 vnodes with individual hosts
+        attr = {'resources_available.ncpus': 1}
+        self.server.create_vnodes('vnode', attr, 3, sharednode=False,
+                                  mom=self.mom)
+        # Create a consumable custom resources 'fooi'
+        self.server.add_resource('fooi', 'long', 'nh')
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'resources_available.fooi': 100}, 'vnode[0]')
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'resources_available.fooi': 100}, 'vnode[1]')
+        self.server.manager(MGR_CMD_SET, NODE, {'resources_available.fooi':
+                                                '@vnode[1]'}, 'vnode[2]')
+        try:
+            self.server.manager(MGR_CMD_SET, NODE,
+                                {'resources_available.fooi': '@vnode[0]'},
+                                'vnode[1]')
+        except PbsManagerError:
+            pass
+        else:
+            _msg = "Setting indirect resources on a target object should fail"
+            self.assertTrue(False, _msg)
+
+    def test_create_node_without_resc_set(self):
+        """
+        Create a consumable resource then create a new node.
+        The resources_assigned value should not get assigned
+        on it without explicitely setting resource on the node.
+        """
+        # Create a consumable custom resources 'fooi'
+        self.server.add_resource('fooi', 'long', 'nh')
+        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom.shortname)
+        self.server.expect(NODE, {'resources_assigned.fooi': ''},
+                           id=self.mom.shortname, op=UNSET, max_attempts=1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *Memory leak occurs when a custom resource is getting deleted on which a direct value had overwritten a previously existing indirect value.*

#### Cause / Analysis / Design
* *When an indirect value assigned to a custom resource, the resource assigned is populated to maintain the same string value. But when it is over-written using a direct resource, only resource_available is freed and modified and resource_assigned is kept intact.*

#### Solution Description
* *Free the resource_assigned value when an indirect resource is over-written using a direct resource.*

#### Testing logs/output
PTL is added.
[ptl_after_fix.log](https://github.com/PBSPro/pbspro/files/2500559/ptl_after_fix.log)
[ptl_before_fix.log](https://github.com/PBSPro/pbspro/files/2500560/ptl_before_fix.log)
[server_after_fix.log](https://github.com/PBSPro/pbspro/files/2500561/server_after_fix.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!
[server_before_fix.log](https://github.com/PBSPro/pbspro/files/2500562/server_before_fix.log)
--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__

CC: @bayucan 