### PR TITLE
TestNodePartition fails due to incorrect node id

### DIFF
--- a/test/tests/interfaces/pbs_node_partition.py
+++ b/test/tests/interfaces/pbs_node_partition.py
@@ -43,7 +43,8 @@ class TestNodePartition(TestInterfaces):
     """
     Test suite to test partition attr for node
     """
-    host_name = socket.gethostname()
+    # Node id is MoM's short name
+    host_name = socket.gethostname().split('.')[0]
 
     def set_node_partition_attr(self, mgr_cmd="MGR_CMD_SET", n_name=host_name,
                                 partition="P1", user=ROOT_USER):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
TestNodePartition fails due to incorrect node id used in the tests.

#### Affected Platform(s)
* All 

#### Cause / Analysis / Design
FQDN is used as node id in manager calls to set partition attribute. But node ids are short names.

#### Solution Description
Use short names rather than FQDN so the node ids match

#### Testing logs/output
[beforefix.txt](https://github.com/PBSPro/pbspro/files/2590451/beforefix.txt)
[afterfix.txt](https://github.com/PBSPro/pbspro/files/2590455/afterfix.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__