### PR TITLE
pbs_comm crash in munge_validate

### DIFF
--- a/src/lib/Libdb/db_postgres_svr.c
+++ b/src/lib/Libdb/db_postgres_svr.c
@@ -176,7 +176,6 @@ pg_db_save_svr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	pbs_db_svr_info_t *ps = obj->pbs_db_un.pbs_db_svr;
 	char *stmt;
 	int params;
-	int rc = 0;
 	char *raw_array = NULL;
 
 	SET_PARAM_INTEGER(conn, ps->sv_numjobs, 0);
@@ -206,12 +205,11 @@ pg_db_save_svr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 
 	if (pg_db_cmd(conn, stmt, params) != 0) {
 		free(raw_array);
-		rc = -1;
+		return -1;
 	}
 
 	free(raw_array);
-
-	return rc;
+	return 0;
 }
 
 /**


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *pbs_comm crash in pbs_munge_validate*

#### Cause / Analysis / Design
* *Multiple threads are invoking init_munge() which is not thread safe*

#### Solution Description
* *Making sure init_munge() is invoked only once using [pthread_once](https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_once.html)*
* *server crash fix in pg_db_save_svr due to double free*

#### Testing logs/output
One way to possibly reproduce this manually is this:

    * Have the comm under gdb and put  breakpoint in pbs_munge_validate  "thread apply all break pbs_munge_validate"

    * Have two moms connect to the comm, (nothing else should be connected to the comm before that, so do not start server or sched)

    * for the first connection let the thread wait in init_munge, and switch to the "other" thread and let it also hit pbs_munge_validate for the second connection

    * In the broken version, you will be able to enter init_munge() after switching to the second thread as well (even though thread one is already inside).

    * In this fixed version, init_munge() will be entered only once due to pthread_once.

gdb logs:
[gdb_with_fix.txt](https://github.com/PBSPro/pbspro/files/2835608/gdb_with_fix.txt)
[gdb_without_fix.txt](https://github.com/PBSPro/pbspro/files/2835609/gdb_without_fix.txt)

Existing automated test results:
[test_t1.txt](https://github.com/PBSPro/pbspro/files/2835194/test_t1.txt)
[test_t2.txt](https://github.com/PBSPro/pbspro/files/2835195/test_t2.txt)
[test_t3.txt](https://github.com/PBSPro/pbspro/files/2835196/test_t3.txt)
[test_t4.txt](https://github.com/PBSPro/pbspro/files/2835197/test_t4.txt)
[test_t5.txt](https://github.com/PBSPro/pbspro/files/2835198/test_t5.txt)


CC: @subhasisb , @bremanandjk , @npadole20 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
