### PR TITLE
Fix buffer overrun on long TMPDIR path

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -227,7 +227,8 @@ static char script_tmp[MAXPATHLEN + 1] = {'\0'}; /* name of script file copy */
 #ifdef WIN32
 static char fl[(2 * MAXPATHLEN) + 1] = {'\0'}; /* the filename used as the pipe name */
 #else
-static char fl[sizeof(((struct sockaddr_un *)0)->sun_path)] = {'\0'}; /* the filename used as the pipe name */
+#define MAXPIPENAME sizeof(((struct sockaddr_un *)0)->sun_path)
+static char fl[MAXPIPENAME] = {'\0'}; /* the filename used as the pipe name */
 #endif
 #define BUFSIZE 1024 /* windows default pipe buffer size */
 #define PIPE_TIMEOUT 0 /* default windows pipe timeout */
@@ -5241,8 +5242,10 @@ get_comm_filename(char *fname)
 {
 	char *env_svr = getenv(PBS_CONF_SERVER_NAME);
 	char *env_port = getenv(PBS_CONF_BATCH_SERVICE_PORT);
+	int count = 0;
 
-	sprintf(fname, "%s/pbs_%.16s_%lu_%.8s_%.32s_%.16s_%.5s",
+
+	count = snprintf(fname, MAXPIPENAME, "%s/pbs_%.16s_%lu_%.8s_%.32s_%.16s_%.5s",
 		tmpdir,
 		((server_out == NULL || server_out[0] == 0) ?
 		"default" : server_out),
@@ -5252,6 +5255,19 @@ get_comm_filename(char *fname)
 		(env_svr == NULL)?"":env_svr,
 		(env_port == NULL)?"":env_port
 		);
+
+	if (count >= MAXPIPENAME) {
+		snprintf(fname, MAXPIPENAME, "%s/pbs_%.16s_%lu_%.8s_%.32s_%.16s_%.5s",
+		TMP_DIR,
+		((server_out == NULL || server_out[0] == 0) ?
+		"default" : server_out),
+		(unsigned long int)getuid(),
+		cred_name,
+		get_conf_path(),
+		(env_svr == NULL)?"":env_svr,
+		(env_port == NULL)?"":env_port
+		);
+	}
 }
 
 /**

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -36,6 +36,7 @@
 # trademark licensing policies.
 
 from tests.functional import *
+import os
 
 
 class TestQsubOptionsArguments(TestFunctional):
@@ -53,11 +54,25 @@ class TestQsubOptionsArguments(TestFunctional):
         self.qsub_cmd = os.path.join(
             self.server.pbs_conf['PBS_EXEC'], 'bin', 'qsub')
 
+    def test_qsub_with_script_with_long_TMPDIR(self):
+        """
+        submit a job with a script and with long path in TMPDIR
+        """
+        longpath = '%s/aaaaaaaaaa/bbbbbbbbbb/cccccccccc/eeeeeeeeee/\
+ffffffffff/gggggggggg/hhhhhhhhhh/iiiiiiiiii/jj/afdj/hlppoo/jkloiytupoo/\
+bhtiusabsdlg' % (os.environ['HOME'])
+        os.environ['TMPDIR'] = longpath
+        if not os.path.exists(longpath):
+            os.makedirs(longpath)
+        cmd = [self.qsub_cmd, self.fn]
+        rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        self.assertEquals(rv['rc'], 0, 'qsub failed')
+
     def test_qsub_with_script_executable(self):
         """
         submit a job with a script and executable
         """
-        cmd = [self.qsub_cmd, self.fn, '--',  '/bin/sleep 10']
+        cmd = [self.qsub_cmd, self.fn, '--', '/bin/sleep 10']
         rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
         failed = rv['rc'] == 2 and rv['err'][0].split(' ')[0] == 'usage:'
         self.assertTrue(failed, 'qsub should have failed, but did not fail')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *If the user define the TMPDIR path longer than ~128 characters then job submission fails with error 'qsub: cannot access script file'*
* ***Steps to reproduce:***
 1.  *export TMPDIR=/home/mohammh/aaaaaaaaaa/bbbbbbbbbb/cccccccccc/eeeeeeeeee/ffffffffff/gggggggggg/hhhhhhhhhh/iiiiiiiiii/jj/afdj/hlppoo/jkloiytupoo/bhtiusabsdlg/*
  2.  *mkdir -p $TMPDIR*
  3.  *qsub job.scr*
 *qsub: cannot access script file*

#### Affected Platform(s)
* *All Linux*

#### Cause / Analysis / Design
* *Function get_comm_filename appends the tmpdir path to the path of unixsocket filename, which is restricted to 108 charecters and thus when the user update the TMPDIR path longer than 108 characters, buffer overflow occurs and that leads to invalid path.*

#### Solution Description
* *Using snprintf to avoid the bufferflow and if the tmpdir path is greater than buffer size we use /var/tmp path for the unixsocket file.*

#### Testing logs/output
[test_qsub_with_script_with_long_TMPDIR_BeforeFix.ptl.txt](https://github.com/PBSPro/pbspro/files/2932817/test_qsub_with_script_with_long_TMPDIR_BeforeFix.ptl.txt)
[test_qsub_with_script_with_long_TMPDIR_AfterFix.ptl.txt](https://github.com/PBSPro/pbspro/files/2932816/test_qsub_with_script_with_long_TMPDIR_AfterFix.ptl.txt)
[TestQsubOptionsArguments.ptl.txt](https://github.com/PBSPro/pbspro/files/2932848/TestQsubOptionsArguments.ptl.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
