### PR TITLE
Handle rpmlint warns: non-conffile-in-etc, non-executable-script,expl…

### DIFF
--- a/pbspro-rpmlintrc
+++ b/pbspro-rpmlintrc
@@ -1,4 +1,6 @@
 # IGNORE: The following are purposely suppressed.
+addFilter("dir-or-file-in-opt")
+addFilter("non-executable-script")
 addFilter("non-standard-executable-perm .*pbs_iff")
 addFilter("setuid-binary .*pbs_iff")
 addFilter("non-standard-executable-perm .*pbs_rcp")

--- a/pbspro.spec
+++ b/pbspro.spec
@@ -149,13 +149,11 @@ Conflicts: pbs-mom
 Conflicts: pbs-cmds
 Requires: bash
 Requires: expat
-Requires: libedit
 Requires: postgresql-server
 Requires: python >= 2.6
 Requires: python < 3.0
 Requires: tcl
 Requires: tk
-Requires: zlib
 %if %{defined suse_version}
 Requires: smtp_daemon
 %if %{suse_version} >= 1500
@@ -166,7 +164,6 @@ Requires: libical1
 %endif
 %else
 Requires: smtpdaemon
-Requires: libical
 %endif
 Autoreq: 1
 
@@ -194,7 +191,6 @@ Requires: bash
 Requires: expat
 Requires: python >= 2.6
 Requires: python < 3.0
-Requires: zlib
 %if 0%{?suse_version} >= 1500
 Requires: hostname
 %endif
@@ -421,6 +417,7 @@ fi
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
+%config(noreplace) %{_sysconfdir}/profile.d/*
 %if %{defined have_systemd}
 %attr(644, root, root) %{_unitdir}/pbs.service
 %else
@@ -437,6 +434,7 @@ fi
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
+%config(noreplace) %{_sysconfdir}/profile.d/*
 %if %{defined have_systemd}
 %attr(644, root, root) %{_unitdir}/pbs.service
 %else
@@ -470,6 +468,7 @@ fi
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
+%config(noreplace) %{_sysconfdir}/profile.d/*
 %exclude %{pbs_prefix}/bin/mpiexec
 %exclude %{pbs_prefix}/bin/pbs_attach
 %exclude %{pbs_prefix}/bin/pbs_tmrsh

--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -149,13 +149,11 @@ Conflicts: pbs-mom
 Conflicts: pbs-cmds
 Requires: bash
 Requires: expat
-Requires: libedit
 Requires: postgresql-server
 Requires: python >= 2.6
 Requires: python < 3.0
 Requires: tcl
 Requires: tk
-Requires: zlib
 %if %{defined suse_version}
 Requires: smtp_daemon
 %if %{suse_version} >= 1500
@@ -166,7 +164,6 @@ Requires: libical1
 %endif
 %else
 Requires: smtpdaemon
-Requires: libical
 %endif
 Autoreq: 1
 
@@ -194,7 +191,6 @@ Requires: bash
 Requires: expat
 Requires: python >= 2.6
 Requires: python < 3.0
-Requires: zlib
 %if 0%{?suse_version} >= 1500
 Requires: hostname
 %endif
@@ -405,6 +401,7 @@ fi
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
+%config(noreplace) %{_sysconfdir}/profile.d/*
 %if %{defined have_systemd}
 %attr(644, root, root) %{_unitdir}/pbs.service
 %else
@@ -421,6 +418,7 @@ fi
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
+%config(noreplace) %{_sysconfdir}/profile.d/*
 %if %{defined have_systemd}
 %attr(644, root, root) %{_unitdir}/pbs.service
 %else
@@ -454,6 +452,7 @@ fi
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
+%config(noreplace) %{_sysconfdir}/profile.d/*
 %exclude %{pbs_prefix}/bin/mpiexec
 %exclude %{pbs_prefix}/bin/pbs_attach
 %exclude %{pbs_prefix}/bin/pbs_tmrsh


### PR DESCRIPTION
Handle rpmlint warnings on PBS RPMs dealing with: non-executable-script, explicit-lib-dependency, non-conffile-in-etc, dir-or-file-in-opt.
#### Bug/feature Description
* *rpmlint "non-executable-script" warnings, for example,
  pbspro-server.x86_64: E: non-executable-script /opt/pbs/lib/MPI/pbsrun.ch_mx.init.in 0644L /bin/sh
* *rpmlint "explicit-lib-dependency" warnings, for example,
pbspro-execution.x86_64: E: explicit-lib-dependency zlib
* *rpmlint "non-conffile-in-etc" warnings, for example,
pbspro-execution.x86_64: W: non-conffile-in-etc /etc/profile.d/pbs.sh
* *rpmlint "dir-or-file-in-opt"
#### Affected Platform(s)
* *Linux/Unix
#### Cause / Analysis / Design / Solution
* Suppress the warnings "non-executable-script' as it relates to files that are shipped with PBS used for pre-processing mpiruns in PBS. 
* Handle the warnings "explicit-lib-dependency" by removing the Require* items as RPM manage library dependencies internally and does not need them listed as a Requires: line in the spec file
* Fix the warnings  "non-conffile-in-etc" by making use of %config(noreplace), where if the file exists locally in the system, then it won't get over-written but instead another file with a *.rpmnew prefix is used instead. 
* *Suppress "dir-or-file-in-opt" as PBS Pro is currently packaged as an ISV application. When packaging for Linux vendor repositories, a different prefix will be used and this error should disappear.


#### Testing logs/output
* Before rpmlint -f pbspro-rpmlintrc run:
[rpmlint.bef.txt](https://github.com/PBSPro/pbspro/files/2635286/rpmlint.bef.txt)
* After rpmlint -f pbspro-rpmlintrc run using the new PBS:
[rpmlint.aft3.txt](https://github.com/PBSPro/pbspro/files/2635287/rpmlint.aft3.txt)
* The diffs:
[rpmlint.diffs.txt](https://github.com/PBSPro/pbspro/files/2635288/rpmlint.diffs.txt)
* Additional testing logs:

[rpmlint.aft7.txt](https://github.com/PBSPro/pbspro/files/2646544/rpmlint.aft7.txt)
[rpmlint.bef_aft7.diffs.txt](https://github.com/PBSPro/pbspro/files/2646545/rpmlint.bef_aft7.diffs.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
