### PR TITLE
Unable to find the psql command and race condition during resv submission

### DIFF
--- a/test/tests/functional/pbs_trillion_jobid.py
+++ b/test/tests/functional/pbs_trillion_jobid.py
@@ -48,7 +48,7 @@ class TestTrillionJobid(TestFunctional):
 . ${PBS_EXEC}/libexec/pbs_pgsql_env.sh
 
 DATA_PORT=${PBS_DATA_SERVICE_PORT}
-if [ -z $DATA_PORT ]; then
+if [ -z ${DATA_PORT} ]; then
     DATA_PORT=15007
 fi
 
@@ -82,7 +82,7 @@ if [ $? -ne 0 ]; then
 fi
 
 args="-U ${DATA_USER} -p ${DATA_PORT} -d pbs_datastore"
-PGPASSWORD=test psql ${args} <<-EOF
+PGPASSWORD=test ${PGSQL_BIN}/psql ${args} <<-EOF
     UPDATE pbs.server SET sv_jobidnumber = %d;
 EOF
 
@@ -213,7 +213,7 @@ exit 0
         :type  resv_msg : string
 
         """
-        resv_start = int(time.time())
+        resv_start = int(time.time()) + 2
         a = {'reserve_start': int(resv_start),
              'reserve_duration': int(resv_dur)
              }


### PR DESCRIPTION

#### Bug/feature Description
* PBS couldn't find the psql command.
* Race condition in submitting a reservation.

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* It couldn't found the psql command because path was not given.
* Sometimes at the time of submitting reservation, given time gets passed already.

#### Solution Description
* Added path to the command.
* Added 2 sec to the reservation time

#### Testing logs/output
* [ptl_trillion_jobid.txt](https://github.com/PBSPro/pbspro/files/2826732/ptl_trillion_jobid.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
