### PR TITLE
PP-1326: fix dirname: missing operand error printed from PTL related init scripts

### DIFF
--- a/test/fw/ptl.csh
+++ b/test/fw/ptl.csh
@@ -37,9 +37,15 @@
 
 # This file will set path variables in case of ptl installation
 
-ptl_prefix_lib=$( rpm -ql pbspro-ptl | grep -m 1 lib$ )
-python_dir=$( /bin/ls -1 ${ptl_prefix_lib} )
-prefix=$( dirname ${ptl_prefix_lib} )
+if [ -f "/etc/debian_version" ]; then
+	ptl_prefix_lib=$( dpkg -L pbspro-ptl 2>/dev/null | grep -m 1 lib$ 2>/dev/null )
+else
+	ptl_prefix_lib=$( rpm -ql pbspro-ptl 2>/dev/null | grep -m 1 lib$ 2>/dev/null )
+fi
+if [ "x${ptl_prefix_lib}" != "x" ]; then
+	python_dir=$( /bin/ls -1 ${ptl_prefix_lib} )
+	prefix=$( dirname ${ptl_prefix_lib} )
 
-setenv PATH=${prefix}/bin/:${PATH}
-setenv PYTHONPATH=${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH
+	setenv PATH=${prefix}/bin/:${PATH} 
+	setenv PYTHONPATH=${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH 
+fi

--- a/test/fw/ptl.sh
+++ b/test/fw/ptl.sh
@@ -37,9 +37,15 @@
 
 # This file will set path variables in case of ptl installation
 
-ptl_prefix_lib=$( rpm -ql pbspro-ptl | grep -m 1 lib$ )
-python_dir=$( /bin/ls -1 ${ptl_prefix_lib} )
-prefix=$( dirname ${ptl_prefix_lib} )
+if [ -f "/etc/debian_version" ]; then
+	ptl_prefix_lib=$( dpkg -L pbspro-ptl 2>/dev/null | grep -m 1 lib$ 2>/dev/null )
+else
+	ptl_prefix_lib=$( rpm -ql pbspro-ptl 2>/dev/null | grep -m 1 lib$ 2>/dev/null )
+fi
+if [ "x${ptl_prefix_lib}" != "x" ]; then
+	python_dir=$( /bin/ls -1 ${ptl_prefix_lib} )
+	prefix=$( dirname ${ptl_prefix_lib} )
 
-export PATH=${prefix}/bin/:${PATH}
-export PYTHONPATH=${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH
+	export PATH=${prefix}/bin/:${PATH} 
+	export PYTHONPATH=${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH 
+fi


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
When installing the pbspro-ptl RPM it creates two files in /etc/profile.d. These files are intended to set environment variables so that user may access PTL after logging in. The problem seen occurs during long after the PTL RPM has been installed. Before a prompt is printed, the following output is visible:

dirname: missing operand
Try 'dirname --help' for more information.

These lines are coming from the ptl.sh script.
* Issue ID: [PP-1326](https://pbspro.atlassian.net/browse/PP-1326)

#### Affected Platform(s)
* Debian

#### Cause / Analysis / Design
* The ptl.sh script was calling an rpm command but there was no call for dpkg in case of debian systems, causing dirname command to call an argument with empty variable. Hence the error showd up while logging in.

#### Solution Description
* Added dpkg call in case of debian system.

#### Testing logs/output
* Upon logging in the error prompt "dirname missing operand" now no longer appears.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
