### PR TITLE
Fix crash in tpp_transport_terminate() after pthread_at_fork() executes

### DIFF
--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -1575,7 +1575,19 @@ tpp_terminate()
 	 * This is not required since our library is effectively
 	 * not used after a fork. The function tpp_mbox_destroy
 	 * calls pthread_mutex_destroy, so don't call them.
-	 * Also never log anything from a terminate handler
+	 * Also never log anything from a terminate handler.
+	 * 
+	 * Don't bother to free any TPP data as well, as the forked 
+	 * process is usually short lived and no point spending time
+	 * freeing space on a short lived forked process. Besides, 
+	 * the TPP thread which is lost after fork might have been in 
+	 * between using these data when the fork happened, so freeing
+	 * some structures might be dangerous.
+	 *
+	 * Thus the only thing we do here is to close file/sockets 
+	 * so that the kernel can recognize when a close happens from the
+	 * main process.
+	 * 
 	 */
 	if (tpp_child_terminated == 1)
 		return;
@@ -1588,11 +1600,6 @@ tpp_terminate()
 	tpp_transport_terminate();
 
 	tpp_mbox_destroy(&app_mbox, 0);
-
-	if (strmarray)
-		free(strmarray);
-
-	free_routers();
 }
 
 /* NULL definitions for some unimplemented functions */

--- a/src/lib/Libtpp/tpp_common.h
+++ b/src/lib/Libtpp/tpp_common.h
@@ -651,7 +651,6 @@ int tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 int tpp_mbox_clear(tpp_mbox_t *mbox, tpp_que_elem_t **n, unsigned int tfd, int *cmdval, void **data);
 int tpp_mbox_post(tpp_mbox_t *mbox, unsigned int tfd, int cmdval, void *data);
 int tpp_mbox_getfd(tpp_mbox_t *mbox);
-void tpp_mbox_drain_unsafe(tpp_mbox_t *mbox);
 
 extern int tpp_going_down;
 /**********************************************************************/

--- a/src/lib/Libtpp/tpp_em.c
+++ b/src/lib/Libtpp/tpp_em.c
@@ -1116,33 +1116,6 @@ tpp_mbox_read(tpp_mbox_t *mbox, unsigned int *tfd, int *cmdval, void **data)
 
 /**
  * @brief
- *	Drain commands and data from an mbox
- *	Thread unsafe, and called only in debug mode to satisfy valgrind after a fork
- *
- * @param[in] - mbox   - The mbox to read from
- *
- * @par Side Effects:
- *	None
- *
- * @par MT-safe: NO
- *
- */
-void
-tpp_mbox_drain_unsafe(tpp_mbox_t *mbox)
-{
-	tpp_que_elem_t *n = NULL;
-
-	while ((n = TPP_QUE_NEXT(&mbox->mbox_queue, n))) {
-		tpp_cmd_t *cmd;
-		if ((cmd = TPP_QUE_DATA(n)))
-			free(cmd->data);
-		free(cmd);
-		n = tpp_que_del_elem(&mbox->mbox_queue, n);
-	}
-}
-
-/**
- * @brief
  *	Clear pending commands pertaining to a connection
  *	from this mbox
  *	Called usually when the connection got closed and


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Crashes are sporadically seen after mom forks, in tpp_transport_terminate(). These are not mom daemon crashes, rather crash of the forked child process of mom. 

#### Affected Platform(s)
* *All*

#### Solution Description
When a threaded program calls fork, only the calling thread is replicated in the child process. The states of the other threads are, well, non-existent. Any data structures these other threads were handling are in "limbo" since the main thread might have called fork() at any point of time (and the other threads might have been working on a data structure but only partially completed it). 
Thus, it is dangerous to try to deal with these data structures in the forked child process (in the main thread who does not own these data structures). Also, the child processes from these mom forks are short lived, and there is no point in trying to free this memory (and waste time and performance in the process). 

Also, a minor nit, attempting to free memory regions in the child can actually be counter-productive (for memory itself) since freeing causes updated to the malloc arenas, and thus would invoke COW (copy on write) for the child process (which might not have been invoked otherwise). 

#### Testing logs/output
* *There is no easy way to reproduce this bug or verify it. We will need to ensure that all existing tests pass and valgrind logs are green*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
