### PR TITLE
[WIP] Server allows jobs/resvs to be run/confirmed on down/stale vnodes

### DIFF
--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -259,6 +259,7 @@ extern "C" {
 #define PBSE_STDG_RESV_OCCR_CONFLICT 15179 /* cannot change start time of a non-empty reservation */
 
 #define PBSE_SOFTWT_STF		     15180 /* soft_walltime is incompatible with STF jobs */
+#define PBSE_BAD_NODE_STATE          15181 /* node is in the wrong state for the operation */
 
 /*
  ** 	Resource monitor specific

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -358,7 +358,7 @@ extern	int  act_resv_add_owner(attribute*, void*, int);
 extern	void svr_mailownerResv(resc_resv*, int, int, char*);
 extern	void resv_free(resc_resv*);
 extern	void set_old_subUniverse(resc_resv *);
-extern	int  assign_resv_resc(resc_resv *, char *);
+extern	int  assign_resv_resc(resc_resv *, char *, int svr_init); /* Adding svr_init parameter to track whether the server is in init start mode */
 extern	void  resv_exclusive_handler(resc_resv *);
 #ifdef	__cplusplus
 }

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -358,7 +358,7 @@ extern	int  act_resv_add_owner(attribute*, void*, int);
 extern	void svr_mailownerResv(resc_resv*, int, int, char*);
 extern	void resv_free(resc_resv*);
 extern	void set_old_subUniverse(resc_resv *);
-extern	int  assign_resv_resc(resc_resv *, char *, int svr_init); /* Adding svr_init parameter to track whether the server is in init start mode */
+extern	int  assign_resv_resc(resc_resv *, char *, int svr_init); 
 extern	void  resv_exclusive_handler(resc_resv *);
 #ifdef	__cplusplus
 }

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -416,7 +416,7 @@ char *msg_stdg_resv_occr_conflict = "Requested time(s) will interfere with a lat
 char *msg_alps_switch_err = "Switching ALPS reservation failed";
 
 char *msg_softwt_stf = "soft_walltime is not supported with Shrink to Fit jobs";
-
+char *msg_bad_node_sate = "node is in the wrong state for the operation";
 /*
  * The following table connects error numbers with text
  * to be returned to the client.  Each is guaranteed to be pure text.
@@ -595,6 +595,7 @@ struct pbs_err_to_txt pbs_err_to_txt[] = {
 	{PBSE_SCHED_OP_NOT_PERMITTED, &msg_sched_op_not_permitted},
 	{PBSE_SCHED_PARTITION_ALREADY_EXISTS, &msg_sched_part_already_used},
 	{PBSE_INVALID_MAX_JOB_SEQUENCE_ID, &msg_invalid_max_job_sequence_id},
+	{PBSE_BAD_NODE_STATE, &msg_bad_node_sate},
 	{ 0, NULL }		/* MUST be the last entry */
 };
 

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7113,20 +7113,18 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 
                         if ((pnode->nd_state & (INUSE_DOWN | INUSE_STALE)) && (svr_init == FALSE)) {
 
-				if(objtype == JOB_OBJECT) {
+				if (objtype == JOB_OBJECT) {
                                    free(phowl);
                                    free(execvncopy);
                                    return (PBSE_BAD_NODE_STATE);
-				} 
-				else {
+				} else {
 					if(presv->ri_qs.ri_state == RESV_UNCONFIRMED) {
 						free(phowl);
                 	                	free(execvncopy);
                         	      		return (PBSE_BAD_NODE_STATE);
-					}
-					else {
+					} else {
 						resv_setResvState(presv, RESV_DEGRADED, RESV_DEGRADED);
-						set_resv_retry(presv, time_now+10);
+						set_resv_retry(presv, time_now + 10);
 					}
 				}
                         }

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7111,6 +7111,25 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				return (PBSE_UNKNODE);
 			}
 
+                        if ((pnode->nd_state & (INUSE_DOWN | INUSE_STALE)) && (svr_init == FALSE)) {
+
+				if(objtype == JOB_OBJECT) {
+                                   free(phowl);
+                                   free(execvncopy);
+                                   return (PBSE_BAD_NODE_STATE);
+				} 
+				else {
+					if(presv->ri_qs.ri_state == RESV_UNCONFIRMED) {
+						free(phowl);
+                	                	free(execvncopy);
+                        	      		return (PBSE_BAD_NODE_STATE);
+					}
+					else {
+						resv_setResvState(presv, RESV_DEGRADED, RESV_DEGRADED);
+						set_resv_retry(presv, time_now+10);
+					}
+				}
+                        }
 
 			if (pjob != NULL) { /* only for jobs do we warn if a mom */
 				/* hook has not been sent */
@@ -8391,7 +8410,7 @@ set_old_subUniverse(resc_resv	*presv)
 		return;
 	}
 	/* set the nodes on the reservation */
-	rc = assign_resv_resc(presv, sp);
+	rc = assign_resv_resc(presv, sp, TRUE);
 	if (rc != PBSE_NONE) {
 		sprintf(log_buffer,
 			"problem assigning resource to reservation %d", rc);

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -234,8 +234,9 @@ cnvrt_timer_init()
  * 		added to its list of resvinfo structures and that structure
  * 		points to the reservation.
  *
- * @parm[in,out]	presv	-	reservation structure
- * @parm[in]	vnodes	-	original vnode list from scheduler/operator
+ * @parm[in,out]	presv	 -	reservation structure
+ * @parm[in]		vnodes	 -	original vnode list from scheduler/operator
+ * @parm[in]    	svr_init -	parameter to track whether the server is in init start mode
  *
  * @return	int
  * @return	0 : no problems detected in the process

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -3385,7 +3385,7 @@ Time4occurrenceFinish(resc_resv *presv)
 	/* Assign the allocated resources to the reservation
 	 * and the reservation to the associated vnodes
 	 */
-	rc = assign_resv_resc(presv, newxc);
+	rc = assign_resv_resc(presv, newxc, FALSE);
 	free(newxc);
 
 	if (rc != PBSE_NONE) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
When a job is run or a reservation is confirmed, the server is sent a list of nodes.  It does not detect if any of these nodes are down or stale and reject the request.

This can happen in the following cases:

When a node goes down/stale after the scheduler has queried it for the cycle.  The scheduler will think it is available for use.

What does this mean:
If a reservation is confirmed on a down or stale vnode, it will go into the RESV_CONFIRMED state. (But if the scheduler identified the node down state before query, the reservation request would have been rejected without confirmation).
If a job is run on a down node, the server will attempt to connect to the mom (even though it knows its down) and that will fail.

* Attach scheduler to one session of gdb and server to another session of gdb.
* At scheduler, we need to put breakpoint after where the scheduler is querying the stats of server.
* At Server put a breakpoint inside set_nodes function.
* run qsub
* at scheduler it will enter the breakpoint , kill the mom, so all node state goes down.
* continue the breakpoint at scheduler to allow it to schedule.
* it comes back to the server, check the steps in set_nodes where the job is allocated to vnode which is down. newly added checks will put the job into the Queue for rescheduling. (or)
* For advance reservations, the request gets rejected just like the case when scheduler couldn't allocate nodes for new request. 

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
The function that parses the list of nodes given the server when a job runs or a reservation is confirmed is called set_nodes().  This function is a very generic and highly critical function to the server.  It is the function that sets the node pointers on the jobs/reservations.  After the Scheduler schedules the job to a node, the call comes back to set_nodes - here if the node is down after the job is scheduled, there is no check in the server, before sending the request to mom. which is causing the mom being contacted by the server to push the job.

#### Solution Description
Added checks to the set_nodes function to check whether the assigned node is down/stale, if it's down/stale function returns with respect to JOB & RESERVATIONS uniquely. 

For Job case, reject the request with "PBSE_BAD_NODE_STATE" error.

For Advance reservations, rejecting the request with "PBSE_BAD_NODE_STATE" error. (Retaining the same behavior if the scheduler identifies the node down state, the reservation request gets rejected)

For Standing reservations, Changing the node state to "DEGRADED" state.

#### Testing logs/output
* [19.4_test_logs_jobs_reservations.txt](https://github.com/PBSPro/pbspro/files/2908656/19.4_test_logs_jobs_reservations.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
