### PR TITLE
Make logging to synchronous for daemons

### DIFF
--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -931,6 +931,7 @@ log_record(int eventtype, int objclass, int sev, const char *objname, const char
 			     eventtype & ~PBSEVENT_FORCE, msg_daemonname,
 			     class_names[objclass], objname, text);
 
+		(void)fflush(logfile);
 		if (rc < 0) {
 			rc = errno;
 			clearerr(logfile);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *Making logging back to synchronous*

#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
* *If one of the daemons die and doesn't drop a core file, with asynchronous logging, there is a possibility of loosing last few log messages.*

#### Solution Description
* *Adding "fflush()" function to make logging to synchronous*
* *Pulling out changes as done in the PR: https://github.com/PBSPro/pbspro/pull/943*

#### Testing logs/output
* *Since we are reverting back to old state, there is no need for any specific testing. Appveyor and Travis should be fine.*

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
