### PR TITLE
PP-1335: PTL test case fails before setUp function with AttributeError

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_db.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_db.py
@@ -43,6 +43,7 @@ import logging
 import platform
 import traceback
 import time
+import datetime
 import json
 import ptl.utils.pbs_logutils as lu
 from ptl.lib.pbs_testlib import PbsTypeDuration
@@ -1710,6 +1711,7 @@ class PTLTestDb(Plugin):
             return {}
         testdata = {}
         data = {}
+        cur_time = datetime.datetime.now()
         if (hasattr(_test, 'server') and
                 (getattr(_test, 'server', None) is not None)):
             testdata['pbs_version'] = _test.server.attributes['pbs_version']
@@ -1725,8 +1727,8 @@ class PTLTestDb(Plugin):
         testdata['module'] = _test.__module__
         testdata['testcase'] = getattr(_test, '_testMethodName', '<unknown>')
         testdata['testdoc'] = getattr(_test, '_testMethodDoc', '<unknown>')
-        testdata['start_time'] = getattr(test, 'start_time', 0)
-        testdata['end_time'] = getattr(test, 'end_time', 0)
+        testdata['start_time'] = getattr(test, 'start_time', cur_time)
+        testdata['end_time'] = getattr(test, 'end_time', cur_time)
         testdata['duration'] = getattr(test, 'duration', 0)
         testdata['tags'] = getattr(_test, TAGKEY, [])
         measurements_dic = getattr(_test, 'measurements', {})

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -58,6 +58,7 @@ from nose.suite import ContextSuite
 from ptl.utils.pbs_testsuite import PBSTestSuite
 from ptl.utils.pbs_testsuite import TIMEOUT_KEY
 from ptl.utils.pbs_testsuite import REQUIREMENTS_KEY
+from ptl.utils.pbs_testsuite import MINIMUM_TESTCASE_TIMEOUT
 from ptl.utils.pbs_dshutils import DshUtils
 from ptl.utils.plugins.ptl_test_info import get_effective_reqs
 from ptl.lib.pbs_testlib import PBSInitServices
@@ -553,12 +554,17 @@ class PTLTestRunner(Plugin):
         try:
             method = getattr(test.test, getattr(test.test, '_testMethodName'))
             return getattr(method, TIMEOUT_KEY)
-        except:
+        except AttributeError:
+            testcase_timeout = MINIMUM_TESTCASE_TIMEOUT
             if hasattr(test, 'test'):
-                __conf = getattr(test.test, 'conf')
-            else:
-                __conf = getattr(test.context, 'conf')
-            return __conf['default_testcase_timeout']
+                if hasattr(test.test, 'conf'):
+                    __conf = getattr(test.test, 'conf')
+                    testcase_timeout = __conf['default_testcase_timeout']
+            elif hasattr(test, 'context'):
+                if hasattr(test.context, 'conf'):
+                    __conf = getattr(test.context, 'conf')
+                    testcase_timeout = __conf['default_testcase_timeout']
+            return testcase_timeout
 
     def __set_test_end_data(self, test, err=None):
         if not hasattr(test, 'start_time'):


### PR DESCRIPTION
#### Bug/feature Description
* [PP-1335](https://pbspro.atlassian.net/browse/PP-1335)
* PTL throws AttributeError if a test suite fails before calling "setUp".
Error:
 File "/home/pbsroot/TEST/tmp/ptl/lib/python2.7/site-packages/ptl/utils/plugins/ptl_report_json.py", line 69, in get_json
    'run_id': data['start_time'].strftime('%s'),
AttributeError: 'int' object has no attribute 'strftime'

#### Affected Platform(s)
* This issue is seen only on Cray platform as it was booted to a different image other than default one which didn't have apstat installed on it.
Now this issue is not reproducible but still PTL has bug. 

#### Cause / Analysis / Design
*  When a test case fails before calling setUp method, PTL throws error while creating json report. This is due to start_time not being initialized.
* Currently start_time is assigned to 0 by default and it gets assigned when test case starts executing.
* If start_time gets assigned then __get_timeout throws error with conf error:
File "/tmp/PTL/lib/python2.7/site-packages/ptl/utils/plugins/ptl_test_runner.py", line 599, in startTest
timeout = self.__get_timeout(test)
File "/tmp/PTL/lib/python2.7/site-packages/ptl/utils/plugins/ptl_test_runner.py", line 551, in __get_timeout
__conf = getattr(test.test, 'conf')
AttributeError: 'Failure' object has no attribute 'conf'

#### Solution Description
*  Initialized start_time to datetime.datetime.now() by default before test case starts executing*
*  modify __get_timeout to return default timeout value if there is any error in except block.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
