### PR TITLE
TPP's use of MT-unsafe function netaddr() causes intermittent failures in name resolution

### DIFF
--- a/src/lib/Libtpp/tpp_common.h
+++ b/src/lib/Libtpp/tpp_common.h
@@ -48,6 +48,8 @@ extern "C" {
 #include <limits.h>
 #include <time.h>
 #include <pthread.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <errno.h>
 
 #include "avltree.h"
@@ -498,6 +500,7 @@ int tpp_sock_resolve_ip(tpp_addr_t *addr, char *host, int len);
 tpp_addr_t *tpp_sock_resolve_host(char *host, int *count);
 
 char *tpp_netaddr(tpp_addr_t *);
+char *tpp_netaddr_sa(struct sockaddr *);
 
 extern void (*tpp_log_func)(int level, const char *id, char *mess); /* log function */
 

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -1563,7 +1563,7 @@ work(void *v)
 	em_event_t *events;
 	phy_conn_t *conn;
 	int slot_state;
-	struct sockaddr_in clientaddr;
+	struct sockaddr clientaddr;
 	int new_connection = 0;
 	int timeout, timeout2;
 	time_t now;
@@ -1765,8 +1765,8 @@ work(void *v)
 				return NULL;
 			}
 			conn->conn_params->auth_type = auth_type;
-			conn->conn_params->hostname = strdup(netaddr((struct sockaddr_in *) &clientaddr));
-			conn->conn_params->port = ntohs(clientaddr.sin_port);
+			conn->conn_params->hostname = strdup(tpp_netaddr_sa(&clientaddr));
+			conn->conn_params->port = ntohs(((struct sockaddr_in *) &clientaddr)->sin_port);
 
 			/**
 			 *  accept socket, and add socket to stream, assign stream to

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -1647,6 +1647,42 @@ tpp_netaddr(tpp_addr_t *ap)
 	return ptr->tppstaticbuf;
 }
 
+/**
+ * @brief return a human readable string representation of an address
+ *        for either an ipv4 or ipv6 address
+ *
+ * @param[in] sa - address in sockaddr format
+ *
+ * @return  - string representation of address
+ *            (uses TLS area to make it easy and yet thread safe)
+ *
+ * @par MT-safe: Yes
+ **/
+char *
+tpp_netaddr_sa(struct sockaddr *sa)
+{
+	tpp_tls_t *ptr;
+	int len = TPP_LOGBUF_SZ;
+
+	ptr = tpp_get_tls();
+	if (!ptr) {
+		fprintf(stderr, "Out of memory\n");
+		exit(1);
+	}
+	ptr->tppstaticbuf[0] = '\0';
+
+#ifdef WIN32
+	WSAAddressToString((LPSOCKADDR)&sa, sizeof(struct sockaddr), NULL, (LPSTR)&ptr->tppstaticbuf, &len);
+#else
+	if (sa->sa_family == AF_INET)
+		inet_ntop(sa->sa_family, &(((struct sockaddr_in *) sa)->sin_addr), ptr->tppstaticbuf, len);
+	else
+		inet_ntop(sa->sa_family, &(((struct sockaddr_in6 *) sa)->sin6_addr), ptr->tppstaticbuf, len);
+#endif
+
+	return ptr->tppstaticbuf;
+}
+
 /*
  * Convenience function to delete information about a router
  */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* The netaddr() function in rpp.c is not tread safe (since it uses a static variable). The primary daemon threads (and other single threaded binaries like commands etc)  uses this function and it is safe as long as it is not used simultaneously by multiple thread. The TPP thread typically uses a thread safe function called tpp_netaddr() (implemented inside tpp library). However, it had escaped earlier checks that at one particular (frequently used place) the tpp thread calls the netaddr() function in rpp.c. This usage can wrongly alter the contents of the static buffer inside that function and lead to ihighly intermittent failures in name resolution handling in PBS. The bug is difficult to reproduce and thus must be evaluated via code inspection.

#### Affected Platform(s)
* *All platforms*

#### Solution Description
* implement an tpp_netaddr_sa (sa for sockaddr) to handle the required type of parameter and use that in tpp_transport.c. This way the netaddr() function is only used by the main threads of the process and never by any other thread (TPP only today).

#### Testing logs/output
* Since the corruption in the IP address is intermittent, it is difficult to reproduce this, but this has shown up at various users installations. The verification of this change has to be based on code inspection and the CI tests.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
