### PR TITLE
Fix tests in TestEquivClass for right job suspension order

### DIFF
--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -1578,35 +1578,39 @@ else:
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
 
         (jid1,) = self.submit_jobs(1)
-        # Jobs most recently started are suspended first.
-        # Sleep for a second to force jid2 to be suspended.
-        time.sleep(1)
-        (jid2, jid3) = self.submit_jobs(2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
-        self.server.expect(JOB, {'job_state=R': 3})
+        (jid2,) = self.submit_jobs(1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+
+        # Jobs most recently started are suspended first.
+        # Sleep for a second to force jid3 to be suspended.
+        time.sleep(1)
+        (jid3,) = self.submit_jobs(1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
 
         a = {'Resource_List.ncpus': 2, 'queue': 'expressq'}
         (jid4,) = self.submit_jobs(1, a)
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
-        self.server.expect(JOB, {'job_state': 'S'}, id=jid2)
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid3)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
 
         (jid5,) = self.submit_jobs(1)
         self.server.expect(JOB, 'comment', op=SET)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid5)
 
-        # 3 equivalence classes: 1 for jid1, jid3, and jid5; 1 for jid4;
-        # jid2 by itself because it is suspended.
+        # 3 equivalence classes: 1 for jid1, jid2, and jid5; 1 for jid4;
+        # jid3 by itself because it is suspended.
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
-        # Make sure jid2 is in its own class.  If it is still in jid5's class
-        # jid5 will not run.  This is because jid2 will be considered first
+        # Make sure jid3 is in its own class.  If it is still in jid5's class
+        # jid5 will not run.  This is because jid3 will be considered first
         # and mark the entire class as can not run.
 
-        self.server.deljob(jid3, wait=True)
+        self.server.deljob(jid2, wait=True)
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid5)
 
@@ -1635,15 +1639,18 @@ else:
         a = {'Resource_List.ncpus': 1}
         J = Job(TEST_USER, attrs=a)
         jid1 = self.server.submit(J)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
         time.sleep(1)
 
         J2 = Job(TEST_USER, attrs=a)
         jid2 = self.server.submit(J2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
 
         time.sleep(1)
         J3 = Job(TEST_USER, attrs=a)
         jid3 = self.server.submit(J3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
test_preemption2 and test_multiple_job_preemption_order sometimes fail as jobs do not get suspended as expected.

#### Affected Platform(s)
All

#### Cause / Analysis / Design
When multiple jobs are running, and a high priority job is submitted,  the running job that is most recently started is suspended first. 
The tests,  test_preemption2 and test_multiple_job_preemption_order do not enforce the order of job starts. Jobs(job2 and job3) get started in random order. Hence when a high priority job is submitted, jobs(job2 and job3) get suspended in random order. This results in test failure.

#### Solution Description
Make sure that job3 always gets started after job2 by submitting job2 and job3 one after the other and have expect statements for 'R' state.

#### Testing logs/output
[afterfix_test_preemption2.txt](https://github.com/PBSPro/pbspro/files/2734481/afterfix_test_preemption2.txt)
[afterfix_test_multiple_job_preemption_order.txt](https://github.com/PBSPro/pbspro/files/2734482/afterfix_test_multiple_job_preemption_order.txt)
[beforefix_test_preemption2.txt](https://github.com/PBSPro/pbspro/files/2734483/beforefix_test_preemption2.txt)
[beforefix_test_multiple_job_preemption_order.txt](https://github.com/PBSPro/pbspro/files/2734484/beforefix_test_multiple_job_preemption_order.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__