### PR TITLE
Compare to `None` using identity `is` operator in yacc.py

### DIFF
--- a/buildutils/attr_parser.py
+++ b/buildutils/attr_parser.py
@@ -179,7 +179,7 @@ def attr(masterf, svrf, eclf):
                 s_flag = 1
             if flag_name == 'ECL':
                 e_flag = 1
-            if flag_name == None:
+            if flag_name is None:
                 e_flag = 0
                 s_flag = 0
             attr_list = attr_list.strip(' \t')
@@ -448,7 +448,7 @@ def attr(masterf, svrf, eclf):
         tail_list = node.getElementsByTagName('tail')
         for t in tail_list:
             tail_value = t.childNodes[0].nodeValue
-            if tail_value == None:
+            if tail_value is None:
                 pass
             fileappend('\n') 
             tail_both = t.getElementsByTagName('both')
@@ -520,7 +520,7 @@ def resc_attr(masterf, svrf, eclf):
                 s_flag = 1
             if flag_name == 'ECL':
                 e_flag = 1
-            if flag_name == None:
+            if flag_name is None:
                 e_flag = 0
                 s_flag = 0
             if macro_name:
@@ -826,7 +826,7 @@ def resc_attr(masterf, svrf, eclf):
         tail_list = node.getElementsByTagName('tail')
         for t in tail_list:
             tail_value = t.childNodes[0].nodeValue
-            if tail_value == None:
+            if tail_value is None:
                 pass
             fileappend('\n') 
             tail_both = t.getElementsByTagName('both')

--- a/src/modules/python/pbs/v1/_base_types.py
+++ b/src/modules/python/pbs/v1/_base_types.py
@@ -736,7 +736,7 @@ class pbs_bool(_generic_attr):
     def __cmp__(self,value):
         iself = int(str(self))
 
-        if value == None:
+        if value is None:
             return 1
 
         ivalue = int(value)

--- a/src/modules/python/pbs/v1/_svr_types.py
+++ b/src/modules/python/pbs/v1/_svr_types.py
@@ -115,7 +115,7 @@ def pbs_statobj(type, name=None, connect_server=None, filter_queue=None):
 
         server_data_fp = _pbs_v1.get_server_data_fp();
 
-        if( connect_server == None ):
+        if( connect_server is None ):
             con=pbs_connect("localhost")
         else:
             con=pbs_connect(connect_server)
@@ -195,18 +195,18 @@ def pbs_statobj(type, name=None, connect_server=None, filter_queue=None):
                     pr=getattr(obj,n)
 
                     # instantiate Resource_List object if not set
-                    if( pr == None):
+                    if( pr is None):
                         setattr(obj,n)
 
                     pr=getattr(obj,n)
-                    if (pr == None):
+                    if (pr is None):
                         _pbs_v1.logmsg(_pbs_v1.LOG_DEBUG,
                                          "pbs_statobj: missing %s" % (n))
                         a=a.next
                         continue
 
                     vo=getattr(pr, r)
-                    if( vo == None ):
+                    if( vo is None ):
                         setattr(pr,r,v)
                         if server_data_fp:
                             server_data_fp.write("%s.%s[%s]=%s\n" %(header_str,n,r,v))
@@ -221,7 +221,7 @@ def pbs_statobj(type, name=None, connect_server=None, filter_queue=None):
                 else:
                     vo=getattr(obj,n)
 
-                    if( vo == None ):
+                    if( vo is None ):
                         setattr(obj,n,v)
                         if server_data_fp:
                             server_data_fp.write("%s.%s=%s\n" %(header_str,n,v))
@@ -695,7 +695,7 @@ class _server(object):
         """
         Flags the server to tell the scheduler to restart scheduling cycle
         """
-        if self._connect_server == None:
+        if self._connect_server is None:
             _pbs_v1.scheduler_restart_cycle(_pbs_v1.get_pbs_server_name())
         else:
             _pbs_v1.scheduler_restart_cycle(self._connect_server)
@@ -863,7 +863,7 @@ class pbs_iter(object):
 	    self._caller = _pbs_v1.get_python_daemon_name()
 	    if self._caller == "pbs_python":
 
-		if( connect_server == None ):
+		if( connect_server is None ):
 		    self._connect_server = "localhost"
 		    sn = ""
 		else:        
@@ -936,7 +936,7 @@ class pbs_iter(object):
 	    self._caller = _pbs_v1.get_python_daemon_name()
 	    if self._caller == "pbs_python":
 
-		if( connect_server == None ):
+		if( connect_server is None ):
 		    self._connect_server = "localhost"
 		    sn = ""
 		else:        
@@ -995,7 +995,7 @@ class pbs_iter(object):
     if NAS_mod != None and NAS_mod != 0:
         def next(self):
 	    if self._caller == "pbs_python":
-		if not hasattr(self, "bs") or self.bs == None:
+		if not hasattr(self, "bs") or self.bs is None:
 		    if not _pbs_v1.use_static_data():
 			pbs_disconnect(self.con)
 			self.con = -1
@@ -1070,18 +1070,18 @@ class pbs_iter(object):
 			    pr=getattr(obj,n)
 
 			    # if resource list does not exist, then set it
-			    if( pr == None):
+			    if( pr is None):
 				setattr(obj,n)
 
 			    pr=getattr(obj,n)
-			    if (pr == None):
+			    if (pr is None):
 				_pbs_v1.logmsg(_pbs_v1.LOG_DEBUG,
 					       "pbs_statobj: missing %s" % (n))
 				a=a.next
 				continue
 
 			    vo=getattr(pr, r)
-			    if( vo == None ):
+			    if( vo is None ):
 				setattr(pr,r,v)
 				if server_data_fp:
 				    server_data_fp.write("%s.%s[%s]=%s\n" %(header_str,n,r,v))
@@ -1096,7 +1096,7 @@ class pbs_iter(object):
 			else:
 			    vo=getattr(obj,n)
 
-			    if( vo == None ):
+			    if( vo is None ):
 				setattr(obj,n,v)
 				if server_data_fp:
 				    server_data_fp.write("%s.%s=%s\n" %(header_str,n,v))
@@ -1118,7 +1118,7 @@ class pbs_iter(object):
     else:
 	def next(self):
 	    if self._caller == "pbs_python":
-		if not hasattr(self, "bs") or self.bs == None:
+		if not hasattr(self, "bs") or self.bs is None:
 		    if not _pbs_v1.use_static_data():
 			pbs_disconnect(self.con)
 			self.con = -1
@@ -1189,18 +1189,18 @@ class pbs_iter(object):
 			    pr=getattr(obj,n)
 
 			    # if resource list does not exist, then set it
-			    if( pr == None):
+			    if( pr is None):
 				setattr(obj,n)
 
 			    pr=getattr(obj,n)
-			    if (pr == None):
+			    if (pr is None):
 				_pbs_v1.logmsg(_pbs_v1.LOG_DEBUG,
 					       "pbs_statobj: missing %s" % (n))
 				a=a.next
 				continue
 
 			    vo=getattr(pr, r)
-			    if( vo == None ):
+			    if( vo is None ):
 				setattr(pr,r,v)
 				if server_data_fp:
 				    server_data_fp.write("%s.%s[%s]=%s\n" %(header_str,n,r,v))
@@ -1215,7 +1215,7 @@ class pbs_iter(object):
 			else:
 			    vo=getattr(obj,n)
 
-			    if( vo == None ):
+			    if( vo is None ):
 				setattr(obj,n,v)
 				if server_data_fp:
 				    server_data_fp.write("%s.%s=%s\n" %(header_str,n,v))


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations