### PR TITLE
Fixing syntax issue in install_db file

### DIFF
--- a/src/cmds/scripts/install_db
+++ b/src/cmds/scripts/install_db
@@ -219,7 +219,7 @@ if [ ! -d "${data_dir}" ]; then
 fi
 
 # delete the password file, if any, since we are creating new db
-[${upgrade} -eq 0] && rm -f "${PBS_HOME}/server_priv/db_password"
+[ ${upgrade} -eq 0 ] && rm -f "${PBS_HOME}/server_priv/db_password"
 passwd="${user}"
 
 chown ${user} ${data_dir}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
While running install_db for database creation, this script will preserve the existing password file. 
There is a syntax issue while verifying the "upgrade" variable.

#### Affected Platform(s)
*Linux

#### Cause / Analysis / Design
* Syntax error

#### Solution Description
* Fixing the systax error.

#### Testing logs/output

**Before fix:**
[root@physics scripts]# /opt/pbs/libexec/install_db 
/opt/pbs/libexec/install_db: line 223: [0: command not found
Creating the PBS Data Service...
Starting PBS Data Service..
Stopping PBS Data Service..
waiting for server to shut down.... done
server stopped

**After fix**
[root@physics scripts]# /opt/pbs/libexec/install_db 
Creating the PBS Data Service...
Starting PBS Data Service..
Stopping PBS Data Service..
waiting for server to shut down.... done
server stopped
[root@physics scripts]# 

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
