### PR TITLE
PBS server reports expired subjobs to scheduler

### DIFF
--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -489,14 +489,15 @@ select_job(job *pjob, struct select_list *psel, int dosubjobs, int dohistjobs)
 		return 0;
 	}
 
+	if ((dosubjobs == 2) && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) &&
+		(pjob->ji_qs.ji_state != JOB_STATE_RUNNING)) /* select only running subjobs */
+		return 0;
+
 	if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_ArrayJob) == 0)
 		dosubjobs = 0;  /* not an Array Job,  ok to check state */
 	else if ((dosubjobs != 2) &&
 		(pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob))
 		return 0;	/* don't bother to look at sub job */
-	else if ((dosubjobs == 2) && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) &&
-		(pjob->ji_qs.ji_state != JOB_STATE_RUNNING)) /* select only running subjobs */
-		return 0;
 
 	while (psel) {
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
While fixing the issue in PR #791 I added a new log message in scheduler which is logged if scheduler find a subjob in invalid state (!RUNNING). Along with this server was also changed to not report non-running subjobs to scheduler. But that part of the fix is not working and as a result, scheduler logs a bunch of messages about subjobs being invalid every cycle when job history is enabled.

#### Affected Platform(s)
All

#### Cause / Analysis / Design
In server the check to bail out if the subjob was a not running subjob was placed at a wrong place.

#### Solution Description
Moved the check to the right place.

#### Testing logs/output
[test_without_fix.txt](https://github.com/PBSPro/pbspro/files/2551199/test_without_fix.txt)
[test_out.txt](https://github.com/PBSPro/pbspro/files/2551200/test_out.txt)
[test_smoketest.txt](https://github.com/PBSPro/pbspro/files/2551201/test_smoketest.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
