### PR TITLE
fix for chk_file_sec() to verify the file security

### DIFF
--- a/src/lib/Libwin/accesinfo.c
+++ b/src/lib/Libwin/accesinfo.c
@@ -811,7 +811,7 @@ perm_granted_admin_and_owner(char *path, int disallow, char *owner, char *errmsg
 		powner_s = getgrpname(powner);
 
 	if (powner_s != NULL) {
-		if ( !sidIsAdminPrivilege(powner) && \
+		if ( !sidIsAdminPrivilege(powner) || \
 			( (owner != NULL) && strcmp(owner, powner_s) != 0 )  ) {
 			rc = EPERM;
 			sprintf(errmsg, "File %s not owned by user %s or an admin-type user!",
@@ -852,7 +852,7 @@ perm_granted_admin_and_owner(char *path, int disallow, char *owner, char *errmsg
 			 ( EqualSid((SID *)&pace->SidStart, esid) || \
 			sid2rid((SID *)&pace->SidStart) != \
 					 SECURITY_CREATOR_OWNER_RID ) && \
-			(!sidIsAdminPrivilege( (SID *)&pace->SidStart)) && \
+			(!sidIsAdminPrivilege( (SID *)&pace->SidStart)) || \
    			((owner != NULL) && strcmp(name, owner) != 0) ) {
 			(void)accessinfo_add(allowed, sizeInfo.AceCount,
 				name, (mask & 0xFFFF));


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Function chk_file_sec() on windows does not work properly, as a result, there are two problems one can face one windows -
1. There is a binary called "chk_tree" which is available on windows. This binary is used to check if the files passed to it as an argument have security issues and have open write permissions for non-admin users. Due to the bug, this binary never reports any security issues

2. Mom/Server dynamic resource scripts also suffer from the same bug on windows. PBS checks that the dynamic resource scripts do not have any security issues but, since the check on windows is broken, it never finds out any security issues and executes the scripts.

#### Affected Platform(s)
* Windows

#### Cause / Analysis / Design
* After populating ACL entities, we are verifying each ACE elements in a loop, the logical expressions used for file permissions check and ownership verifications are not cautiously written. 

#### Solution Description
*  Correct the evaluation expressions in file permission checks.

#### Testing logs/output
* [Test_logs_windows.txt](https://github.com/PBSPro/pbspro/files/2865763/Test_logs_windows.txt)
* [chk_tree_file_test_results.docx](https://github.com/PBSPro/pbspro/files/2865847/chk_tree_file_test_results.docx)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
