### PR TITLE
first subjob not getting resource set in runjob hook

### DIFF
--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -3857,13 +3857,11 @@ process_hooks(struct batch_request *preq, char *hook_msg, size_t msg_len,
 
 		jobid = ((struct rq_runjob *)(req_ptr.rq_run))->rq_jid;
 		t = is_job_array(jobid);
-		if (t == IS_ARRAY_NO) {
-			pjob = find_job(jobid); /* regular job */
-		} else if ((t == IS_ARRAY_Single) || (t == IS_ARRAY_Range)) {
-			pjob = find_arrayparent(jobid); /* subjob(s) */
+		if ((t == IS_ARRAY_Single) || (t == IS_ARRAY_NO)) {
+			pjob = find_job(jobid); /* regular job and single subjob */
 		}
 
-		/* an array job will fall through with pjob set to NULL */
+		/* an array job or range of subjobs will fall through with pjob set to NULL */
 
 		if (pjob == NULL) {
 			log_event(PBSEVENT_DEBUG2,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *any resource modified in runjob hook was not reflected in first subjob*
* *set a resource in a run job hook and check the first subjob's Resource_List, the resource set in run job hook will not be available*

#### Affected Platform(s)
* *All*

#### Cause
* *in `process_hooks()` while processing runjob event for subjob, instead of the instantiated subjob's job object, it's parent's job object was used, this lead to the hook modifying the parent's resource list, which got reflected only in subsequent subjobs*

#### Solution Description
* *for single subjob use job obj of the  subjob instead of parent job*

#### Testing logs/output
[Test_report_logs.zip](https://github.com/PBSPro/pbspro/files/2813122/Test_report_logs.zip)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
