### PR TITLE
PP-1329: Add the dependency for minimum db version require in v19.1 spec file

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -104,8 +104,8 @@ BuildRequires: libedit-devel
 BuildRequires: libical-devel
 BuildRequires: ncurses-devel
 BuildRequires: perl
-BuildRequires: postgresql-devel
-BuildRequires: postgresql-contrib
+BuildRequires: postgresql-devel >= 9.1
+BuildRequires: postgresql-contrib >= 9.1
 BuildRequires: python-devel >= 2.6
 BuildRequires: python-devel < 3.0
 BuildRequires: tcl-devel
@@ -150,8 +150,8 @@ Conflicts: pbs-mom
 Conflicts: pbs-cmds
 Requires: bash
 Requires: expat
-Requires: postgresql-server
-Requires: postgresql-contrib
+Requires: postgresql-server >= 9.1
+Requires: postgresql-contrib >= 9.1
 Requires: python >= 2.6
 Requires: python < 3.0
 Requires: tcl

--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -104,8 +104,8 @@ BuildRequires: libedit-devel
 BuildRequires: libical-devel
 BuildRequires: ncurses-devel
 BuildRequires: perl
-BuildRequires: postgresql-devel
-BuildRequires: postgresql-contrib
+BuildRequires: postgresql-devel >= 9.1
+BuildRequires: postgresql-contrib >= 9.1
 BuildRequires: python-devel >= 2.6
 BuildRequires: python-devel < 3.0
 BuildRequires: tcl-devel
@@ -150,8 +150,8 @@ Conflicts: pbs-mom
 Conflicts: pbs-cmds
 Requires: bash
 Requires: expat
-Requires: postgresql-server
-Requires: postgresql-contrib
+Requires: postgresql-server >= 9.1
+Requires: postgresql-contrib >= 9.1
 Requires: python >= 2.6
 Requires: python < 3.0
 Requires: tcl


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* [PP-1329](https://pbspro.atlassian.net/browse/PP-1329)

#### Affected Platform(s)
* *Linux*

#### Cause / Analysis / Design
* While building RPM packages in CentOS 6, there is no requirement for minimum db version. 
* This leads to build RPMS with older version of DB, but fails to start PBS Pro services. 

#### Solution Description
* These checks will help to notify the user to use supported postgres version which works with PBS Pro v19.1.

#### Testing logs/output
* [min_db_version_test_logs.txt](https://github.com/PBSPro/pbspro/files/2874907/min_db_version_test_logs.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
