### PR TITLE
tests were failing as -h was passed with an option

### DIFF
--- a/test/tests/functional/pbs_hook_unset_res.py
+++ b/test/tests/functional/pbs_hook_unset_res.py
@@ -62,7 +62,7 @@ class TestHookUnsetRes(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {
                             'log_events': 2047}, expect=True)
         j = Job(TEST_USER, attrs={
-                'Resource_List.select': '1:ncpus=1', 'Hold_Types': 'u'})
+                'Resource_List.select': '1:ncpus=1', ATTR_h: None})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'H'}, id=jid)
         self.server.alterjob(jid, {'Resource_List.ncpus': '2'})

--- a/test/tests/functional/pbs_job_routing.py
+++ b/test/tests/functional/pbs_job_routing.py
@@ -80,7 +80,7 @@ class TestJobRouting(TestFunctional):
 
         job_attrib = Job(TEST_USER, attrs={ATTR_queue: 'routeq',
                                            ATTR_l + '.ncpus': 1,
-                                           ATTR_h: 'u',
+                                           ATTR_h: None,
                                            ATTR_J: '1-2',
                                            ATTR_r: 'y'})
 

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -1612,7 +1612,7 @@ pbs.event().job.release_nodes_on_stageout=False
 
         # Test pbs_release_nodes on a non-running job
         a = {'Resource_List.select': '3:ncpus=1',
-             'Hold_Types': 'u',
+             ATTR_h: None,
              'Resource_List.place': 'scatter'}
         jid = self.create_and_submit_job('job', a)
 

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -188,7 +188,7 @@ class TestSoftWalltime(TestFunctional):
         Test that STF jobs can't have soft_walltime
         """
         msg = 'soft_walltime is not supported with Shrink to Fit jobs'
-        J = Job(attrs={'Resource_List.min_walltime': 120, ATTR_h: 'u'})
+        J = Job(attrs={'Resource_List.min_walltime': 120, ATTR_h: None})
         jid = self.server.submit(J)
         try:
             self.server.alterjob(jid, {'Resource_List.soft_walltime': 10})
@@ -198,7 +198,7 @@ class TestSoftWalltime(TestFunctional):
         self.server.expect(JOB, 'Resource_List.soft_walltime',
                            op=UNSET, id=jid)
 
-        J = Job(TEST_USER, attrs={ATTR_h: 'u'})
+        J = Job(TEST_USER, attrs={ATTR_h: None})
         jid = self.server.submit(J)
         self.server.alterjob(jid, {'Resource_List.soft_walltime': 10})
         try:
@@ -209,7 +209,7 @@ class TestSoftWalltime(TestFunctional):
         self.server.expect(JOB, 'Resource_List.min_walltime',
                            op=UNSET, id=jid)
 
-        J = Job(TEST_USER, attrs={ATTR_h: 'u'})
+        J = Job(TEST_USER, attrs={ATTR_h: None})
         jid = self.server.submit(J)
         a = {'Resource_List.soft_walltime': 10,
              'Resource_List.min_walltime': 120}
@@ -226,7 +226,7 @@ class TestSoftWalltime(TestFunctional):
         Test that a job's soft_walltime can't be greater than its hard walltime
         """
         msg = 'Illegal attribute or resource value'
-        J = Job(TEST_USER, attrs={'Resource_List.walltime': 120, ATTR_h: 'u'})
+        J = Job(TEST_USER, attrs={'Resource_List.walltime': 120, ATTR_h: None})
         jid = self.server.submit(J)
 
         try:
@@ -237,7 +237,7 @@ class TestSoftWalltime(TestFunctional):
         self.server.expect(JOB, 'Resource_List.soft_walltime',
                            op=UNSET, id=jid)
 
-        J = Job(TEST_USER, {ATTR_h: 'u'})
+        J = Job(TEST_USER, {ATTR_h: None})
         jid = self.server.submit(J)
         self.server.alterjob(jid, {'Resource_List.soft_walltime': 240})
         try:
@@ -247,7 +247,7 @@ class TestSoftWalltime(TestFunctional):
 
         self.server.expect(JOB, 'Resource_List.walltime', op=UNSET, id=jid)
 
-        J = Job(TEST_USER, {ATTR_h: 'u'})
+        J = Job(TEST_USER, {ATTR_h: None})
         jid = self.server.submit(J)
         try:
             self.server.alterjob(jid, {'Resource_List.walltime': 120,
@@ -517,7 +517,7 @@ e.accept()
                            {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')},
                            id=rid)
 
-        a = {'Resource_List.ncpus': 4, ATTR_h: 'u'}
+        a = {'Resource_List.ncpus': 4, ATTR_h: None}
         J = Job(TEST_USER, attrs=a)
         jid = self.server.submit(J)
         self.server.alterjob(jid, {'Resource_List.soft_walltime': 60})
@@ -547,7 +547,7 @@ e.accept()
                            id=rid)
 
         a = {'Resource_List.ncpus': 4,
-             'Resource_List.walltime': 150, ATTR_h: 'u'}
+             'Resource_List.walltime': 150, ATTR_h: None}
         J = Job(TEST_USER, attrs=a)
         jid = self.server.submit(J)
         self.server.alterjob(jid, {'Resource_List.soft_walltime': 60})


### PR DESCRIPTION
#### Bug/feature Description

* *Bugs: many tests were wrongly passing arguments to '-h'. Previously qsub was not complaining but with some recent fixes in PBS qsub is throwing error *

#### Affected Platform(s)
* *Platform (ALL)*

#### Cause / Analysis / Design
* *If there is an external design, link to it **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)***
* *If there is a discussion on the Forum, link to it **[pbspro community forum](http://community.pbspro.org/)***
* *Bugs: many tests were wrongly passing arguments to '-h'. Previously qsub was not complaining but with some recent fixes in PBS qsub is throwing error *

#### Solution Description
* *update tests to not pass options in '-h'*

#### Testing logs/output
* *  
[test_resv_job_soft_hard.txt](https://github.com/PBSPro/pbspro/files/2728980/test_resv_job_soft_hard.txt)
[test_soft_greater_hard.txt](https://github.com/PBSPro/pbspro/files/2728981/test_soft_greater_hard.txt)
[test_soft_walltime_STF.txt](https://github.com/PBSPro/pbspro/files/2728982/test_soft_walltime_STF.txt)
[test_resv_job_soft.txt](https://github.com/PBSPro/pbspro/files/2728983/test_resv_job_soft.txt)
[TestJobRouting.txt](https://github.com/PBSPro/pbspro/files/2728984/TestJobRouting.txt)
[TestHookUnsetRes.txt](https://github.com/PBSPro/pbspro/files/2728985/TestHookUnsetRes.txt)

[noderampafterfix.txt](https://github.com/PBSPro/pbspro/files/2731642/noderampafterfix.txt)

  *

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__