### PR TITLE
Fixing timed out issues in TestNodeBuckets by deleting sched log in setup 

### DIFF
--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -45,6 +45,11 @@ class TestNodeBuckets(TestFunctional):
 
     def setUp(self):
         TestFunctional.setUp(self)
+        day = time.strftime("%Y%m%d", time.localtime(time.time()))
+        filename = os.path.join(self.server.pbs_conf['PBS_HOME'],
+                                'sched_logs', day)
+        self.du.rm(path=filename, force=True, sudo=True, level=logging.DEBUG2)
+
         self.colors = \
             ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet']
         self.shapes = ['circle', 'square', 'triangle',


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Tests from node buckets were timing out. This was because the scheduler log files were huge and log_match() would take time to read them. 

#### Solution Description
In the test setup, we delete the scheduler log file. Therefore each tests starts with an empty sched log file.

#### Testing logs/output

[node_buckets_r7.txt](https://github.com/PBSPro/pbspro/files/2578556/node_buckets_r7.txt)
[node_buckets_s11_x32.txt](https://github.com/PBSPro/pbspro/files/2578557/node_buckets_s11_x32.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
