### PR TITLE
test_t3 of Test_Rrecord_with_resources_used is failing while verifying accounting logs

### DIFF
--- a/test/tests/functional/pbs_Rrecord_resources_used.py
+++ b/test/tests/functional/pbs_Rrecord_resources_used.py
@@ -194,7 +194,7 @@ class Test_Rrecord_with_resources_used(TestFunctional):
 
         return jid1, jid2, jid3s1
 
-    def test_t1(self):
+    def test_Rrecord_with_nodefailrequeue(self):
         """
         Scenario: The node on which the job was running goes down and
                   node_fail_requeue time-out is hit.
@@ -212,7 +212,7 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             msg='.*R;' + re.escape(jid3s1) + '.*resources_used.*',
             id=jid3s1, regexp=True)
 
-    def test_t2(self):
+    def test_Rrecord_when_mom_restarted_with_r(self):
         """
         Scenario: The node on which the job was running goes down and
                   node_fail_requeue time-out is hit and mom is restarted
@@ -233,14 +233,13 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             msg='.*R;' + re.escape(jid3s1) + '.*resources_used.*run_count=1',
             id=jid3s1, regexp=True)
 
-    def test_t3(self):
+    def test_Rrecord_for_nonrerunnable_jobs(self):
         """
         Scenario: One non-rerunnable job. The node on which the job was
                   running goes down and node_fail_requeue time-out is hit.
         Expected outcome: Server should record last known resource usage in
                   the 'R' record only for rerunnable jobs.
         """
-
         a = {ATTR_JobHistoryEnable: 1}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
@@ -251,12 +250,12 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             regexp=True)
         self.server.accounting_match(
             msg='.*R;' + jid2 + '.*resources_used.*run_count=1', id=jid2,
-            regexp=True)
+            regexp=True, existence=False, max_attempts=5)
         self.server.accounting_match(
             msg='.*R;' + re.escape(jid3s1) + '.*resources_used.*run_count=1',
             id=jid3s1, regexp=True)
 
-    def test_t4(self):
+    def test_Rrecord_when_mom_restarted_without_r(self):
         """
         Scenario: Mom restarted without '-r' option and jobs are requeued
                    using qrerun.
@@ -303,7 +302,7 @@ class Test_Rrecord_with_resources_used(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'},
                             expect=True)
 
-    def test_t5(self):
+    def test_Rrecord_with_multiple_reruns(self):
         """
         Scenario: Job is rerun multiple times.
         Expected outcome: Server should record last known resource usage
@@ -404,7 +403,7 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             '.*Exit_status=-11.*.*resources_used.*.*run_count=1.*',
             id=jid3s1, regexp=True)
 
-    def test_t6(self):
+    def test_Rrecord_with_multiple_reruns_case2(self):
         """
         Scenario: Jobs submitted with select cput and ncpus. Job is rerun
                   multiple times.
@@ -479,7 +478,7 @@ class Test_Rrecord_with_resources_used(TestFunctional):
             '.*.*resources_used.cput=[0-9]*:[0-9]*:[0-9]*.*.*run_count=2.*',
             id=jid2, regexp=True)
 
-    def test_t7(self):
+    def test_Rrecord_job_rerun_forcefully(self):
         """
         Scenario: Job is forcefully rerun.
         Expected outcome: server should record last known resource usage in


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug
* Test "test_t3" of "Test_Rrecord_with_resources_used" is failing while verifying the log-msg in accounting logs
* Change name of the tests according to PTL naming convention

#### Affected Platform(s)
* ALL

#### Cause / Analysis / Design
* The intent of the test is to verify that R record appears only for rerunnable jobs.
* In the test we are submitting 3 jobs(J1: rerunnable jobs with -koe option, J2: Non rerunnable job with -koe option and J3: rerunnable job array) and the test is expecting that a R record entry should exist for J2 job which is not true. As it is non-rerunnable job R record will not appear in the accounting logs

#### Solution Description
* Pass parameter "existence=False" in accounting_match function for J2.

#### Testing logs/output
* [Complete_Execution_logs_Rrecord.txt](https://github.com/PBSPro/pbspro/files/2817526/Complete_Execution_logs_Rrecord.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
