### PR TITLE
Fix rpmlint warnings: script-without-shebang, postin/postun-without-l…

### DIFF
--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -295,6 +295,7 @@ cd build
 %make_install
 
 %post %{pbs_server}
+ldconfig %{_libdir}
 # do not run pbs_postinstall when the CLE is greater than or equal to 6
 imps=0
 cle_release_version=0
@@ -311,6 +312,7 @@ else
 fi
 
 %post %{pbs_execution}
+ldconfig %{_libdir}
 # do not run pbs_postinstall when the CLE is greater than or equal to 6
 imps=0
 cle_release_version=0
@@ -327,6 +329,7 @@ else
 fi
 
 %post %{pbs_client}
+ldconfig %{_libdir}
 # do not run pbs_postinstall when the CLE is greater than or equal to 6
 imps=0
 cle_release_version=0
@@ -404,6 +407,7 @@ fi
 %postun %{pbs_server}
 if [ "$1" != "1" ]; then
 	# This is an uninstall, not an upgrade.
+	ldconfig %{_libdir}
 	echo
 	echo "NOTE: /etc/pbs.conf and the PBS_HOME directory must be deleted manually"
 	echo
@@ -412,6 +416,7 @@ fi
 %postun %{pbs_execution}
 if [ "$1" != "1" ]; then
 	# This is an uninstall, not an upgrade.
+	ldconfig %{_libdir}
 	echo
 	echo "NOTE: /etc/pbs.conf and the PBS_HOME directory must be deleted manually"
 	echo
@@ -420,6 +425,7 @@ fi
 %postun %{pbs_client}
 if [ "$1" != "1" ]; then
 	# This is an uninstall, not an upgrade.
+	ldconfig %{_libdir}
 	echo
 	echo "NOTE: /etc/pbs.conf must be deleted manually"
 	echo
@@ -447,6 +453,7 @@ fi
 %{pbs_prefix}/*
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_rcp
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
+%attr(644, root, root) %{pbs_prefix}/lib/libpbs.la
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
 %config(noreplace) %{_sysconfdir}/profile.d/*
@@ -457,6 +464,8 @@ fi
 %endif
 %exclude %{pbs_prefix}/unsupported/*.pyc
 %exclude %{pbs_prefix}/unsupported/*.pyo
+%doc README
+%license LICENSE
 
 %files %{pbs_execution}
 %defattr(-,root,root, -)
@@ -464,6 +473,7 @@ fi
 %{pbs_prefix}/*
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_rcp
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
+%attr(644, root, root) %{pbs_prefix}/lib/libpbs.la
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
 %config(noreplace) %{_sysconfdir}/profile.d/*
@@ -493,12 +503,16 @@ fi
 %exclude %{pbs_prefix}/sbin/pbsfs
 %exclude %{pbs_prefix}/unsupported/*.pyc
 %exclude %{pbs_prefix}/unsupported/*.pyo
+%doc README
+%license LICENSE
+
 
 %files %{pbs_client}
 %defattr(-,root,root, -)
 %dir %{pbs_prefix}
 %{pbs_prefix}/*
 %attr(4755, root, root) %{pbs_prefix}/sbin/pbs_iff
+%attr(644, root, root) %{pbs_prefix}/lib/libpbs.la
 %{_sysconfdir}/profile.d/pbs.csh
 %{_sysconfdir}/profile.d/pbs.sh
 %config(noreplace) %{_sysconfdir}/profile.d/*
@@ -537,6 +551,8 @@ fi
 %exclude %{pbs_prefix}/unsupported/*.pyc
 %exclude %{pbs_prefix}/unsupported/*.pyo
 %exclude %{_unitdir}/pbs.service
+%doc README
+%license LICENSE
 
 %if %{with ptl}
 %files %{pbs_ptl}


### PR DESCRIPTION
…dconfig, no-documentation

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Fix 3 rpmlint warnings/errors

#### Affected Platform(s)
* CentOS, openSUSE

#### Cause / Analysis / Design
* script-without-shebang: Libpbs.la has execution bit set and was considered a script by rpmlint
* postin/postun-without-ldconfig: postin and postun sections of packages are missing ldconfig
* no-documentation: packages have no documentation packaged with them

#### Solution Description
* remove Libpbs.la
* add ldconfig to postin and postun sections
* add README and LICENSE to packages

#### Testing logs/output
* [rpmlint warnings PTB.txt](https://github.com/PBSPro/pbspro/files/2902265/rpmlint.warnings.PTB.txt)
 * [rpmlint warnings manual test.txt](https://github.com/PBSPro/pbspro/files/2902278/rpmlint.warnings.manual.test.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.

__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__