### PR TITLE
qmove fails to move job and job arrays in windows

### DIFF
--- a/src/send_job_win/w32_send_job.c
+++ b/src/send_job_win/w32_send_job.c
@@ -312,7 +312,8 @@ main(int argc, char *argv[])
 
 	winsock_init();
 
-	connection_init();
+	(void)init_network(0);
+	(void)init_network_add(-1, NULL);
 
 	while (fgets(buf, sizeof(buf), stdin) != NULL) {
 		buf[strlen(buf)-1] = '\0';	/* gets rid of newline */

--- a/src/server/job_recov.c
+++ b/src/server/job_recov.c
@@ -140,9 +140,6 @@ static const size_t extndsize = sizeof(union jobextend);
 int
 job_save_fs(job *pjob, int updatetype)
 {
-#ifndef	PBS_MOM
-	int	isarray = 0;
-#endif	/* PBS_MOM */
 	int	fds;
 	int	i;
 	char	*filename;
@@ -256,7 +253,7 @@ job_save_fs(job *pjob, int updatetype)
 				extndsize) != 0) {
 				redo++;
 #ifndef PBS_MOM
-			} else if (isarray &&
+			} else if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_ArrayJob) &&
 				(save_struct((char *)pjob->ji_ajtrk,
 				pjob->ji_ajtrk->tkm_size) != 0)) {
 				redo++;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
qmove fails to move job and job arrays

#### Affected Platform(s)
Windows

#### Cause / Analysis / Design
- qmove job fails across server daemons running in 2 different ports.
 In windows qmove uses a file, w32_send_job.c, where tpp connections were not initialized. When svr_connect() was trying tpp_em_add_fd(), it was crashing because of null poll_context.

- qmove job array fails
 While saving the job array in a file before moving, job_save_fs(), it used a variable value (isarray), which was unassigned after initialization, depending on whether the pjob is a job or job array.

#### Solution Description
- Initialized tpp in w32_send_job.c before it does svr_connect().
- Modified the check while its saving array jobs structures.

#### Testing logs/output
Did migration upgrade from 18.2 to 19.2. Tested via moving jobs and job arrays across server daemons running on 2 different ports.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
