### PR TITLE
Node attribute last_used_time is lost on server restart

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -8594,6 +8594,9 @@ set_last_used_time_node(void *pobj, int type)
 				snprintf(str_val, sizeof(str_val), "%d", time_int_val);
 				set_attr_svr(&(pnode->nd_attr[(int)ND_ATR_last_used_time]),
 						&node_attr_def[(int) ND_ATR_last_used_time], str_val);
+				pnode->nd_modified = NODE_UPDATE_OTHERS;
+				if(svr_chngNodesfile == 0)
+					svr_chngNodesfile = 1; /*make sure nodes are saved to the database during shutdown*/
 			}
 		}
 		last_pn = pn;

--- a/test/tests/functional/pbs_pbsnodes.py
+++ b/test/tests/functional/pbs_pbsnodes.py
@@ -89,3 +89,21 @@ class TestPbsnodes(TestFunctional):
             self.assertIn(
                 hdr, out2['out'][0],
                 "header %s not found in output" % hdr)
+
+    def test_pbsnodes_av(self):
+        """
+        This verifies the values of last_used_time in 'pbsnodes -av'
+        result before and after server shutdown, once a job submitted.
+        """
+        j = Job(TEST_USER)
+        j.set_sleep_time(1)
+        jid = self.server.submit(j)
+        self.server.accounting_match("E;%s;" % jid)
+        prev = self.server.status(NODE, 'last_used_time')[0]['last_used_time']
+        self.logger.info("Restarting server")
+        self.server.restart()
+        self.assertTrue(self.server.isUp(), 'Failed to restart Server Daemon')
+        now = self.server.status(NODE, 'last_used_time')[0]['last_used_time']
+        self.logger.info("Before: " + prev + ". After: " + now + ".")
+        self.assertEquals(prev.strip(), now.strip(),
+                          'Last used time mismatch after server restart')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Node attribute last_used_time is lost on a server restart.

#### Affected Platform(s)
All

#### Cause / Analysis / Design

- When any job exits, it also modifies the respective exec nodes last_used_time value. But after modifying last_used_time attribute, it was not setting the nd_modified value. 

- As the nodes nd_modified was not set, while saving nodes to DB, it was not considered to save. Once server daemon dies those values are also lost.


#### Solution Description

- Set nodes nd_modified value whenever  last_used_time node attribute changed.

- set svr_chngNodesfile, to indicate there are some changes in nodes, which needs to be considered while server shutdown.


#### Testing logs/output

[PTL Logs.txt](https://github.com/PBSPro/pbspro/files/2514330/PTL.Logs.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
