### PR TITLE
Remote connections to pbs_demux fail in higher version of Windows

### DIFF
--- a/src/cmds/pbs_demux_win.c
+++ b/src/cmds/pbs_demux_win.c
@@ -118,6 +118,12 @@ handle_np_conn(char *pipename, char *jobid, int num_nodes)
 	(void)memset(rs_cmd.hostname, '\0', sizeof(rs_cmd.hostname));
 	(void)memset(rs_cmd.pipename_append, '\0', sizeof(rs_cmd.pipename_append));
 
+	(void)InitializeSecurityDescriptor(&SecDesc, SECURITY_DESCRIPTOR_REVISION);
+	(void)SetSecurityDescriptorDacl(&SecDesc, TRUE, NULL, TRUE);
+	SecAttrib.nLength = sizeof(SECURITY_ATTRIBUTES);
+	SecAttrib.lpSecurityDescriptor = &SecDesc;;
+	SecAttrib.bInheritHandle = TRUE;
+	
 	hPipe = CreateNamedPipe(
 		pipename,
 		PIPE_ACCESS_DUPLEX,
@@ -140,12 +146,7 @@ handle_np_conn(char *pipename, char *jobid, int num_nodes)
 	}
 
 	for (i = 0; i < num_nodes && hPipe != NULL; i++) {
-		(void)InitializeSecurityDescriptor(&SecDesc, SECURITY_DESCRIPTOR_REVISION);
-		(void)SetSecurityDescriptorDacl(&SecDesc, TRUE, NULL, TRUE);
-		SecAttrib.nLength = sizeof(SECURITY_ATTRIBUTES);
-		SecAttrib.lpSecurityDescriptor = &SecDesc;;
-		SecAttrib.bInheritHandle = TRUE;
-
+		
 		(void)do_ConnectNamedPipe(hPipe, NULL);
 		if (!ReadFile(hPipe, hostname, PBS_MAXHOSTNAME, &dwRead, NULL) ||
 			dwRead == 0) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
- Multinode pbsdsh job fails to get the outputs from sister Mom. 

#### Affected Platform(s)
- Higher version than Windows7 (like Windows 10, Windows 12)

#### Cause / Analysis / Design
- In higher version of Windows, named pipe connection from Mom superior to sister Mom fails. Because in server(pbs_demux) it is using a null security attribute while creating a named pipe. 
Whereas on the other end, client (mom_open_demux in sister Mom) is using proper security attribute while connecting to the named pipe.

#### Solution Description
- Initialized the security attribute properly before using it in CreateNamedPipe().

#### Testing logs/output
-Tested the code changes in Windows7, Windows10 and Windows12
[win_demux.txt](https://github.com/PBSPro/pbspro/files/2892647/win_demux.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
