### PR TITLE
holidays file enhancements

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -170,10 +170,13 @@ schedinit(void)
 	else
 		init_non_prime_time(&cstat, NULL);
 
-	tmptr = localtime(&cstat.current_time);
-	if ((tmptr != NULL) && ((tmptr->tm_year + 1900) > conf.holiday_year))
-		schdlog(PBSEVENT_ADMIN, PBS_EVENTCLASS_FILE, LOG_NOTICE,
-			HOLIDAYS_FILE, "The holiday file is out of date; please update it.");
+	if (conf.holiday_year != 0) {
+		tmptr = localtime(&cstat.current_time);
+		if ((tmptr != NULL) && ((tmptr->tm_year + 1900) > conf.holiday_year))
+			schdlog(PBSEVENT_ADMIN, PBS_EVENTCLASS_FILE, LOG_NOTICE,
+			HOLIDAYS_FILE,
+					"The holiday file is out of date; please update it.");
+	}
 
 	parse_ded_file(DEDTIME_FILE);
 
@@ -299,10 +302,13 @@ update_cycle_status(struct status *policy, time_t current_time)
 	else if (prime == NON_PRIME && policy->is_prime)
 		init_non_prime_time(policy, NULL);
 
-	tmptr = localtime(&policy->current_time);
-	if ((tmptr != NULL ) && ((tmptr->tm_year + 1900) > conf.holiday_year))
-		schdlog(PBSEVENT_ADMIN, PBS_EVENTCLASS_FILE, LOG_NOTICE,
-		       HOLIDAYS_FILE, "The holiday file is out of date; please update it.");
+	if (conf.holiday_year != 0) {
+		tmptr = localtime(&policy->current_time);
+		if ((tmptr != NULL) && ((tmptr->tm_year + 1900) > conf.holiday_year))
+			schdlog(PBSEVENT_ADMIN, PBS_EVENTCLASS_FILE, LOG_NOTICE,
+			HOLIDAYS_FILE,
+					"The holiday file is out of date; please update it.");
+	}
 	policy->prime_status_end = end_prime_status(policy->current_time);
 
 	if (policy->prime_status_end == SCHD_INFINITY)

--- a/src/scheduler/pbs_holidays
+++ b/src/scheduler/pbs_holidays
@@ -1,77 +1,58 @@
-*
- * Copyright (C) 1994-2018 Altair Engineering, Inc.
- * For more information, contact Altair at www.altair.com.
- *
- * This file is part of the PBS Professional ("PBS Pro") software.
- *
- * Open Source License Information:
- *
- * PBS Pro is free software. You can redistribute it and/or modify it under the
- * terms of the GNU Affero General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option) any
- * later version.
- *
- * PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.
- * See the GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Commercial License Information:
- *
- * For a copy of the commercial license terms and conditions,
- * go to: (http://www.pbspro.com/UserArea/agreement.html)
- * or contact the Altair Legal Department.
- *
- * Altair’s dual-license business model allows companies, individuals, and
- * organizations to create proprietary derivative works of PBS Pro and
- * distribute them - whether embedded or bundled with other software -
- * under a commercial license agreement.
- *
- * Use of Altair’s trademarks, including but not limited to "PBS™",
- * "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
- * trademark licensing policies.
-*
-
-*
-YEAR  2018
-*
-* Prime/Nonprime Table 
-*
-*   Prime Non-Prime
-* Day   Start Start
-*
-  weekday 0600  1730
-  saturday  none  all
-  sunday  none  all
-*
-* Day of  Calendar  Company
-* Year    Date    Holiday
-*
-
-* if a holiday falls on a saturday, it is observed on the friday before
-* if a holiday falls on a sunday, it is observed on the monday after
-
-* Jan 1 
-    1           Jan 1           New Year's Day
-* Third Monday of Jan
-   15           Jan 15          Martin Luther King Day
-* Third Monday in Feb
-   50           Feb 19          President's Day
-* Last Monday in May
-  148           May 28          Memorial Day
-* July 4th
-  185           Jul 4           Independence Day
-* First Monday in Sept 
-  246           Sep 3           Labor Day
-* Second Monday in Oct
-  281           Oct 8           Columbus Day
-* Nov 11 
-  316           Nov 12          Veterans Day
-* Fourth Thursday in Nov
-  326           Nov 22          Thanksgiving
-* Dec 25 
-  359           Dec 25          Christmas Day
+#
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+#
+#
+# UNCOMMENT AND CHANGE THIS TO THE CURRENT YEAR
+#YEAR  1970
+#
+# Prime/Nonprime Table 
+#
+#   Prime Non-Prime
+# Day   Start Start
+#
+# UNCOMMENT AND SET THE REQUIRED PRIME/NON-PRIME START TIMES
+#  weekday 0600  1730
+#  saturday  none  all
+#  sunday  none  all
+#
+# Day of  Calendar  Company
+# Year    Date    Holiday
+#
+#
+# UNCOMMENT AND ADD CALENDAR HOLIDAYS TO BE CONSIDERED AS NON-PRIME DAYS
+#    1           Jan 1           New Year's Day
+#  359           Dec 25          Christmas Day
 

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -44,6 +44,7 @@ class TestCalendaring(TestFunctional):
     """
     This test suite tests if PBS scheduler calendars events correctly
     """
+
     def test_topjob_start_time(self):
         """
         In this test we test that the top job which gets added to the
@@ -96,7 +97,7 @@ class TestCalendaring(TestFunctional):
         # since only one subjob of array parent can become topjob
         # second job must start 10 seconds after that because
         # walltime of array job is 10 seconds.
-        self.assertEqual(est_epoch2, est_epoch1+10)
+        self.assertEqual(est_epoch2, est_epoch1 + 10)
         # Also make sure that since second subjob from array is running
         # Third subjob should set estimated.start_time in future.
         self.assertGreater(est_epoch1, time_now)

--- a/test/tests/functional/pbs_holidays.py
+++ b/test/tests/functional/pbs_holidays.py
@@ -1,0 +1,392 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+import datetime
+from tests.functional import *
+
+
+class TestHolidays(TestFunctional):
+
+    """
+    This test suite tests if PBS scheduler's holidays file feature
+    works correctly
+    """
+    days = ["monday", "tuesday", "wednesday", "thursday", "friday",
+            "saturday", "sunday"]
+    np_queue = "np_workq"
+    p_queue = "p_workq"
+    cur_year = datetime.datetime.today().year
+    allprime_msg = "It is primetime.  It will never end"
+    tom = datetime.date.today() + datetime.timedelta(days=1)
+    tom = tom.strftime("%m/%d/%Y")
+    dayprime_msg = r"It is primetime.  It will end in \d+ seconds at " +\
+        tom + " 00:00:00"
+    daynp_msg = r"It is non-primetime.  It will end in \d+ seconds at " +\
+        tom + " 00:00:00"
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        # Enable DEBUG2 sched log messages
+        self.scheduler.set_sched_config({'log_filter': 3072})
+
+    def test_missing_days(self):
+        """
+        Test that scheduler correctly assumes 24hr prime-time for days that
+        are missing from the holidays file
+        """
+        self.scheduler.holidays_delete_entry('a')
+
+        self.scheduler.holidays_set_year(self.cur_year)
+
+        # Set all days of the week as non-prime time and today as prime time
+        today_idx = datetime.datetime.today().weekday()
+        today = self.days[today_idx]
+        for i in range(7):
+            if i != today_idx:
+                self.scheduler.holidays_set_day(self.days[i], "none", "all")
+
+        ctime = int(time.time())
+        time.sleep(1)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+
+        # Verify that there's no entry in holidays file for today
+        ret = self.scheduler.holidays_get_day(today)
+        self.assertIsNone(ret['p'])
+        self.assertIsNone(ret['np'])
+        self.assertIsNone(ret['valid'])
+
+        # Verify that it's prime-time until tomorrow
+        self.scheduler.log_match(msg=self.dayprime_msg, regexp=True,
+                                 starttime=ctime)
+
+    def test_inconsistent_days(self):
+        """
+        Test that scheduler correctly assumes 24hr prime-time for days that
+        have inconsistent data
+        """
+        self.scheduler.holidays_delete_entry('a')
+
+        self.scheduler.holidays_set_year(self.cur_year)
+
+        # Set all days of the week as non-prime time except today
+        today_idx = datetime.datetime.today().weekday()
+        today = self.days[today_idx]
+        for i in range(7):
+            if i != today_idx:
+                self.scheduler.holidays_set_day(self.days[i], "none", "all")
+
+        # Set both prime and non-prime start times to 'all' for today
+        # and check that scheduler assumes that day as prime-time
+        self.scheduler.holidays_set_day(today, "all", "all")
+
+        # Verify that it's prime-time until tomorrow
+        ctime = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.dayprime_msg, regexp=True,
+                                 starttime=ctime)
+
+        # Set both prime and non-prime start times to 'all' for today
+        self.scheduler.holidays_set_day(today, "none", "none")
+
+        # Verify that it's prime-time until tomorrow
+        ctime = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.dayprime_msg, regexp=True,
+                                 starttime=ctime)
+
+    def test_only_year(self):
+        """
+        Test that scheduler assumes all prime-time if there's only a year
+        entry in the holidays file
+        """
+        self.scheduler.holidays_delete_entry('a')
+
+        self.scheduler.holidays_set_year(self.cur_year)
+
+        # Verify that the holidays file has only the year line
+        h_content = self.scheduler.holidays_parse_file()
+        self.assertEqual(len(h_content), 1)
+        self.assertEqual(h_content[0], "YEAR\t%d" % self.cur_year)
+
+        # Verify that it's 24x7 prime-time
+        ctime = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.allprime_msg, regexp=True,
+                                 starttime=ctime)
+
+    def test_empty_holidays_file(self):
+        """
+        Test that the scheduler assumes all prime-time if the holidays
+        file is completely empty
+        """
+        ctime = int(time.time())
+        self.scheduler.holidays_delete_entry('a')
+
+        # Verify that the holidays file is empty
+        h_content = self.scheduler.holidays_parse_file()
+        self.assertEqual(len(h_content), 0)
+
+        # Verify that it's 24x7 prime-time
+        ctime2 = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.allprime_msg, regexp=True,
+                                 starttime=ctime2)
+
+        # Verify that scheduler didn't log a message for out of date file
+        msg = "holidays;The holiday file is out of date; please update it."
+        self.scheduler.log_match(msg, starttime=ctime, existence=False,
+                                 max_attempts=5)
+
+    def test_stale_year(self):
+        """
+        Test that the scheduler logs out-of-date log message and assumed
+        all prime-time for a holidays file with just a stale year line
+        """
+        ctime = int(time.time())
+        self.scheduler.holidays_delete_entry('a')
+
+        self.scheduler.holidays_set_year(self.cur_year - 1)
+
+        # Verify that the holidays file has only the year line
+        h_content = self.scheduler.holidays_parse_file()
+        self.assertEqual(len(h_content), 1)
+        self.assertEqual(h_content[0], "YEAR\t%d" % (self.cur_year - 1))
+
+        # Verify that it's 24x7 prime-time
+        ctime2 = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.allprime_msg, regexp=True,
+                                 starttime=ctime2)
+
+        # Verify that scheduler logged a message for out of date file
+        msg = "holidays;The holiday file is out of date; please update it."
+        self.scheduler.log_match(msg, starttime=ctime)
+
+    def test_commented_holidays_file(self):
+        """
+        Test that the scheduler assumes all prime-time if the holidays
+        file is completely commented out
+        """
+        ctime = int(time.time())
+        self.scheduler.holidays_delete_entry('a')
+
+        content = """# YEAR 1970
+#  weekday 0600  1730
+#  saturday  none  all
+#  sunday  none  all"""
+
+        self.scheduler.holidays_write_file(content=content)
+
+        # Verify that the holidays file has 4 lines
+        h_content = self.du.cat(filename=self.scheduler.holidays_file,
+                                sudo=True)['out']
+        self.assertEqual(len(h_content), 4)
+
+        # Verify that it's 24x7 prime-time
+        ctime2 = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.allprime_msg, regexp=True,
+                                 starttime=ctime2)
+
+        # Verify that scheduler didn't log a message for out of date file
+        msg = "holidays;The holiday file is out of date; please update it."
+        self.scheduler.log_match(msg, starttime=ctime, existence=False,
+                                 max_attempts=5)
+
+    def test_non_prime(self):
+        """
+        Test that non-prime time set via holidays file works correctly
+        """
+        self.scheduler.holidays_delete_entry('a')
+
+        self.scheduler.holidays_set_year(self.cur_year)
+
+        # Set all days of the week as prime time except today
+        today_idx = datetime.datetime.today().weekday()
+        today = self.days[today_idx]
+        for i in range(7):
+            if i != today_idx:
+                self.scheduler.holidays_set_day(self.days[i], "all", "none")
+
+        # Set today as all non-prime time
+        self.scheduler.holidays_set_day(today, "none", "all")
+
+        # Verify that it's non-prime time until tomorrow
+        ctime = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.daynp_msg, regexp=True,
+                                 starttime=ctime)
+
+    def test_missing_year(self):
+        """
+        Test that scheduler assumes all prime time if the year entry is
+        missing from holidays file
+        """
+        ctime = int(time.time())
+        self.scheduler.holidays_delete_entry('a')
+
+        # Create a holidays file with no year entry and all days set to
+        # 24hrs non-prime time
+        content = """  weekday none  all
+  saturday  none  all
+  sunday  none  all"""
+
+        self.scheduler.holidays_write_file(content=content)
+
+        # Verify that the holidays file has 3 lines
+        h_content = self.du.cat(filename=self.scheduler.holidays_file,
+                                sudo=True)['out']
+        self.assertEqual(len(h_content), 3)
+
+        # Verify that it's 24x7 prime-time
+        ctime2 = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.allprime_msg, regexp=True,
+                                 starttime=ctime2)
+
+        # Verify that scheduler didn't log a message for out of date file
+        msg = "holidays;The holiday file is out of date; please update it."
+        self.scheduler.log_match(msg, starttime=ctime, existence=False,
+                                 max_attempts=5)
+
+    def test_prime_events_calendar(self):
+        """
+        Test that for a commented out holidays file, scheduler doesn't
+        add policy change events to the calendar
+        """
+        self.scheduler.set_sched_config({'log_filter': 2048,
+                                         'strict_ordering': "true    all"})
+
+        self.scheduler.holidays_delete_entry('a')
+
+        # Create a holidays file with no year entry and all days set to
+        # 24hrs non-prime time
+        content = """# YEAR 1970
+#  weekday 0600  1730
+#  saturday  none  all
+#  sunday  none  all"""
+        self.scheduler.holidays_write_file(content=content)
+
+        time.sleep(1)
+        ctime = int(time.time())
+
+        # Verify that it's 24x7 prime-time
+        ctime2 = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.allprime_msg, regexp=True,
+                                 starttime=ctime2)
+
+        # Set ncpus on vnode to 1
+        attrs = {ATTR_rescavail + ".ncpus": '1'}
+        self.server.manager(MGR_CMD_SET, NODE, attrs)
+
+        # Submit a job that will occupy all resources, without a walltime
+        a = {'Resource_List.select': '1:ncpus=1'}
+        j = Job(TEST_USER, attrs=a)
+        self.server.submit(j)
+
+        # Submit another job which will get calendared
+        j = Job(TEST_USER, attrs=a)
+        self.server.submit(j)
+
+        # Verify that scheduler did not calendar any policy change events
+        msg = r".*Simulation: Policy change.*"
+        self.scheduler.log_match(msg, regexp=True, starttime=ctime,
+                                 existence=False,
+                                 max_attempts=5)
+
+    def test_week_day_after_weekday(self):
+        """
+        Test that an individual weekday's entry after the 'weekday'
+        entry takes precedence in the holidays file
+        """
+        self.scheduler.holidays_delete_entry('a')
+
+        self.scheduler.holidays_set_year(self.cur_year)
+
+        # Add a weekday entry with all prime-time
+        self.scheduler.holidays_set_day("weekday", "all", "none")
+
+        # Set today as all non-prime time
+        today_idx = datetime.datetime.today().weekday()
+        today = self.days[today_idx]
+        self.scheduler.holidays_set_day(today, "none", "all")
+
+        # Verify that it's non-prime time until tomorrow
+        ctime = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.daynp_msg, regexp=True,
+                                 starttime=ctime)
+
+    def test_year_0(self):
+        """
+        Test that setting holidays file's year entry to 0 causes 24x7
+        prime-time
+        """
+        ctime = int(time.time())
+        self.scheduler.holidays_delete_entry('a')
+
+        self.scheduler.holidays_set_year('0')
+
+        # Verify that the holidays file has only the year line
+        h_content = self.scheduler.holidays_parse_file()
+        self.assertEqual(len(h_content), 1)
+        self.assertEqual(h_content[0], "YEAR\t0")
+
+        # Verify that it's 24x7 prime-time
+        ctime2 = int(time.time())
+        time.sleep(1)
+        self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: True})
+        self.scheduler.log_match(msg=self.allprime_msg, regexp=True,
+                                 starttime=ctime2)
+
+        # Verify that scheduler didn't log a message for out of date file
+        msg = "holidays;The holiday file is out of date; please update it."
+        self.scheduler.log_match(msg, starttime=ctime, existence=False,
+                                 max_attempts=5)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Feature Description
* Holidays file has information about prime/non-prime windows for days of the week for a site. Right now, there's no documented behavior for what happens if data for any of the days is missing or if the data is inconsistent. Also, the behavior for when the year entry is missing is not clearly defined. The general use case, as well as the theme of the prime-time feature in PBS, seems to be to assume prime time if data is insufficient, so it seems like a good idea to officially enforce this behavior. It is also desired to have an empty/commented out holidays file which doesn't need to be updated every year so that it is all prime-time by default.

#### Affected Platform(s)
* All

#### Design
* EDD: https://pbspro.atlassian.net/wiki/spaces/PD/pages/1046151225/Holidays+file+missing+inconsistent+days+will+be+treated+as+ALL+PRIME
* Forum discussion:
http://community.pbspro.org/t/holidays-file-missing-inconsistent-days-will-be-treated-as-all-prime/1440
http://community.pbspro.org/t/wrong-holidays-file-makes-scheduler-infinite-loop/1387/

#### Solution Description
* Now, after parsing holidays file, if there's data missing for a day, we enforce 'all' prime-time for it
* If an entry in holidays file sets both prime and non-prime start times to 'all'/'none', we enforce 'all' prime-time for it.
* The holidays file will now be completely commented out by default, so it'll be 24x7 prime-time

#### Testing logs/output
* [testholidays.log](https://github.com/PBSPro/pbspro/files/2850263/testholidays.log)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [X] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [X] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
