### PR TITLE
job submission was failing due to wrong format

### DIFF
--- a/test/tests/functional/pbs_admin_suspend.py
+++ b/test/tests/functional/pbs_admin_suspend.py
@@ -628,7 +628,7 @@ class TestAdminSuspend(TestFunctional):
 
         # submit other jobs asking for specific resources on vn[1]
         j = Job(TEST_USER)
-        j.set_attributes({'foo': '2'})
+        j.set_attributes({'Resource_List.foo': '2'})
         jid2 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
 


### PR DESCRIPTION

#### Bug/feature Description

* *Bugs: job submission was failing due to wrong format of listing custom resource*

#### Affected Platform(s)
* *Platform (seen for RHEL6)*

#### Cause / Analysis / Design
* *Bugs: custom resource was assigned in unacceptable format*

#### Solution Description
* *updated the way custom resource should be requested in job submission*

#### Testing logs/output
* *
[afterfix.txt](https://github.com/PBSPro/pbspro/files/2700657/afterfix.txt)
[beforefix.txt](https://github.com/PBSPro/pbspro/files/2700659/beforefix.txt)

*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
