### PR TITLE
Fix crash in PBS daemons when one with compression enabled talks to another without compression enabled

### DIFF
--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -1045,7 +1045,6 @@ tpp_send(int sd, void *data, int len)
 			tpp_log_func(LOG_CRIT, __func__, "tpp deflate failed");
 			return -1;
 		}
-		tpp_log_func(LOG_INFO, __func__, "tpp_deflate called inside tpp_send routine");
 		pkt = tpp_cr_pkt(outbuf, cmprsd_len, 0);
 		if (pkt == NULL) {
 			free(outbuf);
@@ -3556,12 +3555,13 @@ add_part_packet(stream_t *strm, void *data, int sz)
 			void *uncmpr_data;
 
 			if ((uncmpr_data = tpp_inflate(tmp->data, cmprsd_len, totlen))) {
-				tpp_log_func(LOG_INFO, __func__, "tpp_inflate called inside add_part_packet routine");
 				obj = tpp_cr_pkt(uncmpr_data, totlen, 0);
 				if (!obj)
 					free(uncmpr_data);
-			} else
+			} else {
 				tpp_log_func(LOG_CRIT, __func__, "Decompression failed");
+				obj = NULL;
+			}
 			tpp_free_pkt(tmp);
 		}
 		return obj; /* packet complete */

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -1297,7 +1297,8 @@ tpp_inflate(void *inbuf, unsigned int inlen, unsigned int totlen)
 	ret = inflateInit(&strm);
 	if (ret != Z_OK) {
 		free(outbuf);
-		tpp_log_func(LOG_CRIT, __func__, "Decompression failed");
+		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Decompression Init (inflateInit) failed, ret = %d", ret);
+		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 		return NULL;
 	}
 
@@ -1312,7 +1313,8 @@ tpp_inflate(void *inbuf, unsigned int inlen, unsigned int totlen)
 	inflateEnd(&strm);
 	if (ret != Z_STREAM_END) {
 		free(outbuf);
-		tpp_log_func(LOG_CRIT, __func__, "Decompression failed");
+		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Decompression (inflate) failed, ret = %d", ret);
+		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 		return NULL;
 	}
 	return outbuf;
@@ -1321,30 +1323,35 @@ tpp_inflate(void *inbuf, unsigned int inlen, unsigned int totlen)
 void *
 tpp_multi_deflate_init(int initial_len)
 {
+	tpp_log_func(LOG_CRIT, __func__, "TPP compression disabled");
 	return NULL;
 }
 
 int
 tpp_multi_deflate_do(void *c, int fini, void *inbuf, unsigned int inlen)
 {
+	tpp_log_func(LOG_CRIT, __func__, "TPP compression disabled");
 	return -1;
 }
 
 void *
 tpp_multi_deflate_done(void *c, unsigned int *cmpr_len)
 {
+	tpp_log_func(LOG_CRIT, __func__, "TPP compression disabled");
 	return NULL;
 }
 
 void *
 tpp_deflate(void *inbuf, unsigned int inlen, unsigned int *outlen)
 {
+	tpp_log_func(LOG_CRIT, __func__, "TPP compression disabled");
 	return NULL;
 }
 
 void *
 tpp_inflate(void *inbuf, unsigned int inlen, unsigned int totlen)
 {
+	tpp_log_func(LOG_CRIT, __func__, "TPP compression disabled");
 	return NULL;
 }
 #endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Recently the M4 macro that detects whether compression (zlib) is available was fixed, and thus newer builds of PBS has compression enabled for TPP. When a pbs daemon from the newer version (with compression enabled) talks to an older version (compression disabled due to the M4 macro bug), the older version daemon would crash when the sender sends it a compressed packet. The receiver detects that the packet is compressed and calls a routine to decompress it, however that routine returns NULL (since compression was compiled out) - this NULL return is not handled properly in the code and the daemon crashes.

#### Affected Platform(s)
* *All*

#### Solution Description
* This fix is not to ensure that the PBS daemon does not crash in such a circumstance.

#### Testing logs/output
* Manual test logs are attached

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__


**Test steps: [test_steps.txt](https://github.com/PBSPro/pbspro/files/2730202/test_steps.txt)**
**Bug reproduction: [bef_fix.txt](https://github.com/PBSPro/pbspro/files/2730203/bef_fix.txt)**
**Fix validation: [after_fix.txt](https://github.com/PBSPro/pbspro/files/2730204/after_fix.txt)**


