### PR TITLE
Fixed race condition in node buckets test test_psets

### DIFF
--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -564,7 +564,7 @@ class TestNodeBuckets(TestFunctional):
         """
         a = {'node_group_key': 'shape', 'node_group_enable': 'True',
              'scheduling': 'False'}
-        self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
 
         chunk = '1430:ncpus=1'
         a = {'Resource_List.select': chunk,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Node buckets test test_psets sometimes fails due to race condition

#### Cause / Analysis / Design
* The test turns off scheduling, enables node_group_key, submits some jobs, and turns scheduling back on.
* The race condition goes as follows:
1) Scheduling cycle starts
2) scheduling is turned off (but the cycle is still running)
3) scheduler queries PBS server object and node_group_key is not set
4) node_group_key is set
5) Jobs are submitted
6) Scheduler queries jobs
7) Jobs are run without node_group_key
#### Solution Description
* When turning off scheduling, wait until current cycle is over before starting a new one.
* The PTL manager() call will do this for scheduling=false if the expect=True parameter is passed.
#### Testing logs/output
* [server.log](https://github.com/PBSPro/pbspro/files/2512338/server.log)
* [psets-ptl.log](https://github.com/PBSPro/pbspro/files/2512339/psets-ptl.log)




#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
