### PR TITLE
fixes to job array wrt -o,-e,-R and direct write qsub options

### DIFF
--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -122,6 +122,7 @@ static enum job_atr attrs_to_copy[] = {
 	JOB_ATR_outpath,
 	JOB_ATR_priority,
 	JOB_ATR_qtime,
+	JOB_ATR_remove,
 	JOB_ATR_rerunable,
 	JOB_ATR_resource,
 	JOB_ATR_session_id,
@@ -779,6 +780,7 @@ create_subjob(job *parent, char *newjid, int *rc)
 #else
 	struct timeval	    tval;
 #endif
+	char tmp_path[MAXPATHLEN + 1] = {0};
 
 	if ((parent->ji_qs.ji_svrflags & JOB_SVFLG_ArrayJob) == 0) {
 		*rc = PBSE_IVALREQ;
@@ -892,6 +894,16 @@ create_subjob(job *parent, char *newjid, int *rc)
 		*rc = PBSE_IVALREQ;
 		return NULL;
 	}
+
+	psub = &subj->ji_wattr[JOB_ATR_outpath];
+	strncpy(tmp_path, psub->at_val.at_str, MAXPATHLEN);
+	job_attr_def[JOB_ATR_outpath].at_decode(psub, NULL, NULL,
+		subst_array_index(subj, tmp_path));
+
+	psub = &subj->ji_wattr[JOB_ATR_errpath];
+	strncpy(tmp_path, psub->at_val.at_str, MAXPATHLEN);
+	job_attr_def[JOB_ATR_errpath].at_decode(psub, NULL, NULL,
+		subst_array_index(subj, tmp_path));
 
 	*rc = PBSE_NONE;
 	return subj;

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -296,7 +296,6 @@ req_quejob(struct batch_request *preq)
 	int             rc;
 	int             sock = preq->rq_conn;
 	int             resc_access_perm_save;
-	char            namebuf[MAXPATHLEN+1];
 #ifndef PBS_MOM
 	int              set_project = 0;
 	int		 i;
@@ -310,10 +309,10 @@ req_quejob(struct batch_request *preq)
 	resource_def	*prdefplc;
 	resource	*presc;
 	conn_t		*conn;
-	attribute       temp_attr;
 #else
 	mom_hook_input_t  hook_input;
 	mom_hook_output_t hook_output;
+	char		namebuf[MAXPATHLEN+1];
 	int		hook_errcode = 0;
 	int		hook_rc = 0;
 	char		hook_buf[HOOK_MSG_SIZE];
@@ -884,12 +883,6 @@ req_quejob(struct batch_request *preq)
 						free(pj->ji_wattr[(int)JOB_ATR_outpath].at_val.at_str);
 						pj->ji_wattr[(int)JOB_ATR_outpath].at_val.at_str = result;
 					}
-				} else if (pj->ji_wattr[(int)JOB_ATR_outpath].at_val.at_str[l -1] == '/') {
-					namebuf[0] = 0;
-					spool_filename(pj, namebuf, JOB_STDOUT_SUFFIX);
-					temp_attr.at_flags |= ATR_VFLAG_SET;
-					temp_attr.at_val.at_str = namebuf;
-					set_str(&pj->ji_wattr[(int)JOB_ATR_outpath], &temp_attr, INCR);
 				}
 			}
 		}
@@ -910,12 +903,6 @@ req_quejob(struct batch_request *preq)
 						free(pj->ji_wattr[(int)JOB_ATR_errpath].at_val.at_str);
 						pj->ji_wattr[(int)JOB_ATR_errpath].at_val.at_str = result;
 					}
-				} else if (pj->ji_wattr[(int)JOB_ATR_errpath].at_val.at_str[l -1] == '/') {
-					namebuf[0] = 0;
-					spool_filename(pj, namebuf, JOB_STDERR_SUFFIX);
-					temp_attr.at_flags |= ATR_VFLAG_SET;
-					temp_attr.at_val.at_str = namebuf;
-					set_str(&pj->ji_wattr[(int)JOB_ATR_errpath], &temp_attr, INCR);
 				}
 			}
 		}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *There were issues related to sub job std outputs when used with -o/-e/-R/direct write (-koed) options for Job Array*
* *-R was not working for job array subjobs*
* *-o/-e the std files of all subjobs got overwritten to same file (regression from https://github.com/PBSPro/pbspro/pull/358 )*
* *direct write (-koed) was also making subjobs to overwrite std files to same file*

#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
* *Cause was due to flawed handling of JOB_ATR_outpath and JOB_ATR_errpath job attributes in server and mom*

#### Solution Description
* *Correct handling of JOB_ATR_outpath and JOB_ATR_errpath job attributes in server and mom*

#### Testing logs/output
[Test_report_logs.zip](https://github.com/PBSPro/pbspro/files/2603023/Test_report_logs.zip)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
