### PR TITLE
Server crashes intermittently when the node list in qrun -H is ill formed

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -6758,27 +6758,20 @@ build_execvnode(job *pjob, char *nds)
 		pc = parse_plus_spec(NULL, &rc);
 	}
 
+	*outbuf = '\0';
+
        /* 
         * if the number of nodes defined ndarray is not equal
         * to the number of nodes identified by parse_plus_spec, then there's a 
         * invalid vnode specification on the qrun
         */
 
-	if (i != nnodes) {
-		while (i != nnodes) {
-                	if ((*(ndarray+i) = strdup(nds)) == NULL)
-                        	rc = errno;
-			++i;
-		}
-        }
-
-	if (rc)
+	if (rc || i != nnodes)
 		goto done;
 
 	/* now loop breaking up the select spec into separate chunks */
 	/* and determining how many times each chunk is to be used   */
 
-	*outbuf = '\0';
 	i  = 0;
 	pc = parse_plus_spec(selspec, &rc);
 	while (pc) {
@@ -7037,6 +7030,9 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 		}
 		if (execvnod == NULL)
 			return PBSE_BADNODESPEC;
+
+		if (!strlen(execvnod))
+                        return PBSE_UNKNODE;
 
 		/* are we to allocate the nodes "excl" ? */
 		prsdef = find_resc_def(svr_resc_def, "place", svr_resc_size);

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -6759,11 +6759,20 @@ build_execvnode(job *pjob, char *nds)
 	}
 
        /* 
-        * if the number of nodes defined above in ndarray is not equal
-        * to the number of nodes identified, then skip the below loop
+        * if the number of nodes defined ndarray is not equal
+        * to the number of nodes identified by parse_plus_spec, then there's a 
+        * invalid vnode specification on the qrun
         */
 
-	if (rc || i != nnodes)
+	if (i != nnodes) {
+		while (i != nnodes) {
+                	if ((*(ndarray+i) = strdup(nds)) == NULL)
+                        	rc = errno;
+			++i;
+		}
+        }
+
+	if (rc)
 		goto done;
 
 	/* now loop breaking up the select spec into separate chunks */

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -6761,9 +6761,9 @@ build_execvnode(job *pjob, char *nds)
 	*outbuf = '\0';
 
        /* 
-        * if the number of nodes defined ndarray is not equal
-        * to the number of nodes identified by parse_plus_spec, then there's a 
-        * invalid vnode specification on the qrun
+        * if the number of nodes identified for ndarray (nnodes) are not equal
+        * to the number of nodes identified by parse_plus_spec, then
+        * the vnode specification is invalid.
         */
 
 	if (rc || i != nnodes)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Server crashes intermittently  when the node list in qrun -H is ill formed
* example: jid=$(echo "sleep 10" | qsub -l select=ncpus=36:host=centos7+ncpus=36:host=centos7)
qrun -H "'(centos7)+(centos7)'" $jid
qrun: End of File 4.centos7

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* The original fix for this issue in https://github.com/PBSPro/pbspro/pull/812 was returning garbage values in outbuf from build_execvnode().
* This value was part of the modified execvnode string in set_nodes().
* Eventually, this value is passed to find_nodebyname which intermittently returns a non NULL value which was causing the crash (Please check Valgrind logs).

#### Solution Description
* Make sure the modified execvnode string in set_nodes() has the right vnode value by treating the -H argument to qrun as a single node and passing the same value to the 2nd element of ndarray in build_execvnode().
* Before the fix, for the job in the example above, build_execvnode() will return: '(centos7)': ncpus=36:host=centos7+  '(centos7)': ncpus=36:host=centos7 for qrun  command:  
qrun -H "'(centos7)'"  $jid 

Replicating the above behavior , after fix, for qrun -H "'(centos7)+(centos7)'" $jid, 
build_execvnode() will return:
 '(centos7)+(centos7)': ncpus=36:host=centos7+  '(centos7)+(centos7)': ncpus=36:host=centos7

* After Fix Behavior:
   qrun -H "'(centos7)+(centos7)'" $jid
   qrun: Unknown node  '(centos7)+(centos7)'

#### Testing logs/output
* [valgrind_logs_before_fix.txt](https://github.com/PBSPro/pbspro/files/2940804/valgrind_logs_before_fix.txt)
*  [valgrind_logs_after_fix.txt](https://github.com/PBSPro/pbspro/files/2969617/valgrind_logs_after_fix.txt)
* [Test_logs_before_fix.txt](https://github.com/PBSPro/pbspro/files/2940824/Test_logs_before_fix.txt)
* [Test_logs_after_fix.txt](https://github.com/PBSPro/pbspro/files/2969577/Test_logs_after_fix.txt)






#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
