### PR TITLE
OSS PBS failed to start daemons on postgres upgrade externally

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -401,6 +401,22 @@ if [ "$1" != "1" ]; then
 	echo
 fi
 
+%posttrans %{pbs_server}
+# The %preun section of 14.x unconditially removes /etc/init.d/pbs
+# because it does not check whether the package is being removed
+# or upgraded. Make sure it exists here.
+if [ -r %{pbs_prefix}/libexec/pbs_init.d ]; then
+	install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
+fi
+
+%posttrans %{pbs_execution}
+# The %preun section of 14.x unconditially removes /etc/init.d/pbs
+# because it does not check whether the package is being removed
+# or upgraded. Make sure it exists here.
+if [ -r %{pbs_prefix}/libexec/pbs_init.d ]; then
+	install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
+fi
+
 %files %{pbs_server}
 %defattr(-,root,root, -)
 %dir %{pbs_prefix}

--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -40,6 +40,9 @@
 PBS_TMPDIR="${PBS_TMPDIR:-${TMPDIR:-/var/tmp}}"
 export PBS_TMPDIR
 
+log_file="${PBS_HOME}/spool/pg_start.log"
+version_mismatch=3
+
 get_db_user() {
   dbusr_file="${PBS_HOME}/server_priv/db_user"
   if [ ! -f "${dbusr_file}" ]; then
@@ -253,18 +256,24 @@ start_dataservice() {
 	if [ $ret -eq 0 ]; then
 		if [ "$1" = "startasync" ]; then
 			if [ -n "$NASMODE" ] ; then
-				su - ${PGUSR} -s /bin/sh -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -W start'"
+				su - ${PGUSR} -s /bin/sh -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -W start -l $log_file > /dev/null'"
 			else
-				su - ${PGUSR} -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -W start'"
+				su - ${PGUSR} -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -W start -l $log_file > /dev/null'"
 			fi
 		else
 			if [ -n "$NASMODE" ] ; then
-				su - ${PGUSR} -s /bin/sh -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -w start'"
+				su - ${PGUSR} -s /bin/sh -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -w start -l $log_file > /dev/null'"
 			else
-				su - ${PGUSR} -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -w start'"
+				su - ${PGUSR} -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -w start -l $log_file > /dev/null'"
 			fi
 		fi
 		ret=$?
+		grep -q "database files are incompatible with server" $log_file
+		grep_ret=$?
+
+		if [ $grep_ret -eq 0 ]; then
+			return ${version_mismatch}
+		fi
 
 		if [ $ret -eq 0 -a $is_systemd -eq 1 ] ; then
 			SYSTEMD_CGROUP=`grep ^cgroup /proc/mounts | grep systemd | head -1 | cut -d ' ' -f2`
@@ -323,12 +332,22 @@ case "$1" in
 			fi
 			start_dataservice $1
 			ret=$?
-			if [ ${ret} -ne 0 -a "$2" != "PBS" ]; then
-				echo "Failed to start PBS Data Service"
+			if [ ${ret} -ne 0 ]; then
+				if  [ "$2" != "PBS" ]; then
+					echo "Failed to start PBS Data Service"
+				else
+					cat $log_file 2> /dev/null
+					if [ ${ret} -eq ${version_mismatch} ]; then
+						echo "PBS database needs to be upgraded."
+						echo "Please follow the upgrade instructions in the release notes for the v18.1.2 release at:"
+						echo "https://github.com/PBSPro/pbspro/releases"
+					fi
+				fi
 			fi
 		else
 			echo "$msg - cannot start"
 		fi
+		rm -f $log_file
 
 		exit ${ret}
 		;;

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -229,9 +229,13 @@ upgrade_pbs_database() {
 	[ ${sys_pgsql_ver%.*} -eq ${old_pgsql_ver%.*} ] && [ ${sys_pgsql_ver#*.} \> ${old_pgsql_ver#*.} ] || [ ${sys_pgsql_ver%.*} -gt ${old_pgsql_ver%.*} ];
 	result=$?
 	if [ ${result} -eq 0 ]; then
-		#Start upgrade process of datastore
-		upgrade_db
-		return $?
+		if [ -d "$PBS_EXEC/pgsql" ]; then
+			#Start upgrade process of datastore
+			upgrade_db
+			return $?
+		else
+			return 2
+		fi
 	elif [ "${old_pgsql_ver}" = "${sys_pgsql_ver}" ]; then
 		return 0
 	fi
@@ -897,7 +901,14 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 		upgrade_pbs_database
 		ret=$?
 		if [ $ret -ne 0 ]; then
-			echo "Failed to upgrade PBS Datastore"
+			if [ $ret -eq 2 ]; then
+				echo "It appears that PostgreSQL has been upgraded independently of PBS Pro."
+				echo "The PBS Pro database must be manually upgraded. Please refer to the"
+				echo "instructions in the release notes for version @PBS_VERSION@ located here:"
+				echo "https://github.com/PBSPro/pbspro/releases"
+			else 
+				echo "Failed to upgrade PBS Datastore"
+			fi
 			exit $ret
 		else
 			#Remove old dataservice directory


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *OSS PBS failed to start daemons on postgres upgrade externally*
     This is a cherry-pick from 18.1 branch [PR-708](https://github.com/PBSPro/pbspro/pull/708)    
- If postgresql is upgraded and PBS database is not upgraded, PBS dataservice fails to start.
- To reproduce the issue, upgrade postgresql and restart PBS.

#### Testing logs/output

-  Testing logs attached as  below
[after_fix_test_log.txt](https://github.com/PBSPro/pbspro/files/2571825/after_fix_test_log.txt)
[before_fix_test_log.txt](https://github.com/PBSPro/pbspro/files/2571826/before_fix_test_log.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
