### PR TITLE
Support in PTL to speed up deletion of large number of jobs

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1444,6 +1444,7 @@ class PBSTestSuite(unittest.TestCase):
         if 'skip-teardown' in self.conf:
             return
         self.log_enter_teardown()
+        self.server.cleanup_jobs(runas=ROOT_USER)
         self.stop_proc_monitor()
         self.log_end_teardown()
 

--- a/test/tests/functional/pbs_init_script.py
+++ b/test/tests/functional/pbs_init_script.py
@@ -72,7 +72,7 @@ class TestPbsInitScript(TestFunctional):
         self.assertIn("PBS mom", output)
 
     def tearDown(self):
-        TestFunctional.tearDown(self)
         # Above test leaves system in unusable state for PTL and PBS.
         # Hence restarting PBS explicitly
         PBSInitServices().restart()
+        TestFunctional.tearDown(self)

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -401,8 +401,3 @@ class TestPreemptPerformance(TestPerformance):
         self.logger.info(res_str)
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
-
-    def tearDown(self):
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
-        job_ids = self.server.select()
-        self.server.delete(id=job_ids)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Couple of PTL performance tests run large number of jobs. The tearDown() of these tests or setUp() of subsequent tests clean up by deleting these jobs using qdel. This qdel operation takes very long. Consequently these tests timeout.

#### Affected Platform(s)
All linux

#### Cause / Analysis / Design

- The scheduler is constantly cycling and it may tell the server to start the jobs we are trying to delete. This makes server busy and the delete job requests have to wait to get processed until the server is done talking to the scheduler at the start of the sched cycle. This causes  deletions take much longer.
- A lot of MoM and server<->MoM activity happens when terminating a running job. This adds delay. 

#### Solution Description

- PTL tests turn off scheduling before qdel. 
- A custom PTL function, cleanup_jobs_for_perftest() is introduced that does the following for every job:
   - Get pids from jobs’s session_id attribute
   - Kill the process (kill -9 )
   - Delete job from server using qdel -Wforce

This function will be exclusively used in the tearDown of tests that deal with huge number of jobs to speed up job deletion.

Discussion forum:  http://community.pbspro.org/t/add-support-in-ptl-to-speed-up-deletion-of-large-number-of-jobs/1400

###Testing logs/output
[TestPreemptPerformance.test_insufficient_resc_multiple_non_cons_afterfix.txt](https://github.com/PBSPro/pbspro/files/2818615/TestPreemptPerformance.test_insufficient_resc_multiple_non_cons_afterfix.txt)
[TestPreemptPerformance.test_insufficient_resc_non_cons_afterfix.txt](https://github.com/PBSPro/pbspro/files/2818609/TestPreemptPerformance.test_insufficient_resc_non_cons_afterfix.txt)
Time taken for job deletion:

  | With changes in this PR | Existing
-- | -- | --
10K running jobs | 37.8 minutes | qdel operation hanged.noresponse for close to 1 hr
10K Queued jobs | 26.16 minutes | 27.16 minutes
10K jobs (5K Running and  5K Queued) | 36.8 minutes | qdel operation hanged.noresponse for close to 1 hr
5K Running jobs | 25 mins | qdel operation hanged.noresponse for close to 1 hr
5K Queued jobs  | 14.8 mins | 14.6mins
1K Running jobs | 2.96 mins | 10.26mins
500 Running 500 Queued jobs | 1.2 | 4.56 mins

Latest test results: 
[TestPremptPerformance_afterfix.txt](https://github.com/PBSPro/pbspro/files/2877201/TestPremptPerformance_afterfix.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__