### PR TITLE
Unsupported usage of qsub should throw error

### DIFF
--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -1,0 +1,113 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestQsubOptionsArguments(TestFunctional):
+    """
+    validate qsub submission with a script and executable.
+    note: The no-arg test is an interactive job, which is tested in
+    SmokeTest.test_interactive_job
+    """
+    fn = None
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        script = '/bin/hostname'
+        self.fn = self.du.create_temp_file(body=script)
+        self.qsub_cmd = os.path.join(
+            self.server.pbs_conf['PBS_EXEC'], 'bin', 'qsub')
+
+    def test_qsub_with_script_executable(self):
+        """
+        submit a job with a script and executable
+        """
+        cmd = [self.qsub_cmd, self.fn, '--',  '/bin/sleep 10']
+        rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        failed = rv['rc'] == 2 and rv['err'][0].split(' ')[0] == 'usage:'
+        self.assertTrue(failed, 'qsub should have failed, but did not fail')
+
+    def test_qsub_with_script_dashes(self):
+        """
+        submit a job with a script and dashes
+        """
+        cmd = [self.qsub_cmd, self.fn, '--']
+        rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        failed = rv['rc'] == 2 and rv['err'][0].split(' ')[0] == 'usage:'
+        self.assertTrue(failed, 'qsub should have failed, but did not fail')
+
+    def test_qsub_with_dashes(self):
+        """
+        submit a job with only dashes
+        """
+        cmd = [self.qsub_cmd, '--']
+        rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        failed = rv['rc'] == 2 and rv['err'][0].split(' ')[0] == 'usage:'
+        self.assertTrue(failed, 'qsub should have failed, but did not fail')
+
+    def test_qsub_with_script(self):
+        """
+        submit a job with only a script
+        """
+        cmd = [self.qsub_cmd, self.fn]
+        rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        self.assertEquals(rv['rc'], 0, 'qsub failed')
+
+    def test_qsub_with_executable(self):
+        """
+        submit a job with only an executable
+        """
+        cmd = [self.qsub_cmd, '--', '/bin/sleep 10']
+        rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        self.assertEquals(rv['rc'], 0, 'qsub failed')
+
+    def test_qsub_with_option_executable(self):
+        """
+        submit a job with an option and executable
+        """
+        cmd = [self.qsub_cmd, '-V', '--', '/bin/sleep', '10']
+        rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        self.assertEquals(rv['rc'], 0, 'qsub failed')
+
+    def test_qsub_with_option_script(self):
+        """
+        submit a job with an option and script
+        """
+        cmd = [self.qsub_cmd, '-V', self.fn]
+        rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        self.assertEquals(rv['rc'], 0, 'qsub failed')


### PR DESCRIPTION
#### Bug/feature Description
* Using qsub with both a script and executable should fail.
* Currently, it does not.

#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* qsub's usage says `qsub ... [script | -- command [arg1 ...]]`
* getopt would rearrange argv to put all of the options before the non-options. This would include `--`.
* If someone put both, it would move the `--` before the script, leading qsub to believe that the script is actually an executable with arguments.
* getopt returns the index of the first non-option.

#### Solution Description
* Before calling getopt, make a copy of argv. After calling getopt, if the string at the index of the first non-option is different between the copy and the original, then getopt must have changed the order.
* The only reason why getopt would change the order is that there was an argument before the `--`. The usage says this is unsupported, and we return an error.
* PBS_GNU_GETOPTS never gets defined, so I have removed the dead code. PBS_GNU_GETOPTS used to get defined by the configure script by compiling a little .c program and checking the return code, but from looking at it, I don't think it tested the option correctly.

#### Testing logs/output
[my_version_windows.txt](https://github.com/PBSPro/pbspro/files/2622308/my_version_windows.txt)
[after_linux.txt](https://github.com/PBSPro/pbspro/files/2622309/after_linux.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
