### PR TITLE
Fix test test_last_pset_can_never_run

### DIFF
--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -921,8 +921,7 @@ class TestNodeBuckets(TestFunctional):
         a = {'resources_available.ncpus': 80,
              'resources_available.bar': 'large'}
         self.server.create_vnodes(name='vnode', attrib=a, num=8,
-                                  mom=self.mom, sharednode=False,
-                                  expect=False)
+                                  mom=self.mom, sharednode=False)
         self.scheduler.add_resource('foo')
         a['resources_available.foo'] = 8
         a['resources_available.ncpus'] = 8


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
In test test_last_pset_can_never_run, for server.create_vnodes() expect was set to false. Because of this test continued before the nodes were created and failed with error- node not found.

#### Solution Description
Remove expect=False from server.create_vnodes()

#### Testing logs/output
[test_last_pset_can_never_run.txt](https://github.com/PBSPro/pbspro/files/2651521/test_last_pset_can_never_run.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
