### PR TITLE
Allow extra user plugins in pbs_benchpress

### DIFF
--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -44,8 +44,10 @@ import logging.config
 import platform
 import errno
 import signal
+import importlib
 import ptl
 import nose
+from nose.plugins.base import Plugin
 from ptl.lib.pbs_testlib import PtlConfig
 from distutils.version import LooseVersion
 from ptl.utils.pbs_cliutils import CliUtils
@@ -100,6 +102,10 @@ def usage():
     msg += [' pairs. Note that the comma can not be used in val\n']
     msg += ['-t <test suites>: comma-separated list of test suites to run\n']
     msg += ['--exclude=<names>: comma-separated string of tests to exclude\n']
+    msg += ['--user-plugins=<names>: comma-separated list of key=val of']
+    msg += [' user plugins to load, where key is module and val is']
+    msg += [' classname of plugin which is subclass of nose.plugins.base']
+    msg += ['.Plugin\n']
     msg += ['--db-type=<type>: Type of database to use.']
     msg += [' can be one of "html", "file", "sqlite", "pgsql".']
     msg += [' Default to "file"\n']
@@ -214,6 +220,7 @@ if __name__ == '__main__':
     tc_failure_threshold = 10
     cumulative_tc_failure_threshold = 100
     max_postdata_threshold = 10
+    user_plugins = None
     PtlConfig()
 
     largs = ['exclude=', 'log-conf=', 'timeout=']
@@ -225,7 +232,7 @@ if __name__ == '__main__':
     largs += ['stop-on-failure', 'enable-nose-debug']
     largs += ['post-analysis-data=', 'gen-ts-tree']
     largs += ['tc-failure-threshold=', 'cumulative-tc-failure-threshold=']
-    largs += ['max-postdata-threshold=']
+    largs += ['max-postdata-threshold=', 'user-plugins=']
 
     try:
         opts, args = getopt.getopt(
@@ -264,6 +271,8 @@ if __name__ == '__main__':
             testfiles = CliUtils.expand_abs_path(val)
         elif o == '-t':
             testsuites = val
+        elif o == '--user-plugins':
+            user_plugins = val
         elif o == '--tags':
             tags.append(val.strip())
         elif o == '--eval-tags':
@@ -449,6 +458,35 @@ if __name__ == '__main__':
         db.set_data(dbtype, dbname, dbaccess)
         data.set_data(post_data_dir, max_postdata_threshold)
         plugins = (loader, testtags, runner, db, data)
+    if user_plugins:
+        for plugin in user_plugins.split(','):
+            if '=' not in plugin:
+                _msg = 'Invalid value (%s)' % (plugin)
+                _msg += ' provided in user-plugins, it should be key value'
+                _msg += ' pair where key is module name and value is class'
+                _msg += ' name of plugin'
+                logging.error(_msg)
+                sys.exit(1)
+            mod, clsname = plugin.split('=', 1)
+            try:
+                loaded_mod = importlib.import_module(mod)
+            except ImportError:
+                _msg = 'Failed to load module (%s)' % mod
+                _msg += ' for plugin (%s)' % plugin
+                logging.error(_msg)
+                sys.exit(1)
+            _plugin = getattr(loaded_mod, clsname, None)
+            if not _plugin:
+                _msg = 'Could not find class named "%s"' % clsname
+                _msg += ' in module (%s)' % mod
+                logging.error(_msg)
+                sys.exit(1)
+            if not issubclass(_plugin, Plugin):
+                _msg = 'Plugin class (%s) should be subclass of ' % (clsname)
+                _msg += 'nose.plugins.base.Plugin'
+                logging.error(_msg)
+                sys.exit(1)
+            plugins += (_plugin(),)
     test_regex = r'(^(?:[\w]+|^)Test|pbs_|^test_[\(]*)'
     os.environ['NOSE_TESTMATCH'] = test_regex
     if nosedebug:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Currently pbs_benchpress in PTL has hard coded list of plugins which it is loading from ptl.utils.plugins directory and so it doesn't allow user to do extra stuff before and after test runs. For example force restart server before each test case or send test execution status to some central database etc...

#### Affected Platform(s)
* All platform which PTL supports

#### Cause / Analysis / Design
* Design document: https://pbspro.atlassian.net/wiki/spaces/PD/pages/823459843/Allow+extra+user+plugins+in+pbs+benchpress
* Forum discussion: http://community.pbspro.org/t/allow-extra-user-plugins-in-pbs-benchpress/1254

#### Solution Description
* Added new option in pbs_benchpress which takes list of custom plugins which will get loaded along with hard coded plugins in pbs_benchpress

#### Testing logs/output
* [extra_plugins_test_result.txt](https://github.com/PBSPro/pbspro/files/2510794/extra_plugins_test_result.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
