### PR TITLE
Race conditions in PTL tests when using manager()

### DIFF
--- a/test/tests/selftest/pbs_expect.py
+++ b/test/tests/selftest/pbs_expect.py
@@ -36,6 +36,8 @@
 # trademark licensing policies.
 
 from tests.selftest import *
+from StringIO import StringIO
+import logging
 
 
 class TestExpect(TestSelf):
@@ -56,3 +58,36 @@ class TestExpect(TestSelf):
         # Set other attributes normally
         a = {'enabled': 'True', 'started': 'True', 'priority': 150}
         self.server.manager(MGR_CMD_SET, QUEUE, a, 'expressq', expect=True)
+
+    def test_unsupported_operator(self):
+        """
+        Test that expect can handle unsupported operators correctly
+        """
+        # Add a new log handler which writes into a StringIO buffer
+        logbuffer = StringIO()
+        ptllogger = logging.getLogger('ptl')
+        temploghandler = logging.StreamHandler(logbuffer)
+        tempfmt = logging.Formatter("%(message)s")
+        temploghandler.setFormatter(tempfmt)
+        ptllogger.addHandler(temploghandler)
+        ptllogger.propagate = True
+
+        # Call manager on an unsupported operator (INCR)
+        # As expect is done automatically for set operations,
+        # we should see a log message for unsupported operator
+        manager = str(MGR_USER) + '@*'
+        rc = self.server.manager(MGR_CMD_SET, SERVER,
+                                 {'managers': (INCR, manager)}, sudo=True)
+        self.assertEqual(rc, 0)
+        ptllogger.removeHandler(temploghandler)
+
+        # Verify that expect logged the expected log message
+        logmsg = "Operator not supported by expect(), " +\
+            "cannot verify change in managers"
+        msgfound = False
+        for line in logbuffer.getvalue().splitlines():
+            if line == logmsg:
+                msgfound = True
+                break
+        self.assertTrue(msgfound,
+                        "Didn't find expected log message from expect()")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Many PTL tests suffer from race conditions wrt using the manager() call, many tests set attributes via manager and move on assuming that the attributes got set even when they might not be set yet, which leads to race conditions. Many PTL calls automatically do verification, but manager() doesn't unless explicitly instructed to do so.

#### Affected Platform(s)
* All Linux

#### Cause / Analysis / Design
* manager()'s expect is set to False by default and it doesn't do any verification automatically

#### Solution Description
* For set and delete operations, set expect to True inside manager(). expect() doesn't correctly handle the unset operation for default attributes, so not including unset in the list for now.
* manager() now returns 0 for Success for non-zero for error
* Modified expect() to not error out for operators that it doesn't support (like INCR)

#### Testing logs/output
* Since this is for fixing race conditions, it's not possible to write a PTL test for this as such. If existing tests pass, it'll verify that the changes don't do any harm.
* Wrote a test for the secondary changes to expect, the part where it was fixed to handle unsupported operators: 
[testunsupportedoperator.log](https://github.com/PBSPro/pbspro/files/2732292/testunsupportedoperator.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
