### PR TITLE
test_subjob_comments failing due to race condition

### DIFF
--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -299,12 +299,13 @@ class TestJobArray(TestFunctional):
         a = {'resources_available.ncpus': 1}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         j = Job(TEST_USER, attrs={
-            ATTR_J: '1-3', 'Resource_List.select': 'ncpus=1'})
-        j.set_sleep_time(5)
+            ATTR_J: '1-30', 'Resource_List.select': 'ncpus=1'})
+        j.set_sleep_time(8)
         j_id = self.server.submit(j)
         subjid_1 = j.create_subjob_id(j_id, 1)
         subjid_2 = j.create_subjob_id(j_id, 2)
-        self.server.expect(JOB, {'comment': 'Subjob finished'}, subjid_1)
+        self.server.expect(JOB, {'comment': 'Subjob finished'}, subjid_1,
+                           offset=8)
         self.server.delete(subjid_2, extend='force')
         self.server.expect(JOB, {'comment': 'Subjob terminated'}, subjid_2)
         self.kill_and_restart_svr()


### PR DESCRIPTION

#### Bug/feature Description

* *Bugs: test_subjob_comments was failing due to a race condition. job array was getting over by the time test is looking for subjoin comment. It is intermittent and might be seen on a heavy loaded slow machine*

#### Affected Platform(s)
* *Platform (for example ALL)*

#### Cause / Analysis / Design
* *Bugs: test_subjob_comments submits 3 subjoins for 5s and restart server in between. by the time server gets restarted and test looks for subjob1 comment, whole job array would got over causing test to fail*

#### Solution Description
* *increased submitting 3 subjobs to 30 subjobs. Also increased the job sleep time from 5 to 8s just to be safe*

#### Testing logs/output
* *
[afterfix.txt](https://github.com/PBSPro/pbspro/files/2766631/afterfix.txt)

*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [ ] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
