### PR TITLE
updating test in TestMultipleSchedulers test suite to avoid race condition

### DIFF
--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -1890,10 +1890,8 @@ class TestMultipleSchedulers(TestFunctional):
         a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq3'}
 
         J1 = Job(TEST_USER1, attrs=a)
-        J1.set_sleep_time(5)
 
         J2 = Job(TEST_USER1, attrs=a)
-        J2.set_sleep_time(5)
 
         jid1 = self.server.submit(J1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
@@ -1904,6 +1902,7 @@ class TestMultipleSchedulers(TestFunctional):
         # accrue_type = 2 is eligible_time
         self.server.expect(JOB, {ATTR_accrue_type: 2}, id=jid2)
 
+        self.server.delete(jid1, wait=True)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
         # This makes sure that accrue_type is indeed getting changed
         self.server.expect(JOB, {ATTR_accrue_type: 3}, id=jid2)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *TestMultipleSchedulers.test_set_msched_update_inbuilt_attrs_accrue_type fails due to race condition*

#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
* *The test fails sometimes as the second submitted job gets started before it is being able to check for accrue_type=2.*

#### Solution Description
* *Running both the submitted jobs for default sleep time.*
* *Deleting first job after checking the accrue_type of second submitted job.*

#### Testing logs/output
* *[ptl_output.txt](https://github.com/PBSPro/pbspro/files/2794908/ptl_output.txt)*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
