### PR TITLE
pbs_rstat displays long reservation duration as a negative number

### DIFF
--- a/src/cmds/pbs_rstat.c
+++ b/src/cmds/pbs_rstat.c
@@ -42,6 +42,7 @@
 #include <pbs_version.h>
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <time.h>
 #include "cmds.h"
 #include "pbs_ifl.h"
@@ -100,7 +101,7 @@ display_single_reservation(struct batch_status *resv, int how)
 			else if (strcmp(attrp->name, ATTR_resv_end) == 0)
 				resv_end = attrp->value;
 			else if (strcmp(attrp->name, ATTR_resv_duration) == 0)
-				resv_duration = atoi(attrp->value);
+				resv_duration = strtol(attrp->value, NULL, 10);
 			else if (strcmp(attrp->name, ATTR_resv_state) == 0)
 				resv_state = convert_resv_state(attrp->value, 0);/*short state str*/
 #ifdef NAS /* localmod 075 */

--- a/test/tests/functional/pbs_resv_start_dur_end.py
+++ b/test/tests/functional/pbs_resv_start_dur_end.py
@@ -140,3 +140,22 @@ class TestReservationRequests(TestFunctional):
 
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
         self.server.expect(RESV, a, id=rid)
+
+    def test_rstat_longterm_resv(self):
+        """
+        Test to submit a reservation, where duration > INT_MAX.
+        Check whether rstat displaying negative number.
+        """
+        now = int(time.time())
+        a = {'Resource_List.select': '1:ncpus=1',
+             'reserve_start': now + 3600,
+             'reserve_end': now + 4294970895}
+        r = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+
+        out = self.server.status(RESV, 'reserve_duration', id=rid)[0][
+            'reserve_duration']
+        dur = long(out)
+        self.assertTrue(dur > 0, 'Duration ' + str(dur) + 'is negative.')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Duration field of pbs_rstat showing negative number for long duration reservation.

#### Affected Platform(s)
All

#### Cause / Analysis / Design

- For longer reservation, when duration is greater than INT_MAX, the corresponding field is displaying a negative number.  As its overflowing the INT_MAX value and rearranging itself according to the INT_MIN.

- Although resv_duration is "long int" type internally. But while converting the string to long int we used atoi() instead of atol().

#### Solution Description

- Used atol() while converting to long int.
- Included the corresponding library 

#### Testing logs/output
[PTL Log.txt](https://github.com/PBSPro/pbspro/files/2517730/PTL.Log.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
