### PR TITLE
SLES15-Cray gcc warning fix

### DIFF
--- a/src/resmom/linux/alps.c
+++ b/src/resmom/linux/alps.c
@@ -2980,7 +2980,7 @@ accelerator_start(ud_t *d, const XML_Char *el, const XML_Char **atts)
 		parse_err_unspecified_attr(d, BASIL_ATR_STATE);
 		return;
 	}
-	if (gpu->family == '\0') {
+	if (!gpu->family) {
 		parse_err_unspecified_attr(d, BASIL_ATR_FAMILY);
 		return;
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* PBS compilation on SLES15 cray platfrom complaining about following error message

pbspro/src/resmom/linux/alps.c:2983:18: error: comparison between pointer and zero character constant [-Werror=pointer-compare]
  if (gpu->family == '\0') {
                  ^~
pbspro/src/resmom/linux/alps.c:2983:6: note: did you mean to dereference the pointer?
  if (gpu->family == '\0') {
      ^
cc1: all warnings being treated as errors

#### Affected Platform(s)
* SLES15-CRAY (GCC 7.3.1)

#### Cause / Analysis / Design
* pointer was compared with empty string

#### Solution Description
* Updated pointer comparison with NULL 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
