### PR TITLE
Handle server memory leak

### DIFF
--- a/src/lib/Libifl/int_hook.c
+++ b/src/lib/Libifl/int_hook.c
@@ -132,7 +132,7 @@ PBSD_hookbuf(int c, int reqtype, int seq, char *buf, int len,
  *
  * @return int
  * @retval	0 for success
- * @retval	-2 for success, no hookfile
+ * @retval	-2 for success, no hookfile or empty hookfile
  * @retval	non-zero otherwise.
  */
 int
@@ -141,7 +141,7 @@ PBSD_copyhookfile(int c, char *hook_filepath, int rpp, char **msgid)
 	int i;
 	int fd;
 	int cc;
-	int rc;
+	int rc = -2;
 	char s_buf[SCRIPT_CHUNK_Z];
 	char	*p;
 	char	hook_file[MAXPATHLEN+1];

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -5507,8 +5507,10 @@ svr_setjob_histinfo(job *pjob, histjob_type type)
 	 * through the work task list of the job and delete them using
 	 * delete_task().
 	 */
-	while ((pwt = (struct work_task *)GET_NEXT(pjob->ji_svrtask)) != NULL)
+	while ((pwt = (struct work_task *)GET_NEXT(pjob->ji_svrtask)) != NULL) {
+		free(pwt->wt_event2);	/* wt_event2 either has additional data (like msgid) or NULL */
 		delete_task(pwt);
+	}
 
 }
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *In case of an **empty mom hookfile**, server leaks some memory continuously. Steps to reproduce the leak :*
*1. Run server on valgrind*
*2. Create an empty hookfile*
*3. Create a mom hook and import the hookfile*

* *Stack trace for empty mom hookfile leak :*
**==124735== 224 bytes in 14 blocks are possibly lost in loss record 1,019 of 1,563**
==124735==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
==124735==    by 0x432E90: mk_deferred_hook_info (hook_func.c:5713)
==124735==    by 0x432E90: check_add_hook_mcast_info (hook_func.c:6029)
==124735==    by 0x43C9A6: sync_mom_hookfilesRPP (hook_func.c:6242)
==124735==    by 0x43CBA6: bg_sync_mom_hookfiles (hook_func.c:6494)
==124735==    by 0x43CF7F: next_sync_mom_hookfiles (hook_func.c:6769)
==124735==    by 0x429785: next_task (pbsd_main.c:2383)
==124735==    by 0x429785: main (pbsd_main.c:2031)
**==124735== 1,904 bytes in 14 blocks are possibly lost in loss record 1,433 of 1,563**
==124735==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
==124735==    by 0x4A891D: set_task (work_task.c:87)
==124735==    by 0x43E472: add_mom_deferred_list (issue_request.c:345)
==124735==    by 0x432ED7: check_add_hook_mcast_info (hook_func.c:6033)
==124735==    by 0x43C9A6: sync_mom_hookfilesRPP (hook_func.c:6242)
==124735==    by 0x43CBA6: bg_sync_mom_hookfiles (hook_func.c:6494)
==124735==    by 0x43CF7F: next_sync_mom_hookfiles (hook_func.c:6769)
==124735==    by 0x429785: next_task (pbsd_main.c:2383)
==124735==    by 0x429785: main (pbsd_main.c:2031)

* *If **stageout fails** after a job finishes and the job also goes to history, then server leaks some memory for each such job. Steps to reproduce this leak :*
*1. qmgr -c "s s job_history_enable=1"*
*2. Run the pbs_server under valgrind: export LD_LIBRARY_PATH=/opt/pbs/lib:/opt/pbs/pgsql/lib:${LD_LIBRARY_PATH}; valgrind --tool=memcheck --log-file=svr.out --leak-check=full --child-silent-after-fork=yes --track-origins=yes /opt/pbs/sbin/pbs_server.bin -N*
*3. Submit around 100 jobs. Remove the write permissions from the user submission directory. This will result in stageout failures.*
*4. Allow all the 100 jobs to complete with stageout failures recorded in server logs and once all jobs are gone and this is recorded in server_logs then send  SIGTERM to the server process running with valgrind.*
* *Stack Trace for stageout failure leak :*
**==21771== 1,338 bytes in 100 blocks are definitely lost in loss record 1,408 of 1,597**
==21771==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
==21771==    by 0x6DA9809: strdup (strdup.c:42)
==21771==    by 0x4E17F7: get_msgid (int_submit.c:131)
==21771==    by 0x4E185D: is_compose_cmd (int_submit.c:165)
==21771==    by 0x4E0EC0: PBSD_mgr_put (int_manage2.c:85)
==21771==    by 0x43E9E9: issue_Drequest (issue_request.c:457)
==21771==    by 0x45AD84: on_job_exit (req_jobobit.c:976)
==21771==    by 0x4A9CA8: dispatch_task (work_task.c:142)
==21771==    by 0x4A9ED4: default_next_task (work_task.c:308)
==21771==    by 0x429AF8: next_task (pbsd_main.c:2371)
==21771==    by 0x429AF8: main (pbsd_main.c:2031)

#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
* ***For empty hookfile***
When server is updating a zero length mom hookfile, it allocates some memory for the reply/acknowledgement from the mom. Since it is a zero length file, server does not send any data to mom and hence mom doesn't reply or gives any acknowledgement. This allocated memory keeps on pilling up as it was not freed.
* ***For stageout failure***
The issue is that it forgets to delete the cmd_msgid attached to the ptask structure while deleting the work task before moving the job to history.

#### Solution Description
* ***For empty hookfile***
Initializing return code (rc) to -2. This will return -2 by default if the hookfile is empty. If rc is -2, then allocated memory for the expected reply from mom is freed.
* ***For stageout failure***
Freeing the memory of event which will have either additional data like msgid or NULL. 

#### Testing logs/output
* ***Smoketest***
[smoketest_ptl_output.txt](https://github.com/PBSPro/pbspro/files/2909709/smoketest_ptl_output.txt)
* ***valgrind logs for empty hookfile***
[server_log_before_change.txt](https://github.com/PBSPro/pbspro/files/2909771/server_log_before_change.txt)
[server_log_after_change.txt](https://github.com/PBSPro/pbspro/files/2909774/server_log_after_change.txt)

* ***valgrind logs for stageout failure***
[server_log_stageout_before_change.txt](https://github.com/PBSPro/pbspro/files/2909768/server_log_stageout_before_change.txt)
[server_log_stageout_after_change.txt](https://github.com/PBSPro/pbspro/files/2909770/server_log_stageout_after_change.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
