### PR TITLE
Optimization to calendaring and psets

### DIFF
--- a/src/scheduler/check.h
+++ b/src/scheduler/check.h
@@ -130,10 +130,14 @@ sch_resource_t find_counts_elm(counts *cts_list, char *name, char *res);
 
 
 /*
- *      check_nodes - check to see if there is suficient nodes available to
- *                    run a job.
+ *      check_nodes - check to see if there is sufficient nodes available to
+ *                    run a job/resv.
  */
 nspec **check_nodes(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv *resresv, unsigned int flags, schd_error *err);
+
+/* Normal node searching algorithm */
+nspec **
+check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, resource_resv *resresv, unsigned int flags, schd_error *err);
 
 
 /*

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -297,6 +297,7 @@ struct server_info
 	unsigned enforce_prmptd_job_resumption:1;/* If set, preempted jobs will resume after the preemptor finishes */
 	unsigned preempt_targets_enable:1;/* if preemptable limit targets are enabled */
 	unsigned use_hard_duration:1;	/* use hard duration when creating the calendar */
+	unsigned pset_metadata_stale:1;	/* The placement set meta data is stale and needs to be regenerated before the next use */
 	char *name;			/* name of server */
 	struct schd_resource *res;	/* list of resources */
 	void *liminfo;			/* limit storage information */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1667,10 +1667,8 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 		}
 
 		update_queue_on_run(qinfo, rr, &old_state);
-		if (flags & NO_ALLPART)
-			update_all_nodepart(policy, sinfo, rr, NO_ALLPART);
-		else
-			update_all_nodepart(policy, sinfo, rr, NO_FLAGS);
+
+		sinfo->pset_metadata_stale = 1;
 
 		update_server_on_run(policy, sinfo, qinfo, rr, &old_state);
 

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -5377,14 +5377,11 @@ node_up_event(node_info *node, void *arg)
 
 	sinfo = node->server;
 	if (sinfo->node_group_enable && sinfo->node_group_key != NULL) {
-		node_info *arr[2];
-		arr[0] = node;
-		arr[1] = NULL;
-		node_partition_update_array(sinfo->policy, sinfo->nodepart, (node_info **) arr);
+		node_partition_update_array(sinfo->policy, sinfo->nodepart);
 		qsort(sinfo->nodepart, sinfo->num_parts,
 			sizeof(node_partition *), cmp_placement_sets);
 	}
-	update_all_nodepart(sinfo->policy, sinfo, NULL, NO_ALLPART);
+	update_all_nodepart(sinfo->policy, sinfo, NO_ALLPART);
 
 	return 1;
 }
@@ -5428,14 +5425,11 @@ node_down_event(node_info *node, void *arg)
 	set_node_info_state(node, ND_down);
 
 	if (sinfo->node_group_enable && sinfo->node_group_key != NULL) {
-		node_info *arr[2];
-		arr[0] = node;
-		arr[1] = NULL;
-		node_partition_update_array(sinfo->policy, sinfo->nodepart, (node_info **) arr);
+		node_partition_update_array(sinfo->policy, sinfo->nodepart);
 		qsort(sinfo->nodepart, sinfo->num_parts,
 			sizeof(node_partition *), cmp_placement_sets);
 	}
-	update_all_nodepart(sinfo->policy, sinfo, NULL, NO_ALLPART);
+	update_all_nodepart(sinfo->policy, sinfo, NO_ALLPART);
 
 	return 1;
 }

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -579,36 +579,37 @@ update_buckets_for_node_array(node_bucket **bkts, node_info **ninfo_arr) {
 	for (i = 0; ninfo_arr[i] != NULL; i++) {
 		for (j = 0; bkts[j] != NULL; j++) {
 			int node_ind = ninfo_arr[i]->node_ind;
+
+			/* Is this node in the bucket? */
 			if (pbs_bitmap_get_bit(bkts[j]->bkt_nodes, node_ind)) {
-				if (ninfo_arr[i]->num_jobs > 0 || ninfo_arr[i]->num_run_resv > 0) {
-					if (pbs_bitmap_get_bit(bkts[j]->free_pool->truth, node_ind)) {
-						pbs_bitmap_bit_off(bkts[j]->free_pool->truth, node_ind);
-						bkts[j]->free_pool->truth_ct--;
-					} else if(pbs_bitmap_get_bit(bkts[j]->busy_later_pool->truth, node_ind)) {
-						pbs_bitmap_bit_off(bkts[j]->busy_later_pool->truth, node_ind);
-						bkts[j]->busy_later_pool->truth_ct--;
-					}
-					pbs_bitmap_bit_on(bkts[j]->busy_pool->truth, node_ind);
-					bkts[j]->busy_pool->truth_ct++;
-				} else if (pbs_bitmap_get_bit(bkts[j]->busy_pool->truth, node_ind)) {
+				/* First turn off the current bit */
+				if (pbs_bitmap_get_bit(bkts[j]->free_pool->truth, node_ind)) {
+					pbs_bitmap_bit_off(bkts[j]->free_pool->truth, node_ind);
+					bkts[j]->free_pool->truth_ct--;
+				} else if (pbs_bitmap_get_bit(bkts[j]->busy_later_pool->truth, node_ind)) {
+					pbs_bitmap_bit_off(bkts[j]->busy_later_pool->truth, node_ind);
+					bkts[j]->busy_later_pool->truth_ct--;
+				}  else if (pbs_bitmap_get_bit(bkts[j]->busy_pool->truth, node_ind)) {
 					pbs_bitmap_bit_off(bkts[j]->busy_pool->truth, node_ind);
 					bkts[j]->busy_pool->truth_ct--;
+				}
 
+				/* Next, turn on the correct bit */
+				if (ninfo_arr[i]->num_jobs > 0 || ninfo_arr[i]->num_run_resv > 0) {
+					pbs_bitmap_bit_on(bkts[j]->busy_pool->truth, node_ind);
+					bkts[j]->busy_pool->truth_ct++;
+				} else {
 					if (ninfo_arr[i]->node_events != NULL) {
 						pbs_bitmap_bit_on(bkts[j]->busy_later_pool->truth, node_ind);
 						bkts[j]->busy_later_pool->truth_ct++;
-					}
-					else {
+					} else {
 						pbs_bitmap_bit_on(bkts[j]->free_pool->truth, node_ind);
 						bkts[j]->free_pool->truth_ct++;
 					}
 				}
-
-				break;
 			}
 		}
 	}
-
 }
 
 /**
@@ -630,7 +631,7 @@ update_buckets_for_node_array(node_bucket **bkts, node_info **ninfo_arr) {
  *
  */
 int
-node_partition_update_array(status *policy, node_partition **nodepart, node_info **ninfo_arr)
+node_partition_update_array(status *policy, node_partition **nodepart)
 {
 	int i;
 	int cur_rc = 0;
@@ -643,7 +644,7 @@ node_partition_update_array(status *policy, node_partition **nodepart, node_info
 		cur_rc = node_partition_update(policy, nodepart[i]);
 		if (cur_rc == 0)
 			rc = 0;
-		update_buckets_for_node_array(nodepart[i]->bkts, ninfo_arr);
+		update_buckets_for_node_array(nodepart[i]->bkts, nodepart[i]->ninfo_arr);
 	}
 
 	return rc;
@@ -1253,7 +1254,6 @@ create_placement_sets(status *policy, server_info *sinfo)
  *
  *	  @param[in] policy - policy info
  *	  @param[in] sinfo - server info
- *	  @param[in] resresv- the job that was just run
  *	  @param[in] flags - flags to modify behavior
  *	  			NO_ALLPART - do not update the metadata in the allpart.
  *	  				     There are circumstances (e.g., calendaring) where
@@ -1264,20 +1264,19 @@ create_placement_sets(status *policy, server_info *sinfo)
  *
  */
 void
-update_all_nodepart(status *policy, server_info *sinfo, resource_resv *resresv, unsigned int flags)
+update_all_nodepart(status *policy, server_info *sinfo, unsigned int flags)
 {
 	queue_info *qinfo;
-	int update_allpart = 1;
 	int i;
 
-	if (sinfo == NULL || sinfo->queues == NULL || resresv == NULL)
+	if (sinfo == NULL || sinfo->queues == NULL)
 		return;
 
 	if(sinfo->allpart == NULL)
 		return;
 
 	if (sinfo->node_group_enable && sinfo->node_group_key != NULL) {
-		node_partition_update_array(policy, sinfo->nodepart, resresv->ninfo_arr);
+		node_partition_update_array(policy, sinfo->nodepart);
 		qsort(sinfo->nodepart, sinfo->num_parts,
 			sizeof(node_partition *), cmp_placement_sets);
 	}
@@ -1287,7 +1286,7 @@ update_all_nodepart(status *policy, server_info *sinfo, resource_resv *resresv, 
 		qinfo = sinfo->queues[i];
 
 		if (sinfo->node_group_enable && qinfo->node_group_key != NULL) {
-			node_partition_update_array(policy, qinfo->nodepart, resresv->ninfo_arr);
+			node_partition_update_array(policy, qinfo->nodepart);
 
 			qsort(qinfo->nodepart, qinfo->num_parts,
 			   sizeof(node_partition *), cmp_placement_sets);
@@ -1299,26 +1298,16 @@ update_all_nodepart(status *policy, server_info *sinfo, resource_resv *resresv, 
 	}
 
 	/* Update and resort the hostsets */
-	node_partition_update_array(policy, sinfo->hostsets, NULL);
+	node_partition_update_array(policy, sinfo->hostsets);
 	if (policy->node_sort[0].res_name != NULL &&
 	    conf.node_sort_unused && sinfo->hostsets != NULL) {
 		/* Resort the nodes in host sets to correctly reflect unused resources */
 		qsort(sinfo->hostsets, sinfo->num_hostsets, sizeof(node_partition*), multi_nodepart_sort);
 	}
 
-	if ((flags & NO_ALLPART) == 0) {
-		/* If the job is in a queue with nodes, we only need to update
-		 * the allpart of that queue.  This has already happened above.
-		 * */
-		if (resresv != NULL && resresv ->is_job) {
-			if (resresv->job != NULL)
-				if (resresv->job->queue->has_nodes)
-					update_allpart = 0;
-		}
-
-		/* Otherwise, update the server's allpart */
-		if (update_allpart || sinfo->allpart->res == NULL)
+	if ((flags & NO_ALLPART) == 0)
 			node_partition_update(policy, sinfo->allpart);
-	}
+
+	sinfo->pset_metadata_stale = 0;
 
 }

--- a/src/scheduler/node_partition.h
+++ b/src/scheduler/node_partition.h
@@ -143,7 +143,7 @@ node_partition *find_node_partition_by_rank(node_partition **np_arr, int rank);
  *	returns 1 on all success, 0 on any failure
  *	Note: This is not an atomic operation
  */
-int node_partition_update_array(status *policy, node_partition **nodepart, node_info **ninfo_arr);
+int node_partition_update_array(status *policy, node_partition **nodepart);
 
 /*
  *	node_partition_update - update the meta data about a node partition
@@ -217,7 +217,7 @@ node_partition *create_specific_nodepart(status *policy, char *name, node_info *
 int create_placement_sets(status *policy, server_info *sinfo);
 
 /* Update placement sets and allparts */
-void update_all_nodepart(status *policy, server_info *sinfo, resource_resv *resresv, unsigned int flags);
+void update_all_nodepart(status *policy, server_info *sinfo, unsigned int flags);
 
 
 #ifdef	__cplusplus

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1184,6 +1184,7 @@ new_server_info(int limallocflag)
 	sinfo->has_nonCPU_licenses = 0;
 	sinfo->enforce_prmptd_job_resumption = 0;
 	sinfo->use_hard_duration = 0;
+	sinfo->pset_metadata_stale = 0;
 	sinfo->sched_cycle_len = 0;
 	sinfo->num_parts = 0;
 	sinfo->partitions = NULL;
@@ -2181,6 +2182,7 @@ dup_server_info(server_info *osinfo)
 	nsinfo->has_nonCPU_licenses = osinfo->has_nonCPU_licenses;
 	nsinfo->enforce_prmptd_job_resumption = osinfo->enforce_prmptd_job_resumption;
 	nsinfo->use_hard_duration = osinfo->use_hard_duration;
+	nsinfo->pset_metadata_stale = osinfo->pset_metadata_stale;
 	nsinfo->sched_cycle_len = osinfo->sched_cycle_len;
 	nsinfo->partitions = dup_string_array(osinfo->partitions);
 	nsinfo->opt_backfill_fuzzy_time = osinfo->opt_backfill_fuzzy_time;
@@ -2989,10 +2991,8 @@ update_universe_on_end(status *policy, resource_resv *resresv, char *job_state, 
 	if (qinfo != NULL)
 		update_queue_on_end(qinfo, resresv, job_state);
 
-	if (flags & NO_ALLPART)
-		update_all_nodepart(policy, sinfo, resresv, NO_ALLPART);
-	else
-		update_all_nodepart(policy, sinfo, resresv, NO_FLAGS);
+	/* Mark the metadata stale.  It will be updated in the next call to is_ok_to_run() */
+	sinfo->pset_metadata_stale = 1;
 
 	update_resresv_on_end(resresv, job_state);
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
The scheduler's placement sets have resource metadata associated with them.  The scheduler uses the metadata to determine if it is at all possible for a job to fit within a placement set.  If it can't, there is no reason to bother checking the nodes of that set.  The problem is keeping this metadata up to date is expensive.

Before this optimization, if the scheduler ran/ended a job/resv, it would recreate the metadata for all the placement sets and the all partitions.  This is required because when that job/resv starts/ends, the metadata is now stale.

This made sense before opt_backfill_fuzzy.  Calendaring was a loop of run/end a job/resv, then check if the topjob could run.  With opt_backfill_fuzzy, we end many jobs/resvs, and then check if the top job can run.  This means we may recreate the metadata many times before we actually use it again.

This optimization fixes that by marking the metadata as stale when we run/end a job/resv.  We don't recreate it until right before we need it.

#### Testing logs/output
The performance test runs a cycle with opt_backfill_fuzzy at the default value, and then again at high.
Before:
Cycle: Cycle 1: 701.598765 Cycle 2: 31.353018 
After: 
Cycle: Cycle 1: 707.332365 Cycle 2: 24.326485 Perc 2907.66%

These results were run on a VM, so explains variation on cycle 1.  I ran many cycle 2s and before is around 30-31 seconds.  After is 22-24 seconds.

This is about a 25% speedup when opt_backfill_fuzzy is set to high.

It can help when opt_backfill_fuzzy is set to the default value, but this test is specifically crafted to not allow that to happen.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
