### PR TITLE
log_match fix: update n='All' if first attempt fails

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4086,8 +4086,7 @@ class PBSService(PBSObject):
                 self.logger.log(level, infomsg + '... OK')
                 break
             else:
-                if ((starttime is not None or endtime is not None) and
-                        n != 'ALL'):
+                if n != 'ALL':
                     if attempt > max_attempts:
                         # We will do one last attempt to match in case the
                         # number of lines that were provided did not capture


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *remove day argument(PR#956) introduced a new bug if first attempt fails then number of lines(n) value was not updated to All*

#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
* *Since intialization of starttime has moved to log_lines method n value remains same for all attempts*

#### Solution Description
* *Update the n value to 'All' for 2nd and next attempts if already not set*

#### Testing logs/output
* *[log_match_fix_test_acctlog.txt](https://github.com/PBSPro/pbspro/files/2810979/log_match_fix_test_acctlog.txt)*
* *[log_match_fix_eligible_time_job_array.txt](https://github.com/PBSPro/pbspro/files/2810980/log_match_fix_eligible_time_job_array.txt)*


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
