### PR TITLE
qrun hangs indefinitely

### DIFF
--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2097,8 +2097,7 @@ try_db_again:
 
 					psched->sch_next_schedule = time_now +
 							psched->sch_attr[(int)	SCHED_ATR_schediteration].at_val.at_long;
-					if (psched->sch_attr[SCHED_ATR_scheduling].at_val.at_long &&
-							(schedule_jobs(psched) == 0) && (svr_unsent_qrun_req))
+					if ((schedule_jobs(psched) == 0) && (svr_unsent_qrun_req))
 						svr_unsent_qrun_req = 0;
 				}
 			}


### PR DESCRIPTION
#### Bug/feature Description
- If we submit "qrun jobid" immediately after disabling "scheduling = 0", that request may processed in existing scheduling cycle. In case the job was unable to run because of some reason (like Not Running: Not enough free nodes available) then qrun hangs.

#### Affected Platform(s)
-All Linux platform OS

#### Cause / Analysis / Design
- After job comment modification, another scheduler cycle is not started as we are checking there whether "scheduling" is enabled.

#### Solution Description
- If there are any qrun request in server deffered list, it should start another scheduling cycle, irrespective of "scheduling" is enabled.

#### Testing logs/output
* *Please attach your test log output from running the test you added (or from existing tests that cover your changes)*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
