### PR TITLE
Fix qstat -pt crash with array jobs

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -1139,10 +1139,12 @@ percent_cal(char *state, char *timeu, char *timer, char *wtimu, char *wtimr, cha
 		case 'Q':
 		case 'T':
 		case 'W':
+			pbs_asprintf(&rtn, "%3s", "-- ");
 			return (rtn);
 
 		case 'X':
-			return ("100");
+			pbs_asprintf(&rtn, "%3s", "100");
+			return (rtn);
 	}
 
 

--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -1,0 +1,81 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestQstat(TestFunctional):
+    """
+    This test suite validates output of qstat with various options
+    """
+
+    def test_qstat_pt(self):
+        """
+        Test that checks correct output for qstat -pt
+        """
+
+        attr = {'resources_available.ncpus': 1}
+        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.hostname)
+
+        job_count = 10
+        j = Job(TEST_USER)
+        j.set_sleep_time(5)
+        j.set_attributes({ATTR_J: '1-' + str(job_count)})
+        jid = self.server.submit(j)
+
+        self.server.expect(JOB, {'job_state': 'B'}, id=jid)
+
+        self.logger.info('Sleep for 7 seconds to let at least one job finish.')
+        time.sleep(7)
+
+        qstat_cmd = \
+            os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin', 'qstat')
+        qstat_cmd_pt = [qstat_cmd, '-pt', str(jid)]
+        ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_pt)
+
+        self.assertEquals(ret['rc'], 0,
+                          'Qstat returned with non-zero exit status')
+        qstat_out = '\n'.join(ret['out'])
+
+        sjids = [j.create_subjob_id(jid, x) for x in range(1, job_count)]
+        for sjid in sjids:
+            self.assertIn(sjid, qstat_out, 'Job %s not in output' % sjid)
+            sj_escaped = re.escape(sjid)
+            match = re.search(
+                sj_escaped + r'\s+\S+\s+\S+\s+(--\s+[RQ]|100\s+X)\s+\S+',
+                qstat_out)
+            self.assertIsNotNone(match, 'Job output does not match')


### PR DESCRIPTION
#### Bug/feature Description
* `qstat -pt` would result in a segmentation fault if 1 subjob with jobstate X was present in the output.
* `qstat -pt` would print (null) if the job was in the Q state.

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* `percent_cal` was returning a string literal, and the calling function was freeing it.

#### Solution Description
* Allocate a character array and return it instead.

#### Testing logs/output
* [after-fix.txt](https://github.com/PBSPro/pbspro/files/2794306/after-fix.txt)
* [before-fix.txt](https://github.com/PBSPro/pbspro/files/2794307/before-fix.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
