### PR TITLE
Use short hostname in pbs.conf while reverting pbs.conf changes

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1104,8 +1104,8 @@ class PBSTestSuite(unittest.TestCase):
             if new_pbsconf["PBS_CORE_LIMIT"] != "unlimited":
                 new_pbsconf["PBS_CORE_LIMIT"] = "unlimited"
                 restart_pbs = True
-            if new_pbsconf["PBS_SERVER"] != primary_server.hostname:
-                new_pbsconf["PBS_SERVER"] = primary_server.hostname
+            if new_pbsconf["PBS_SERVER"] != primary_server.shortname:
+                new_pbsconf["PBS_SERVER"] = primary_server.shortname
                 restart_pbs = True
             if "PBS_SCP" not in new_pbsconf:
                 scppath = self.du.which(server.hostname, "scp")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
*  The revert method while reverting test configuration to out of box configuration writes hostname with FQDN as value to PBS_SERVER in pbs.conf instead of hostname without FQDN

#### Affected Platform(s)
* All

#### Solution Description
* Updated revert method to write hostname without FQDN as value for PBS_SERVER while reverting pbs.conf changes to out of box configuration.

The postinstall script sets PBS_SERVER to hostname without FQDN.
Code snippet

		case $INSTALL_PACKAGE in
		server)
			if [ -z "$PBS_SERVER" ]; then
				PBS_SERVER=`hostname | awk -F. '{print $1}'`
				echo "PBS_SERVER=$PBS_SERVER" >>"$newconf"
                        fi

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
