### PR TITLE
Set PBS_HOOK_CONFIG_FILE correctly in MoM

### DIFF
--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -850,7 +850,7 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 		/* must copy up to HOOK_SCRIPT_SUFFIX length so as to not */
 		/* overflow */
 		snprintf(p, sizeof(hook_config_path) - (p - hook_config_path),
-			"%s", HOOK_SCRIPT_SUFFIX);
+			"%s", HOOK_CONFIG_SUFFIX);
 		if (stat(hook_config_path, &sbuf) != 0) {
 			hook_config_path[0] = '\0';
 		}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* While addressing the gcc 8 warnings the value for PBS_HOOK_CONFIG_FILE was mistakenly changed

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* The cgroup regression tests were failing because the wrong suffix for PBS_HOOK_CONFIG_FILE was being used

#### Solution Description
* Restore correct value using HOOK_CONFIG_SUFFIX rather than HOOK_SCRIPT_SUFFIX
* No new tests required because this was a regression

#### Testing logs/output
* Test logs attached in comment

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
