### PR TITLE
Address cpuset platform gcc warnings

### DIFF
--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -8031,7 +8031,6 @@ pidcache_reset(pidcachetype_t *pidcache)
 {
 	struct dirent		*dent = NULL;
 	pid_t			pid = 0;
-	char			taskname[256] = {0};
 	int			ncantstat = 0;
 	FILE			*fd = NULL;
 	char			line[25] = {0};
@@ -8048,13 +8047,14 @@ pidcache_reset(pidcachetype_t *pidcache)
 		rewinddir(cpusetdir);
 
 	while (errno = 0, (dent = readdir(cpusetdir)) != NULL) {
+		char *taskname = NULL;
 		if (!isdigit(dent->d_name[0]))
 			continue;
-
-		sprintf(taskname, "%s/%s/tasks", cpusetfs, dent->d_name);
+		pbs_asprintf(&taskname, "%s/%s/tasks", cpusetfs, dent->d_name);
 
 		if ((fd = fopen(taskname, "r")) == NULL) {
 			ncantstat++;
+			free(taskname);
 			continue;
 		}
 
@@ -8063,6 +8063,7 @@ pidcache_reset(pidcachetype_t *pidcache)
 			if (pidcache_insert(pid, pidcache))
 				nprocs++;
 		}
+		free(taskname);
 		fclose(fd);
 	}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
*  PBS compilation on SLES15 cpuset platfrom complaining about follwoing warning message
/home/pbsbuild/build/pbspro/src/resmom/linux/mom_mach.c: In function ‘mom_get_sample’:
/home/pbsbuild/build/pbspro/src/resmom/linux/mom_mach.c:8054:27: error: ‘/tasks’ directive writing 6 bytes into a region of size between 0 and 255 [-Werror=format-overflow=]
   sprintf(taskname, "%s/%s/tasks", cpusetfs, dent->d_name);
                           ^~~~~~
/home/pbsbuild/build/pbspro/src/resmom/linux/mom_mach.c:8054:3: note: ‘sprintf’ output 8 or more bytes (assuming 263) into a destination of size 256
   sprintf(taskname, "%s/%s/tasks", cpusetfs, dent->d_name);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:857: pbs_mom-mom_mach.o] Error 1
make[1]: *** [Makefile:501: all-recursive] Error 1
make: *** [Makefile:537: all-recursive] Error 1
Build failed! 

#### Affected Platform(s)
* SLES-15 cpuset (GCC 7.3.1 )

#### Cause / Analysis / Design
* The destination was 256 char while we were copying 281 char to it 

#### Solution Description
* Updated code to use snprintf() instead of sprintf().
* Updated to make use of 230 bytes from dir_name instead of 256 chars.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
