### PR TITLE
Removed unneeded prolific logging from sched perf test

### DIFF
--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -171,8 +171,9 @@ class TestSchedPerf(TestPerformance):
         """
         Test opt_backfill_fuzzy with placement sets.
         """
-        self.scheduler.set_sched_config(
-            {'strict_ordering': 'True', 'log_filter': '2048'})
+
+        a = {'strict_ordering': 'True'}
+        self.scheduler.set_sched_config(a)
 
         a = {'node_group_key': 'color', 'node_group_enable': 'True',
              'scheduling': 'False'}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
test test_pset_fuzzy_perf had the scheduler logging set unnecessarily high which generated gigabytes of logs for the test.

#### Solution Description
I left logging at the default level.

#### Testing logs/output
[perf.log](https://github.com/PBSPro/pbspro/files/2823085/perf.log)
 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
