### PR TITLE
test_revert_pbsconf_corelimit fails intermittently

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -12718,12 +12718,12 @@ class MoM(PBSService):
         self.version = None
         self._is_cpuset_mom = None
 
-    def isUp(self):
+    def isUp(self, max_attempts=20):
         """
         Check for PBS mom up
         """
         # Poll for few seconds to see if mom is up and node is free
-        for _ in range(20):
+        for _ in range(max_attempts):
             rv = super(MoM, self)._isUp(self)
             if rv:
                 break

--- a/test/tests/selftest/pbs_pbstestsuite.py
+++ b/test/tests/selftest/pbs_pbstestsuite.py
@@ -165,7 +165,12 @@ class TestPBSTestSuite(TestSelf):
         # Send SIGSEGV to pbs_mom
         self.assertTrue(self.mom.isUp())
         self.mom.signal("-SEGV")
-        self.assertFalse(self.mom.isUp())
+        for _ in range(20):
+            ret = self.mom.isUp(max_attempts=1)
+            if not ret:
+                break
+            time.sleep(1)
+        self.assertFalse(ret, "Mom was expected to go down but it didn't")
 
         # Confirm that no core file was generated
         mom_priv_filenames = self.du.listdir(self.server.hostname,
@@ -188,7 +193,12 @@ class TestPBSTestSuite(TestSelf):
         # Send another SIGSEGV to pbs_mom
         self.assertTrue(self.mom.isUp())
         self.mom.signal("-SEGV")
-        self.assertFalse(self.mom.isUp())
+        for _ in range(20):
+            ret = self.mom.isUp(max_attempts=1)
+            if not ret:
+                break
+            time.sleep(1)
+        self.assertFalse(ret, "Mom was expected to go down but it didn't")
 
         # Confirm that a core file was generated this time
         mom_priv_filenames = self.du.listdir(self.server.hostname,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* The test seems to fail intermittently as follows:
2018-12-14 12:01:36,883 INFO     running init script to start pbs on pbi-01-r6.pbspro.com using /etc/pbs.conf init_cmd=['sudo', '/opt/pbs/libexec/pbs_init.d', 'start']
2018-12-14 12:01:36,884 INFOCLI2 pbi-01-r6: sudo /opt/pbs/libexec/pbs_init.d start
2018-12-14 12:01:40,758 INFOCLI2 pbi-01-r6: sudo -H /opt/tools/wrappers/cat /var/spool/pbs/mom_priv/mom.loc
2018-12-14 12:01:40,793 INFO     mom pbi-01-r6: sent signal -SEGV
2018-12-14 12:01:40,794 INFOCLI2 pbi-01-r6: sudo -H kill -SEGV 15602
2018-12-14 12:01:40,859 INFOCLI2 pbi-01-r6: sudo -H /opt/tools/wrappers/cat /var/spool/pbs/mom_priv/mom.lock
2018-12-14 12:01:40,894 INFO     FAILED
Traceback (most recent call last): File "/usr/pbsroot13590/tmp/ptl_src/tests/selftest/pbs_pbstestsuite.py", line 168, in test_revert_pbsconf_corelimit self.assertFalse(self.mom.isUp()) AssertionError: True is not false

#### Affected Platform(s)
* Linux

#### Cause / Analysis / Design
* There's a race condition in the test w.r.t checking whether the mom is up or not. The test just passes SEGV and immediately does an assert on mom.isUp() to see whether the mom is down or not. Sometimes the mom might be up when SEGV is sent, so the test fails.

#### Solution Description
* mom.isUp() was recently enhanced to wait 20 seconds, checking every second to see if the mom was up yet. This was done to solve similar race condition issues. So, I enhanced the function to take an 'expectation' argument. If set to false, the function checks for the mom to be down instead of up. This argument is set to True by default.

#### Testing logs/output
* 
[test_revert_pbsconf_corelimit.log](https://github.com/PBSPro/pbspro/files/2936148/test_revert_pbsconf_corelimit.log)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
 - [X] I have attached **test logs to this pull request** as evidence of testing/verification


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
