### PR TITLE
PTL's expect() must have PTL_AND as 'attrop' parameter's default value

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8052,7 +8052,7 @@ class Server(PBSService):
         if c:
             self._disconnect(c)
 
-    def expect(self, obj_type, attrib=None, id=None, op=EQ, attrop=PTL_OR,
+    def expect(self, obj_type, attrib=None, id=None, op=EQ, attrop=PTL_AND,
                attempt=0, max_attempts=None, interval=None, count=None,
                extend=None, offset=0, runas=None, level=logging.INFO,
                msg=None):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
The default of the 'attrop' parameter to expect() is PTL_OR.  This means if multiple attributes are passed to expect(), only one has to be true for the expect() to pass. But it is more appropriate that, If you pass two attributes to expect(), the default should be that both have to be true.  
see the discussion here http://community.pbspro.org/t/using-ptl-and-as-default-for-expect-function-in-ptl/1083

https://pbspro.atlassian.net/browse/PP-1290

#### Affected Platform(s)
All Linux

#### Cause / Analysis / Design
The default of the attrop parameter to expect() is PTL_OR.  

#### Solution Description
Changed attrop parameter to expect() as PTL_AND.

#### Testing logs/output
This is one of the existing tests that checks 2 attributes in the expect() call.
[beforefix.txt](https://github.com/PBSPro/pbspro/files/2938429/beforefix.txt)
[afterfix.txt](https://github.com/PBSPro/pbspro/files/2938430/afterfix.txt)
Also ran existing testsuites with this change and there seems to be no test that is affected by this change.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__