### PR TITLE
TestFairshare.test_pbsfs fails intermittently

### DIFF
--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -338,7 +338,8 @@ class TestFairshare(TestFunctional):
 
         self.scheduler.set_fairshare_usage(TEST_USER1, 50)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'},
+                            expect=True)
         J3 = Job(TEST_USER)
         jid3 = self.server.submit(J3)
         J4 = Job(TEST_USER1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* The test fails intermittently as follows:
2018-09-16 12:24:25,447 INFO manager on x43-64-sles11sp3: set server {'scheduling': 'True'}
2018-09-16 12:24:25,447 INFOCLI x43-64-sles11sp3: /opt/pbs/bin/qmgr -c set server scheduling=True
2018-09-16 12:24:26,395 INFO scheduler x43-64-sles11sp3 log match: searching for "Leaving Scheduling Cycle"... OK

**Traceback (most recent call last):
File "/home/pbsroot/TEST/tmp/PBSPro_18.2.2/tests/functional/pbs_fairshare.py", line 356, in test_pbsfs
self.assertEqual(job_order[i].split('.')[0], c.political_order[i])
IndexError: list index out of range**

#### Affected Platform(s)
* All Linux

#### Cause / Analysis / Design
* It's hard to reproduce this, but there's a race condition w.r.t turning scheduling off and submitting jobs 3 and 4 which can cause this. The test doesn't verify that the scheduler is idle before submitting the jobs, so if a sched cycle was active when the jobs were submitted, it might run just one of them in the current cycle, then run the other job when the test turns scheduling on again. This means that 'c.political_order[i]' will throw an index error for job4, which is the error that was observed.


#### Solution Description
* set 'expect=True' when turning scheduling off

#### Testing logs/output
* [testpbsfs.log](https://github.com/PBSPro/pbspro/files/2666938/testpbsfs.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
