### PR TITLE
missing argument to the function in pbs_cgroups_stress.py test

### DIFF
--- a/test/tests/performance/pbs_cgroups_stress.py
+++ b/test/tests/performance/pbs_cgroups_stress.py
@@ -132,7 +132,7 @@ class TestCgroupsStress(TestPerformance):
         # Restart mom so exechost_startup hook is run
         self.mom.signal('-HUP')
 
-    def get_paths():
+    def get_paths(self):
         """
         Returns a dictionary containing the location where each cgroup
         is mounted.


### PR DESCRIPTION

#### Bug/feature Description
* *Bugs: missing argument to the function which was causing failure on some platforms*

#### Affected Platform(s)
* *Platform (SLES11)*

#### Cause / Analysis / Design
* *Bugs: updated function by passing 'self' as default*

#### Solution Description
* *updated function by passing 'self' as default*

#### Testing logs/output
* *
[afterfix.txt](https://github.com/PBSPro/pbspro/files/2623432/afterfix.txt)
[beforefix.txt](https://github.com/PBSPro/pbspro/files/2623433/beforefix.txt)

*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [ ] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__