### PR TITLE
qsub does not accept job script with extension

### DIFF
--- a/src/lib/Libcmds/ck_job_name.c
+++ b/src/lib/Libcmds/ck_job_name.c
@@ -58,7 +58,7 @@ isalnumspch(int c)
 	if (isalnum(c) != 0)
 		return c;
 
-	if (c == '-' || c == '_' || c == '+')
+	if (c == '-' || c == '_' || c == '+' || c == '.')
 		return c;
 
 	return 0;

--- a/test/tests/functional/pbs_validate_job_qsub_attributes.py
+++ b/test/tests/functional/pbs_validate_job_qsub_attributes.py
@@ -142,3 +142,18 @@ pbs.logmsg(pbs.LOG_DEBUG, "submitted job with long select" )
         else:
             self.logger.info('Job created with illegal name: ' + jid)
             self.assertTrue(False, "Job shouldn't be accepted")
+
+    def test_qsub_N_validchar(self):
+        """
+        This test case validates whether character "."
+        in job name passed via -N args in qsub works fine
+        """
+        j = Job(TEST_USER, {ATTR_N: 'job.scr'})
+        try:
+            jid = self.server.submit(j)
+        except PbsSubmitError as e:
+            self.assertNotIn('illegal -N value', e.msg[0],
+                             'qsub: Not accepted "." in job name')
+        else:
+            self.server.expect(JOB, {'job_state': (MATCH_RE, '[RQ]')}, id=jid)
+            self.logger.info('Job submitted successfully: ' + jid)

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -517,6 +517,18 @@ class SmokeTest(PBSTestSuite):
         j.create_script('sleep 120\n', hostname=self.server.client)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.logger.info("Testing script with extension")
+        j = Job(TEST_USER)
+        fn = self.du.create_temp_file(suffix=".scr", body="/bin/sleep 10",
+                                      asuser=str(TEST_USER))
+        try:
+            jid = self.server.submit(j, script=fn)
+        except PbsSubmitError as e:
+            self.assertNotIn('illegal -N value', e.msg[0],
+                             'qsub: Not accepted "." in job name')
+        else:
+            self.server.expect(JOB, {'job_state': (MATCH_RE, '[RQ]')}, id=jid)
+            self.logger.info('Job submitted successfully: ' + jid)
 
     @skipOnCpuSet
     def test_formula_match(self):


### PR DESCRIPTION
#### Bug/feature Description
qsub does not accept job script with extension, if the script doesn't have any -N args

#### Affected Platform(s)
All

#### Cause / Analysis / Design

- If we don't provide any name of the job script explicitly  (like -N args), then default, the job’s name is the name of the script, which also includes special character "." in job name.

- Currently the allowed special characters in job name are ('+', '-', '_'), as per "PBS Professional 18.2 Reference Guide" in Chapter:7. Where we need to allow '.' in job name.

 

#### Solution Description
Allowed special character "." in job name.

#### Testing logs/output
Attached

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
