### PR TITLE
Test failures post manager() interface change

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6691,11 +6691,17 @@ class Server(PBSService):
                 op = EQ
 
             # If scheduling is set to false then check for
-            # 'server_state' to be 'Idle'
+            # state to be idle
             if attrib and isinstance(attrib,
                                      dict) and 'scheduling' in attrib.keys():
                 if str(attrib['scheduling']) in PTL_FALSE:
-                    attrib['server_state'] = 'Idle'
+                    if obj_type == MGR_OBJ_SERVER:
+                        state_val = 'Idle'
+                        state_attr = ATTR_status
+                    else:   # SCHED object
+                        state_val = 'idle'
+                        state_attr = 'state'
+                    attrib[state_attr] = state_val
                     attrop = PTL_AND
 
             if oid is None:
@@ -8214,8 +8220,8 @@ class Server(PBSService):
             except PbsStatusError:
                 statlist = []
 
-        if (len(statlist) == 0 or statlist[0] is None or
-                len(statlist[0]) == 0):
+        if (statlist is None or len(statlist) == 0 or
+                statlist[0] is None or len(statlist[0]) == 0):
             if op == UNSET or list(set(attrib.values())) == [0]:
                 self.logger.log(level, prefix + " ".join(msg) + ' ...  OK')
                 return True
@@ -8288,7 +8294,7 @@ class Server(PBSService):
                         v = rv
 
                 stat_v = self.utils.decode_value(stat_v)
-                v = self.utils.decode_value(v)
+                v = self.utils.decode_value(str(v))
 
                 if stat_k == ATTR_version:
                     stat_v = LooseVersion(str(stat_v))

--- a/test/tests/functional/pbs_Rrecord_resources_used.py
+++ b/test/tests/functional/pbs_Rrecord_resources_used.py
@@ -70,25 +70,19 @@ class Test_Rrecord_with_resources_used(TestFunctional):
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
 
-        rc = self.server.manager(MGR_CMD_DELETE, NODE, None, "")
-        self.assertEqual(rc, 0)
+        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
 
-        rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
-        self.assertEqual(rc, 0)
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
 
-        rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
-        self.assertEqual(rc, 0)
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
 
         a = {'resources_available.ncpus': 4}
-        rv = self.server.manager(MGR_CMD_SET, NODE, a,
-                                 id=self.hostA, expect=True)
-        self.assertTrue(rv)
-        rv = self.server.manager(MGR_CMD_SET, NODE, a,
-                                 id=self.hostB, expect=True)
-        self.assertTrue(rv)
-        rv = self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'},
-                                 expect=True)
-        self.assertTrue(rv)
+        self.server.manager(MGR_CMD_SET, NODE, a,
+                            id=self.hostA, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a,
+                            id=self.hostB, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'},
+                            expect=True)
 
     def common(self, is_nonrerunnable, restart_mom):
 

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -772,7 +772,7 @@ class TestEquivClass(TestFunctional):
                              'enabled': 'True'}, id='workq2')
 
         self.server.manager(MGR_CMD_SET, QUEUE,
-                            {'priority': 120}, id='workq')
+                            {'Priority': 120}, id='workq')
 
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'scheduling': 'False'})
@@ -816,7 +816,7 @@ class TestEquivClass(TestFunctional):
                              'enabled': 'True'}, id='limits2')
 
         self.server.manager(MGR_CMD_SET, QUEUE,
-                            {'priority': 120}, id='workq')
+                            {'Priority': 120}, id='workq')
 
         self.server.manager(MGR_CMD_SET, QUEUE,
                             {'max_run': '[o:PBS_ALL=20]'}, id='limits1')
@@ -864,7 +864,7 @@ class TestEquivClass(TestFunctional):
 
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
-                             'enabled': 'True', 'priority': 100}, id='workq2')
+                             'enabled': 'True', 'Priority': 100}, id='workq2')
 
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
@@ -874,7 +874,7 @@ class TestEquivClass(TestFunctional):
                             {'queue': 'nodes_queue'}, id='vnode[0]')
 
         self.server.manager(MGR_CMD_SET, QUEUE,
-                            {'priority': 120}, id='workq')
+                            {'Priority': 120}, id='workq')
 
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'scheduling': 'False'})
@@ -924,7 +924,7 @@ class TestEquivClass(TestFunctional):
 
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
-                             'enabled': 'True', 'priority': 100},
+                             'enabled': 'True', 'Priority': 100},
                             id='anytime1')
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
@@ -932,14 +932,14 @@ class TestEquivClass(TestFunctional):
 
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
-                             'enabled': 'True', 'priority': 100},
+                             'enabled': 'True', 'Priority': 100},
                             id='p_queue1')
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
                              'enabled': 'True'}, id='p_queue2')
 
         self.server.manager(MGR_CMD_SET, QUEUE,
-                            {'priority': 120}, id='workq')
+                            {'Priority': 120}, id='workq')
 
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'scheduling': 'False'})
@@ -986,7 +986,7 @@ class TestEquivClass(TestFunctional):
 
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
-                             'enabled': 'True', 'priority': 100},
+                             'enabled': 'True', 'Priority': 100},
                             id='anytime1')
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
@@ -994,7 +994,7 @@ class TestEquivClass(TestFunctional):
 
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
-                             'enabled': 'True', 'priority': 100},
+                             'enabled': 'True', 'Priority': 100},
                             id='np_queue1')
 
         self.server.manager(MGR_CMD_CREATE, QUEUE,
@@ -1002,7 +1002,7 @@ class TestEquivClass(TestFunctional):
                              'enabled': 'True'}, id='np_queue2')
 
         self.server.manager(MGR_CMD_SET, QUEUE,
-                            {'priority': 120}, id='workq')
+                            {'Priority': 120}, id='workq')
 
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'scheduling': 'False'})
@@ -1045,16 +1045,16 @@ class TestEquivClass(TestFunctional):
 
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
-                             'enabled': 'True', 'priority': 100},
+                             'enabled': 'True', 'Priority': 100},
                             id='ded_queue1')
 
         self.server.manager(MGR_CMD_CREATE, QUEUE,
                             {'queue_type': 'e', 'started': 'True',
-                             'enabled': 'True', 'priority': 100},
+                             'enabled': 'True', 'Priority': 100},
                             id='ded_queue2')
 
         self.server.manager(MGR_CMD_SET, QUEUE,
-                            {'priority': 120}, id='workq')
+                            {'Priority': 120}, id='workq')
 
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'scheduling': 'False'})
@@ -1522,7 +1522,7 @@ else:
         self.server.create_vnodes('vnode', a, 4, self.mom, usenatvnode=True)
 
         a = {'queue_type': 'e', 'started': 't',
-             'enabled': 't', 'priority': 150}
+             'enabled': 't', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
 
         (jid1, ) = self.submit_jobs(1)
@@ -1574,7 +1574,7 @@ else:
         self.server.create_vnodes('vnode', a, 4, self.mom, usenatvnode=True)
 
         a = {'queue_type': 'e', 'started': 't',
-             'enabled': 't', 'priority': 150}
+             'enabled': 't', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
 
         (jid1,) = self.submit_jobs(1)
@@ -1631,7 +1631,7 @@ else:
 
         # Create expressq
         a = {'queue_type': 'execution', 'started': 'true',
-             'enabled': 'true', 'priority': 150}
+             'enabled': 'true', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
 
         # Submit 3 jobs with delay of 1 sec
@@ -1752,7 +1752,7 @@ else:
 
         # Create a expressq
         a = {'queue_type': 'execution', 'started': 'true',
-             'enabled': 'true', 'priority': 150}
+             'enabled': 'true', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
 
         # Submit regular job

--- a/test/tests/functional/pbs_job_requeue_timeout_error.py
+++ b/test/tests/functional/pbs_job_requeue_timeout_error.py
@@ -63,20 +63,16 @@ class TestJobRequeueTimeoutErrorMsg(TestFunctional):
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
 
-        rc = self.server.manager(MGR_CMD_DELETE, NODE, None, "")
-        self.assertEqual(rc, 0)
+        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
 
         islocal = self.du.is_localhost(self.hostA)
         if islocal is False:
-            rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
-            self.assertEqual(rc, 0)
+            self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
         else:
-            rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
-            self.assertEqual(rc, 0)
+            self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
 
-        rc = self.server.manager(MGR_CMD_SET, SERVER, {
-                                 'job_requeue_timeout': 1}, expect=True)
-        self.assertTrue(rc)
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'job_requeue_timeout': 1}, expect=True)
 
     def test_error_message(self):
         j = Job(TEST_USER, attrs={ATTR_N: 'job_requeue_timeout'})

--- a/test/tests/functional/pbs_job_routing.py
+++ b/test/tests/functional/pbs_job_routing.py
@@ -50,20 +50,16 @@ class TestJobRouting(TestFunctional):
 
         self.hostA = self.momA.shortname
 
-        rc = self.server.manager(MGR_CMD_DELETE, NODE, None, "")
-        self.assertEqual(rc, 0)
+        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
 
-        rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
-        self.assertEqual(rc, 0)
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
 
         a = {'resources_available.ncpus': 3}
-        rv = self.server.manager(MGR_CMD_SET, NODE, a,
-                                 id=self.hostA, expect=True)
-        self.assertTrue(rv)
+        self.server.manager(MGR_CMD_SET, NODE, a,
+                            id=self.hostA, expect=True)
 
-        rv = self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'},
-                                 expect=True)
-        self.assertTrue(rv)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'},
+                            expect=True)
 
     def test_t1(self):
         """
@@ -145,9 +141,8 @@ class TestJobRouting(TestFunctional):
 
         # Start scheduling cycle. This will move all 3 subjobs to R state.
         # And parent job state to B state.
-        rv = self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'true'},
-                                 expect=True)
-        self.assertTrue(rv)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'true'},
+                            expect=True)
 
         self.server.expect(JOB, {ATTR_state + '=R': 3}, count=True,
                            id=jid, extend='t')
@@ -163,8 +158,8 @@ class TestJobRouting(TestFunctional):
         self.momA = self.moms.values()[0]
         self.hostA = self.momA.shortname
         a = {'state': 'offline'}
-        rv = self.server.manager(MGR_CMD_SET, NODE, a,
-                                 id=self.hostA, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a,
+                            id=self.hostA, expect=True)
 
         # Rerun Third job, job will move to Q state.
         self.server.rerunjob(subjobs[3]['id'])

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -1627,7 +1627,7 @@ class TestMultipleSchedulers(TestFunctional):
 
         # Create a high priority queue
         a = {'queue_type': 'e', 'started': 't',
-             'enabled': 't', 'priority': '150'}
+             'enabled': 't', 'Priority': '150'}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id="highp")
 
         # Submit 2 jobs to high priority queue
@@ -2023,7 +2023,7 @@ class TestMultipleSchedulers(TestFunctional):
         t = int(time.time())
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id='sc1', expect=True)
-        self.server.log_match("processing priority sockets", starttime=t)
+        self.server.log_match("processing priority socket", starttime=t)
         a = {ATTR_queue: 'wq2',
              'Resource_List.select': '1:ncpus=2',
              'Resource_List.walltime': 60}
@@ -2032,4 +2032,4 @@ class TestMultipleSchedulers(TestFunctional):
         t = int(time.time())
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id='sc2', expect=True)
-        self.server.log_match("processing priority sockets", starttime=t)
+        self.server.log_match("processing priority socket", starttime=t)

--- a/test/tests/functional/pbs_only_small_files_over_tpp.py
+++ b/test/tests/functional/pbs_only_small_files_over_tpp.py
@@ -63,24 +63,19 @@ class TestOnlySmallFilesOverTPP(TestFunctional):
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
 
-        rc = self.server.manager(MGR_CMD_DELETE, NODE, None, "")
-        self.assertEqual(rc, 0)
+        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
 
         islocal = self.du.is_localhost(self.hostA)
         if islocal is False:
-            rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
-            self.assertEqual(rc, 0)
+            self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
         else:
-            rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
-            self.assertEqual(rc, 0)
+            self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
 
-        rc = self.server.manager(MGR_CMD_SET, SERVER, {
-                                 'job_requeue_timeout': 175}, expect=True)
-        self.assertTrue(rc)
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'job_requeue_timeout': 175}, expect=True)
 
-        rc = self.server.manager(MGR_CMD_SET, SERVER, {
-            'log_events': 4095}, expect=True)
-        self.assertTrue(rc)
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'log_events': 4095}, expect=True)
 
     def test_small_job_file(self):
         """

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -58,9 +58,9 @@ class TestPBSSnapshot(TestFunctional):
         # Create a custom resource called 'ngpus'
         # This will help us test parts of PBSSnapUtils which handle resources
         attr = {"type": "long", "flag": "nh"}
-        self.assertTrue(self.server.manager(MGR_CMD_CREATE, RSC, attr,
-                                            id="ngpus", expect=True,
-                                            sudo=True))
+        self.server.manager(MGR_CMD_CREATE, RSC, attr,
+                            id="ngpus", expect=True,
+                            sudo=True)
 
         # Check whether pbs_snapshot is accessible
         try:

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -730,34 +730,34 @@ e.accept()
         msg = 'Illegal attribute or resource value'
         try:
             self.server.manager(
-                MGR_CMD_SET, SERVER, {'Resources_default.soft_walltime': '0'})
+                MGR_CMD_SET, SERVER, {'resources_default.soft_walltime': '0'})
         except PbsManagerError as e:
             self.assertTrue(msg in e.msg[0])
 
         try:
             self.server.manager(
                 MGR_CMD_SET, SERVER,
-                {'Resources_default.soft_walltime': '00:00:00'})
+                {'resources_default.soft_walltime': '00:00:00'})
         except PbsManagerError as e:
             self.assertTrue(msg in e.msg[0])
 
         try:
             self.server.manager(
                 MGR_CMD_SET, SERVER,
-                {'Resources_default.soft_walltime': 'abc'})
+                {'resources_default.soft_walltime': 'abc'})
         except PbsManagerError as e:
             self.assertTrue(msg in e.msg[0])
 
         try:
             self.server.manager(
                 MGR_CMD_SET, SERVER,
-                {'Resources_default.soft_walltime': '01:20:aa'})
+                {'resources_default.soft_walltime': '01:20:aa'})
         except PbsManagerError as e:
             self.assertTrue(msg in e.msg[0])
 
         try:
             self.server.manager(MGR_CMD_SET, SERVER, {
-                                'Resources_default.soft_walltime':
+                                'resources_default.soft_walltime':
                                 '1000000000000000000000000'})
         except PbsManagerError as e:
             self.assertTrue(msg in e.msg[0])
@@ -765,20 +765,20 @@ e.accept()
         try:
             self.server.manager(
                 MGR_CMD_SET, SERVER,
-                {'Resources_default.soft_walltime': '-1'})
+                {'resources_default.soft_walltime': '-1'})
         except PbsManagerError as e:
             self.assertTrue(msg in e.msg[0])
 
         try:
             self.server.manager(
                 MGR_CMD_SET, SERVER,
-                {'Resources_default.soft_walltime': '00.10'})
+                {'resources_default.soft_walltime': '00.10'})
         except PbsManagerError as e:
             self.assertTrue(msg in e.msg[0])
 
         self.server.manager(
             MGR_CMD_SET, SERVER,
-            {'Resources_default.soft_walltime': '00:01:00'})
+            {'resources_default.soft_walltime': '00:01:00'})
 
     def test_soft_runjob_hook(self):
         """
@@ -831,7 +831,7 @@ e.accept()
         """
 
         self.server.manager(MGR_CMD_SET, SERVER,
-                            {'Resources_default.soft_walltime': '15'})
+                            {'resources_default.soft_walltime': '15'})
 
         J = Job(TEST_USER, attrs={'Resource_List.walltime': 15})
         jid = self.server.submit(J)
@@ -886,7 +886,7 @@ e.accept()
             " doesn't change while job is held" % est_soft_walltime)
         time.sleep(10)
         self.server.expect(JOB, {'estimated.soft_walltime':
-                           est_soft_walltime}, id=jid)
+                                 est_soft_walltime}, id=jid)
 
         # release the job and look for the soft_walltime again
         self.server.rlsjob(jid, 'u')

--- a/test/tests/functional/pbs_strict_ordering.py
+++ b/test/tests/functional/pbs_strict_ordering.py
@@ -60,8 +60,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         self.assertTrue(rv)
 
         a = {'backfill_depth': 0}
-        rv = self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
-        self.assertTrue(rv)
+        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
 
         j1 = Job(TEST_USER)
         a = {'Resource_List.select': '1:ncpus=2',
@@ -102,38 +101,32 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
              'strict_ordering': 'true all'})
         self.assertTrue(rv)
         a = {'backfill_depth': 2}
-        rv = self.server.manager(
+        self.server.manager(
             MGR_CMD_SET, QUEUE, a, id='workq', expect=True)
-        self.assertTrue(rv)
         a = {
             'queue_type': 'execution',
             'started': 't',
             'enabled': 't',
             'backfill_depth': 1}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq2')
-        self.assertTrue(rv)
         a = {
             'queue_type': 'execution',
             'started': 't',
             'enabled': 't',
             'backfill_depth': 0}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq3')
-        self.assertTrue(rv)
         a = {'backfill_depth': 0}
-        rv = self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
-        self.assertTrue(rv)
+        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
         a = {'resources_available.ncpus': 5}
-        rv = self.server.manager(
+        self.server.manager(
             MGR_CMD_SET,
             NODE,
             a,
             self.mom.shortname,
             expect=True)
-        self.assertTrue(rv)
-        rv = self.server.manager(
+        self.server.manager(
             MGR_CMD_SET, SERVER, {
                 'scheduling': 'False'}, expect=True)
-        self.assertTrue(rv)
         a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'workq'}
         j = Job(TEST_USER, a)
         j.set_sleep_time(100)
@@ -148,31 +141,26 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         j = Job(TEST_USER, a)
         j.set_sleep_time(100)
         j5id = self.server.submit(j)
-        rv = self.server.manager(
+        self.server.manager(
             MGR_CMD_SET, SERVER, {
                 'scheduling': 'True'}, expect=True)
-        self.assertTrue(rv)
-        rv = self.server.expect(JOB,
-                                {'job_state': 'R'},
-                                id=j1id,
-                                max_attempts=30,
-                                interval=2)
-        self.assertTrue(rv)
-        rv = self.server.expect(JOB,
-                                {'job_state': 'R'},
-                                id=j2id,
-                                max_attempts=30,
-                                interval=2)
-        self.assertTrue(rv)
-        rv = self.server.expect(JOB,
-                                {'job_state': 'R'},
-                                id=j4id,
-                                max_attempts=30,
-                                interval=2)
-        self.assertTrue(rv)
-        rv = self.server.expect(JOB,
-                                {'job_state': 'Q'},
-                                id=j5id,
-                                max_attempts=30,
-                                interval=2)
-        self.assertTrue(rv)
+        self.server.expect(JOB,
+                           {'job_state': 'R'},
+                           id=j1id,
+                           max_attempts=30,
+                           interval=2)
+        self.server.expect(JOB,
+                           {'job_state': 'R'},
+                           id=j2id,
+                           max_attempts=30,
+                           interval=2)
+        self.server.expect(JOB,
+                           {'job_state': 'R'},
+                           id=j4id,
+                           max_attempts=30,
+                           interval=2)
+        self.server.expect(JOB,
+                           {'job_state': 'Q'},
+                           id=j5id,
+                           max_attempts=30,
+                           interval=2)

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -192,8 +192,8 @@ class SmokeTest(PBSTestSuite):
         Test for backfilling
         """
         a = {'resources_available.ncpus': 2}
-        rv = self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname,
-                                 expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname,
+                            expect=True)
         self.scheduler.set_sched_config({'strict_ordering': 'True'})
         a = {'Resource_List.select': '1:ncpus=1',
              'Resource_List.walltime': 3600}

--- a/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
+++ b/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
@@ -62,13 +62,11 @@ class JobRerunFileTransferPerf(TestPerformance):
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
 
-        rv = self.server.manager(MGR_CMD_SET, SERVER, {
-                                 'log_events': 4095}, expect=True)
-        self.assertTrue(rv)
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'log_events': 4095}, expect=True)
 
-        rv = self.server.manager(MGR_CMD_SET, SERVER, {
-                                 'job_requeue_timeout': 1000}, expect=True)
-        self.assertTrue(rv)
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'job_requeue_timeout': 1000}, expect=True)
 
     @timeout(600)
     def test_huge_job_file(self):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/ Description & Analysis
* After the check-in of #922 manager()'s interface was changed to always return either the return value of qmgr/pbs_manager(), or 0 for success and non zero for failure in case expect was done. This change was done to make things consistent (earlier the function returned a 0 or a 1 for success depending on whether expect was True or not, now it returns 0 on success regardless of expect). But, it caused some tests to fail as they were working off of the previous behavior.
* Also, manager() was changed to always do an expect for SET and DELETE operations. This caused issues with some tests which set attributes with incorrect case (like 'priority' instead of 'Priority'). I had tried making expect case insensitive with #931 , but it was not enough, we also need to make status() case insensitive, or figure out a different way to handle this in the framework.

#### Affected Platform(s)
* All Linux

#### Solution Description
* fixed tests to check for the new return value
* fixed tests to set attributes with the correct case
* some bugfixes in the manager and expect functions

#### Testing logs/output
[teststrictbackfill.log](https://github.com/PBSPro/pbspro/files/2788635/teststrictbackfill.log)
[teststrictbackfill_after.log](https://github.com/PBSPro/pbspro/files/2788636/teststrictbackfill_after.log)
[testsoftwalltime.log](https://github.com/PBSPro/pbspro/files/2788637/testsoftwalltime.log)
[testsoftwalltime_after.log](https://github.com/PBSPro/pbspro/files/2788638/testsoftwalltime_after.log)
[testpbssnapshot.log](https://github.com/PBSPro/pbspro/files/2788639/testpbssnapshot.log)
[testpbssnapshot_after.log](https://github.com/PBSPro/pbspro/files/2788640/testpbssnapshot_after.log)
[testmultiplesched.log](https://github.com/PBSPro/pbspro/files/2788641/testmultiplesched.log)
[testmultiplesched_after.log](https://github.com/PBSPro/pbspro/files/2788642/testmultiplesched_after.log)
[testjobrouting.log](https://github.com/PBSPro/pbspro/files/2788643/testjobrouting.log)
[testjobrouting_after.log](https://github.com/PBSPro/pbspro/files/2788644/testjobrouting_after.log)
[testequivclass.log](https://github.com/PBSPro/pbspro/files/2788646/testequivclass.log)
[testequivclass_after.log](https://github.com/PBSPro/pbspro/files/2788647/testequivclass_after.log)
[testaclgrps.log](https://github.com/PBSPro/pbspro/files/2788648/testaclgrps.log)
[testaclgrps_after.log](https://github.com/PBSPro/pbspro/files/2788649/testaclgrps_after.log)
[testrootownedscript.log](https://github.com/PBSPro/pbspro/files/2790542/testrootownedscript.log)
[testrootownedscript_after.log](https://github.com/PBSPro/pbspro/files/2790543/testrootownedscript_after.log)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
