### PR TITLE
pbs_snapshot errors out when capturing mom hosts

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -346,7 +346,7 @@ class _PBSSnapUtils(object):
 
         # Check which of the PBS daemons' information is available
         self.server = Server(primary_host)
-        self.scheduler = Scheduler(server=self.server)
+        self.scheduler = None
         daemon_status = self.server.pi.status()
         if len(daemon_status) > 0 and daemon_status['rc'] == 0 and \
                 len(daemon_status['err']) == 0:
@@ -357,6 +357,7 @@ class _PBSSnapUtils(object):
                         self.server_up = True
                 elif d_stat.startswith("pbs_sched"):
                     self.sched_info_avail = True
+                    self.scheduler = Scheduler(server=self.server)
                 elif d_stat.startswith("pbs_mom"):
                     self.mom_info_avail = True
                 elif d_stat.startswith("pbs_comm"):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* pbs_snapshot fails on mom hosts as follows:

[ragrawal@pbs ~]$ /opt/pbs/sbin/pbs_snapshot --with-sudo -o .
2019-02-05 14:21:00,543 INFO server pbs: server operating mode set to cli
2019-02-05 14:21:00,543 INFOCLI pbs: /opt/pbs/bin/qstat -Bf pbs
2019-02-05 14:21:00,553 ERROR err: ['Connection refused', 'qstat: cannot connect to server pbs (errno=111)']
2019-02-05 14:21:00,553 INFO server pbs: version unknown
2019-02-05 14:21:00,580 INFOCLI2 pbs: sudo -H /opt/pbs/sbin/pbsfs
Traceback (most recent call last):
File "/opt/pbs/unsupported/fw/bin/pbs_snapshot.py", line 315, in <module>
with_sudo=with_sudo) as snap_utils:
File "/opt/pbs/unsupported/fw/ptl/utils/pbs_snaputils.py", line 247, in _enter_
self.with_sudo)
File "/opt/pbs/unsupported/fw/ptl/utils/pbs_snaputils.py", line 349, in _init_
self.scheduler = Scheduler(server=self.server)
File "/opt/pbs/unsupported/fw/ptl/lib/pbs_testlib.py", line 10573, in _init_
self.setup_sched_priv(sched_priv)
File "/opt/pbs/unsupported/fw/ptl/lib/pbs_testlib.py", line 10600, in setup_sched_priv
self.fairshare_tree = self.query_fairshare()
File "/opt/pbs/unsupported/fw/ptl/lib/pbs_testlib.py", line 12082, in query_fairshare
msg=str(ret['err']))
ptl.lib.pbs_testlib.PbsFairshareError: rc=1, rv=None, msg=['sudo: /opt/pbs/sbin/pbsfs: command not found']

#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* The reason was that we were trying to create a Scheduler PTL object for all kinds of primary hosts, be it the server host, or mom host. When run on a mom host, creating a Scheduler object crashes because there's no pbsfs on the system.

#### Solution Description
* Moved the creation of Scheduler object to when we know for sure that sched daemon exists on the system.

#### Testing logs/output
* PTL doesn't seem to support running on a mom host, so I did manual testing instead:
[snapshot_mom.log](https://github.com/PBSPro/pbspro/files/2835939/snapshot_mom.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
