### PR TITLE
Restriction of special characters in job name

### DIFF
--- a/src/lib/Libcmds/ck_job_name.c
+++ b/src/lib/Libcmds/ck_job_name.c
@@ -85,26 +85,20 @@ isalnumspch(int c)
  * @retval -2	job name length is too long.
  */
 int
-check_job_name(name, chk_alpha)
-char *name;
-int   chk_alpha;
+check_job_name(char *name, int chk_alpha)
 {
+
+	char *p;
+	if (!name)
+		return (-1);
 
 	if (strlen(name) > (size_t)PBS_MAXJOBNAME)
 		return (-2);
 	else if ((chk_alpha == 1) && (isalpha((int)*name) == 0))
 		return (-1);
 
-	/* if caller is job submission request then allow 1st char to be
-	 * only alpha or numeric or permitted special char
-	 */
-	if ((chk_alpha == 0) && (isalnumspch((int)*name) == 0)) {
-		return (-1);
-	}
-
-	while (*name) {
-		if (isgraph((int)*name++) == 0)	/* disallow any non-printing */
+	for (p = name; *p; p++)
+		if (isalnumspch((int)*p) == 0)
 			return (-1);
-	}
 	return (0);
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description

- Special character in job name causing unexpected behavior. 
- While creating jobs output and error file destination, depending on special characters resulting unexpected behavior. 
Example: in default_std(), while making the default name for standard output or error files , it parses the job name depending on '/'. So for a job name "j&whoami>/tmp/b&" the output path is misleading.
Similarly, while doing scp also we may face problem, if job name consists "&",  

#### Affected Platform(s)
All

#### Cause / Analysis / Design

- When we submit job to qsub with job name, where the name contains special characters, it accepts the job. But as per "PBS Professional 18.2 Big Book, Reference Guide, Chapter 7, page 1453", we should restrict special characters in job name (except the allowed special characters mentioned below)

> Job Name, Job Array Name
A job name or job array name can be at most 236 characters. It must consist of printable, non-whitespace characters. The first character must be alphabetic, numeric, plus sign (“+”), dash or minus (“-”), or underscore (“_”). The name must not contain special characters.
Default: if a script is used to submit the job, the job’s name is the name of the script. If no script is used, the job’s name is “STDIN”.

 

#### Solution Description
- When we submit any job to qsub either via command line or via job script, in both cases it uses check_job_name() to verify the job name. 
But in this function after checking the 1st character, for remaining characters of the job name it used isgraph(). Which returns true for alphanumeric characters and special characters. 

- Replaces it with isalnum()  [As per doc, name must not contain special characters].

#### Testing logs/output
[PTL_qsub_N_cmdline.txt](https://github.com/PBSPro/pbspro/files/2561095/PTL_qsub_N_cmdline.txt)
[PTL_qsub_N_jobscrpt.txt](https://github.com/PBSPro/pbspro/files/2561096/PTL_qsub_N_jobscrpt.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
