### PR TITLE
Show non-printing chars in attribute values and hook names

### DIFF
--- a/.travis/opensuse_leap_15.sh
+++ b/.travis/opensuse_leap_15.sh
@@ -17,4 +17,4 @@ ${DOCKER_EXEC} /bin/bash -c 'CFLAGS="-g -O2 -Wall -Werror" rpmbuild -bb pbspro.s
 ${DOCKER_EXEC} /bin/bash -c 'zypper --no-gpg-checks -n install /root/rpmbuild/RPMS/x86_64/pbspro-server-??.*.x86_64.rpm'
 ${DOCKER_EXEC} /bin/bash -c 'sed -i "s@PBS_START_MOM=0@PBS_START_MOM=1@" /etc/pbs.conf'
 ${DOCKER_EXEC} /etc/init.d/pbs start
-${DOCKER_EXEC} zypper -n install python-pip sudo which net-tools man time.x86_64
+${DOCKER_EXEC} zypper -n install python-pip sudo which net-tools man time.x86_64 python-curses

--- a/src/cmds/pbs_rstat.c
+++ b/src/cmds/pbs_rstat.c
@@ -134,7 +134,7 @@ display_single_reservation(struct batch_status *resv, int how)
 		printf("Resv ID: %s\n", resv->name);
 		while (attrp != NULL) {
 			if (attrp->resource != NULL)
-				printf("%s.%s = %s\n", attrp->name, attrp->resource, attrp->value);
+				printf("%s.%s = %s\n", attrp->name, attrp->resource, show_nonprint_chars(attrp->value));
 			else {
 				if (strcmp(attrp->name, ATTR_resv_state) == 0) {
 					str = convert_resv_state(attrp->value, 1);  /* long state str */
@@ -164,7 +164,7 @@ display_single_reservation(struct batch_status *resv, int how)
 				} else {
 					str = attrp->value;
 				}
-				printf("%s = %s\n", attrp->name, str);
+				printf("%s = %s\n", attrp->name, show_nonprint_chars(str));
 			}
 			attrp = attrp->next;
 		}

--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -551,7 +551,7 @@ prt_node_summary(char *def_server, struct batch_status *bstatus, int job_summary
 				} else {
 					printf("vnode=%s%sstate=%s%sOS=%s%shardware=%s%shost=%s%squeue=%s%smem=%s%sncpus=%s%snmics=%s%sngpus=%s%scomment=%s\n",
 						name, dsv_delim, state, dsv_delim, os, dsv_delim, hardware, dsv_delim, host, dsv_delim, queue,
-						dsv_delim, mem_info, dsv_delim, ncpus_info, dsv_delim, nmic_info, dsv_delim, ngpus_info, dsv_delim, comment);
+						dsv_delim, mem_info, dsv_delim, ncpus_info, dsv_delim, nmic_info, dsv_delim, ngpus_info, dsv_delim, show_nonprint_chars(comment));
 				}
 				break;
 
@@ -632,12 +632,12 @@ prt_node_summary(char *def_server, struct batch_status *bstatus, int job_summary
 					if (long_summary)
 						printf("%-*s %-*s %-*s %-*s %-*s %-*s %*s %*s %*s %*s %s\n", NODE_NAME, name, NODE_STATE, state,
 							NODE_OS, os, NODE_HARDW, hardware, NODE_HOST, host, QUEUE, queue, MEM, mem_info, NCPUS, ncpus_info,
-							NMIC, nmic_info, NGPUS, ngpus_info, comment);
+							NMIC, nmic_info, NGPUS, ngpus_info, show_nonprint_chars(comment));
 					else
 						printf("%-*.*s %-*.*s %-*.*s %-*.*s %-*.*s %-*.*s %*.*s %*.*s %*.*s %*.*s %s\n", NODE_NAME, NODE_NAME, name,
 							NODE_STATE, NODE_STATE, state, NODE_OS, NODE_OS, os, NODE_HARDW, NODE_HARDW, hardware,
 							NODE_HOST, NODE_HOST, host, QUEUE, QUEUE, queue, MEM, MEM, mem_info, NCPUS, NCPUS, ncpus_info,
-							NMIC, NMIC, nmic_info, NGPUS, NGPUS, ngpus_info, comment);
+							NMIC, NMIC, nmic_info, NGPUS, NGPUS, ngpus_info, show_nonprint_chars(comment));
 				}
 		}
 	}
@@ -673,20 +673,31 @@ prt_node(struct batch_status *bstat)
 			printf("Name=%s%s", bstat->name, dsv_delim);
 			for (pattr = bstat->attribs; pattr; pattr = pattr->next) {
 				if (pattr->resource)
-					printf("%s.%s=%s", pattr->name, pattr->resource, pattr->value);
+					printf("%s.%s=%s", pattr->name, pattr->resource, show_nonprint_chars(pattr->value));
 				else if (strcmp(pattr->name, "jobs") == 0) {
 					printf("%s=", pattr->name);
 					pc = pattr->value;
 					while (*pc) {
+						char *sbuf;
+						char char_buf[2];
 						if (*pc == ' ') {
 							pc++;
 							continue;
 						}
-						printf("%c", *pc);
+
+						sprintf(char_buf, "%c", *pc);
+						sbuf = show_nonprint_chars(char_buf);
+						if (sbuf != NULL) {
+							int  c;
+							for (c=0; c < strlen(sbuf); c++)
+								printf("%c", sbuf[c]);
+						} else {
+							printf("%c", *pc);
+						}
 						pc++;
 					}
 				} else
-					printf("%s=%s", pattr->name, pattr->value);
+					printf("%s=%s", pattr->name, show_nonprint_chars(pattr->value));
 				if (pattr->next)
 					printf("%s", dsv_delim);
 			}
@@ -703,7 +714,7 @@ prt_node(struct batch_status *bstat)
 					epoch = (time_t) atol(pattr->value);
 					printf(" = %s", ctime(&epoch));
 				} else				
-					printf(" = %s\n", pattr->value);
+					printf(" = %s\n", show_nonprint_chars(pattr->value));
 			}
 			printf("\n");
 			break;
@@ -1234,7 +1245,7 @@ main(int argc, char *argv[])
 			for (bstat = bstat_head; bstat; bstat = bstat->next) {
 				if (is_down(bstat) || is_offline(bstat)) {
 					printf("%-20s %s %s\n", bstat->name,
-						get_nstate(bstat), get_comment(bstat));
+						get_nstate(bstat), show_nonprint_chars(get_comment(bstat)));
 				}
 			}
 			break;

--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -2071,18 +2071,18 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 		}
 		else if (otype == MGR_OBJ_SITE_HOOK) {
 			if (format) {
-				printf("#\n# Create and define hook %s\n#\n", status->name);
-				printf("create hook %s\n", status->name);
+				printf("#\n# Create and define hook %s\n#\n", show_nonprint_chars(status->name));
+				printf("create hook %s\n", show_nonprint_chars(status->name));
 			}
 			else
-				printf("Hook %s\n", status->name);
+				printf("Hook %s\n", show_nonprint_chars(status->name));
 		}
 		else if (otype == MGR_OBJ_PBS_HOOK) {
 			if (format) {
-				printf("#\n# Set pbshook %s\n#\n", status->name);
+				printf("#\n# Set pbshook %s\n#\n", show_nonprint_chars(status->name));
 			}
 			else
-				printf("Hook %s\n", status->name);
+				printf("Hook %s\n", show_nonprint_chars(status->name));
 		}
 		else if (otype == MGR_OBJ_RSC) {
 			if ((oname == NULL) || (strcmp(oname, "") == 0)) {
@@ -2172,9 +2172,9 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 							printf("node %s ", status->name);
 						}
 						else if (otype == MGR_OBJ_SITE_HOOK)
-							printf("hook %s ", status->name);
+							printf("hook %s ", show_nonprint_chars(status->name));
 						else if (otype == MGR_OBJ_PBS_HOOK)
-							printf("pbshook %s ", status->name);
+							printf("pbshook %s ", show_nonprint_chars(status->name));
 
 						if (attr->name != NULL)
 							printf("%s", attr->name);
@@ -2187,7 +2187,7 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 								}
 							}
 							if((attrdef_l != NULL) && (attrdef_l[i].at_type == ATR_TYPE_STR)) {
-								printf(" = %s\n", c);
+								printf(" = %s\n", show_nonprint_chars(c));
 								break;
 							}
 							else {
@@ -2213,9 +2213,9 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 										q = '\'';
 									else
 										q = '"';
-									printf("%c%s%c", q, c, q);
+									printf("%c%s%c", q, show_nonprint_chars(c), q);
 								} else
-									printf("%s", c);	/* no quoting */
+									printf("%s", show_nonprint_chars(c));	/* no quoting */
 
 								c = e;
 							}
@@ -2279,7 +2279,7 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 								c++;
 						}
 
-						printf("%s", c);
+						printf("%s", show_nonprint_chars(c));
 						first = FALSE;
 
 						if (comma) {
@@ -2304,7 +2304,7 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 					fprintf(stderr, "can't display hooks data - no hook_tempfile!\n");
 				} else if (pbs_manager(mysvr->s_connect, MGR_CMD_EXPORT, otype,
 					status->name, exp_attribs, NULL) == 0) {
-					printf(PRINT_HOOK_IMPORT_CALL, status->name);
+					printf(PRINT_HOOK_IMPORT_CALL, show_nonprint_chars(status->name));
 					if (dump_file(hook_tempfile, NULL, HOOKSTR_BASE64,
 						dump_msg, sizeof(dump_msg)) != 0) {
 						fprintf(stderr, "%s\n", dump_msg);
@@ -2316,7 +2316,7 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 					fprintf(stderr, "can't display hooks data - no hook_tempfile!\n");
 				} else if (pbs_manager(mysvr->s_connect, MGR_CMD_EXPORT, otype,
 					status->name, exp_attribs_config, NULL) == 0) {
-					printf(PRINT_HOOK_IMPORT_CONFIG, status->name);
+					printf(PRINT_HOOK_IMPORT_CONFIG, show_nonprint_chars(status->name));
 					if (dump_file(hook_tempfile, NULL, HOOKSTR_BASE64,
 						dump_msg, sizeof(dump_msg)) != 0) {
 						fprintf(stderr, "%s\n", dump_msg);
@@ -2329,7 +2329,7 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 					fprintf(stderr, "can't display pbs hooks data - no hook_tempfile!\n");
 				} else if (pbs_manager(mysvr->s_connect, MGR_CMD_EXPORT, otype,
 					status->name, exp_attribs_config, NULL) == 0) {
-					printf(PRINT_HOOK_IMPORT_CONFIG, status->name);
+					printf(PRINT_HOOK_IMPORT_CONFIG, show_nonprint_chars(status->name));
 					if (dump_file(hook_tempfile, NULL, HOOKSTR_BASE64,
 						dump_msg, sizeof(dump_msg)) != 0) {
 						fprintf(stderr, "%s\n", dump_msg);

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -463,9 +463,9 @@ prt_attr(char *name, char *resource, char *value, int one_line) {
 		if (buf == NULL)
 			exit_qstat("out of memory");
 		if (resource)
-			printf("%s.%s=%s", name, resource, buf);
+			printf("%s.%s=%s", name, resource, show_nonprint_chars(buf));
 		else
-			printf("%s=%s", name, buf);
+			printf("%s=%s", name, show_nonprint_chars(buf));
 		free(buf);
 		break;
 
@@ -477,7 +477,7 @@ prt_attr(char *name, char *resource, char *value, int one_line) {
 			if (resource)
 				printf("    %s.%s = %s", name, resource, buf);
 			else
-				printf("    %s = %s", name, buf);
+				printf("    %s = %s", name, show_nonprint_chars(buf));
 			free(buf);
 		} else {
 			start = strlen(name) + 7; /* 4 spaces + ' = ' is 7 */
@@ -492,7 +492,7 @@ prt_attr(char *name, char *resource, char *value, int one_line) {
 			buf = strtok(temp, comma);
 			while (buf) {
 				if ((len = strlen(buf)) + start < CHAR_LINE_LIMIT) {
-					printf("%s", buf);
+					printf("%s", show_nonprint_chars(buf));
 					start += len;
 				} else {
 					if (!first) {
@@ -500,7 +500,20 @@ prt_attr(char *name, char *resource, char *value, int one_line) {
 						start = 9; /* tab + 1 */
 					}
 					while (*buf) {
-						putchar(*buf++);
+						char *sbuf;
+						int  ch;
+						char char_buf[2];
+
+						ch = *buf++;
+						sprintf(char_buf, "%c", ch);
+						sbuf = show_nonprint_chars(char_buf);
+						if (sbuf != NULL) {
+							int c;
+							for (c=0; c < strlen(sbuf); c++)
+								putchar(sbuf[c]);
+						} else {
+							putchar(ch);
+						}
 						if (++start > CHAR_LINE_LIMIT) {
 							start = 8; /* tab */
 							printf("\n\t");
@@ -569,9 +582,9 @@ prt_nodes(char *nodes, int no_newl)
 				/* flush line and start next */
 				linebuf[i] = '\0';
 				if (no_newl)
-					printf("%s", linebuf);
+					printf("%s", show_nonprint_chars(linebuf));
 				else
-					printf("   %s\n", linebuf);
+					printf("   %s\n", show_nonprint_chars(linebuf));
 				i = 0;
 				while (nodes < stp)
 					linebuf[i++] = *nodes++;
@@ -588,9 +601,9 @@ prt_nodes(char *nodes, int no_newl)
 	if (i != 0) {
 		linebuf[i] = '\0';
 		if (no_newl)
-			printf("%s\n", linebuf);
+			printf("%s\n", show_nonprint_chars(linebuf));
 		else
-			printf("   %s\n", linebuf);
+			printf("   %s\n", show_nonprint_chars(linebuf));
 	} else if (no_newl)
 		printf("\n");
 }
@@ -721,7 +734,7 @@ altdsp_statjob(struct batch_status *pstat, struct batch_status *prtheader, int a
 		printf("\n%s: ", prtheader->name);
 		pc = get_attr(prtheader->attribs, ATTR_comment, NULL);
 		if (pc)
-			printf("%s", pc);
+			printf("%s", show_nonprint_chars(pc));
 		if (wide) {
 
 			/* Used for for displaying spaces and dashes dynamically for wide formatted output */
@@ -954,7 +967,7 @@ altdsp_statjob(struct batch_status *pstat, struct batch_status *prtheader, int a
 		if (alt_opt & ALT_DISPLAY_s) {
 			/* print (scheduler) comment */
 			if (*comment != '\0')
-				printf("   %s\n", comment);
+				printf("   %s\n", show_nonprint_chars(comment));
 		}
 
 		pstat = pstat->next;
@@ -1211,7 +1224,7 @@ display_statjob(struct batch_status *status, struct batch_status *prtheader, int
 	if (! full && prtheader && output_format == FORMAT_DEFAULT) {
 		c = get_attr(prtheader->attribs, ATTR_comment, NULL);
 		if (c)
-			printf("%s\n", c);
+			printf("%s\n", show_nonprint_chars(c));
 		if (how_opt & ALT_DISPLAY_p) {
 				if (how_opt & ALT_DISPLAY_INCR_WIDTH) {
 					printf("Job id                 Name             User               %% done  S Queue\n");

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -50,6 +50,9 @@ extern "C" {
 /* replace - Replace sub-string  with new pattern in string */
 void replace(char *, char *, char *, char *);
 
+/* show_nonprint_chars - show non-printable characters in string */
+char *show_nonprint_chars(char *);
+
 /*	char_in_set - is the char c in the tokenset */
 int char_in_set(char c, const char *tokset);
 

--- a/src/lib/Libcmds/pbs_json.c
+++ b/src/lib/Libcmds/pbs_json.c
@@ -377,9 +377,9 @@ generate_json(FILE * stream) {
 				else
 					fprintf(stream, "\n");
 				if (arr_lvl[curnt_arr_lvl]==indent)
-					fprintf(stream, "%*.*s\"%s\"", indent, indent, " ", node->value.string);
+					fprintf(stream, "%*.*s\"%s\"", indent, indent, " ", show_nonprint_chars(node->value.string));
 				else
-					fprintf(stream, "%*.*s\"%s\":\"%s\"", indent, indent, " ", node->key, node->value.string);
+					fprintf(stream, "%*.*s\"%s\":\"%s\"", indent, indent, " ", node->key, show_nonprint_chars(node->value.string));
 				prnt_comma = 1;
 				break;
 

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1413,3 +1413,62 @@ get_mem_info(void) {
 }
 #endif /* malloc_info */
 #endif /* WIN32 */
+
+/**
+ * @brief
+ *	Return a copy of 'str' where non-printing characters
+ *	(except the ones listed in the local variable 'special_char') are
+ *	shown in ^<translated_char> notation.
+ *
+ * @param[in]	str - input string
+ *
+ * @return char *
+ *
+ * @note
+ * 	Do not free the return value - it's in a fixed memory area that
+ *	will get overwritten the next time the function is called.
+ *      So best to use the result immediately or strdup() it.
+ *
+ *	This will return the original (non-translated) 'str' value if 
+ *	an error was encounted, like a realloc() error.
+ */
+char *
+show_nonprint_chars(char *str)
+{
+#ifndef WIN32
+	static char	*locbuf = NULL;
+	static size_t	locbuf_size = 0;
+	char		*buf, *buf2;
+	size_t		nsize;
+	int		ch;
+	char		special_char[] = "\n\t";
+
+	if ((str == NULL) || (str[0] == '\0'))
+		return str;
+
+	nsize = (strlen(str) * 2) + 1;
+	if (nsize > locbuf_size) {
+		char *tmpbuf;
+		if ((tmpbuf = realloc(locbuf, nsize)) == NULL)
+			return str;
+		locbuf = tmpbuf;
+		locbuf_size = nsize;
+	}
+
+	locbuf[0] = '\0';
+	buf = str;
+	buf2 = locbuf;
+	while ((ch = *buf++) != '\0') {
+		if ((ch < 32) && !char_in_set(ch, special_char)) {
+			*buf2++ = '^';
+			*buf2++ = ch + 64;
+		} else {
+			*buf2++ = ch;
+		}
+	}
+	*buf2 = '\0';
+	return (locbuf);
+#else
+	return (str);
+#endif
+}

--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -251,7 +251,7 @@ read_attr(int fd)
 		printf(".%s", pal->al_resc);
 	printf(" = ");
 	if (pal->al_value)
-		printf("%s", pal->al_value);
+		printf("%s", show_nonprint_chars(pal->al_value));
 	printf("\n");
 
 	free(pal);
@@ -422,7 +422,7 @@ print_db_job(char *id, int no_attributes)
 					printf(".%s", attrs->attr_resc);
 				printf(" = ");
 				if (attrs->attr_value)
-					printf("%s", attrs->attr_value);
+					printf("%s", show_nonprint_chars(attrs->attr_value));
 				printf("\n");
 
 			}

--- a/src/tools/tracejob.c
+++ b/src/tools/tracejob.c
@@ -729,7 +729,7 @@ line_wrap(char *line, int start, int end)
 	start_index = 0;
 
 	if (end == 0)
-		printf("%s\n", line);
+		printf("%s\n", show_nonprint_chars(line));
 	else {
 		while (start_index < total_size) {
 			if (start_index + wrap_at < total_size) {
@@ -751,9 +751,9 @@ line_wrap(char *line, int start, int end)
 
 			/* first line, don't indent */
 			if (start_ptr == line)
-				printf("%s\n", start_ptr);
+				printf("%s\n", show_nonprint_chars(start_ptr));
 			else
-				printf("%*s%s\n", start, " ", start_ptr);
+				printf("%*s%s\n", start, " ", show_nonprint_chars(start_ptr));
 
 			start_ptr = cur_ptr + 1;
 			start_index = cur_ptr - line;

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -1,0 +1,1102 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2018 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+import curses
+import json
+import os
+
+
+class TestNonprintingCharacters(TestFunctional):
+    """
+    Test to check passing non-printable environment variables
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        # Mapping of ASCII non-printable character to escaped representation
+        self.npcat = {
+            "\x00": "^@", "\x01": "^A", "\x02": "^B", "\x03": "^C",
+            "\x04": "^D", "\x05": "^E", "\x06": "^F", "\x07": "^G",
+            "\x08": "^H", "\x09": "^I", "\x0A": "^J", "\x0B": "^K",
+            "\x0C": "^L", "\x0D": "^M", "\x0E": "^N", "\x0F": "^O",
+            "\x10": "^P", "\x11": "^Q", "\x12": "^R", "\x13": "^S",
+            "\x14": "^T", "\x15": "^U", "\x16": "^V", "\x17": "^W",
+            "\x18": "^X", "\x19": "^Y", "\x1A": "^Z", "\x1B": "^[",
+            "\x1C": "^\\", "\x1D": "^]", "\x1E": "^^", "\x1F": "^_"
+        }
+
+        # Exclude these:
+        # NULL(\0) causes qsub error, LINE FEED(\n) causes error in expect()
+        self.npch_exclude = ['\x00', '\x0A']
+
+        # Characters displayed as is: TAB (\t), LINE FEED(\n)
+        self.npch_asis = ['\x09', '\x0A']
+
+        # Terminal control characters used in the tests
+        curses.setupterm()
+        self.bold = curses.tparm(curses.tigetstr("bold"))
+        self.red = curses.tparm(curses.tigetstr("setaf"), 1)
+        self.reset = curses.tparm(curses.tigetstr("sgr"), 0, 0)
+        # Mapping of terminal control character to escaped representation
+        self.bold_esc = "^[[1m"
+        self.red_esc = "^[[31m"
+        self.reset_esc = "^[(B^[[0m"
+
+        self.ATTR_V = 'Full_Variable_List'
+        api_to_cli.setdefault(self.ATTR_V, 'V')
+
+        self.os_version = self.find_os_ver()
+        self.osv, self.pver = self.os_version[0], self.os_version[1]
+        # Platforms that have bash changes due to ShellShock malware
+        self.osv1 = {'"SLES"': '"12"', '"CentOS Linux"': '"7"'}
+        self.osv2 = {'"Ubuntu"': '"16"'}
+
+    @staticmethod
+    def find_os_ver():
+        """
+        If /etc/os-release exists find and return the NAME and VERSION_ID.
+        Otherwise return an empty list. Use this instead of module 'platform'
+        due to platform.py behavior difference in pbs_python.
+        """
+        osrelpath = '/etc/os-release'
+        searchfor = ['NAME', 'VERSION_ID']
+        os_ver = []
+        if os.path.exists(osrelpath):
+            with open("/etc/os-release") as osrel:
+                for line in osrel:
+                    l1 = line.strip().split('=')
+                    if l1[0] in searchfor:
+                        os_ver.append(l1[1])
+        else:
+            os_ver = ['', '']
+        return os_ver
+
+    def create_and_submit_job(self, user=None, attribs=None, content=None,
+                              content_interactive=None, preserve_env=False):
+        """
+        Create the job object and submit it to the server as 'user',
+        attributes list 'attribs' script 'content' or 'content_interactive',
+        and to 'preserve_env' if interactive job.
+        """
+        # A user=None value means job will be executed by current user
+        # where the environment is set up
+        if attribs is None:
+            use_attribs = {}
+        else:
+            use_attribs = attribs
+        retjob = Job(username=user, attrs=use_attribs)
+
+        if content is not None:
+            retjob.create_script(body=content)
+        elif content_interactive is not None:
+            retjob.interactive_script = content_interactive
+            retjob.preserve_env = preserve_env
+
+        return self.server.submit(retjob)
+
+    def check_jobout(self, chk_var, jid, job_outfile):
+        """
+        Check if unescaped variable is in job output
+        """
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=1)
+        job_output = ""
+        with open(job_outfile, 'r') as f:
+            job_output = f.read().strip()
+        self.assertEqual(job_output, chk_var)
+        self.logger.info('job output has: %s' % chk_var)
+
+    def test_nonprint_character_qsubv(self):
+        """
+        Using each of the non-printable ASCII characters, except NULL
+        (x00), and LINE FEED (x0A) which will cause a qsub error,
+        submit a job script with
+        qsub -v "var1='A,B,<non-printable character>,C,D'"
+        and check that the value with the character is passed correctly
+        """
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            a = {ATTR_v: "var1=\'A,B,%s,C,D\'" % ch}
+            script = ['sleep 1']
+            script += ['env | grep var1']
+            jid = self.create_and_submit_job(attribs=a, content=script)
+            qstat = self.server.status(JOB, ATTR_o, id=jid)
+            job_outfile = qstat[0][ATTR_o].split(':')[1]
+
+            # variable to check if with escaped nonprinting character or not
+            chk_var = 'var1=A\,B\,%s\,C\,D' % self.npcat[ch]
+            if ch in self.npch_asis:
+                chk_var = 'var1=A\,B\,%s\,C\,D' % ch
+
+            # Check if Variable_List contains the escaped character
+            self.server.expect(
+                JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+
+            # Check if job output contains the character as is
+            chk_var = "var1=A,B,%s,C,D" % ch
+            self.check_jobout(chk_var, jid, job_outfile)
+
+    def test_nonprint_character_directive(self):
+        """
+        Using each of the non-printable ASCII characters, except NULL
+        (hex 00) and LINE FEED (hex 0A) which will cause a qsub error,
+        submit a job script with PBS directive
+        -v "var1='A,B,<non-printable character>,C,D'"
+        and check that the value with the character is passed correctly
+        """
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            script = ['#PBS -v "var1=\'A,B,%s,C,D\'"' % ch]
+            script += ['sleep 1']
+            script += ['env | grep var1']
+            jid = self.create_and_submit_job(content=script)
+            qstat = self.server.status(JOB, ATTR_o, id=jid)
+            job_outfile = qstat[0][ATTR_o].split(':')[1]
+
+            # variable to check if with escaped nonprinting character or not
+            chk_var = 'var1=A\,B\,%s\,C\,D' % self.npcat[ch]
+            if ch in self.npch_asis:
+                chk_var = 'var1=A\,B\,%s\,C\,D' % ch
+
+            # Check if Variable_List contains the escaped character
+            self.server.expect(
+                JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+
+            # Check if job output contains the character
+            chk_var = "var1=A,B,%s,C,D" % ch
+            self.check_jobout(chk_var, jid, job_outfile)
+
+    def test_nonprint_character_qsubV(self):
+        """
+        Using each of the non-printable ASCII characters, except NULL
+        (hex 00) and LINE FEED (hex 0A) which will cause a qsub error,
+        test exporting the character in environment variable
+        when -V is passed through command line.
+        """
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            os.environ["NONPRINT_VAR"] = "X%sY" % ch
+            script = ['sleep 1']
+            script += ['env | grep NONPRINT_VAR']
+            a = {self.ATTR_V: None}
+            j = Job(self.du.get_current_user(), attrs=a)
+            j.create_script(body=script)
+            jid = self.server.submit(j)
+            qstat = self.server.status(JOB, ATTR_o, id=jid)
+            job_outfile = qstat[0][ATTR_o].split(':')[1]
+
+            # variable to check if with escaped nonprinting character or not
+            chk_var = 'NONPRINT_VAR=X%sY' % self.npcat[ch]
+            if ch in self.npch_asis:
+                chk_var = 'NONPRINT_VAR=X%sY' % ch
+
+            # Check if Variable_List contains the escaped character
+            self.server.expect(
+                JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+
+            # Check if job output contains the character
+            chk_var = 'NONPRINT_VAR=X%sY' % ch
+            self.check_jobout(chk_var, jid, job_outfile)
+
+    def test_nonprint_character_default_qsubV(self):
+        """
+        Using each of the non-printable ASCII characters, except NULL
+        (hex 00) and LINE FEED (hex 0A) which will cause a qsub error,
+        test exporting the character in environment variable
+        when -V is in the server's default_qsub_arguments.
+        """
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            os.environ["NONPRINT_VAR"] = "X%sY" % ch
+            self.server.manager(MGR_CMD_SET, SERVER,
+                                {'default_qsub_arguments': '-V'})
+            script = ['sleep 1']
+            script += ['env | grep NONPRINT_VAR']
+            j = Job(self.du.get_current_user())
+            j.create_script(body=script)
+            jid = self.server.submit(j)
+            qstat = self.server.status(JOB, ATTR_o, id=jid)
+            job_outfile = qstat[0][ATTR_o].split(':')[1]
+
+            # variable to check if with escaped nonprinting character or not
+            chk_var = 'NONPRINT_VAR=X%sY' % self.npcat[ch]
+            if ch in self.npch_asis:
+                chk_var = 'NONPRINT_VAR=X%sY' % ch
+
+            # Check if Variable_List contains the escaped character
+            self.server.expect(
+                JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+
+            # Check if job output contains the character
+            chk_var = 'NONPRINT_VAR=X%sY' % ch
+            self.check_jobout(chk_var, jid, job_outfile)
+
+    def test_nonprint_shell_function(self):
+        """
+        Export a shell function with a non-printable character and check
+        that the function is passed correctly.
+        Using each of the non-printable ASCII characters, except
+        NULL (hex 00), SOH (hex 01), TAB (hex 09), LINE FEED (hex 0A)
+        which will cause problems in the exported shell function.
+        """
+        self.npch_exclude += ['\x01', '\x09']
+
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            func = '() { a=%s; echo XX${a}YY}; }' % ch
+            # Adjustments in bash due to ShellShock malware fix in various OS
+            if self.osv in self.osv1 and self.pver >= self.osv1[self.osv]:
+                os.environ['BASH_FUNC_foo()'] = func
+                chk_var = 'BASH_FUNC_foo()=() ' + \
+                    '{ a=%s; echo XX${a}YY}; }' % self.npcat[ch]
+                if ch in self.npch_asis:
+                    chk_var = 'BASH_FUNC_foo()=() ' + \
+                        '{ a=%s; echo XX${a}YY}; }' % ch
+                out = 'BASH_FUNC_foo()=() ' + \
+                    '{  a=%s;\n echo XX${a}YY}\n}\nXX%sYY}' % (ch, ch)
+            elif self.osv in self.osv2 and self.pver >= self.osv2[self.osv]:
+                os.environ['BASH_FUNC_foo%%'] = func
+                chk_var = 'BASH_FUNC_foo%%=() ' + \
+                    '{ a=%s; echo XX${a}YY}; }' % self.npcat[ch]
+                if ch in self.npch_asis:
+                    chk_var = 'BASH_FUNC_foo%%=() ' + \
+                        '{ a=%s; echo XX${a}YY}; }' % ch
+                out = 'BASH_FUNC_foo%%=() ' + \
+                    '{  a=%s;\n echo XX${a}YY}\n}\nXX%sYY}' % (ch, ch)
+            else:
+                os.environ['foo'] = func
+                chk_var = 'foo=() { a=%s; echo XX${a}YY}; }' % self.npcat[ch]
+                if ch in self.npch_asis:
+                    chk_var = 'foo=() { a=%s; echo XX${a}YY}; }' % ch
+                out = 'foo=() {  a=%s;\n echo XX${a}YY}\n}\nXX%sYY}' % (ch, ch)
+
+            script = ['#PBS -V']
+            script += ['env | grep -A 3 foo\n']
+            script += ['foo\n']
+            script += ['sleep 1']
+            jid = self.create_and_submit_job(content=script)
+            qstat = self.server.status(JOB, ATTR_o, id=jid)
+            job_outfile = qstat[0][ATTR_o].split(':')[1]
+
+            # Check if Variable_List contains the escaped character
+            self.server.expect(
+                JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+            # Check if job output contains the character
+            self.check_jobout(out, jid, job_outfile)
+
+    def test_terminal_control_in_qsubv(self):
+        """
+        Using terminal control in environment variable
+        submit a job script with qsub
+        -v "var1='X<terminal control>Y'"
+        and check that the value with the character is passed correctly
+        """
+        a = {ATTR_v: "var1=\'X%s%sY\'" % (self.bold, self.red)}
+        script = ['env | grep var1']
+        script += ['sleep 1']
+        jid = self.create_and_submit_job(attribs=a, content=script)
+        qstat = self.server.status(JOB, ATTR_o, id=jid)
+        job_outfile = qstat[0][ATTR_o].split(':')[1]
+        # Check if Variable_List contains the escaped character
+        chk_var = "var1=X%s%sY" % (self.bold_esc, self.red_esc)
+        self.server.expect(
+            JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+        # Check if job output contains the character
+        match = "var1=X%s%sY" % (self.bold, self.red)
+        self.check_jobout(match, jid, job_outfile)
+        # Reset the terminal
+        self.logger.info('%sReset terminal' % self.reset)
+
+    def test_terminal_control_in_directive(self):
+        """
+        Using terminal control in environment variable
+        submit a job script with PBS directive
+        -v "var1='X<terminal control>Y'"
+        and check that the value with the character is passed correctly
+        """
+        script = ['#PBS -v "var1=\'X%s%sY\'"' % (self.bold, self.red)]
+        script += ['env | grep var1']
+        script += ['sleep 1']
+        jid = self.create_and_submit_job(content=script)
+        qstat = self.server.status(JOB, ATTR_o, id=jid)
+        job_outfile = qstat[0][ATTR_o].split(':')[1]
+        # Check if Variable_List contains the escaped character
+        chk_var = "var1=X%s%sY" % (self.bold_esc, self.red_esc)
+        self.server.expect(
+            JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+        # Check if job output contains the character
+        match = "var1=X%s%sY" % (self.bold, self.red)
+        self.check_jobout(match, jid, job_outfile)
+        # Reset the terminal
+        self.logger.info('%sReset terminal' % self.reset)
+
+    def test_terminal_control_qsubV(self):
+        """
+        Test exporting terminal control in environment variable
+        when -V is passed through command line.
+        """
+        os.environ["VAR_IN_TERM"] = "X" + self.bold + self.red + "Y"
+        script = ['sleep 1']
+        script += ['env | grep VAR_IN_TERM']
+        a = {self.ATTR_V: None}
+        j = Job(self.du.get_current_user(), attrs=a)
+        j.create_script(body=script)
+        jid = self.server.submit(j)
+        qstat = self.server.status(JOB, ATTR_o, id=jid)
+        job_outfile = qstat[0][ATTR_o].split(':')[1]
+        # Check if Variable_List contains the escaped character
+        chk_var = 'VAR_IN_TERM=X%s%sY' % (self.bold_esc, self.red_esc)
+        self.server.expect(
+            JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+        # Check if job output contains the character
+        chk_var = 'VAR_IN_TERM=X%s%sY' % (self.bold, self.red)
+        self.check_jobout(chk_var, jid, job_outfile)
+        # Reset the terminal
+        self.logger.info('%sReset terminal' % self.reset)
+
+    def test_terminal_control_default_qsubV(self):
+        """
+        Test exporting terminal control in environment variable
+        when -V is in the server's default_qsub_arguments.
+        """
+        os.environ["VAR_IN_TERM"] = "X" + self.bold + self.red + "Y"
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'default_qsub_arguments': '-V'})
+        script = ['sleep 1']
+        script += ['env | grep VAR_IN_TERM']
+        j = Job(self.du.get_current_user())
+        j.create_script(body=script)
+        jid = self.server.submit(j)
+        qstat = self.server.status(JOB, ATTR_o, id=jid)
+        job_outfile = qstat[0][ATTR_o].split(':')[1]
+        # Check if Variable_List contains the escaped character
+        chk_var = 'VAR_IN_TERM=X%s%sY' % (self.bold_esc, self.red_esc)
+        self.server.expect(
+            JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+        # Check if job output contains the character
+        chk_var = 'VAR_IN_TERM=X%s%sY' % (self.bold, self.red)
+        self.check_jobout(chk_var, jid, job_outfile)
+        # Reset the terminal
+        self.logger.info('%sReset terminal' % self.reset)
+
+    def test_terminal_control_shell_function(self):
+        """
+        Export a shell function with terminal control
+        characters and check that the function is passed correctly
+        """
+        func = '() { a=$(%s; %s); echo XX${a}YY; }' % (self.bold, self.red)
+        # Adjustments in bash due to ShellShock malware fix in various OS
+        if self.osv in self.osv1 and self.pver >= self.osv1[self.osv]:
+            os.environ['BASH_FUNC_foo()'] = func
+            chk_var = 'BASH_FUNC_foo()=() { a=$(%s; %s); echo XX${a}YY; }' % (
+                self.bold_esc, self.red_esc)
+            out = 'BASH_FUNC_foo()=() ' + \
+                '{  a=$(%s; %s);\n echo XX${a}YY\n}\nXXYY' % (
+                    self.bold, self.red)
+        elif self.osv in self.osv2 and self.pver >= self.osv2[self.osv]:
+            os.environ['BASH_FUNC_foo%%'] = func
+            chk_var = 'BASH_FUNC_foo' + '%%' + \
+                '=() { a=$(%s; %s); echo XX${a}YY; }' % (
+                    self.bold_esc, self.red_esc)
+            out = 'BASH_FUNC_foo' + '%%' + \
+                '=() {  a=$(%s; %s);\n echo XX${a}YY\n}\nXXYY' % (
+                    self.bold, self.red)
+        else:
+            os.environ['foo'] = func
+            chk_var = 'foo=() { a=$(%s; %s); echo XX${a}YY; }' % (
+                self.bold_esc, self.red_esc)
+            out = 'foo=() {  a=$(%s; %s);\n echo XX${a}YY\n}\nXXYY' % (
+                self.bold, self.red)
+        script = ['#PBS -V']
+        script += ['env | grep -A 3 foo\n']
+        script += ['foo\n']
+        script += ['sleep 1']
+        jid = self.create_and_submit_job(content=script)
+        qstat = self.server.status(JOB, ATTR_o, id=jid)
+        job_outfile = qstat[0][ATTR_o].split(':')[1]
+        # Check if Variable_List contains the escaped character
+        self.server.expect(
+            JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+        # Check if job output contains the character
+        self.check_jobout(out, jid, job_outfile)
+        # Reset the terminal
+        self.logger.info('%sReset terminal' % self.reset)
+
+    def find_in_tracejob(self, msg, jid):
+        """
+        Find msg in tracejob output of jid.
+        """
+        rc = 0
+        cmd = ['tracejob', jid]
+        ret = self.du.run_cmd(self.server.hostname, cmd, sudo=True)
+        self.assertEqual(ret['rc'], 0)
+        for m in ret['out']:
+            if m.find(msg) != -1:
+                self.logger.info('Found \"%s\" in tracejob output' % msg)
+                rc += 1
+                continue
+        return rc
+
+    def find_in_printjob(self, msg, jid):
+        """
+        Find msg in printjob output of jid.
+        """
+        self.server.expect(JOB, {ATTR_state: 'R'}, offset=1, id=jid)
+        rc = 0
+        jbfile = os.path.join(self.mom.pbs_conf['PBS_HOME'], 'mom_priv',
+                              'jobs', jid + '.JB')
+        cmd = ['printjob', jbfile]
+        ret = self.du.run_cmd(self.mom.hostname, cmd, sudo=True)
+        self.assertEqual(ret['rc'], 0)
+        for m in ret['out']:
+            if m.find(msg) != -1:
+                self.logger.info('Found \"%s\" in printjob output' % msg)
+                rc += 1
+                continue
+        return rc
+
+    def test_nonprint_character_in_qsubA(self):
+        """
+        Using each of the non-printable ASCII characters, except
+        NULL (hex 00) and LINE FEED (hex 0A),
+        submit a job script with Account_Name containing the character
+        qsub -A "J<non-printable character>K"
+        and check that the value with the character is passed correctly
+        """
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            j = Job(TEST_USER, {ATTR_A: "J%sK" % ch})
+            jid = self.server.submit(j)
+            job_stat = self.server.status(JOB, id=jid)
+            acct_name = job_stat[0]['Account_Name']
+            self.logger.info("job Account_Name: %s" % repr(acct_name))
+            exp_name = 'J%sK' % self.npcat[ch]
+            if ch in self.npch_asis:
+                exp_name = 'J%sK' % ch
+            self.logger.info("exp Account_Name: %s" % repr(exp_name))
+            self.assertEqual(acct_name, exp_name)
+            # Check printjob output
+            msg = 'Account_Name = %s' % exp_name
+            rc = self.find_in_printjob(msg, jid)
+            self.assertEqual(rc, 1)
+            # Check tracejob output
+            msg = 'account="%s"' % exp_name
+            rc = self.find_in_tracejob(msg, jid)
+            self.assertGreaterEqual(rc, 1)
+            self.server.delete(jid)
+            self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=1)
+
+    def test_terminal_control_in_qsubA(self):
+        """
+        Using terminal control in environment variable
+        submit a job script with Account_Name
+        qsub -A "J<terminal control>K"
+        and check that the value with the character is passed correctly
+        """
+        j = Job(TEST_USER, {ATTR_A: "J%s%sK" % (self.bold, self.red)})
+        jid = self.server.submit(j)
+        job_stat = self.server.status(JOB, id=jid)
+        acct_name = job_stat[0]['Account_Name']
+        self.logger.info("job Account_Name: %s" % repr(acct_name))
+        exp_name = 'J%s%sK' % (self.bold_esc, self.red_esc)
+        self.logger.info("exp Account_Name: %s" % exp_name)
+        self.assertEqual(acct_name, exp_name)
+        # Check printjob output
+        msg = 'Account_Name = %s' % exp_name
+        rc = self.find_in_printjob(msg, jid)
+        self.assertEqual(rc, 1)
+        # Check tracejob output
+        msg = 'account="%s"' % exp_name
+        rc = self.find_in_tracejob(msg, jid)
+        self.assertGreaterEqual(rc, 1)
+        self.logger.info('%sReset terminal' % self.reset)
+
+    def find_in_json_valid(self, cmd, msg, jid):
+        """
+        Check if qstat json output is valid of jid and find msg in output.
+        Returns 2 or greater on success (valid + found).
+        """
+        rc = 0
+        if cmd == 'qstat':
+            qstat_cmd_json = os.path.join(
+                self.server.pbs_conf['PBS_EXEC'], 'bin', 'qstat') + \
+                ' -f -F json ' + str(jid)
+            ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
+        elif cmd == 'nodes':
+            nodes_cmd_json = os.path.join(
+                self.server.pbs_conf['PBS_EXEC'], 'bin', 'pbsnodes') + \
+                ' -av -F json'
+            ret = self.du.run_cmd(self.server.hostname, cmd=nodes_cmd_json)
+        ret_out = "\n".join(ret['out'])
+        try:
+            json.loads(ret_out)
+        except ValueError as err:
+            self.assertFalse(err)
+        rc += 1
+        self.logger.info('json output is valid')
+        # Check msg is in output
+        for m in ret['out']:
+            if m.find(msg) != -1:
+                self.logger.info('Found \"%s\" in json output' % msg)
+                rc += 1
+                continue
+        return rc
+
+    def test_nonprint_character_in_qstat_json_valid(self):
+        """
+        Using each of the non-printable ASCII characters, except NULL
+        (hex 00) and LINE FEED (hex 0A) which will cause a qsub error,
+        and File Separator (hex 1C) which will cause invalid json,
+        submit a job script with
+        qsub -v "var1='A,B,<non-printable character>,C,D'"
+        and check that the qstat -f -F json output is valid
+        """
+        self.npch_exclude += ['\x1C']
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            a = {ATTR_v: "var1=\'A,B,%s,C,D\'" % ch}
+            msg = 'A,B,%s,C,D' % self.npcat[ch]
+            npch_msg = {
+                '\x08': 'A,B,\\b,C,D',
+                '\x09': 'A,B,\\t,C,D',
+                '\x0C': 'A,B,\\f,C,D',
+                '\x0D': 'A,B,\\r,C,D'
+            }
+            if ch in npch_msg:
+                msg = npch_msg[ch]
+            script = ['env | grep var1']
+            jid = self.create_and_submit_job(attribs=a, content=script)
+            rc = self.find_in_json_valid('qstat', msg, jid)
+            self.assertGreaterEqual(rc, 2)
+
+    def test_terminal_control_in_qstat_json_valid(self):
+        """
+        Using terminal control in environment variable
+        submit a job script with qsub
+        -v "var1='<terminal control>XY<terminal control>'"
+        and check that the qstat -f -F json output is valid
+        """
+        a = {ATTR_v: "var1=\'%s%sXY%s\'" % (self.bold, self.red, self.reset)}
+        msg = "%s%sXY%s" % (self.bold_esc, self.red_esc, self.reset_esc)
+        script = ['env | grep var1']
+        jid = self.create_and_submit_job(attribs=a, content=script)
+        rc = self.find_in_json_valid('qstat', msg, jid)
+        self.assertGreaterEqual(rc, 2)
+
+    def test_nonprint_character_in_qstat_dsv(self):
+        """
+        Using each of the non-printable ASCII characters, except NULL
+        (hex 00) and LINE FEED (hex 0A) which will cause a qsub error,
+        submit a job script with
+        qsub -v "var1='AB<non-printable character>CD'"
+        and check that the 'qstat -f -F dsv' output contains proper var1
+        """
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            a = {ATTR_v: "var1=\'AB%sCD\'" % ch}
+            script = ['env | grep var1']
+            jid = self.create_and_submit_job(attribs=a, content=script)
+            qstat_cmd_dsv = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                         'bin', 'qstat') + \
+                ' -f -F dsv ' + str(jid)
+            ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_dsv)
+            qstat_out = "\n".join(ret['out'])
+            match = 'var1=AB%sCD' % self.npcat[ch]
+            if qstat_out.find(match) != -1:
+                self.logger.info('Found %s in qstat -f -F dsv output' % match)
+
+    def test_terminal_control_in_qstat_dsv(self):
+        """
+        Using terminal control in environment variable
+        submit a job script with qsub
+        -v "var1='<terminal control>XY<terminal control>'"
+        and check that the 'qstat -f -F dsv' output contains proper var1
+        """
+        a = {ATTR_v: "var1=\'%s%sXY%s\'" % (self.bold, self.red, self.reset)}
+        script = ['env | grep var1']
+        jid = self.create_and_submit_job(attribs=a, content=script)
+        qstat_cmd_dsv = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                     'bin', 'qstat') + \
+            ' -f -F dsv ' + str(jid)
+        ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_dsv)
+        qstat_out = "\n".join(ret['out'])
+        match = 'var1=%s%sXY%s' % (self.bold_esc, self.red_esc, self.reset_esc)
+        if qstat_out.find(match) != -1:
+            self.logger.info('Found %s in qstat -f -F dsv output' % match)
+
+    def test_nonprint_character_job_array(self):
+        """
+        Using each of the non-printable ASCII characters, except NULL
+        (hex 00) and LINE FEED (hex 0A) which will cause a qsub error,
+        test exporting the character in environment variable of
+        job array when qsub -V is passed through command line.
+        """
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            os.environ["NONPRINT_VAR"] = "X%sY" % ch
+            script = ['sleep 1']
+            script += ['env | grep NONPRINT_VAR']
+            a = {self.ATTR_V: None, ATTR_J: '1-2'}
+            j = Job(self.du.get_current_user(), attrs=a)
+            j.create_script(body=script)
+            jid = self.server.submit(j)
+            subj1 = jid.replace('[]', '[1]')
+            subj2 = jid.replace('[]', '[2]')
+            qstat1 = self.server.status(JOB, ATTR_o, id=subj1)
+            job_outfile1 = qstat1[0][ATTR_o].split(':')[1]
+            job_outfile2 = job_outfile1.replace('.1', '.2')
+            # variable to check if with escaped nonprinting character or not
+            chk_var = 'NONPRINT_VAR=X%sY' % self.npcat[ch]
+            if ch in self.npch_asis:
+                chk_var = 'NONPRINT_VAR=X%sY' % ch
+            # Check if Variable_List contains the escaped character
+            ja = [jid, subj1, subj2]
+            for j in ja:
+                self.server.expect(
+                    JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=j)
+            # Check if job array output contains the character as is
+            chk_var = 'NONPRINT_VAR=X%sY' % ch
+            self.check_jobout(chk_var, subj1, job_outfile1)
+            self.check_jobout(chk_var, subj2, job_outfile2)
+
+    def test_terminal_control_job_array(self):
+        """
+        Using terminal control in environment variable of
+        job array when qsub -V is passed through command line.
+        """
+        os.environ["NONPRINT_VAR"] = "X%s%sY" % (self.bold, self.red)
+        script = ['sleep 1']
+        script += ['env | grep NONPRINT_VAR']
+        a = {self.ATTR_V: None, ATTR_J: '1-2'}
+        j = Job(self.du.get_current_user(), attrs=a)
+        j.create_script(body=script)
+        jid = self.server.submit(j)
+        subj1 = jid.replace('[]', '[1]')
+        subj2 = jid.replace('[]', '[2]')
+        qstat1 = self.server.status(JOB, ATTR_o, id=subj1)
+        job_outfile1 = qstat1[0][ATTR_o].split(':')[1]
+        job_outfile2 = job_outfile1.replace('.1', '.2')
+        # variable to check if with escaped nonprinting character
+        chk_var = 'NONPRINT_VAR=X%s%sY' % (self.bold_esc, self.red_esc)
+        # Check if Variable_List contains the escaped character
+        ja = [jid, subj1, subj2]
+        for j in ja:
+            self.server.expect(
+                JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=j)
+        # Check if job array output contains the character as is
+        chk_var = 'NONPRINT_VAR=X%s%sY' % (self.bold, self.red)
+        self.check_jobout(chk_var, subj1, job_outfile1)
+        self.logger.info('%sReset terminal' % self.reset)
+        self.check_jobout(chk_var, subj2, job_outfile2)
+        self.logger.info('%sReset terminal' % self.reset)
+
+    @checkModule("pexpect")
+    def test_nonprint_character_interactive_job(self):
+        """
+        Using each of the non-printable ASCII characters, except NULL
+        (hex 00) and LINE FEED (hex 0A) which will cause a qsub error,
+        test exporting the character in environment variable of
+        interactive job when qsub -V is passed through command line.
+        """
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            os.environ["NONPRINT_VAR"] = "X,%s,Y" % ch
+            fn = self.du.create_temp_file(prefix="job_out1")
+            self.job_out1_tempfile = fn
+            # submit an interactive job
+            cmd = 'env > ' + self.job_out1_tempfile
+            a = {self.ATTR_V: None, ATTR_inter: ''}
+            interactive_script = [('hostname', '.*'), (cmd, '.*')]
+            jid = self.create_and_submit_job(
+                attribs=a,
+                content_interactive=interactive_script,
+                preserve_env=True)
+            # variable to check if with escaped nonprinting character or not
+            chk_var = 'NONPRINT_VAR=X\,%s\,Y' % self.npcat[ch]
+            if ch in self.npch_asis:
+                chk_var = 'NONPRINT_VAR=X\,%s\,Y' % ch
+            # Check if Variable_List contains the escaped character
+            self.server.expect(
+                JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+            # Once all commands sent and matched, job exits
+            self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=1)
+            # Check for the non-printable character in the output file
+            with open(self.job_out1_tempfile) as fd:
+                pkey = ""
+                penv = {}
+                for line in fd:
+                    l = line.split('=', 1)
+                    if len(l) == 2:
+                        pkey = l[0]
+                        penv[pkey] = l[1]
+            np_var = penv['NONPRINT_VAR']
+            np_char = np_var.split(',')[1]
+            self.assertEqual(ch, np_char)
+            self.logger.info(
+                "non-printable %s was in interactive job environment"
+                % repr(np_char))
+
+    @checkModule("pexpect")
+    def test_terminal_control_interactive_job(self):
+        """
+        Using terminal control characters test exporting them
+        in environment variable of interactive job
+        when qsub -V is passed through command line.
+        """
+        var = "X,%s,%s,Y" % (self.bold, self.red)
+        os.environ["NONPRINT_VAR"] = var
+        fn = self.du.create_temp_file(prefix="job_out1")
+        self.job_out1_tempfile = fn
+        # submit an interactive job
+        cmd = 'env > ' + self.job_out1_tempfile
+        a = {self.ATTR_V: None, ATTR_inter: ''}
+        interactive_script = [('hostname', '.*'), (cmd, '.*')]
+        jid = self.create_and_submit_job(
+            attribs=a,
+            content_interactive=interactive_script,
+            preserve_env=True)
+        # variable to check if with escaped nonprinting character
+        chk_var = 'NONPRINT_VAR=X\,%s\,%s\,Y' % (self.bold_esc, self.red_esc)
+        self.server.expect(
+            JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+        # Once all commands sent and matched, job exits
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=1)
+        # Parse for the non-printable character in the output file
+        with open(self.job_out1_tempfile) as fd:
+            pkey = ""
+            penv = {}
+            for line in fd:
+                l = line.split('=', 1)
+                if len(l) == 2:
+                    pkey = l[0]
+                    penv[pkey] = l[1]
+        np_var = penv['NONPRINT_VAR']
+        self.logger.info("np_var: %s" % repr(np_var))
+        np_char1 = np_var.split(',')[1]
+        np_char2 = np_var.split(',')[2]
+        var_env = "X,%s,%s,Y" % (np_char1, np_char2)
+        self.logger.info(
+            "np_chars are: %s and %s" % (repr(np_char1), repr(np_char2)))
+        self.assertEqual(var, var_env)
+        self.logger.info(
+            "non-printables were in interactive job environment %s"
+            % repr(var_env))
+
+    def test_terminal_control_begin_launch_hook(self):
+        """
+        Using terminal control characters test exporting them
+        in environment variable of job having hooks execjob_begin and
+        execjob_launch when qsub -V is passed through command line.
+        """
+        var = "X,%s,%s,Y" % (self.bold, self.red)
+        os.environ["NONPRINT_VAR"] = var
+        a = {'Resource_List.select': '1:ncpus=1',
+             'Resource_List.walltime': 3,
+             self.ATTR_V: None}
+        script = ['env\n']
+        script += ['sleep 3\n']
+        # hook1: execjob_begin
+        hook_body = """
+import pbs
+e=pbs.event()
+e.job.Variable_List["BEGIN_NONPRINT"] = "AB"
+pbs.logmsg(pbs.LOG_DEBUG,"Variable List is %s" % (e.job.Variable_List,))
+"""
+        hook_name = "begin"
+        a2 = {'event': "execjob_begin", 'enabled': 'True', 'debug': 'True'}
+        rv = self.server.create_import_hook(
+            hook_name,
+            a2,
+            hook_body,
+            overwrite=True)
+        self.assertTrue(rv)
+        # hook2: execjob_launch
+        hook_body = """
+import pbs
+e=pbs.event()
+e.env["LAUNCH_NONPRINT"] = "CD"
+"""
+        hook_name = "launch"
+        a2 = {'event': "execjob_launch", 'enabled': 'True', 'debug': 'True'}
+        rv = self.server.create_import_hook(
+            hook_name,
+            a2,
+            hook_body,
+            overwrite=True)
+        self.assertTrue(rv)
+
+        # Submit a job with hooks in the system
+        jid = self.create_and_submit_job(attribs=a, content=script)
+        qstat = self.server.status(JOB, ATTR_o, id=jid)
+        job_outfile = qstat[0][ATTR_o].split(':')[1]
+        # variable to check if with escaped nonprinting character
+        chk_var = 'NONPRINT_VAR=X\,%s\,%s\,Y' % (self.bold_esc, self.red_esc)
+        self.server.expect(
+            JOB, {'Variable_List': (MATCH, '%s' % chk_var)}, id=jid)
+        # Check for the non-printable character in the job output file
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=3)
+        with open(job_outfile) as fd:
+            pkey = ""
+            penv = {}
+            for line in fd:
+                l = line.split('=', 1)
+                if len(l) == 2:
+                    pkey = l[0]
+                    penv[pkey] = l[1]
+        np_var = penv['NONPRINT_VAR']
+        self.logger.info("np_var: %s" % repr(np_var))
+        np_char1 = np_var.split(',')[1]
+        np_char2 = np_var.split(',')[2]
+        var_env = "X,%s,%s,Y" % (np_char1, np_char2)
+        self.logger.info(
+            "np_chars are: %s and %s" % (repr(np_char1), repr(np_char2)))
+        self.assertEqual(var, var_env)
+        self.logger.info(
+            "non-printables were in interactive job environment %s"
+            % repr(var_env))
+
+    def check_print_list_hook(self, hook_name, hook_name_esc):
+        """
+        Check if the hook_name_esc is displayed in the output of qmgr
+        'print hook' and 'list hook'
+        """
+        # Print hook displays escaped nonprinting characters
+        phook = 'create hook %s' % hook_name_esc
+        cmd = ['qmgr', '-c', 'print hook']
+        ret = self.du.run_cmd(self.server.hostname, cmd, sudo=True)
+        self.assertEqual(ret['rc'], 0)
+        if phook in ret['out']:
+            self.logger.info('Found \"%s\" in print hook output' % phook)
+        # List hook displays escaped nonprinting characters
+        lhook = 'Hook %s' % hook_name_esc
+        cmd = ['qmgr', '-c', 'list hook']
+        ret = self.du.run_cmd(self.server.hostname, cmd, sudo=True)
+        self.assertEqual(ret['rc'], 0)
+        if lhook in ret['out']:
+            self.logger.info('Found \"%s\" in list hook output' % lhook)
+
+    def test_terminal_control_hook_name(self):
+        """
+        Test using terminal control characters in hook name. Qmgr
+        'print hook' and 'list hook' displays the escaped nonprint character.
+        """
+        # Create hook
+        hook_name = "h%s%sd" % (self.bold, self.red)
+        a = {'event': "execjob_begin", 'enabled': 'True', 'debug': 'True'}
+        try:
+            rv = self.server.create_hook(hook_name, a)
+        except PbsManagerError:
+            # Delete the hook first then create the hook
+            self.server.manager(MGR_CMD_DELETE, HOOK, id=hook_name)
+            rv = self.server.create_hook(hook_name, a)
+        self.assertTrue(rv)
+        hook_name_esc = "h%s%sd" % (self.bold_esc, self.red_esc)
+        self.check_print_list_hook(hook_name, hook_name_esc)
+        # Delete the hook
+        self.server.manager(MGR_CMD_DELETE, HOOK, id=hook_name, expect=True)
+        # Reset the terminal
+        self.logger.info('%sReset terminal' % self.reset)
+
+    def test_nonprint_character_hook_name(self):
+        """
+        Use in a hook name each of the non-printable ASCII characters, except
+        NULL (x00), TAB (x09), LINE FEED (x0A), VT (x0B), FF (x0C), CR (x0D)
+        which will cause a qmgr create hook error. Qmgr 'print hook' and
+        'list hook' displays the escaped nonprint character.
+        """
+        self.npch_exclude += ['\x09', '\x0B', '\x0C', '\x0D']
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            # Create hook
+            hk_name = 'h%sd' % ch
+            a = {'event': "execjob_begin", 'enabled': 'True', 'debug': 'True'}
+            try:
+                rv = self.server.create_hook(hk_name, a)
+            except PbsManagerError:
+                # Delete pre-existing hook first then create the hook
+                self.server.manager(MGR_CMD_DELETE, HOOK, id=hk_name)
+                rv = self.server.create_hook(hk_name, a)
+            self.assertTrue(rv)
+            hk_name_esc = "h%sd" % self.npcat[ch]
+            self.check_print_list_hook(hk_name, hk_name_esc)
+            self.server.manager(MGR_CMD_DELETE, HOOK, id=hk_name, expect=True)
+
+    def test_terminal_control_in_rsubH(self):
+        """
+        Using terminal control in authorized hostnames submit a reservation
+        pbs_rsub -H "h<terminal control>d" and check that the escaped
+        representation is displayed in pbs_rstat correctly.
+        """
+        r = Reservation(TEST_USER, {"-H": "h%s%sd" % (self.bold, self.red)})
+        rid = self.server.submit(r)
+        resv_stat = self.server.status(RESV, id=rid)
+        auth_hname = resv_stat[0]['Authorized_Hosts']
+        self.logger.info("job Authorized_Hosts: %s" % auth_hname)
+        exp_name = 'h%s%sd' % (self.bold_esc, self.red_esc)
+        self.logger.info("expected Authorized_Hosts: %s" % exp_name)
+        self.assertEqual(auth_hname, exp_name)
+        self.logger.info('%sReset terminal' % self.reset)
+
+    def test_nonprint_character_in_rsubH(self):
+        """
+        Using each of the non-printable ASCII characters, except NULL (hex 00)
+        and LINE FEED (hex 0A), submit a reservation with authorized hostnames
+        pbs_rsub -H "h<terminal control>d" and check that the escaped
+        representation is displayed in pbs_rstat correctly.
+        """
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            r = Reservation(TEST_USER, {"-H": "h%sd" % ch})
+            rid = self.server.submit(r)
+            resv_stat = self.server.status(RESV, id=rid)
+            auth_hname = resv_stat[0]['Authorized_Hosts']
+            self.logger.info("job Authorized_Hosts: %s" % auth_hname)
+            exp_name = 'h%sd' % self.npcat[ch]
+            if ch in self.npch_asis:
+                exp_name = 'h%sd' % ch
+            self.logger.info("expected Authorized_Hosts: %s" % exp_name)
+            self.assertEqual(auth_hname, exp_name)
+            self.server.delete(rid)
+
+    def test_terminal_control_in_node_comment(self):
+        """
+        Test if pbsnodes -C with terminal control characters results in
+        valid json and escaped representation id displayed correctly.
+        """
+        comment = 'h%s%sd%s' % (self.bold, self.red, self.reset)
+        cmd = ['pbsnodes', '-C', '%s' % comment, self.mom.shortname]
+        self.du.run_cmd(self.server.hostname, cmd)
+        # Check json output
+        comm1 = 'h%s%sd%s' % (self.bold_esc, self.red_esc, self.reset_esc)
+        rc = self.find_in_json_valid('nodes', comm1, None)
+        self.assertGreaterEqual(rc, 2)
+        # Check qmgr -c 'list node @default' output
+        comm2 = '    comment = %s' % comm1
+        cmd = ['qmgr', '-c', 'list node @default']
+        ret = self.du.run_cmd(self.server.hostname, cmd, sudo=True)
+        self.assertEqual(ret['rc'], 0)
+        if comm2 in ret['out']:
+            self.logger.info('Found \"%s\" in qmgr list node output' % comm2)
+        # Check pbsnodes -a output
+        comm3 = '     comment = %s' % comm1
+        cmd = ['pbsnodes', '-a']
+        ret = self.du.run_cmd(self.server.hostname, cmd)
+        self.assertEqual(ret['rc'], 0)
+        if comm3 in ret['out']:
+            self.logger.info('Found \"%s\" in pbsnodes -a output' % comm3)
+
+    def test_nonprint_character_in_node_comment(self):
+        """
+        Using each of the non-printable ASCII characters, except NULL (hex 00),
+        LINE FEED (hex 0A), and File Separator (hex 1C) which will cause
+        invalid json, test if pbsnodes -C with special characters results in
+        valid json and escaped representation id displayed correctly.
+        """
+        self.npch_exclude += ['\x1C']
+        for ch in self.npcat:
+            self.logger.info('##### non-printable char: %s #####' % repr(ch))
+            if ch in self.npch_exclude:
+                self.logger.info('##### excluded char: %s' % repr(ch))
+                continue
+            comment = 'h%sd' % ch
+            cmd = ['pbsnodes', '-C', '%s' % comment, self.mom.shortname]
+            self.du.run_cmd(self.server.hostname, cmd, sudo=True)
+            comm1 = 'h%sd' % self.npcat[ch]
+            if ch in self.npch_asis:
+                comm1 = 'h%sd' % ch
+            json_msg = {
+                '\x08': 'h\\bd',
+                '\x09': 'h\\td',
+                '\x0C': 'h\\fd',
+                '\x0D': 'h\\rd'
+            }
+            if ch in json_msg:
+                comm1 = json_msg[ch]
+            # Check json output
+            rc = self.find_in_json_valid('nodes', comm1, None)
+            self.assertGreaterEqual(rc, 2)
+            # Check qmgr -c 'list node @default' output
+            comm2 = '    comment = %s' % comm1
+            cmd = ['qmgr', '-c', 'list node @default']
+            ret = self.du.run_cmd(self.server.hostname, cmd, sudo=True)
+            self.assertEqual(ret['rc'], 0)
+            if comm2 in ret['out']:
+                self.logger.info('Found \"%s\" in qmgr list node out' % comm2)
+            # Check pbsnodes -a output
+            comm3 = '     comment = %s' % comm1
+            cmd = ['pbsnodes', '-a']
+            ret = self.du.run_cmd(self.server.hostname, cmd)
+            self.assertEqual(ret['rc'], 0)
+            if comm3 in ret['out']:
+                self.logger.info('Found \"%s\" in pbsnodes -a output' % comm3)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Various pbs commands qstat, pbs_rstat, printjob, tracejob, pbsnodes, qmgr will display as is attribute/resource values as well as hook names with special non-printing characters that have been set. This is not ideal as the non-printing characters could be a sequence of control characters that cause terminal output to be affected, like changing colors of the text unexpectedly.
* For instance, the following:
    export abc=$(tput bold; tput setaf 1)qsub -v abc -- /bin/sleep 60
 will will display a bold red text after 'abc=' in the Variable_List output of qstat -f

#### Affected Platform(s)
* Linux/Unix only.

#### Cause / Analysis / Design
* The solution is to simply translate those non-printing characters into something consistent with what 'cat -v' does.
* The fix is for the client commands qstat, pbs_rstat, printjob, tracejob, pbsnodes, and qmgr and will not affect the raw output of the PBS apis pbs_stat(), manager(), and so on.
* The details on the fix is in: [https://pbspro.atlassian.net/wiki/spaces/PD/pages/945127456/Non-printing+characters+in+job+attribute+and+resource+values+as+well+as+hook+names](url) 
* There is a discussion on the Forum: [http://community.pbspro.org/t/escape-control-characters-in-job-environment-variables-and-account-name/1369](url)
#### Testing logs/output
* Test logs:
[TestNonprintingCharacters_x90.txt](https://github.com/PBSPro/pbspro/files/2811747/TestNonprintingCharacters_x90.txt)
[TestNonprintingCharacters_td-09.txt](https://github.com/PBSPro/pbspro/files/2811748/TestNonprintingCharacters_td-09.txt)
[TestNonprintingCharacters_td-08.txt](https://github.com/PBSPro/pbspro/files/2811749/TestNonprintingCharacters_td-08.txt)
[TestNonprintingCharacters_td-02.txt](https://github.com/PBSPro/pbspro/files/2811750/TestNonprintingCharacters_td-02.txt)
[TestNonprintingCharacters_a01.txt](https://github.com/PBSPro/pbspro/files/2811751/TestNonprintingCharacters_a01.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [X] My change requires project documentation. See (https://pbspro.atlassian.net/wiki/spaces/PD/pages/945127456/Non-printing+characters+in+job+attribute+and+resource+values+as+well+as+hook+names)** for details.
   - [X] I have added documentation in the above(https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
