### PR TITLE
TestMultipleSchedulers.test_equiv_suspend_jobs fails sometimes due to race condition

### DIFF
--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -1340,7 +1340,10 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].log_match("Number of job equivalence classes: 2",
                                      max_attempts=10, starttime=t)
         t = int(time.time())
+        # Make sure that Job is in R state before issuing a signal to suspend
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
         self.server.sigjob(jobid=jid1, signal="suspend")
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
         self.server.sigjob(jobid=jid3, signal="suspend")
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id="sc1")


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Timing errors between job's state transition (from 'Q' to 'R') and qsig command.

#### Affected Platform(s)
* ALL

#### Cause / Analysis / Design
* Request to signal a job (qsig -s suspend job_name) when job is in 'Q' state resulting error occurs:
**err: ['qsig: Request invalid for state of job']**

#### Solution Description
* Added code to make sure that job is in 'R' state before issuing a signal.

#### Testing logs/output
* [ptl_test_equiv_suspend_jobs.txt](https://github.com/PBSPro/pbspro/files/2710212/ptl_test_equiv_suspend_jobs.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
