### PR TITLE
Scheduler does not check permissions on server_dyn_res script

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -121,6 +121,7 @@ extern int  tmp_file_sec(char *path, int isdir, int sticky,
 extern int  chk_file_sec2(char *path, int isdir, int sticky,
 	int disallow, int fullpath, char *owner);
 #endif
+extern char *get_script_name(char *input);
 
 extern int  setup_env(char *filename);
 

--- a/src/lib/Liblog/chk_file_sec.c
+++ b/src/lib/Liblog/chk_file_sec.c
@@ -525,7 +525,7 @@ get_script_name(char *input) {
 
 	/* If control is here then it would mean that "tok" must have only file path */
 	memset (&sbuf, 0, sizeof(struct stat));
-	ret_fs = stat(tok, &sbuf);
+	stat(tok, &sbuf);
 	if (S_ISREG(sbuf.st_mode))
 		return tok;
 

--- a/src/lib/Liblog/chk_file_sec.c
+++ b/src/lib/Liblog/chk_file_sec.c
@@ -452,3 +452,84 @@ chkerr:
 	free(real);
 	return (rc);
 }
+
+/**
+ * @brief - This function takes an <program name> <args> as input in string format
+ *	    and returns the program name
+ *
+ * @return - char *
+ * @retval - NULL when no valid program name is found
+ * @retval - a newly allocated program name
+ *
+ * @note - Caller holds the responsibility of freeing up the return value
+ */
+char *
+get_script_name(char *input) {
+	char * tok;
+	char *next_space;
+	int ret_fs;
+	int path_exists = 0;
+	char *prev_space = NULL;
+	int starts_with_quotes = 0;
+	char *delim = " ";
+	struct stat sbuf;
+
+	if (input == NULL)
+		return NULL;
+
+	/* if path starts with double quotes, skip it */
+	if (input[0] == '\"') {
+		input++;
+		starts_with_quotes = 1;
+	}
+
+	tok = strdup(input);
+	if (tok == NULL)
+		return NULL;
+
+	/* get rid of double quotes at the end */
+	if (starts_with_quotes && tok[strlen(tok) - 1] == '\"')
+		tok[strlen(tok)-1] = '\0';
+
+	for (next_space = strpbrk(tok, delim); next_space != NULL; next_space = strpbrk(next_space, delim)) {
+		*next_space = '\0';
+		memset (&sbuf, 0, sizeof(struct stat));
+		ret_fs = stat(tok, &sbuf);
+		if (ret_fs != 0) {
+			if (path_exists == 1) {
+				*prev_space = '\0';
+				return (tok);
+			}
+		}
+		else if (S_ISREG(sbuf.st_mode)) {
+			/* even if we encounter a regular file, do not break out of loop
+			 * unless we hit a case where stat call fails. This is because there is a
+			 * possibility that we might be looking at a file with a prefix
+			 * similar to the script but not exactly the same.
+			 * Example, if input is "/get foo" and there exists a filename "/get"
+			 * then we do not want to return from this place.
+			 */
+			path_exists = 1;
+			prev_space = next_space;
+		}
+		*next_space = ' ';
+		/* Ignore any extra spaces */
+		next_space += strspn(next_space, delim);
+	}
+
+	if (path_exists == 1) {
+		/* set last known space as '\0' so that returned path contains no arguments */
+		*prev_space = '\0';
+		return tok;
+	}
+
+	/* If control is here then it would mean that "tok" must have only file path */
+	memset (&sbuf, 0, sizeof(struct stat));
+	ret_fs = stat(tok, &sbuf);
+	if (S_ISREG(sbuf.st_mode))
+		return tok;
+
+	/* No file found */
+	free(tok);
+	return NULL;
+}

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -970,7 +970,8 @@ struct preempt_ordering
 struct dyn_res
 {
 	char *res;
-	char *program;
+	char *command_line;
+	char *script_name;
 };
 
 struct peer_queue

--- a/src/scheduler/parse.c
+++ b/src/scheduler/parse.c
@@ -740,13 +740,13 @@ parse_config(char *fname)
 								tok++;
 
 							if (tok != NULL && tok[0] == '!') {
-								int err;
 								tok++;
 								tmp2 = string_dup(tok);
 								filename = get_script_name(tok);
 								if (filename == NULL)
 									error = 1;
 								else {
+									int err;
 #ifdef  WIN32
 									err = tmp_file_sec(filename, 0, 1, WRITES_MASK, 1);
 #else

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -700,19 +700,34 @@ query_server_dyn_res(server_info *sinfo)
 	char			  cmd_line[512];
 #endif
 
-	for (i = 0; i < MAX_SERVER_DYN_RES && conf.dynamic_res[i].res != NULL; i ++) {
+	for (i = 0; (i < MAX_SERVER_DYN_RES) && (conf.dynamic_res[i].res != NULL); i++) {
 		res = find_alloc_resource_by_str(sinfo->res, conf.dynamic_res[i].res);
 		if (res != NULL) {
+			int err;
+			char *filename = conf.dynamic_res[i].script_name;
 			if (sinfo->res == NULL)
 				sinfo->res = res;
 
 			pipe_err = errno = 0;
+			/* Make sure file does not have open permissions */
+#ifdef  WIN32
+			err = tmp_file_sec(filename, 0, 1, WRITES_MASK, 1);
+#else
+			err = tmp_file_sec(filename, 0, 1, S_IWGRP|S_IWOTH, 1);
+#endif
+			if (err != 0) {
+				snprintf(buf, sizeof(buf),
+					"error: %s file has a non-secure file access, setting resource %s to 0, errno: %d",
+					filename, res->name, err);
+				schdlog(PBSEVENT_SECURITY, PBS_EVENTCLASS_SERVER, LOG_ERR, "server_dyn_res", buf);
+				(void) set_resource(res, res_zero, RF_AVAIL);
+			}
 #ifdef	WIN32
 			/* In Windows, don't use popen() as this crashes if COMSPEC not set */
 			/* also, let's quote command line so that paths with spaces can be */
 			/* executed. */
 			snprintf(cmd_line, sizeof(cmd_line), "\"%s\"",
-				conf.dynamic_res[i].program);
+				conf.dynamic_res[i].command_line);
 
 			if (((win_popen(cmd_line, "r", &pio, NULL) == 0) ||
 				((k = win_pread(&pio, buf, 255)) <= 0))) {
@@ -722,7 +737,7 @@ query_server_dyn_res(server_info *sinfo)
 			if (pio.hReadPipe_out != INVALID_HANDLE_VALUE) /* did win_popen() succeed? */
 				win_pclose(&pio);
 #else
-			if (((fp = popen(conf.dynamic_res[i].program, "r")) == NULL) ||
+			if (((fp = popen(conf.dynamic_res[i].command_line, "r")) == NULL) ||
 				(fgets(buf, 256, fp) == NULL)) {
 				pipe_err = errno;
 				k = 0;
@@ -743,7 +758,7 @@ query_server_dyn_res(server_info *sinfo)
 
 				if (set_resource(res, buf, RF_AVAIL) == 0) {
 					snprintf(buf, sizeof(buf), "Script %s returned bad output",
-							conf.dynamic_res[i].program);
+							conf.dynamic_res[i].command_line);
 					schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
 										"server_dyn_res", buf);
 					(void) set_resource(res, res_zero, RF_AVAIL);
@@ -752,21 +767,21 @@ query_server_dyn_res(server_info *sinfo)
 			else {
 				if (pipe_err != 0)
 					snprintf(buf, sizeof(buf), "Can't pipe to program %s: %s",
-						conf.dynamic_res[i].program, strerror(pipe_err));
+						conf.dynamic_res[i].command_line, strerror(pipe_err));
 				else
 					snprintf(buf, sizeof(buf), "Error piping to program %s.",
-						conf.dynamic_res[i].program);
+						conf.dynamic_res[i].command_line);
 				schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
 					"server_dyn_res", buf);
 				(void) set_resource(res, res_zero, RF_AVAIL);
 			}
 			if (res->type.is_non_consumable) {
 				snprintf(log_buffer, sizeof(log_buffer), "%s = %s",
-					conf.dynamic_res[i].program, res_to_str(res, RF_AVAIL));
+					conf.dynamic_res[i].command_line, res_to_str(res, RF_AVAIL));
 			}
 			else {
 				snprintf(log_buffer, sizeof(log_buffer), "%s = %s (\"%s\")",
-					conf.dynamic_res[i].program, res_to_str(res, RF_AVAIL), buf);
+					conf.dynamic_res[i].command_line, res_to_str(res, RF_AVAIL), buf);
 			}
 			schdlog(PBSEVENT_DEBUG2, PBS_EVENTCLASS_SERVER, LOG_DEBUG,
 				"server_dyn_res", log_buffer);

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -11080,24 +11080,21 @@ class Scheduler(PBSService):
                          configuration settings.
         :type validate: bool
         """
-        file_specified = False
         if res_file is not None:
             f = open(file)
             script_body = f.readlines()
             f.close()
-            file_specified = True
+            self.du.chmod(self.hostname, path=res_file, mode=0755, sudo=True)
         else:
+            f_prefix = 'PtlPbsSchedConfig'
             res_file = self.du.create_dyn_res_script(script_body,
-                                                     prefix='\
-                                                     PtlPbsSchedConfig')
+                                                     prefix=f_prefix)
 
         self.server_dyn_res = res_file
         self.logger.info(self.logprefix + "adding server dyn res " + res_file)
         self.logger.info("-" * 30)
         self.logger.info(script_body)
         self.logger.info("-" * 30)
-        if file_specified is True:
-            self.du.chmod(self.hostname, path=res_file, mode=0755)
 
         a = {'server_dyn_res': '"' + custom_resource + ' !' + res_file + '"'}
         self.set_sched_config(a, apply=apply, validate=validate)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -11080,6 +11080,8 @@ class Scheduler(PBSService):
                          configuration settings.
         :type validate: bool
         """
+        super_user_grp = PbsGroup(grp.getgrgid(0).gr_name, gid=0) 
+        super_user = PbsUser('root', uid=0, groups=[super_user_grp])
         if res_file is not None:
             f = open(file)
             script_body = f.readlines()
@@ -11087,7 +11089,7 @@ class Scheduler(PBSService):
         else:
             res_file = self.du.create_temp_file(prefix='PtlPbsSchedConfig',
                                                 body=script_body,
-                                                asuser=ROOT_USER)
+                                                asuser=super_user)
 
         self.server_dyn_res = res_file
         self.logger.info(self.logprefix + "adding server dyn res " + res_file)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -11086,7 +11086,8 @@ class Scheduler(PBSService):
             f.close()
         else:
             res_file = self.du.create_temp_file(prefix='PtlPbsSchedConfig',
-                                                body=script_body)
+                                                body=script_body,
+                                                asuser=ROOT_USER)
 
         self.server_dyn_res = res_file
         self.logger.info(self.logprefix + "adding server dyn res " + res_file)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -11080,22 +11080,24 @@ class Scheduler(PBSService):
                          configuration settings.
         :type validate: bool
         """
+        file_specified = False
         if res_file is not None:
             f = open(file)
             script_body = f.readlines()
             f.close()
+            file_specified = True
         else:
-            res_file = self.du.create_temp_file(prefix='PtlPbsSchedConfig',
-                                                body=script_body,
-                                                asuser="root")
+            res_file = self.du.create_dyn_res_script(script_body,
+                                                     prefix='\
+                                                     PtlPbsSchedConfig')
 
         self.server_dyn_res = res_file
         self.logger.info(self.logprefix + "adding server dyn res " + res_file)
         self.logger.info("-" * 30)
         self.logger.info(script_body)
         self.logger.info("-" * 30)
-
-        self.du.chmod(self.hostname, path=res_file, mode=0755)
+        if file_specified is True:
+            self.du.chmod(self.hostname, path=res_file, mode=0755)
 
         a = {'server_dyn_res': '"' + custom_resource + ' !' + res_file + '"'}
         self.set_sched_config(a, apply=apply, validate=validate)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -11080,8 +11080,6 @@ class Scheduler(PBSService):
                          configuration settings.
         :type validate: bool
         """
-        super_user_grp = PbsGroup(grp.getgrgid(0).gr_name, gid=0) 
-        super_user = PbsUser('root', uid=0, groups=[super_user_grp])
         if res_file is not None:
             f = open(file)
             script_body = f.readlines()
@@ -11089,7 +11087,7 @@ class Scheduler(PBSService):
         else:
             res_file = self.du.create_temp_file(prefix='PtlPbsSchedConfig',
                                                 body=script_body,
-                                                asuser=super_user)
+                                                asuser="root")
 
         self.server_dyn_res = res_file
         self.logger.info(self.logprefix + "adding server dyn res " + res_file)

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1968,6 +1968,25 @@ class DshUtils(object):
                        sudo=True)
         return fn
 
+    def create_dyn_res_script(self, body, prefix=None, suffix=None, perm=0755,
+                              dirname=None, host=None):
+        """
+        Create a dynamic resource script owned by root
+        """
+        home_dir = os.path.expanduser("~")
+        fp = self.create_temp_file(prefix="mom_resc", suffix=".scr",
+                                   body=body, asuser="root",
+                                   dirname=home_dir, hostname=host)
+        self.chmod(path=fp, mode=perm, sudo=True, hostname=host)
+        if dirname is None:
+            dest_file = os.path.join(os.sep, 'tmp', fp.split(os.sep)[-1])
+        else:
+            dest_file = os.path.join(dirname, fp.split(os.sep)[-1])
+        if dest_file != fp:
+            self.run_copy(src=fp, dest=dest_file, runas="root", hosts=host)
+            self.rm(path=fp, sudo=True, hostname=host)
+        return dest_file
+
     def parse_strace(self, lines):
         """
         strace parsing. Just the regular expressions for now

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1876,7 +1876,7 @@ class DshUtils(object):
         :type body: str or None
         :param level: logging level, defaults to INFOCLI2
         :type level: int
-        :param mode: mode to use while creating directories
+        :param mode: mode to use while creating files
                      (must be octal like 0777)
         """
         home_dir = os.path.expanduser("~")
@@ -1903,7 +1903,7 @@ class DshUtils(object):
             if dirname:
                 dest_file = os.path.join(dirname, tmpfile.split(os.sep)[-1])
             else:
-                dest_file = os.path.join(os.sep, 'home', str(asuser),
+                dest_file = os.path.join(os.path.expanduser("~" + str(asuser)),
                                          tmpfile.split(os.sep)[-1])
         elif dirname:
             # create the file in specified directory
@@ -1911,7 +1911,8 @@ class DshUtils(object):
         else:
             # Neither user is provided nor directory, create the file in
             # tmp directory
-            dest_file = os.path.join(os.sep, 'tmp', tmpfile.split(os.sep)[-1])
+            temp_dir = self.get_tempdir(hostname)
+            dest_file = os.path.join(temp_dir, tmpfile.split(os.sep)[-1])
         # copy file in any of the following conditions:
         # 1 - If asuser is set and it is not the current user
         # 2 - If destination file path is not same as temporary file path

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1446,6 +1446,15 @@ class PBSTestSuite(unittest.TestCase):
         self.log_enter_teardown()
         self.server.cleanup_jobs(runas=ROOT_USER)
         self.stop_proc_monitor()
+
+        for server in self.servers.values():
+            server.cleanup_files()
+
+        for mom in self.moms.values():
+            mom.cleanup_files()
+
+        self.scheduler.cleanup_files()
+
         self.log_end_teardown()
 
     @classmethod

--- a/test/tests/functional/pbs_mom_dynamic_resource.py
+++ b/test/tests/functional/pbs_mom_dynamic_resource.py
@@ -62,7 +62,8 @@ class TestMomDynRes(TestFunctional):
                                 id=resc_name[i], expect=True)
 
             fp = self.du.create_temp_file(prefix="mom_resc", suffix=".scr",
-                                          body=script_body[i])
+                                          body=script_body[i],
+                                          asuser=ROOT_USER)
             self.du.chmod(path=fp, mode=0755)
             mom_config_str = "!" + fp
             self.mom.add_config({resc_name[i]: mom_config_str})
@@ -360,7 +361,8 @@ class TestMomDynRes(TestFunctional):
         """
         scr_body = ['echo "10"', 'exit 0']
         home_dir = os.path.expanduser("~")
-        fp = self.du.create_temp_file(body=scr_body, dirname=home_dir)
+        fp = self.du.create_temp_file(body=scr_body, dirname=home_dir,
+                                      asuser=ROOT_USER)
         # Add to filenames for cleanup
         self.filenames.append(fp)
 
@@ -391,7 +393,8 @@ class TestMomDynRes(TestFunctional):
         # Create the dirctory name with a space in it, to make sure PBS parses
         # it correctly.
         dir_temp = self.du.mkdtemp(mode=0766, dir=home_dir, suffix=' tmp')
-        fp = self.du.create_temp_file(body=scr_body, dirname=dir_temp)
+        fp = self.du.create_temp_file(body=scr_body, dirname=dir_temp,
+                                      asuser=ROOT_USER)
         # Add to filenames for cleanup
         self.filenames.append(fp)
         self.filenames.append(dir_temp)
@@ -419,7 +422,8 @@ class TestMomDynRes(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, RSC, attr,
                             id="foo", expect=True)
         # Create a dynamic script with right permissions
-        fp = self.du.create_temp_file(body=scr_body, dirname=home_dir)
+        fp = self.du.create_temp_file(body=scr_body, dirname=home_dir,
+                                      asuser=ROOT_USER)
         # Add to filenames for cleanup
         self.filenames.append(fp)
 
@@ -443,7 +447,7 @@ class TestMomDynRes(TestFunctional):
 
         # Create dynamic resource script in tmp directory and check
         # file permissions
-        fp = self.du.create_temp_file(body=scr_body)
+        fp = self.du.create_temp_file(body=scr_body, asuser=ROOT_USER)
         # Add to filenames for cleanup
         self.filenames.append(fp)
 

--- a/test/tests/functional/pbs_mom_dynamic_resource.py
+++ b/test/tests/functional/pbs_mom_dynamic_resource.py
@@ -390,9 +390,7 @@ class TestMomDynRes(TestFunctional):
 
         # give write permission to user only
         self.du.chmod(path=fp, mode=0744, sudo=True)
-        root_priv = self.du.run_cmd(
-            cmd=["ls", os.path.join(os.sep, "root")])
-        if root_priv['rc'] != 0:
+        if os.getuid() != 0:
                 self.check_access_log(fp, exist=True)
         else:
                 self.check_access_log(fp, exist=False)
@@ -427,9 +425,9 @@ class TestMomDynRes(TestFunctional):
         self.du.chmod(path=fp, mode=0744, sudo=True)
         self.check_access_log(fp)
 
-        # Create dynamic resource script in tmp directory and check
+        # Create dynamic resource script in PBS_HOME directory and check
         # file permissions
-        # du.create_dyn_res_script by default creates the script in /tmp
+        # du.create_dyn_res_script by default creates the script in PBS_HOME
 
         # give write permission to group and others
         fp = self.du.create_dyn_res_script(scr_body, perm=0766)
@@ -467,4 +465,5 @@ class TestMomDynRes(TestFunctional):
         # removing all files creating in test
         self.du.rm(path=self.filenames, sudo=True, force=True,
                    recursive=True)
-        self.filenames = []
+        del self.filenames[:]
+        TestFunctional.tearDown(self)

--- a/test/tests/functional/pbs_mom_dynamic_resource.py
+++ b/test/tests/functional/pbs_mom_dynamic_resource.py
@@ -40,7 +40,7 @@ from tests.functional import *
 
 class TestMomDynRes(TestFunctional):
 
-    filenames = []
+    dirnames = []
 
     def create_mom_resources(self, resc_name, resc_type, resc_flag,
                              script_body):
@@ -55,8 +55,7 @@ class TestMomDynRes(TestFunctional):
                                         validate=True)
         self.scheduler.add_resource(resc_name_svr)
 
-        ln = len(resc_name)
-        for i in range(ln):
+        for i in range(len(resc_name)):
             attr = {"type": resc_type[i], "flag": resc_flag[i]}
             self.server.manager(MGR_CMD_CREATE, RSC, attr,
                                 id=resc_name[i], expect=True)
@@ -65,7 +64,6 @@ class TestMomDynRes(TestFunctional):
                                                  prefix="mom_resc",
                                                  suffix=".scr")
             fp_list.append(dest_file)
-            self.filenames.append(dest_file)
         return fp_list
 
     def check_access_log(self, fp, exist=True):
@@ -328,8 +326,8 @@ class TestMomDynRes(TestFunctional):
         resc_flag = ["nh"]
         script_body = ["/bin/echo 3"]
 
-        filename = self.create_mom_resources(resc_name, resc_type,
-                                             resc_flag, script_body)
+        self.create_mom_resources(resc_name, resc_type,
+                                  resc_flag, script_body)
         # Submit a job that requests mom dynamic resource
         attr = {"Resource_List." + resc_name[0]: '2'}
         j = Job(TEST_USER, attrs=attr)
@@ -342,7 +340,6 @@ class TestMomDynRes(TestFunctional):
         change_res = "/bin/echo 1"
         src_file = self.mom.add_mom_dyn_res(resc_name[0],
                                             script_body=change_res)
-        self.filenames.append(src_file)
 
         self.server.rerunjob(jobid=jid)
 
@@ -365,27 +362,25 @@ class TestMomDynRes(TestFunctional):
         home_dir = os.path.expanduser("~")
         fp = self.mom.add_mom_dyn_res("foo", script_body=scr_body,
                                       dirname=home_dir)
-        # Add to filenames for cleanup
-        self.filenames.append(fp)
 
         self.scheduler.set_sched_config({'mom_resources': 'foo'},
                                         validate=True)
         self.scheduler.add_resource('foo')
 
         # give write permission to group and others
-        self.du.chmod(path=fp, mode=0766, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0766, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to group
-        self.du.chmod(path=fp, mode=0764, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0764, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to others
-        self.du.chmod(path=fp, mode=0746, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0746, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to user only
-        self.du.chmod(path=fp, mode=0744, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0744, sudo=True)
         if os.getuid() != 0:
                 self.check_access_log(fp, exist=True)
         else:
@@ -399,24 +394,23 @@ class TestMomDynRes(TestFunctional):
         fp = self.mom.add_mom_dyn_res("foo", script_body=scr_body,
                                       dirname=dir_temp)
 
-        # Add to filenames for cleanup
-        self.filenames.append(fp)
-        self.filenames.append(dir_temp)
+        # Add to dirnames for cleanup
+        self.dirnames.append(dir_temp)
 
         # give write permission to group and others
-        self.du.chmod(path=fp, mode=0766, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0766, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to group
-        self.du.chmod(path=fp, mode=0764, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0764, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to others
-        self.du.chmod(path=fp, mode=0746, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0746, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to user only
-        self.du.chmod(path=fp, mode=0744, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0744, sudo=True)
         self.check_access_log(fp)
 
         # Create dynamic resource script in PBS_HOME directory and check
@@ -426,26 +420,24 @@ class TestMomDynRes(TestFunctional):
 
         # give write permission to group and others
         fp = self.mom.add_mom_dyn_res("foo", script_body=scr_body, perm=0766)
-        # Add to filenames for cleanup
-        self.filenames.append(fp)
         self.check_access_log(fp)
 
         # give write permission to group
-        self.du.chmod(path=fp, mode=0764, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0764, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to others
-        self.du.chmod(path=fp, mode=0746, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0746, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to user only
-        self.du.chmod(path=fp, mode=0744, sudo=True, runas=ROOT_USER)
+        self.du.chmod(path=fp, mode=0744, sudo=True)
         self.check_access_log(fp, exist=False)
 
     def tearDown(self):
         # removing all files creating in test
-        if len(self.filenames) != 0:
-            self.du.rm(path=self.filenames, sudo=True, force=True,
+        if len(self.dirnames) != 0:
+            self.du.rm(path=self.dirnames, sudo=True, force=True,
                        recursive=True)
-            self.filenames[:] = []
+            self.dirnames[:] = []
         TestFunctional.tearDown(self)

--- a/test/tests/functional/pbs_release_limited_res_suspend.py
+++ b/test/tests/functional/pbs_release_limited_res_suspend.py
@@ -987,7 +987,9 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
                 kill $1
                 exit 0
                 """
-        self.chk_file = self.du.create_temp_file(body=chk_script)
+        pbs_home = self.server.pbs_conf['PBS_HOME']
+        self.chk_file = self.du.create_temp_file(body=chk_script,
+                                                 dirname=pbs_home)
         self.du.chmod(path=self.chk_file, mode=0o755)
         self.du.chown(path=self.chk_file, uid=0, gid=0, sudo=True)
         c = {'$action': 'checkpoint_abort 30 !' + self.chk_file + ' %sid'}

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -110,10 +110,9 @@ class TestServerDynRes(TestFunctional):
         resname = ["mybadres"]
         restype = ["long"]
         script_body = "echo abc"
-        fn = self.du.create_temp_file(prefix="PtlPbs_badoutfile",
-                                      body=script_body, asuser=ROOT_USER)
-
-        self.du.chmod(path=fn, mode=0755, sudo=True)
+        fn = self.du.create_dyn_res_script(script_body,
+                                           prefix="PtlPbs_badoutfile",
+                                           perm=0755)
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
 
         # Add it as a server_dyn_res that returns a string output
@@ -214,9 +213,9 @@ class TestServerDynRes(TestFunctional):
 
         fpath_out = os.path.join(os.sep, "tmp", "PtlPbs_got_foo")
 
-        fn_in = self.du.create_temp_file(prefix="PtlPbs_get_foo",
-                                         body=script_body, asuser=ROOT_USER)
-        self.du.chmod(path=fn_in, mode=0755, sudo=True)
+        fn_in = self.du.create_dyn_res_script(script_body,
+                                              prefix="PtlPbs_get_foo")
+        self.filenames.append(fn_in)
 
         # Add additional white space between resource name and the script
         resval = ['"' + resname[0] + '  ' + ' !' + fn_in + '"']
@@ -241,6 +240,8 @@ class TestServerDynRes(TestFunctional):
         # Job must run successfully
         a = {'job_state': 'R', 'Resource_List.foo': 1}
         self.server.expect(JOB, a, id=jid)
+        # Cleanup dynamically created file
+        self.du.rm(fpath_out, sudo=True, force=True)
 
     def test_multiple_res(self):
         """
@@ -256,22 +257,18 @@ class TestServerDynRes(TestFunctional):
         script_body_m = "echo 12"
         script_body_l = "echo 20"
 
-        fn_s = self.du.create_temp_file(prefix="PtlPbs_small",
-                                        suffix=".scr",
-                                        body=script_body_s,
-                                        asuser=ROOT_USER)
-        fn_m = self.du.create_temp_file(prefix="PtlPbs_medium",
-                                        suffix=".scr",
-                                        body=script_body_m,
-                                        asuser=ROOT_USER)
-        fn_l = self.du.create_temp_file(prefix="PtlPbs_large",
-                                        suffix=".scr",
-                                        body=script_body_l,
-                                        asuser=ROOT_USER)
-
-        self.du.chmod(path=fn_s, mode=0755, sudo=True)
-        self.du.chmod(path=fn_m, mode=0755, sudo=True)
-        self.du.chmod(path=fn_l, mode=0755, sudo=True)
+        fn_s = self.du.create_dyn_res_script(script_body_s,
+                                             prefix="PtlPbs_small",
+                                             suffix=".scr")
+        fn_m = self.du.create_dyn_res_script(script_body_m,
+                                             prefix="PtlPbs_medium",
+                                             suffix=".scr")
+        fn_l = self.du.create_dyn_res_script(script_body_l,
+                                             prefix="PtlPbs_large",
+                                             suffix=".scr")
+        self.filenames.append(fn_s)
+        self.filenames.append(fn_m)
+        self.filenames.append(fn_l)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn_s + '"',
                   '"' + resname[1] + ' ' + '!' + fn_m + '"',
@@ -318,10 +315,9 @@ class TestServerDynRes(TestFunctional):
         # Prep for server_dyn_resource script
         script_body = "echo abc"
 
-        fn = self.du.create_temp_file(prefix="PtlPbs_check",
-                                      suffix=".scr",
-                                      body=script_body, asuser=ROOT_USER)
-        self.du.chmod(path=fn, mode=0755, sudo=True)
+        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_check",
+                                           suffix=".scr")
+        self.filenames.append(fn)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
 
@@ -361,10 +357,9 @@ class TestServerDynRes(TestFunctional):
         # Prep for server_dyn_resource script
         script_body = "echo white, red, blue"
 
-        fn = self.du.create_temp_file(prefix="PtlPbs_color",
-                                      suffix=".scr",
-                                      body=script_body, asuser=ROOT_USER)
-        self.du.chmod(path=fn, mode=0755, sudo=True)
+        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_color",
+                                           suffix=".scr")
+        self.filenames.append(fn)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
 
@@ -404,10 +399,9 @@ class TestServerDynRes(TestFunctional):
         # Prep for server_dyn_resource script
         script_body = "echo 100gb"
 
-        fn = self.du.create_temp_file(prefix="PtlPbs_size",
-                                      suffix=".scr",
-                                      body=script_body, asuser=ROOT_USER)
-        self.du.chmod(path=fn, mode=0755, sudo=True)
+        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_size",
+                                           suffix=".scr")
+        self.filenames.append(fn)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
 
@@ -466,10 +460,9 @@ class TestServerDynRes(TestFunctional):
         # Prep for server_dyn_resource script
         script_body = "echo 100gb"
 
-        fn = self.du.create_temp_file(prefix="PtlPbs_size",
-                                      suffix=".scr",
-                                      body=script_body, asuser=ROOT_USER)
-        self.du.chmod(path=fn, mode=0755, sudo=True)
+        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_size",
+                                           suffix=".scr")
+        self.filenames.append(fn)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
 
@@ -485,9 +478,11 @@ class TestServerDynRes(TestFunctional):
         self.server.expect(JOB, a, id=jid)
 
         # Change script during job run
-        with open(fn, "rw+") as fd:
-            fd.truncate()
-            fd.write("echo 50gb")
+        change_res = "echo 50gb"
+        home_dir = os.path.expanduser("~")
+        fp = self.du.create_dyn_res_script(change_res, dirname=home_dir)
+        self.du.run_copy(src=fp, dest=fn, runas=ROOT_USER)
+        self.filenames.append(fn)
 
         # Rerun job
         self.server.rerunjob(jid)
@@ -511,10 +506,9 @@ class TestServerDynRes(TestFunctional):
         # Script returns invalid value for resource type 'size'
         script_body = "echo two gb"
 
-        fn = self.du.create_temp_file(prefix="PtlPbs_size",
-                                      suffix=".scr",
-                                      body=script_body, asuser=ROOT_USER)
-        self.du.chmod(path=fn, mode=0755, sudo=True)
+        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_size",
+                                           suffix=".scr")
+        self.filenames.append(fn)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
 
@@ -549,10 +543,9 @@ class TestServerDynRes(TestFunctional):
         # Prep for server_dyn_resource script
         script_body = "echo abc"
 
-        fn = self.du.create_temp_file(prefix="PtlPbs_float",
-                                      suffix=".scr",
-                                      body=script_body, asuser=ROOT_USER)
-        self.du.chmod(path=fn, mode=0755, sudo=True)
+        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_float",
+                                           suffix=".scr")
+        self.filenames.append(fn)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
 
@@ -587,10 +580,9 @@ class TestServerDynRes(TestFunctional):
         # Prep for server_dyn_resource script
         script_body = "echo yes"
 
-        fn = self.du.create_temp_file(prefix="PtlPbs_bool",
-                                      suffix=".scr",
-                                      body=script_body, asuser=ROOT_USER)
-        self.du.chmod(path=fn, mode=0755, sudo=True)
+        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_bool",
+                                           suffix=".scr")
+        self.filenames.append(fn)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
 
@@ -623,8 +615,7 @@ class TestServerDynRes(TestFunctional):
 
         scr_body = ['echo "10"', 'exit 0']
         home_dir = os.path.expanduser("~")
-        fp = self.du.create_temp_file(body=scr_body, dirname=home_dir,
-                                      asuser=ROOT_USER)
+        fp = self.du.create_dyn_res_script(scr_body, dirname=home_dir)
         # Add to filenames for cleanup
         self.filenames.append(fp)
 
@@ -633,28 +624,33 @@ class TestServerDynRes(TestFunctional):
                                         validate=False)
 
         # give write permission to group and others
-        self.du.chmod(path=fp, mode=0766)
+        self.du.chmod(path=fp, mode=0766, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to group
-        self.du.chmod(path=fp, mode=0764)
+        self.du.chmod(path=fp, mode=0764, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to others
-        self.du.chmod(path=fp, mode=0746)
+        self.du.chmod(path=fp, mode=0746, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to user only
-        self.du.chmod(path=fp, mode=0744)
-        self.check_access_log(fp, exist=False)
+        self.du.chmod(path=fp, mode=0744, sudo=True)
+        root_priv = self.du.run_cmd(
+            cmd=["ls", os.path.join(os.sep, "root")])
+        if root_priv['rc'] != 0:
+                self.check_access_log(fp, exist=True)
+        else:
+                self.check_access_log(fp, exist=False)
 
         # Create script in a directory which has more open privileges
         # This should make loading of this file fail in all cases
         # Create the dirctory name with a space in it, to make sure PBS parses
         # it correctly.
         dir_temp = self.du.mkdtemp(mode=0766, dir=home_dir, suffix=' tmp')
-        fp = self.du.create_temp_file(body=scr_body, dirname=dir_temp,
-                                      asuser=ROOT_USER)
+        fp = self.du.create_dyn_res_script(scr_body, dirname=dir_temp)
+
         # Add to filenames for cleanup
         self.filenames.append(fp)
         self.filenames.append(dir_temp)
@@ -664,19 +660,19 @@ class TestServerDynRes(TestFunctional):
                                         validate=False)
 
         # give write permission to group and others
-        self.du.chmod(path=fp, mode=0766)
+        self.du.chmod(path=fp, mode=0766, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to group
-        self.du.chmod(path=fp, mode=0764)
+        self.du.chmod(path=fp, mode=0764, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to others
-        self.du.chmod(path=fp, mode=0746)
+        self.du.chmod(path=fp, mode=0746, sudo=True)
         self.check_access_log(fp)
 
         # give write permission to user only
-        self.du.chmod(path=fp, mode=0744)
+        self.du.chmod(path=fp, mode=0744, sudo=True)
         self.check_access_log(fp)
 
         # Create a dynamic script with right permissions
@@ -685,52 +681,44 @@ class TestServerDynRes(TestFunctional):
         # Add to filenames for cleanup
         self.filenames.append(fp)
 
-        dyn_scr = '"foo !' + fp + '"'
-        # give write permission to user only
-        self.du.chmod(path=fp, mode=0744)
-        self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
-                                        validate=False)
-        self.check_access_log(fp, exist=False)
-
-        time.sleep(1)
-        match_from = int(time.time())
-        # give write permission to others
-        self.du.chmod(path=fp, mode=0746)
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.scheduler.log_match(fp + ' file has a non-secure file access',
-                                 starttime=match_from, existence=True,
-                                 max_attempts=10)
-
         # Create dynamic resource script in tmp directory and check
         # file permissions
-        fp = self.du.create_temp_file(body=scr_body, asuser=ROOT_USER)
-        # Add to filenames for cleanup
-        self.filenames.append(fp)
+        # du.create_dyn_res_script by default creates the script in /tmp
 
+        # give write permission to group and others
+        fp = self.du.create_dyn_res_script(scr_body, perm=0766)
+        self.filenames.append(fp)
         dyn_scr = '"foo !' + fp + '"'
         self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
                                         validate=False)
-
-        # give write permission to group and others
-        self.du.chmod(path=fp, mode=0766)
         self.check_access_log(fp)
 
         # give write permission to group
-        self.du.chmod(path=fp, mode=0764)
+        fp = self.du.create_dyn_res_script(scr_body, perm=0764)
+        self.filenames.append(fp)
+        dyn_scr = '"foo !' + fp + '"'
+        self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
+                                        validate=False)
         self.check_access_log(fp)
 
         # give write permission to others
-        self.du.chmod(path=fp, mode=0746)
+        fp = self.du.create_dyn_res_script(scr_body, perm=0746)
+        self.filenames.append(fp)
+        dyn_scr = '"foo !' + fp + '"'
+        self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
+                                        validate=False)
         self.check_access_log(fp)
 
         # give write permission to user only
-        self.du.chmod(path=fp, mode=0744)
+        fp = self.du.create_dyn_res_script(scr_body, perm=0744)
+        self.filenames.append(fp)
+        dyn_scr = '"foo !' + fp + '"'
+        self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
+                                        validate=False)
         self.check_access_log(fp, exist=False)
 
     def tearDown(self):
         # removing all files creating in test
-        for i in self.filenames:
-            if os.path.isfile(i):
-                os.remove(i)
-            elif os.path.isdir(i):
-                os.removedirs(i)
+        self.du.rm(path=self.filenames, sudo=True, force=True,
+                   recursive=True)
+        self.filenames = []

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -67,20 +67,21 @@ class TestServerDynRes(TestFunctional):
                                  starttime=match_from, existence=exist,
                                  max_attempts=10)
 
-    def setup_dyn_res(self, resname, restype, resval):
+    def setup_dyn_res(self, resname, restype, script_body):
         """
         Helper function to setup server dynamic resources
         """
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
-
-        for i in resname:
-            attr = {"type": restype[0]}
-            self.server.manager(MGR_CMD_CREATE, RSC, attr, id=i, expect=True)
+        val = []
+        attr = {}
+        ln = len(resname)
+        for i in range(ln):
+            attr["type"] = restype[i]
+            self.server.manager(MGR_CMD_CREATE, RSC, attr, id=resname[i],
+                                expect=True)
             # Add resource to sched_config's 'resources' line
-            self.scheduler.add_resource(i)
+            self.scheduler.add_resource(resname[i])
 
-        # Add server_dyn_res entry in sched_config
-        if len(resval) > 1:  # Mutliple resources
             # To create multiple server dynamic resources in sched_config
             # from PTL, a list containing "resource !<script>" should be
             # supplied as value to the key 'server_dyn_res' when calling
@@ -89,12 +90,13 @@ class TestServerDynRes(TestFunctional):
             # server_dyn_res entry.
             # HACK: So adding a single resource first and then the list.
             # There wouldn't be any duplicate entries though.
-            a = {'server_dyn_res': resval[0]}
-            self.scheduler.set_sched_config(a)
-            a = {'server_dyn_res': resval}
-        else:
-            a = {'server_dyn_res': resval[0]}
-
+            dest_file = self.scheduler.add_server_dyn_res(resname[i],
+                                                          script_body[i],
+                                                          prefix="svr_resc",
+                                                          suffix=".scr")
+            val.append('"' + resname[i] + ' ' + '!' + dest_file + '"')
+            self.filenames.append(dest_file)
+        a = {'server_dyn_res': val}
         self.scheduler.set_sched_config(a)
 
         # The server dynamic resource script gets executed for every
@@ -109,14 +111,10 @@ class TestServerDynRes(TestFunctional):
         # Create a server_dyn_res of type long
         resname = ["mybadres"]
         restype = ["long"]
-        script_body = "echo abc"
-        fn = self.du.create_dyn_res_script(script_body,
-                                           prefix="PtlPbs_badoutfile",
-                                           perm=0755)
-        resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
+        script_body = ["echo abc"]
 
         # Add it as a server_dyn_res that returns a string output
-        self.setup_dyn_res(resname, restype, resval)
+        self.setup_dyn_res(resname, restype, script_body)
 
         # Submit a job
         j = Job(TEST_USER)
@@ -129,7 +127,7 @@ class TestServerDynRes(TestFunctional):
 
         # Also check that "<script> returned bad output"
         # is in the logs
-        self.scheduler.log_match("%s returned bad output" % (fn))
+        self.scheduler.log_match("%s returned bad output" % self.filenames[0])
 
         # The scheduler uses 0 as the available amount of the dynamic resource
         # if the server_dyn_res script output is bad
@@ -146,7 +144,7 @@ class TestServerDynRes(TestFunctional):
         # Check for the expected log message for insufficient resources
         self.scheduler.log_match(
             "Insufficient amount of server resource: %s (R: 1 A: 0 T: 0)"
-            % (resname[0]))
+            % (resname[0]), level=logging.DEBUG2)
 
     def test_res_long_pos(self):
         """
@@ -156,7 +154,7 @@ class TestServerDynRes(TestFunctional):
         # Create a resource of type long. positive value
         resname = ["foobar"]
         restype = ["long"]
-        resval = ['"' + resname[0] + ' ' + '!/bin/echo 4' + '"']
+        resval = ['/bin/echo 4']
 
         # Add server_dyn_res entry in sched_config
         self.setup_dyn_res(resname, restype, resval)
@@ -178,7 +176,7 @@ class TestServerDynRes(TestFunctional):
         # Create a resource of type long. negative value
         resname = ["foobar"]
         restype = ["long"]
-        resval = ['"' + resname[0] + ' ' + '!/bin/echo -1' + '"']
+        resval = ['/bin/echo -1']
 
         # Add server_dyn_res entry in sched_config
         self.setup_dyn_res(resname, restype, resval)
@@ -206,19 +204,11 @@ class TestServerDynRes(TestFunctional):
         # Create a resource of type long
         resname = ["foo"]
         restype = ["long"]
+        resval = ['echo get_foo > /tmp/PtlPbs_got_foo; echo 1']
 
         # Prep for server_dyn_resource scripts. Script "PbsPtl_get_foo*"
         # generates file "PbsPtl_got_foo" and returns 1.
-        script_body = "echo get_foo > /tmp/PtlPbs_got_foo; echo 1"
-
         fpath_out = os.path.join(os.sep, "tmp", "PtlPbs_got_foo")
-
-        fn_in = self.du.create_dyn_res_script(script_body,
-                                              prefix="PtlPbs_get_foo")
-        self.filenames.append(fn_in)
-
-        # Add additional white space between resource name and the script
-        resval = ['"' + resname[0] + '  ' + ' !' + fn_in + '"']
 
         self.setup_dyn_res(resname, restype, resval)
 
@@ -253,28 +243,9 @@ class TestServerDynRes(TestFunctional):
         restype = ["long", "long", "long"]
 
         # Prep for server_dyn_resource scripts.
-        script_body_s = "echo 8"
-        script_body_m = "echo 12"
-        script_body_l = "echo 20"
+        script_body = ["echo 8", "echo 12", "echo 20"]
 
-        fn_s = self.du.create_dyn_res_script(script_body_s,
-                                             prefix="PtlPbs_small",
-                                             suffix=".scr")
-        fn_m = self.du.create_dyn_res_script(script_body_m,
-                                             prefix="PtlPbs_medium",
-                                             suffix=".scr")
-        fn_l = self.du.create_dyn_res_script(script_body_l,
-                                             prefix="PtlPbs_large",
-                                             suffix=".scr")
-        self.filenames.append(fn_s)
-        self.filenames.append(fn_m)
-        self.filenames.append(fn_l)
-
-        resval = ['"' + resname[0] + ' ' + '!' + fn_s + '"',
-                  '"' + resname[1] + ' ' + '!' + fn_m + '"',
-                  '"' + resname[2] + ' ' + '!' + fn_l + '"']
-
-        self.setup_dyn_res(resname, restype, resval)
+        self.setup_dyn_res(resname, restype, script_body)
 
         a = {'Resource_List.foobar_small': '4'}
         # Submit job
@@ -313,13 +284,7 @@ class TestServerDynRes(TestFunctional):
         restype = ["string"]
 
         # Prep for server_dyn_resource script
-        script_body = "echo abc"
-
-        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_check",
-                                           suffix=".scr")
-        self.filenames.append(fn)
-
-        resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
+        resval = ["echo abc"]
 
         self.setup_dyn_res(resname, restype, resval)
 
@@ -355,13 +320,7 @@ class TestServerDynRes(TestFunctional):
         restype = ["string_array"]
 
         # Prep for server_dyn_resource script
-        script_body = "echo white, red, blue"
-
-        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_color",
-                                           suffix=".scr")
-        self.filenames.append(fn)
-
-        resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
+        resval = ["echo white, red, blue"]
 
         self.setup_dyn_res(resname, restype, resval)
 
@@ -397,13 +356,7 @@ class TestServerDynRes(TestFunctional):
         restype = ["size"]
 
         # Prep for server_dyn_resource script
-        script_body = "echo 100gb"
-
-        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_size",
-                                           suffix=".scr")
-        self.filenames.append(fn)
-
-        resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
+        resval = ["echo 100gb"]
 
         self.setup_dyn_res(resname, restype, resval)
 
@@ -453,18 +406,18 @@ class TestServerDynRes(TestFunctional):
         returned by a script. Check if the script change during
         job run is correctly considered
         """
+
+        # This test must run as root because it modifies a root owned
+        # file
+        if os.getuid() != 0:
+            self.skipTest("Test must run as root")
+
         # Create a resource of type size
         resname = ["foobar"]
         restype = ["size"]
 
         # Prep for server_dyn_resource script
-        script_body = "echo 100gb"
-
-        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_size",
-                                           suffix=".scr")
-        self.filenames.append(fn)
-
-        resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
+        resval = ["echo 100gb"]
 
         self.setup_dyn_res(resname, restype, resval)
 
@@ -478,11 +431,8 @@ class TestServerDynRes(TestFunctional):
         self.server.expect(JOB, a, id=jid)
 
         # Change script during job run
-        change_res = "echo 50gb"
-        home_dir = os.path.expanduser("~")
-        fp = self.du.create_dyn_res_script(change_res, dirname=home_dir)
-        self.du.run_copy(src=fp, dest=fn, runas=ROOT_USER)
-        self.filenames.append(fn)
+        cmd = ["echo", "\"echo 50gb\"", " > ", self.filenames[0]]
+        self.du.run_cmd(cmd=cmd, runas=ROOT_USER, as_script=True)
 
         # Rerun job
         self.server.rerunjob(jid)
@@ -504,13 +454,7 @@ class TestServerDynRes(TestFunctional):
         restype = ["size"]
 
         # Script returns invalid value for resource type 'size'
-        script_body = "echo two gb"
-
-        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_size",
-                                           suffix=".scr")
-        self.filenames.append(fn)
-
-        resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
+        resval = ["echo two gb"]
 
         self.setup_dyn_res(resname, restype, resval)
 
@@ -521,7 +465,7 @@ class TestServerDynRes(TestFunctional):
 
         # Also check that "<script> returned bad output"
         # is in the logs
-        self.scheduler.log_match("%s returned bad output" % (fn))
+        self.scheduler.log_match("%s returned bad output" % self.filenames[0])
 
         # The job shouldn't run
         job_comment = "Can Never Run: Insufficient amount of server resource:"
@@ -541,13 +485,7 @@ class TestServerDynRes(TestFunctional):
         restype = ["float"]
 
         # Prep for server_dyn_resource script
-        script_body = "echo abc"
-
-        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_float",
-                                           suffix=".scr")
-        self.filenames.append(fn)
-
-        resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
+        resval = ["echo abc"]
 
         self.setup_dyn_res(resname, restype, resval)
 
@@ -558,7 +496,7 @@ class TestServerDynRes(TestFunctional):
 
         # Also check that "<script> returned bad output"
         # is in the logs
-        self.scheduler.log_match("%s returned bad output" % (fn))
+        self.scheduler.log_match("%s returned bad output" % self.filenames[0])
 
         # The job shouldn't run
         job_comment = "Can Never Run: Insufficient amount of server resource:"
@@ -578,13 +516,7 @@ class TestServerDynRes(TestFunctional):
         restype = ["boolean"]
 
         # Prep for server_dyn_resource script
-        script_body = "echo yes"
-
-        fn = self.du.create_dyn_res_script(script_body, prefix="PtlPbs_bool",
-                                           suffix=".scr")
-        self.filenames.append(fn)
-
-        resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
+        resval = ["echo yes"]
 
         self.setup_dyn_res(resname, restype, resval)
 
@@ -595,7 +527,7 @@ class TestServerDynRes(TestFunctional):
 
         # Also check that "<script> returned bad output"
         # is in the logs
-        self.scheduler.log_match("%s returned bad output" % (fn))
+        self.scheduler.log_match("%s returned bad output" % self.filenames[0])
 
         # The job shouldn't run
         job_comment = "Can Never Run: Insufficient amount of server resource:"
@@ -608,35 +540,34 @@ class TestServerDynRes(TestFunctional):
         Test whether scheduler rejects the server_dyn_res script when the
         permission of the script are open to write for others and group
         """
+
         # Create a new resource
-        attr = {'type': 'long', 'flag': 'nh'}
+        attr = {'type': 'long', 'flag': 'q'}
         self.server.manager(MGR_CMD_CREATE, RSC, attr, id='foo')
         self.scheduler.add_resource('foo')
 
         scr_body = ['echo "10"', 'exit 0']
         home_dir = os.path.expanduser("~")
-        fp = self.du.create_dyn_res_script(scr_body, dirname=home_dir)
+        fp = self.scheduler.add_server_dyn_res("foo", scr_body,
+                                               dirname=home_dir,
+                                               validate=False)
         # Add to filenames for cleanup
         self.filenames.append(fp)
 
-        dyn_scr = '"foo !' + fp + '"'
-        self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
-                                        validate=False)
-
         # give write permission to group and others
-        self.du.chmod(path=fp, mode=0766, sudo=True)
+        self.du.chmod(path=fp, mode=0766, sudo=True, runas=ROOT_USER)
         self.check_access_log(fp)
 
         # give write permission to group
-        self.du.chmod(path=fp, mode=0764, sudo=True)
+        self.du.chmod(path=fp, mode=0764, sudo=True, runas=ROOT_USER)
         self.check_access_log(fp)
 
         # give write permission to others
-        self.du.chmod(path=fp, mode=0746, sudo=True)
+        self.du.chmod(path=fp, mode=0746, sudo=True, runas=ROOT_USER)
         self.check_access_log(fp)
 
         # give write permission to user only
-        self.du.chmod(path=fp, mode=0744, sudo=True)
+        self.du.chmod(path=fp, mode=0744, sudo=True, runas=ROOT_USER)
         if os.getuid() != 0:
                 self.check_access_log(fp, exist=True)
         else:
@@ -647,77 +578,56 @@ class TestServerDynRes(TestFunctional):
         # Create the dirctory name with a space in it, to make sure PBS parses
         # it correctly.
         dir_temp = self.du.mkdtemp(mode=0766, dir=home_dir, suffix=' tmp')
-        fp = self.du.create_dyn_res_script(scr_body, dirname=dir_temp)
+        fp = self.scheduler.add_server_dyn_res("foo", scr_body,
+                                               dirname=dir_temp,
+                                               validate=False)
 
         # Add to filenames for cleanup
         self.filenames.append(fp)
         self.filenames.append(dir_temp)
 
-        dyn_scr = "\'foo !" + "\"" + fp + "\"\'"
-        self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
-                                        validate=False)
-
         # give write permission to group and others
-        self.du.chmod(path=fp, mode=0766, sudo=True)
+        self.du.chmod(path=fp, mode=0766, sudo=True, runas=ROOT_USER)
         self.check_access_log(fp)
 
         # give write permission to group
-        self.du.chmod(path=fp, mode=0764, sudo=True)
+        self.du.chmod(path=fp, mode=0764, sudo=True, runas=ROOT_USER)
         self.check_access_log(fp)
 
         # give write permission to others
-        self.du.chmod(path=fp, mode=0746, sudo=True)
+        self.du.chmod(path=fp, mode=0746, sudo=True, runas=ROOT_USER)
         self.check_access_log(fp)
 
         # give write permission to user only
-        self.du.chmod(path=fp, mode=0744, sudo=True)
+        self.du.chmod(path=fp, mode=0744, sudo=True, runas=ROOT_USER)
         self.check_access_log(fp)
 
-        # Create a dynamic script with right permissions
-        fp = self.du.create_temp_file(body=scr_body, dirname=home_dir,
-                                      asuser=ROOT_USER)
-        # Add to filenames for cleanup
-        self.filenames.append(fp)
-
-        # Create dynamic resource script in tmp directory and check
+        # Create dynamic resource script in PBS_HOME directory and check
         # file permissions
-        # du.create_dyn_res_script by default creates the script in /tmp
-
-        # give write permission to group and others
-        fp = self.du.create_dyn_res_script(scr_body, perm=0766)
+        # self.scheduler.add_mom_dyn_res by default creates the script in
+        # PBS_HOME as root
+        fp = self.scheduler.add_server_dyn_res("foo", scr_body, perm=0766,
+                                               validate=False)
         self.filenames.append(fp)
-        dyn_scr = '"foo !' + fp + '"'
-        self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
-                                        validate=False)
+
         self.check_access_log(fp)
 
         # give write permission to group
-        fp = self.du.create_dyn_res_script(scr_body, perm=0764)
-        self.filenames.append(fp)
-        dyn_scr = '"foo !' + fp + '"'
-        self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
-                                        validate=False)
+        self.du.chmod(path=fp, mode=0764, sudo=True, runas=ROOT_USER)
         self.check_access_log(fp)
 
         # give write permission to others
-        fp = self.du.create_dyn_res_script(scr_body, perm=0746)
-        self.filenames.append(fp)
-        dyn_scr = '"foo !' + fp + '"'
-        self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
-                                        validate=False)
+        self.du.chmod(path=fp, mode=0746, sudo=True, runas=ROOT_USER)
         self.check_access_log(fp)
 
         # give write permission to user only
-        fp = self.du.create_dyn_res_script(scr_body, perm=0744)
-        self.filenames.append(fp)
-        dyn_scr = '"foo !' + fp + '"'
-        self.scheduler.set_sched_config({'server_dyn_res': dyn_scr},
-                                        validate=False)
+        self.du.chmod(path=fp, mode=0744, sudo=True, runas=ROOT_USER)
         self.check_access_log(fp, exist=False)
 
     def tearDown(self):
         # removing all files creating in test
-        self.du.rm(path=self.filenames, sudo=True, force=True,
-                   recursive=True)
-        del self.filenames[:]
+        if len(self.filenames) != 0:
+            self.du.rm(path=self.filenames, sudo=True, force=True,
+                       recursive=True)
+            self.filenames[:] = []
         TestFunctional.tearDown(self)

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -111,7 +111,7 @@ class TestServerDynRes(TestFunctional):
         restype = ["long"]
         script_body = "echo abc"
         fn = self.du.create_temp_file(prefix="PtlPbs_badoutfile",
-                                      body=script_body)
+                                      body=script_body, asuser=ROOT_USER)
 
         self.du.chmod(path=fn, mode=0755, sudo=True)
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
@@ -215,7 +215,7 @@ class TestServerDynRes(TestFunctional):
         fpath_out = os.path.join(os.sep, "tmp", "PtlPbs_got_foo")
 
         fn_in = self.du.create_temp_file(prefix="PtlPbs_get_foo",
-                                         body=script_body)
+                                         body=script_body, asuser=ROOT_USER)
         self.du.chmod(path=fn_in, mode=0755, sudo=True)
 
         # Add additional white space between resource name and the script
@@ -258,13 +258,16 @@ class TestServerDynRes(TestFunctional):
 
         fn_s = self.du.create_temp_file(prefix="PtlPbs_small",
                                         suffix=".scr",
-                                        body=script_body_s)
+                                        body=script_body_s,
+                                        asuser=ROOT_USER)
         fn_m = self.du.create_temp_file(prefix="PtlPbs_medium",
                                         suffix=".scr",
-                                        body=script_body_m)
+                                        body=script_body_m,
+                                        asuser=ROOT_USER)
         fn_l = self.du.create_temp_file(prefix="PtlPbs_large",
                                         suffix=".scr",
-                                        body=script_body_l)
+                                        body=script_body_l,
+                                        asuser=ROOT_USER)
 
         self.du.chmod(path=fn_s, mode=0755, sudo=True)
         self.du.chmod(path=fn_m, mode=0755, sudo=True)
@@ -317,7 +320,7 @@ class TestServerDynRes(TestFunctional):
 
         fn = self.du.create_temp_file(prefix="PtlPbs_check",
                                       suffix=".scr",
-                                      body=script_body)
+                                      body=script_body, asuser=ROOT_USER)
         self.du.chmod(path=fn, mode=0755, sudo=True)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
@@ -360,7 +363,7 @@ class TestServerDynRes(TestFunctional):
 
         fn = self.du.create_temp_file(prefix="PtlPbs_color",
                                       suffix=".scr",
-                                      body=script_body)
+                                      body=script_body, asuser=ROOT_USER)
         self.du.chmod(path=fn, mode=0755, sudo=True)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
@@ -403,7 +406,7 @@ class TestServerDynRes(TestFunctional):
 
         fn = self.du.create_temp_file(prefix="PtlPbs_size",
                                       suffix=".scr",
-                                      body=script_body)
+                                      body=script_body, asuser=ROOT_USER)
         self.du.chmod(path=fn, mode=0755, sudo=True)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
@@ -465,7 +468,7 @@ class TestServerDynRes(TestFunctional):
 
         fn = self.du.create_temp_file(prefix="PtlPbs_size",
                                       suffix=".scr",
-                                      body=script_body)
+                                      body=script_body, asuser=ROOT_USER)
         self.du.chmod(path=fn, mode=0755, sudo=True)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
@@ -510,7 +513,7 @@ class TestServerDynRes(TestFunctional):
 
         fn = self.du.create_temp_file(prefix="PtlPbs_size",
                                       suffix=".scr",
-                                      body=script_body)
+                                      body=script_body, asuser=ROOT_USER)
         self.du.chmod(path=fn, mode=0755, sudo=True)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
@@ -548,7 +551,7 @@ class TestServerDynRes(TestFunctional):
 
         fn = self.du.create_temp_file(prefix="PtlPbs_float",
                                       suffix=".scr",
-                                      body=script_body)
+                                      body=script_body, asuser=ROOT_USER)
         self.du.chmod(path=fn, mode=0755, sudo=True)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
@@ -586,7 +589,7 @@ class TestServerDynRes(TestFunctional):
 
         fn = self.du.create_temp_file(prefix="PtlPbs_bool",
                                       suffix=".scr",
-                                      body=script_body)
+                                      body=script_body, asuser=ROOT_USER)
         self.du.chmod(path=fn, mode=0755, sudo=True)
 
         resval = ['"' + resname[0] + ' ' + '!' + fn + '"']
@@ -620,7 +623,8 @@ class TestServerDynRes(TestFunctional):
 
         scr_body = ['echo "10"', 'exit 0']
         home_dir = os.path.expanduser("~")
-        fp = self.du.create_temp_file(body=scr_body, dirname=home_dir)
+        fp = self.du.create_temp_file(body=scr_body, dirname=home_dir,
+                                      asuser=ROOT_USER)
         # Add to filenames for cleanup
         self.filenames.append(fp)
 
@@ -649,7 +653,8 @@ class TestServerDynRes(TestFunctional):
         # Create the dirctory name with a space in it, to make sure PBS parses
         # it correctly.
         dir_temp = self.du.mkdtemp(mode=0766, dir=home_dir, suffix=' tmp')
-        fp = self.du.create_temp_file(body=scr_body, dirname=dir_temp)
+        fp = self.du.create_temp_file(body=scr_body, dirname=dir_temp,
+                                      asuser=ROOT_USER)
         # Add to filenames for cleanup
         self.filenames.append(fp)
         self.filenames.append(dir_temp)
@@ -675,7 +680,8 @@ class TestServerDynRes(TestFunctional):
         self.check_access_log(fp)
 
         # Create a dynamic script with right permissions
-        fp = self.du.create_temp_file(body=scr_body, dirname=home_dir)
+        fp = self.du.create_temp_file(body=scr_body, dirname=home_dir,
+                                      asuser=ROOT_USER)
         # Add to filenames for cleanup
         self.filenames.append(fp)
 
@@ -697,7 +703,7 @@ class TestServerDynRes(TestFunctional):
 
         # Create dynamic resource script in tmp directory and check
         # file permissions
-        fp = self.du.create_temp_file(body=scr_body)
+        fp = self.du.create_temp_file(body=scr_body, asuser=ROOT_USER)
         # Add to filenames for cleanup
         self.filenames.append(fp)
 

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -637,9 +637,7 @@ class TestServerDynRes(TestFunctional):
 
         # give write permission to user only
         self.du.chmod(path=fp, mode=0744, sudo=True)
-        root_priv = self.du.run_cmd(
-            cmd=["ls", os.path.join(os.sep, "root")])
-        if root_priv['rc'] != 0:
+        if os.getuid() != 0:
                 self.check_access_log(fp, exist=True)
         else:
                 self.check_access_log(fp, exist=False)
@@ -721,4 +719,5 @@ class TestServerDynRes(TestFunctional):
         # removing all files creating in test
         self.du.rm(path=self.filenames, sudo=True, force=True,
                    recursive=True)
-        self.filenames = []
+        del self.filenames[:]
+        TestFunctional.tearDown(self)

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -765,9 +765,12 @@ class SmokeTest(PBSTestSuite):
         self.scheduler.add_server_dyn_res("foo", script_body=body)
         self.scheduler.add_resource("foo", apply=True)
         j1 = Job(TEST_USER)
-        j1.set_attributes({'Resource_List': 'foo=5'})
+        j1.set_attributes({'Resource_List': 'foo=15'})
         j1id = self.server.submit(j1)
-        a = {'job_state': 'R', 'Resource_List.foo': '5'}
+        msg = "Can Never Run: Insufficient amount of server resource: foo "\
+              "(R: 15 A: 10 T: 10)"
+        a = {'job_state': 'Q', 'Resource_List.foo': '15',
+             'comment': msg}
         self.server.expect(JOB, a, id=j1id)
 
     @skipOnCpuSet

--- a/test/tests/selftest/pbs_create_tmp_file.py
+++ b/test/tests/selftest/pbs_create_tmp_file.py
@@ -1,0 +1,109 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.selftest import *
+from stat import *
+from pwd import getpwuid
+
+class TestPBStempfile(TestSelf):
+    """
+    Test suite to test create_temp_file functionality in PBS
+    """
+    def test_default_temp_file(self):
+        """
+        Test that by default the file created by create_temp_file
+        interface is present in tmp directory with 0644 permissions
+        """
+        f = self.du.create_temp_file()
+        name = f.split(os.sep)[-1]
+
+        self.assertTrue(name.startswith('PtlPbs'))
+        self.assertTrue(f.startswith('/tmp'))
+        mode = str(oct(os.stat(f)[ST_MODE])[-3:])
+        self.assertEqual(mode,'644')
+    
+    def test_tmp_file_owner(self):
+        """
+        Test that temp file is created as specified owner
+        """
+        file_user = getpwuid(os.getuid()).pw_name
+        f = self.du.create_temp_file(asuser=file_user)
+        
+        user = getpwuid(os.stat(f).st_uid).pw_name
+        self.assertEqual(file_user, user)
+
+    def test_tmp_file_directory(self):
+        """
+        Test temp file is created in specified directory
+        """
+        home = os.path.expanduser('~')
+        f = self.du.create_temp_file(dirname=home)
+        dirname = os.sep.join(f.split(os.sep)[:-1])
+        self.assertEqual(home, dirname)
+
+    def test_tmp_file_perm(self):
+        """
+        Test temp file is created with certain permissions
+        """
+        mode = 0755
+        f = self.du.create_temp_file(mode=mode)
+        mode_out = oct(os.stat(f)[ST_MODE])[-4:]
+        self.assertEqual(oct(mode), mode_out)
+
+    def test_tmp_file_with_perm_in_directory(self):
+        """
+        Test temp file is created with certain permissions
+        """
+        mode = 0755
+        home = os.path.expanduser('~')
+        f = self.du.create_temp_file(mode=mode, dirname=home)
+        mode_out = oct(os.stat(f)[ST_MODE])[-4:]
+        dirname = os.sep.join(f.split(os.sep)[:-1])
+        self.assertEqual(oct(mode), mode_out)
+        self.assertEqual(home, dirname)
+
+    def test_tmp_file_with_perm_in_directory_as_user(self):
+        """
+        Test temp file is created with certain permissions
+        """
+        mode = 0755
+        dirname = '/tmp'
+        f = self.du.create_temp_file(mode=mode, dirname=dirname)
+        mode_out = oct(os.stat(f)[ST_MODE])[-4:]
+        dirname_out = os.sep.join(f.split(os.sep)[:-1])
+        self.assertEqual(oct(mode), mode_out)
+        self.assertEqual(dirname, dirname_out)

--- a/test/tests/selftest/pbs_create_tmp_file.py
+++ b/test/tests/selftest/pbs_create_tmp_file.py
@@ -39,6 +39,7 @@ from tests.selftest import *
 from stat import *
 from pwd import getpwuid
 
+
 class TestPBStempfile(TestSelf):
     """
     Test suite to test create_temp_file functionality in PBS
@@ -54,15 +55,15 @@ class TestPBStempfile(TestSelf):
         self.assertTrue(name.startswith('PtlPbs'))
         self.assertTrue(f.startswith('/tmp'))
         mode = str(oct(os.stat(f)[ST_MODE])[-3:])
-        self.assertEqual(mode,'644')
-    
+        self.assertEqual(mode, '644')
+
     def test_tmp_file_owner(self):
         """
         Test that temp file is created as specified owner
         """
         file_user = getpwuid(os.getuid()).pw_name
         f = self.du.create_temp_file(asuser=file_user)
-        
+
         user = getpwuid(os.stat(f).st_uid).pw_name
         self.assertEqual(file_user, user)
 
@@ -86,7 +87,8 @@ class TestPBStempfile(TestSelf):
 
     def test_tmp_file_with_perm_in_directory(self):
         """
-        Test temp file is created with certain permissions
+        Test temp file is created with certain permissions and inside
+        a specified directory
         """
         mode = 0755
         home = os.path.expanduser('~')
@@ -98,7 +100,8 @@ class TestPBStempfile(TestSelf):
 
     def test_tmp_file_with_perm_in_directory_as_user(self):
         """
-        Test temp file is created with certain permissions
+        Test temp file is created with certain permissions and inside
+        a specified directory as a specific user
         """
         mode = 0755
         dirname = '/tmp'


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
PBS does not check for permissions of server/mom dynamic resource script. There can be a case that the permissions of this file are open for 'write' to others and group.

#### Affected Platform(s)
All

#### Cause / Analysis / Design
No permission checks were performed.


#### Solution Description
Added permission checks and also added a check that the user owning the script should have a uid <10 or be an admin (on windows)

#### Testing logs/output
[test_momdynres.txt](https://github.com/PBSPro/pbspro/files/2631339/test_momdynres.txt)
[test_svrdynres.txt](https://github.com/PBSPro/pbspro/files/2631340/test_svrdynres.txt)
[test_smoketest.txt](https://github.com/PBSPro/pbspro/files/2631342/test_smoketest.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__



#### NOTE
This pull request is copy of "https://github.com/PBSPro/pbspro/pull/905" which was failing to load and possibly causing Travis/appveyor to not run