### PR TITLE
increase the default timeout for PTL tests

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -133,6 +133,7 @@ SMOKE = 'smoke'
 REGRESSION = 'regression'
 NUMNODES = 'numnodes'
 TIMEOUT_KEY = '__testcase_timeout__'
+MINIMUM_TESTCASE_TIMEOUT = 600
 
 
 def skip(reason="Skipped test execution"):
@@ -155,7 +156,18 @@ def timeout(val):
     """
     Decorator to set timeout value of test case
     """
+    logger = logging.getLogger(__name__)
+    old_val = None
+    if val < MINIMUM_TESTCASE_TIMEOUT:
+        old_val = val
+        val = MINIMUM_TESTCASE_TIMEOUT
+
     def wrapper(obj):
+        msg = 'for test ' + obj.func_name
+        msg += ' minimum-testcase-timeout updated to '
+        msg += str(val) + ' from ' + str(old_val)
+        if old_val:
+            logger.info(msg)
         setattr(obj, TIMEOUT_KEY, int(val))
         return obj
     return wrapper
@@ -564,7 +576,7 @@ class PBSTestSuite(unittest.TestCase):
         cls._validate_param('revert-queues')
         cls._validate_param('revert-resources')
         if 'default-testcase-timeout' not in cls.conf.keys():
-            cls.conf['default_testcase_timeout'] = 180
+            cls.conf['default_testcase_timeout'] = MINIMUM_TESTCASE_TIMEOUT
         else:
             cls.conf['default_testcase_timeout'] = int(
                 cls.conf['default-testcase-timeout'])

--- a/test/tests/selftest/pbs_default_timeout.py
+++ b/test/tests/selftest/pbs_default_timeout.py
@@ -1,0 +1,110 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.selftest import *
+from ptl.utils.plugins.ptl_test_runner import TimeOut
+
+
+class TestDefaultTimeout(TestSelf):
+    """
+    Test suite to verify increase default testcase timeout working properly.
+    """
+
+    def test_default_timeout(self):
+        """
+        Verify that test not timedout after 180 sec.
+        i.e. after previous default timeout value
+        """
+        try:
+            mssg = 'sleeping for %ssec and minimum-testcase-timeout is %ssec' \
+                   % (MINIMUM_TESTCASE_TIMEOUT/2, MINIMUM_TESTCASE_TIMEOUT)
+            self.logger.info(mssg)
+            time.sleep(MINIMUM_TESTCASE_TIMEOUT/2)
+        except TimeOut as e:
+            mssg = 'Timed out after %s second' % MINIMUM_TESTCASE_TIMEOUT
+            err_mssg = 'The test timed out for an incorrect timeout duration'
+            self.assertEqual(mssg, e.message, err_mssg)
+
+    def test_timeout_greater_default_value(self):
+        """
+        Verify that test timedout after 600 sec.
+        """
+        try:
+            mssg = 'sleeping for %ssec and minimum-testcase-timeout is %ssec' \
+                   % (MINIMUM_TESTCASE_TIMEOUT+1, MINIMUM_TESTCASE_TIMEOUT)
+            self.logger.info(mssg)
+            time.sleep(MINIMUM_TESTCASE_TIMEOUT+1)
+        except TimeOut as e:
+            mssg = 'Timed out after %s second' % MINIMUM_TESTCASE_TIMEOUT
+            err_mssg = 'The test timed out for an incorrect timeout duration'
+            self.assertEqual(mssg, e.message, err_mssg)
+        else:
+            msg = 'Test did not timeout after the min. timeout period of %d' \
+                  % MINIMUM_TESTCASE_TIMEOUT
+            self.fail(msg)
+
+    @timeout(200)
+    def test_timeout_decorator_less_default_value(self):
+        """
+        If timeout decorator value is less than 600 then
+        default testcase timeout is considered
+        """
+        try:
+            mssg = 'sleeping for %ssec and minimum-testcase-timeout is %ssec' \
+                   % (MINIMUM_TESTCASE_TIMEOUT/2, MINIMUM_TESTCASE_TIMEOUT)
+            self.logger.info(mssg)
+            time.sleep(MINIMUM_TESTCASE_TIMEOUT/2)
+        except TimeOut as e:
+            mssg = 'Timed out after %s second' % MINIMUM_TESTCASE_TIMEOUT
+            err_mssg = 'The test timed out for an incorrect timeout duration'
+            self.assertEqual(mssg, e.message, err_mssg)
+
+    @timeout(800)
+    def test_timeout_decorator_greater_default_value(self):
+        """
+        If timeout decorator value is greater than 600 then
+        testcase timeout value consider as timeout decorator value
+        """
+        try:
+            mssg = 'sleeping for %ssec and minimum-testcase-timeout is %ssec' \
+                   % (MINIMUM_TESTCASE_TIMEOUT+1, 800)
+            self.logger.info(mssg)
+            time.sleep(MINIMUM_TESTCASE_TIMEOUT+1)
+        except TimeOut as e:
+            mssg = 'Timed out after 800 second'
+            err_mssg = 'The test timed out for an incorrect timeout duration'
+            self.assertEqual(mssg, e.message, err_mssg)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Increase the default timeout for PTL tests to 600sec.
* [PP-1047](https://pbspro.atlassian.net/browse/PP-1047)*

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* sometime if setup takes longer time in some tests where there are too many jobs or nodes to cleanup then it affects test execution time. default time for each test case execution is 180sec including setUp and tearDown. If setUp and test execution is not completed in 180sec then test got timeout.

#### Solution Description
* Increase the default timeout for PTL tests to 600sec. if timeout decorator have value less than 600sec(Default testcase timeout) then PTL consider testcase timeout value as Default testcase timeout otherwise consider value provided by decorator. 

#### Testing logs/output
* [res_TestDefaultTimeout.txt](https://github.com/PBSPro/pbspro/files/2648964/res_TestDefaultTimeout.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
