### PR TITLE
setting sync_mom_hookfiles_timeout to lower value to avoid hook copy r…

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -9454,6 +9454,16 @@ class Server(PBSService):
         :returns: True on success.
         :raises: PbsManagerError
         """
+        # sync_mom_hookfiles_timeout is 15min by default
+        # Setting it to lower value to avoid the race condition at hook copy
+        srv_stat = self.status(SERVER, 'sync_mom_hookfiles_timeout')
+        try:
+            sync_val = srv_stat[0]['sync_mom_hookfiles_timeout']
+        except:
+            self.logger.info("Setting sync_mom_hookfiles_timeout to 15s")
+            self.manager(MGR_CMD_SET, SERVER,
+                         {"sync_mom_hookfiles_timeout": 15})
+
         fn = self.du.create_temp_file(body=body)
 
         if not self._is_local:


### PR DESCRIPTION
…ace condition

#### Bug/feature Description
* *Bugs: sometime hook tests fails due to race condition in hook copy. This is mostly seen for execjob_prologue hook*


#### Affected Platform(s)
* *Platform (ALL)*

#### Cause / Analysis / Design
* *Bugs: If hook copy fails to mom for any reason then next retry happens after 15min which is way too long for test execution life cycle.*

#### Solution Description
* *decrease the value from 15min to 15s if sync_mom_hookfiles_timeout not set to anything*

#### Testing logs/output
* *  
[ptl.txt](https://github.com/PBSPro/pbspro/files/2831069/ptl.txt)
  *

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
