### PR TITLE
Scheduler may oversubscribe node while confirming reservation

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -559,6 +559,7 @@ struct node_info
 	int   port;			/* port on which Mom is listening */
 
 	char **jobs;			/* the name of the jobs currently on the node */
+	char **resvs;			/* the name of the reservations currently on the node */
 	resource_resv **job_arr;	/* ptrs to structs of the jobs on the node */
 	resource_resv **run_resvs_arr;	/* ptrs to structs of resvs holding resources on the node */
 

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -442,6 +442,8 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp == '\0')
 				ninfo->last_used_time = count;
+		} else if (!strcmp(attrp->name, ATTR_NODE_resvs)) {
+			ninfo->resvs = break_comma_list(attrp->value);
 		}
 		attrp = attrp->next;
 	}
@@ -507,6 +509,7 @@ new_node_info()
 	new->mom = NULL;
 	new->port = pbs_rm_port;
 	new->jobs = NULL;
+	new->resvs = NULL;
 	new->job_arr = NULL;
 	new->run_resvs_arr = NULL;
 	new->res = NULL;
@@ -591,6 +594,9 @@ free_node_info(node_info *ninfo)
 
 		if (ninfo->jobs != NULL)
 			free_string_array(ninfo->jobs);
+
+		if (ninfo->resvs != NULL)
+			free_string_array(ninfo->resvs);
 
 		if (ninfo->job_arr != NULL)
 			free(ninfo->job_arr);
@@ -1252,6 +1258,7 @@ dup_node_info(node_info *onode, server_info *nsinfo,
 	nnode->priority = onode->priority;
 
 	nnode->jobs = dup_string_array(onode->jobs);
+	nnode->resvs = dup_string_array(onode->resvs);
 	if (flags & DUP_INDIRECT)
 		nnode->res = dup_ind_resource_list(onode->res);
 	else
@@ -1749,9 +1756,10 @@ update_node_on_end(node_info *ninfo, resource_resv *resresv, char *job_state)
 						res->assigned -= resreq->amount;
 						if (res->assigned < 0) {
 							snprintf(logbuf, MAX_LOG_SIZE,
-								"Setting %s assigned to %.2lf", res->name, res->assigned);
+								"%s turned negative %.2lf, setting it to 0", res->name, res->assigned);
 							schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE,
 								LOG_DEBUG, ninfo->name, logbuf);
+							res->assigned = 0;
 						}
 						if (res->def == getallres(RES_NCPUS)) {
 							ninfo->loadave -= resreq->amount;
@@ -2324,7 +2332,7 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 	 * remark: reorder_nodes doesn't reorder in place, returns
 	 *         a ptr to a reordered static array
 	 */
-	if ((pl->pack && spec->total_chunks == 1 && nspec_arr != NULL) ||
+	if ((pl->pack && spec->total_chunks == 1) ||
 		(conf.provision_policy == AVOID_PROVISION && resresv->aoename != NULL) ||
 		(resresv->is_resv && resresv->resv != NULL && resresv->resv->check_alternate_nodes))
 		nptr = reorder_nodes(ninfo_arr, resresv);
@@ -4664,41 +4672,42 @@ reorder_nodes(node_info **nodes, resource_resv *resresv)
 	node_array[0] = NULL;
 	nptr = node_array;
 
-	if (resresv != NULL && resresv->is_resv && resresv->resv != NULL && resresv->resv->check_alternate_nodes) {
-		int		i = 0;
-		node_info	*temp = NULL;
-
-		memcpy(nptr, nodes, (nsize+1) * sizeof(node_info *));
-		for (i = 0; nptr[i] != NULL; i++) {
-			temp = find_node_by_rank(resresv->ninfo_arr, nptr[i]->rank);
-			if (temp != NULL)
-				nptr[i]->nscr.to_be_sorted = 0;
-			else
-				nptr[i]->nscr.to_be_sorted = 1;
-		}
-		qsort(nptr, i, sizeof(node_info*), cmp_nodes_sort);
-		return nptr;
-	}
-
 	if (last_node_name[0] == '\0')
 		strcpy(last_node_name, nodes[0]->name);
 
-	if (resresv->aoename != NULL && conf.provision_policy == AVOID_PROVISION) {
-		memcpy(nptr, nodes, (nsize+1) * sizeof(node_info *));
+	if (resresv != NULL) {
+		if (resresv->is_resv && resresv->resv != NULL && resresv->resv->check_alternate_nodes) {
+			int		i = 0;
+			node_info	*temp = NULL;
 
-		if (cmp_aoename != NULL)
-			free(cmp_aoename);
+			memcpy(nptr, nodes, (nsize + 1) * sizeof(node_info *));
+			for (i = 0; nptr[i] != NULL; i++) {
+				temp = find_node_by_rank(resresv->ninfo_arr, nptr[i]->rank);
+				if (temp != NULL)
+					nptr[i]->nscr.to_be_sorted = 0;
+				else
+					nptr[i]->nscr.to_be_sorted = 1;
+			}
+			qsort(nptr, i, sizeof(node_info*), cmp_nodes_sort);
+			return nptr;
+		}
+		if (resresv->aoename != NULL && conf.provision_policy == AVOID_PROVISION) {
+			memcpy(nptr, nodes, (nsize+1) * sizeof(node_info *));
 
-		cmp_aoename = string_dup(resresv->aoename);
-		qsort(nptr, nsize, sizeof(node_info *), cmp_aoe);
+			if (cmp_aoename != NULL)
+				free(cmp_aoename);
 
-		sprintf(errbuf, "Re-sorted the nodes on aoe %s, since aoe was requested",
-			resresv->aoename);
-		errbuf[MAX_LOG_SIZE - 1] = '\0';
-		schdlog(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name,
-			errbuf);
+			cmp_aoename = string_dup(resresv->aoename);
+			qsort(nptr, nsize, sizeof(node_info *), cmp_aoe);
 
-		return nptr;
+			sprintf(errbuf, "Re-sorted the nodes on aoe %s, since aoe was requested",
+				resresv->aoename);
+			errbuf[MAX_LOG_SIZE - 1] = '\0';
+			schdlog(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name,
+				errbuf);
+
+			return nptr;
+		}
 	}
 
 	switch (cstat.smp_dist) {

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -191,9 +191,8 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 	resresv_arr[0] = NULL;
 	sinfo->num_resvs = num_resv;
 
-	cur_resv = resvs;
-
-	while (cur_resv != NULL) {
+	for (cur_resv = resvs; cur_resv != NULL; cur_resv = cur_resv->next) {
+		int ignore_resv = 0;
 		/* convert resv info from server batch_status into resv_info */
 		if ((resresv = query_resv(cur_resv, sinfo)) == NULL) {
 			pbs_statfree(resvs);
@@ -207,6 +206,33 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 		}
 #endif /* localmod 047 */
 
+		/* We continue adding valid resvs to our array.  We're
+		 * freeing what we allocated and ignoring this resv completely.
+		 */
+		if (!is_resource_resv_valid(resresv, err) || resresv->is_invalid) {
+			schdlogerr(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_DEBUG, resresv->name,
+				"Reservation is invalid - ignoring for this cycle", err);
+			ignore_resv = 1;
+		}
+		/* Make sure it is not a future reservation that is being deleted, if so ignore it */
+		else if ((resresv->resv->resv_state == RESV_BEING_DELETED) && (resresv->start > sinfo->server_time)) {
+			schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+				resresv->name, "Future reservation is being deleted, ignoring this reservation");
+			ignore_resv = 1;
+		}
+		else if ((resresv->resv->resv_state == RESV_BEING_DELETED) && (resresv->resv->resv_nodes != NULL) &&
+			(!find_string(resresv->resv->resv_nodes[0]->resvs, resresv->name))) {
+			schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+				resresv->name, "Reservation is being deleted and not present on node, ignoring this reservation");
+			ignore_resv = 1;
+		}
+
+		if (ignore_resv == 1) {
+			sinfo->num_resvs--;
+			free_resource_resv(resresv);
+			continue;
+		}
+
 		resresv->rank = get_sched_rank();
 
 		resresv->aoename = getaoename(resresv->select);
@@ -216,19 +242,6 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 		if (resresv->aoename) {
 			resresv->place_spec->share = 0;
 			resresv->place_spec->excl = 1;
-		}
-
-		if (!is_resource_resv_valid(resresv, err) || resresv->is_invalid) {
-			schdlogerr(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_DEBUG, resresv->name,
-				"Reservation is invalid - ignoring for this cycle", err);
-
-			/* We continue adding valid resvs to our array.  We're
-			 * freeing what we allocated and ignoring this resv completely.
-			 */
-			sinfo->num_resvs--;
-			free_resource_resv(resresv);
-			cur_resv = cur_resv->next;
-			continue;
 		}
 
 		/*
@@ -396,7 +409,6 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 					free(execvnodes_seq);
 					sinfo->num_resvs--;
 					free_resource_resv(resresv);
-					cur_resv = cur_resv->next;
 					continue;
 				}
 				/* unroll_execvnode_seq will destroy the first argument that is passed
@@ -539,7 +551,6 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 				/* The parent reservation has already been added so move on to handling
 				 * the next reservation
 				 */
-				cur_resv = cur_resv->next;
 
 				free_execvnode_seq(tofree);
 				free(execvnodes_seq);
@@ -551,7 +562,6 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 				resresv_arr[idx] = NULL;
 			}
 		}
-		cur_resv = cur_resv->next;
 	}
 
 	pbs_statfree(resvs);
@@ -1559,13 +1569,13 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 			errmsg = "";
 
 		if (rconf == RESV_CONFIRM_FAIL)
-			snprintf(logmsg, MAX_LOG_SIZE, "PBS Failed to confirm resv: %s", logmsg2);
+			snprintf(logmsg2, MAX_LOG_SIZE, "PBS Failed to confirm resv: %s", logmsg);
 		else {
-			snprintf(logmsg, MAX_LOG_SIZE, "PBS Failed to confirm resv: %s (%d)", errmsg, pbs_errno);
+			snprintf(logmsg2, MAX_LOG_SIZE, "PBS Failed to confirm resv: %s (%d)", errmsg, pbs_errno);
 			rconf = RESV_CONFIRM_RETRY;
 		}
 		schdlog(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO, nresv_parent->name,
-			logmsg);
+			logmsg2);
 		if (nresv_parent->resv->resv_substate == RESV_DEGRADED) {
 			snprintf(logmsg, MAX_LOG_SIZE,
 				"Reservation is in degraded mode, %d out of %d vnodes are unavailable; %s",

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1391,9 +1391,9 @@ add_resource_list(status *policy, schd_resource *r1, schd_resource *r2, unsigned
 						end_r1 = nres;
 					} else {
 						nres = false_res();
-						nres->name = boolres[i]->name;
 						if (nres == NULL)
 							return 0;
+						nres->name = boolres[i]->name;
 						(void)add_resource_bool(cur_r1, nres);
 					}
 				}
@@ -1760,8 +1760,18 @@ update_server_on_end(status *policy, server_info *sinfo, queue_info *qinfo,
 		while (req != NULL) {
 			res = find_resource(sinfo->res, req->def);
 
-			if (res != NULL)
+			if (res != NULL) {
 				res->assigned -= req->amount;
+
+				if (res->assigned < 0) {
+					char logbuf[MAX_LOG_SIZE] = {0};
+					snprintf(logbuf, MAX_LOG_SIZE,
+						"%s turned negative %.2lf, setting it to 0", res->name, res->assigned);
+					schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER,
+						LOG_DEBUG, __func__, logbuf);
+					res->assigned = 0;
+				}
+			}
 
 			req = req->next;
 		}

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -225,7 +225,7 @@ chk_job_statenum(int istat, char *statelist)
 
 	if (statelist == NULL)
 		return 1;
-	if (istat >= 0 || istat <= 9)
+	if (istat >= 0 && istat <= 9)
 		if (strchr(statelist, (int)(statechars[istat])))
 			return 1;
 	return 0;
@@ -494,6 +494,9 @@ select_job(job *pjob, struct select_list *psel, int dosubjobs, int dohistjobs)
 	else if ((dosubjobs != 2) &&
 		(pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob))
 		return 0;	/* don't bother to look at sub job */
+	else if ((dosubjobs == 2) && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) &&
+		(pjob->ji_qs.ji_state != JOB_STATE_RUNNING)) /* select only running subjobs */
+		return 0;
 
 	while (psel) {
 

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -1,0 +1,103 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2016 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# The PBS Pro software is licensed under the terms of the GNU Affero General
+# Public License agreement ("AGPL"), except where a separate commercial license
+# agreement for PBS Pro version 14 or later has been executed in writing with
+# Altair.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software - under
+# a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+import time
+from tests.functional import *
+
+
+class TestCalendaring(TestFunctional):
+
+    """
+    This test suite tests if PBS scheduler calendars events correctly
+    """
+    def test_topjob_start_time(self):
+        """
+        In this test we test that the top job which gets added to the
+        calendar has estimated start time correctly set for future when
+        job history is enabled and opt_backfill_fuzzy is turned off.
+        """
+
+        self.scheduler.set_sched_config({'strict_ordering': 'true all'})
+        a = {'resources_available.ncpus': 1}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        a = {'backfill_depth': '2', 'job_history_enable': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        # Turn opt_backfill_fuzzy off because we want to check if the job can
+        # run after performing every end event in calendaring code instead
+        # of rounding it off to next time boundary (default it 60 seconds)
+        a = {'opt_backfill_fuzzy': 'off'}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+
+        res_req = {'Resource_List.select': '1:ncpus=1',
+                   'Resource_List.walltime': 10,
+                   'array_indices_submitted': '1-6'}
+        j1 = Job(TEST_USER, attrs=res_req)
+        j1.set_sleep_time(10)
+        jid1 = self.server.submit(j1)
+        j1_sub1 = j1.create_subjob_id(jid1, 1)
+        j1_sub2 = j1.create_subjob_id(jid1, 2)
+
+        res_req = {'Resource_List.select': '1:ncpus=1',
+                   'Resource_List.walltime': 10}
+        j2 = Job(TEST_USER, attrs=res_req)
+        jid2 = self.server.submit(j2)
+
+        self.server.expect(JOB, {'job_state': 'X'}, j1_sub1)
+        self.server.expect(JOB, {'job_state': 'R'}, j1_sub2)
+        self.server.expect(JOB, {'job_state': 'Q'}, jid2)
+        job1 = self.server.status(JOB, id=jid1)
+        job2 = self.server.status(JOB, id=jid2)
+        time_now = int(time.time())
+
+        # get estimated start time of both the jobs
+        self.assertIn('estimated.start_time', job1[0])
+        est_val1 = job1[0]['estimated.start_time']
+        self.assertIn('estimated.start_time', job2[0])
+        est_val2 = job2[0]['estimated.start_time']
+        est1 = time.strptime(est_val1, "%a %b %d %H:%M:%S %Y")
+        est2 = time.strptime(est_val2, "%a %b %d %H:%M:%S %Y")
+        est_epoch1 = int(time.mktime(est1))
+        est_epoch2 = int(time.mktime(est2))
+
+        # since only one subjob of array parent can become topjob
+        # second job must start 10 seconds after that because
+        # walltime of array job is 10 seconds.
+        self.assertEqual(est_epoch2, est_epoch1+10)
+        # Also make sure that since second subjob from array is running
+        # Third subjob should set estimated.start_time in future.
+        self.assertGreater(est_epoch1, time_now)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
(18.1 cherry-pick)
It is found that in some cases scheduler may end up oversubscribing the node. Below are the two cases where this can happen:

- If a reservation that is scheduled to start in future is deleted, the server puts the reservation in 'RESV_BEING_DELETED' state and goes on to delete the jobs present in that reservation. Now during this time if the scheduling cycle is triggered, then the scheduler assumes that the reservation must be running and it is going to release resources very soon. This makes scheduler release resources requested by the reservation when it is simulating future. Due to this problem scheduler sometimes end up oversubscribing the node.

- Second problem was introduced in ["PP-479"](https://pbspro.atlassian.net/browse/PP-479) After this change, when scheduler queries server to select all the jobs, it also gets a list of expired sub jobs of job-array. This was not the case before because the server was only reporting array-parent and running sub jobs to the scheduler. Now, upon receiving expired sub jobs scheduler releases more resources during simulation (for top jobs or reservation) and can end up oversubscribing the node.


#### Affected Platform(s)
* All


#### Solution Description
It has 3 way fix -

* Server now does not report expired sub jobs to the scheduler. It only reports queued array-parent, running sub jobs and other non-finished jobs to the scheduler.
* Scheduler detects that if it received reservation in being_deleted state or sub jobs in non-running state then it ignores it.
* While simulating, if scheduler ever falls into a case where resources assigned on node/server/queue are turning negative then it sets them to 0.

#### Testing logs/output
[test_array_jobs.txt](https://github.com/PBSPro/pbspro/files/2518918/test_array_jobs.txt)
[pbs_calendaring.txt](https://github.com/PBSPro/pbspro/files/2518919/pbs_calendaring.txt)
[gdb_test_logs.txt](https://github.com/PBSPro/pbspro/files/2518922/gdb_test_logs.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
