### PR TITLE
Preserving db_password file while upgrading database

### DIFF
--- a/src/cmds/scripts/install_db
+++ b/src/cmds/scripts/install_db
@@ -219,7 +219,7 @@ if [ ! -d "${data_dir}" ]; then
 fi
 
 # delete the password file, if any, since we are creating new db
-rm -f "${PBS_HOME}/server_priv/db_password"
+[${upgrade} -eq 0] && rm -f "${PBS_HOME}/server_priv/db_password"
 passwd="${user}"
 
 chown ${user} ${data_dir}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Affected Platform(s)
* Linux 

#### Cause / Analysis / Design
* This issue will happen only when upgrading the postgres database from two different major/minor versions.
Eg: (From pgsql v9.3.* to pgsql v9.6.*)

#### Solution Description
* Preserve the db_password file for retaining previous user's encrypted password.

#### Testing logs/output
* STEPS TO REPRODUCE:

1) Build PBS pro using v9.3 postgres DBMS using --with-database-dir
2) Install using "make install", 
3) Run some jobs and configure some server settings. 
4) Build PBS Pro with v9.6 postgres DBMS using --with-database-dir.
5) While configuring, specify different prefix but the same PBS_HOME.
6) Install using "make install".
7) while starting PBS pro, database scripts will delete the db_password and fail to start pbs_server.

 Test logs:  [upgrade_db_v9.3_v9.6.txt](https://github.com/PBSPro/pbspro/files/2855220/upgrade_db_v9.3_v9.6.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
 - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
