### PR TITLE
Failures in TestResvEndHook 

### DIFF
--- a/test/tests/functional/pbs_resv_end_hook.py
+++ b/test/tests/functional/pbs_resv_end_hook.py
@@ -586,9 +586,11 @@ if e.type == pbs.RESV_END:
 
         self.scheduler.stop()
 
-        offset = 10
-        duration = 10
+        offset = 40
+        duration = 60
         rid = self.submit_resv(offset, duration)
+        exp_attr = {'reserve_state': (MATCH_RE, "RESV_UNCONFIRMED|1")}
+        self.server.expect(RESV, exp_attr, id=rid)
 
         self.server.delete(rid)
         msg = 'Hook;Server@%s;Reservation ID - %s' % \

--- a/test/tests/functional/pbs_resv_end_hook.py
+++ b/test/tests/functional/pbs_resv_end_hook.py
@@ -122,7 +122,7 @@ if e.type == pbs.RESV_END:
 
         self.server.delete(rid)
         msg = 'Hook;Server@%s;Reservation ID - %s' % \
-              (self.server.hostname.lower(), rid)
+              (self.server.shortname, rid)
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
 
     def test_delete_degraded_resv(self):
@@ -148,7 +148,7 @@ if e.type == pbs.RESV_END:
 
         self.server.delete(rid)
         msg = 'Hook;Server@%s;Reservation ID - %s' % \
-              (self.server.hostname.lower(), rid)
+              (self.server.shortname, rid)
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
 
     def test_server_down_case_1(self):
@@ -174,7 +174,7 @@ if e.type == pbs.RESV_END:
         self.server.delete(rid)
 
         msg = 'Hook;Server@%s;Reservation ID - %s' % \
-              (self.server.hostname.lower(), rid)
+              (self.server.shortname, rid)
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
 
     @timeout(300)
@@ -202,7 +202,7 @@ if e.type == pbs.RESV_END:
         self.server.start()
 
         msg = 'Hook;Server@%s;Reservation ID - %s' % \
-              (self.server.hostname.lower(), rid)
+              (self.server.shortname, rid)
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
 
     @timeout(240)
@@ -228,7 +228,7 @@ if e.type == pbs.RESV_END:
         time.sleep(30)
 
         msg = 'Hook;Server@%s;Reservation ID - %s' % \
-              (self.server.hostname.lower(), rid)
+              (self.server.shortname, rid)
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
 
     def test_delete_advance_resv_with_jobs(self):
@@ -264,7 +264,7 @@ if e.type == pbs.RESV_END:
 
         self.server.delete(rid)
         msg = 'Hook;Server@%s;Reservation ID - %s' % \
-              (self.server.hostname.lower(), rid)
+              (self.server.shortname, rid)
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
 
     @timeout(240)
@@ -300,7 +300,7 @@ if e.type == pbs.RESV_END:
         time.sleep(30)
 
         msg = 'Hook;Server@%s;Reservation ID - %s' % \
-              (self.server.hostname.lower(), rid)
+              (self.server.shortname, rid)
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
 
     def test_set_attrs(self):
@@ -333,7 +333,7 @@ if e.type == pbs.RESV_END:
         self.server.delete(rid)
         msg = 'Svr;Server@%s;PBS server internal error (15011) in Error ' \
               'evaluating Python script, attribute '"'resources_used'"' is ' \
-              'part of a readonly object' % self.server.hostname.lower()
+              'part of a readonly object' % self.server.shortname
         self.server.log_match(msg, tail=True, max_attempts=30, interval=2)
 
     @timeout(300)
@@ -361,7 +361,7 @@ if e.type == pbs.RESV_END:
         time.sleep(30)
 
         msg = 'Hook;Server@%s;Reservation occurrence - 1' % \
-              self.server.hostname.lower()
+              self.server.shortname
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
         self.logger.info('Reservation end hook ran for first occurrence of '
                          'a standing reservation')
@@ -372,7 +372,7 @@ if e.type == pbs.RESV_END:
 
         self.server.delete(rid)
         msg = 'Hook;Server@%s;Reservation occurrence - 2' % \
-              self.server.hostname.lower()
+              self.server.shortname
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
 
     @timeout(300)
@@ -401,7 +401,7 @@ if e.type == pbs.RESV_END:
         time.sleep(30)
 
         msg = 'Hook;Server@%s;Reservation occurrence - 1' % \
-              self.server.hostname.lower()
+              self.server.shortname
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
         self.logger.info('Reservation end hook ran for first occurrence of a '
                          'standing reservation')
@@ -415,7 +415,7 @@ if e.type == pbs.RESV_END:
         self.server.expect(RESV, attrs, id=rid, attrop=PTL_AND)
 
         msg = 'Hook;Server@%s;Reservation occurrence - 2' % \
-              self.server.hostname.lower()
+              self.server.shortname
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
         self.logger.info('Reservation end hook ran for second occurrence of a'
                          ' standing reservation')
@@ -456,7 +456,7 @@ if e.type == pbs.RESV_END:
         time.sleep(30)
 
         msg = 'Hook;Server@%s;Reservation occurrence - 1' % \
-              self.server.hostname.lower()
+              self.server.shortname
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
         self.logger.info('Reservation end hook ran for first occurrence of a '
                          'standing reservation')
@@ -467,7 +467,7 @@ if e.type == pbs.RESV_END:
 
         self.server.delete(rid)
         msg = 'Hook;Server@%s;Reservation occurrence - 2' % \
-              self.server.hostname.lower()
+              self.server.shortname
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
 
     @timeout(300)
@@ -505,7 +505,7 @@ if e.type == pbs.RESV_END:
         time.sleep(30)
 
         msg = 'Hook;Server@%s;Reservation occurrence - 1' % \
-              self.server.hostname.lower()
+              self.server.shortname
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
         self.logger.info('Reservation end hook ran for first occurrence of a '
                          'standing reservation')
@@ -519,7 +519,7 @@ if e.type == pbs.RESV_END:
         self.server.expect(RESV, attrs, id=rid, attrop=PTL_AND)
 
         msg = 'Hook;Server@%s;Reservation occurrence - 2' % \
-              self.server.hostname.lower()
+              self.server.shortname
         self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
         self.logger.info('Reservation end hook ran for second occurrence of a '
                          'standing reservation')
@@ -547,7 +547,7 @@ if e.type == pbs.RESV_END:
         new_rid = self.submit_resv(offset, duration)
 
         msg = 'Hook;Server@%s;Reservation ID - %s' % \
-              (self.server.hostname.lower(), new_rid)
+              (self.server.shortname, new_rid)
         self.server.log_match(msg, tail=True, max_attempts=10,
                               existence=False)
 
@@ -563,7 +563,7 @@ if e.type == pbs.RESV_END:
 
         self.scheduler.stop()
 
-        offset = 10
+        offset = 40
         duration = 30
         rid = self.submit_resv(offset, duration)
 
@@ -571,7 +571,7 @@ if e.type == pbs.RESV_END:
         time.sleep(30)
 
         msg = 'Hook;Server@%s;Reservation ID - %s' % \
-              (self.server.hostname.lower(), rid)
+              (self.server.shortname, rid)
         self.server.log_match(msg, tail=True, max_attempts=10,
                               existence=False)
 
@@ -587,13 +587,13 @@ if e.type == pbs.RESV_END:
         self.scheduler.stop()
 
         offset = 40
-        duration = 60
+        duration = 30
         rid = self.submit_resv(offset, duration)
         exp_attr = {'reserve_state': (MATCH_RE, "RESV_UNCONFIRMED|1")}
         self.server.expect(RESV, exp_attr, id=rid)
 
         self.server.delete(rid)
         msg = 'Hook;Server@%s;Reservation ID - %s' % \
-              (self.server.hostname.lower(), rid)
+              (self.server.shortname, rid)
         self.server.log_match(msg, tail=True, max_attempts=10,
                               existence=False)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
- test_scheduler_down_case_2 of TestResvEndHook failing with 'pbs_rsub: Bad time specification(s)'
Issue ID: [PP-1294](https://pbspro.atlassian.net/browse/PP-1294)
- Fixed server log message to have host's shortname rather than the FQDN 
Issue ID: [PP-1286](https://pbspro.atlassian.net/browse/PP-1286)

#### Affected Platform(s)
All

#### Cause / Analysis / Design
The reservation start time in the test goes past the current time on some test machines and hence the reservation fails with the above error message. In some slow test machines a offset of 10 sec (from current time) is not sufficient. This happens in tests test_scheduler_down_case_1 and test_scheduler_down_case_2.
The log messages created in the test ,( for example "Hook;Server@x19-64-sles11-altix.pbspro.com;Reservation") use FQDN of the host, while the server log prints short names. This mismatch causes tests to fail.

#### Solution Description
-- Start reservation after 40 sec (instead of 10 sec) from the current time to accommodate time spent on statements before reservation submit.  This will avoid race conditions in slower test machines. Also increased the reservation duration.
Applying the same fix to test_scheduler_down_case_1 and test_scheduler_down_case_2. Both the tests stop the scheduler before reservation submit. An offset of 40 sec will prevent any race condition due to time taken for scheduler stop operation. 
-- Change FQDN to short names of the host so the server log messages match

#### Testing logs/output
[afterfix.txt](https://github.com/PBSPro/pbspro/files/2612889/afterfix.txt)
[beforefix.txt](https://github.com/PBSPro/pbspro/files/2612890/beforefix.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__