### PR TITLE
Insufficient privileges causes Test_explicit_psets to fail

### DIFF
--- a/test/tests/functional/pbs_only_explicit_psets.py
+++ b/test/tests/functional/pbs_only_explicit_psets.py
@@ -49,7 +49,7 @@ class Test_explicit_psets(TestFunctional):
         Set the attributes 'only_explicit_psets', 'do_not_span_psets'
         to True and create 'foo' host resource.
         """
-
+        TestFunctional.setUp(self)
         sched_qmgr_attr = {'do_not_span_psets': 'True',
                            'only_explicit_psets': 'True'}
         self.server.manager(MGR_CMD_SET, SCHED, sched_qmgr_attr)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
   Insufficient privileges to set sched attributes causes test_only_explicit_psets in pbs_only_explicit_psets.py fail
*  [PP-1172](https://pbspro.atlassian.net/browse/PP-1172)

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
The sched attributes, 'only_explicit_psets' and 'do_not_span_psets can be set only by managers and operators. The test user is not added to the managers list and hence test fails when attempting to set  these attributes.

#### Solution Description
Call TestFunctional.setUp() so the test user is added to the managers' list. 

#### Testing logs/output
[afterfix_explicit_psets.txt](https://github.com/PBSPro/pbspro/files/2665484/afterfix_explicit_psets.txt)
[beforefix_explicit_psets.txt](https://github.com/PBSPro/pbspro/files/2665485/beforefix_explicit_psets.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__