### PR TITLE
Upgrade fails from 18.1.3 to 19.1.1 with postgresql error on Open SUSE

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -221,8 +221,10 @@ upgrade_pbs_database() {
 		return 1
 	fi
 	
-	sys_pgsql_ver=$(echo `${PGSQL_DIR}/bin/psql -V` | awk 'NR==1 {print $NF}' | cut -d '.' -f 1,2)
+	sys_pgsql_ver=$(echo `${PGSQL_BIN}/postgres -V` | awk 'NR==1 {print $NF}' | cut -d '.' -f 1,2)
 	old_pgsql_ver=`cat ${data_dir}/PG_VERSION`
+	# strip the minor version from sys_pgsql_ver if old_pgsql_ver does not have minor version (for comparison).
+	[[ ! $old_pgsql_ver =~ "." ]] && sys_pgsql_ver=$(echo $sys_pgsql_ver | cut -d '.' -f 1)
 
 	[ ${sys_pgsql_ver%.*} -eq ${old_pgsql_ver%.*} ] && [ ${sys_pgsql_ver#*.} \> ${old_pgsql_ver#*.} ] || [ ${sys_pgsql_ver%.*} -gt ${old_pgsql_ver%.*} ];
 	result=$?


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *Upgrade fails from 18.1.3 to 19.1.1 with postgresql error on Open SUSE*
* *If there is an issue ID, link to it: [PP-1325](https://pbspro.atlassian.net/browse/PP-1325)*

#### Cause / Analysis / Design
* *Current PostgreSQL version numbers consist of a major and a minor version number. For example, in the version number 10.1, the 10 is the major version number and the 1 is the minor version number, meaning this would be the first minor release of the major release 10. For releases before PostgreSQL version 10.0, version numbers consist of three numbers, for example, 9.5.3. In those cases, the major version consists of the first two digit groups of the version number, e.g., 9.5, and the minor version is the third number, e.g., 3, meaning this would be the third minor release of the major release 9.5.*
https://www.postgresql.org/docs/current/upgrading.html
* *The check for upgrading database was failing due to this change*

#### Solution Description
* *The postgres version check has been modified to accommodate the above mentioned change by postgres*
* *If the old version(in PG_VERSION) has only major version, minor version is omitted from the present version of postgres before comparing*

#### Testing logs/output
[centos7_logs.txt](https://github.com/PBSPro/pbspro/files/2745177/centos7_logs.txt)
[opensuse logs.txt](https://github.com/PBSPro/pbspro/files/2745178/opensuse.logs.txt)
Test scenario:
Do overlay upgrade from PBSPro-18.1 to PBSPro-19.1 on systems having postgres >= 10.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
