### PR TITLE
pbs_habitat fails when psql -V on CentOS/RHEL 6

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -223,7 +223,7 @@ upgrade_pbs_database() {
 		return 1
 	fi
 	
-	sys_pgsql_ver=$(echo `${PGSQL_DIR}/bin/psql -V` | awk 'NR==1 {print $NF}' | cut -d '.' -f 1,2)
+	sys_pgsql_ver=$(${PGSQL_DIR}/bin/psql -V | awk 'NR==1 {print $NF}' | cut -d '.' -f 1,2)
 	old_pgsql_ver=`cat ${data_dir}/PG_VERSION`
 
 	[ ${sys_pgsql_ver%.*} -eq ${old_pgsql_ver%.*} ] && [ ${sys_pgsql_ver#*.} \> ${old_pgsql_ver#*.} ] || [ ${sys_pgsql_ver%.*} -gt ${old_pgsql_ver%.*} ];


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
pbs_habitat fails when psql -V on CentOS/RHEL 6 with PostgreSQL

#### Affected Platform(s)
CentOS/RHEL 6.x with PostgreSQL 8.X

#### Cause / Analysis / Design
"echo" combines two-line output to one line.

#### Solution Description
Use the standard output of "psql -V" directly.

#### Testing logs/output
[root@227b16d557b0 /]# psql -V
psql (PostgreSQL) 8.4.20
contains support for command-line editing
[root@227b16d557b0 /]# echo \`psql -V\`
psql (PostgreSQL) 8.4.20 contains support for command-line editing

without this fix (e.g. v18.1.2):
Starting PBS
PBS Home directory /var/spool/pbs needs updating.
Running /opt/pbs/libexec/pbs_habitat to update it.
\*\*\*
/opt/pbs/libexec/pbs_habitat: line 246: [: editing: integer expression expected
/opt/pbs/libexec/pbs_habitat: line 246: [: editing: integer expression expected
Upgrade from version 8.4 unsupported
Failed to upgrade PBS Datastore

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
