### PR TITLE
printjob_svr does not iterate attributes

### DIFF
--- a/src/tools/printjob.c
+++ b/src/tools/printjob.c
@@ -417,14 +417,13 @@ print_db_job(char *id, int no_attributes)
 			int i;
 			printf("--attributes--\n");
 			for (i=0; i< dbjob.attr_list.attr_count; i++) {
-				printf("%s", attrs->attr_name);
-				if (attrs->attr_resc && attrs->attr_resc[0] != 0)
-					printf(".%s", attrs->attr_resc);
+				printf("%s", attrs[i].attr_name);
+				if (attrs[i].attr_resc && attrs[i].attr_resc[0] != 0)
+					printf(".%s", attrs[i].attr_resc);
 				printf(" = ");
-				if (attrs->attr_value)
-					printf("%s", show_nonprint_chars(attrs->attr_value));
+				if (attrs[i].attr_value)
+					printf("%s", show_nonprint_chars(attrs[i].attr_value));
 				printf("\n");
-
 			}
 
 		}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* This bug was introduced in #904. There is a missing iteration over attributes while the attributes are printed by printjob_svr.bin. The first attribute is printed instead of various attributes.
```
root@took27:~# printjob_svr.bin 1
---------------------------------------------------
jobid:	1.took27
---------------------------------------------------
state:		0x4
substate:	0x2a (42)
svrflgs:	0x3001 (12289)
ordering:	0
inter prior:	0
stime:		1550739146
file base:	
queue:		default
union type exec:
	momaddr	18446744071897349403
	exits	0
--attributes--
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
ctime = 1550739146
```

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* There is a missing iteration over attributes in printjob_svr.

#### Solution Description
* Itterate the attributes.

#### Testing logs/output
* Smoke test: 
[ptl_smoke.txt](https://github.com/PBSPro/pbspro/files/2888511/ptl_smoke.txt)


*  Manual test:
```
root@took27:~# printjob_svr.bin 1
---------------------------------------------------
jobid:	1.took27
---------------------------------------------------
state:		0x9
substate:	0x5c (92)
svrflgs:	0x1 (1)
ordering:	0
inter prior:	0
stime:		1550739146
file base:	
queue:		default
union type exec:
	momaddr	18446744071897349403
	exits	0
--attributes--
ctime = 1550739146
etime = 1550739146
euser = pbstest
mtime = 1550739283
qtime = 1550739146
queue = default
stime = 1550739146
egroup = tstgrp00
jobdir = /home/pbstest
server = took27
comment = Job run at Thu Feb 21 at 09:52 on (took27:ncpus=1) and finished
project = _pbs_project_default
Job_Name = STDIN
Priority = 0
hashname = 1.took27
substate = 92
Job_Owner = pbstest@took27.ics.muni.cz
Join_Path = n
Rerunable = False
exec_host = took27/0
hop_count = 1
job_state = F
run_count = 1
Checkpoint = u
Error_Path = /dev/pts/3
Hold_Types = n
Keep_Files = n
exec_host2 = took27.ics.muni.cz:15002/0
exec_vnode = (took27:ncpus=1)
queue_rank = 1550739146314
queue_type = E
session_id = 13902
Exit_status = 0
Mail_Points = a
Output_Path = /dev/pts/3
interactive = 49055
run_version = 1
schedselect = 1:ncpus=1
Variable_List = PBS_O_HOME=/home/pbstest,PBS_O_LANG=en_US.UTF-8,PBS_O_LOGNAME=pbstest,PBS_O_PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games,PBS_O_MAIL=/var/mail/pbstest,PBS_O_SHELL=/bin/bash,PBS_O_WORKDIR=/home/pbstest,PBS_O_SYSTEM=Linux,PBS_O_QUEUE=default,PBS_O_HOST=took27.ics.muni.cz
job_kill_delay = 10
Submit_arguments = <jsdl-hpcpa:Argument>-I</jsdl-hpcpa:Argument>
history_timestamp = 1550739283
resources_used.mem = 12852kb
Resource_List.ncpus = 1
Resource_List.place = pack
resources_used.cput = 00:00:00
resources_used.vmem = 278768kb
Resource_List.nodect = 1
Resource_List.select = 1:ncpus=1
resources_used.ncpus = 1
Resource_List.walltime = 24:00:00
resources_used.walltime = 00:02:16
resources_used.cpupercent = 0
resources_used_update.mem = 12852kb
resources_used_update.cput = 00:00:00
resources_used_update.vmem = 278768kb
resources_used_update.ncpus = 1
resources_used_update.walltime = 00:02:16
resources_used_update.cpupercent = 0
```
#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
