### PR TITLE
Fix qstat queue json output

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -1520,14 +1520,11 @@ display_statque(struct batch_status *status, int prtheader, int full, int alt_op
 		strcpy(trn, "0");
 		strcpy(ext, "0");
 		type = "not defined";
+		prev_resc_name = NULL;
 		if (full) {
 			if(output_format == FORMAT_DSV || output_format == FORMAT_DEFAULT)
 				printf("Queue: %s%s", p->name, delimiter);
 			else if (output_format == FORMAT_JSON) {
-				if (prev_resc_name != NULL)
-					if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL, NULL)
-							== NULL)
-						return 1;
 				if (add_json_node(JSON_OBJECT, JSON_NULL, JSON_NOVALUE, p->name, NULL)
 						== NULL)
 					return 1;
@@ -1546,6 +1543,10 @@ display_statque(struct batch_status *status, int prtheader, int full, int alt_op
 							== NULL)
 						return 1;
 			}
+			/* end the resource node, if it exists */
+			if (output_format == FORMAT_JSON && prev_resc_name != NULL)
+				if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL, NULL) == NULL)
+					return 1;
 		} else {
 			if (p->name != NULL) {
 				l = strlen(p->name);

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -1525,8 +1525,7 @@ display_statque(struct batch_status *status, int prtheader, int full, int alt_op
 			if(output_format == FORMAT_DSV || output_format == FORMAT_DEFAULT)
 				printf("Queue: %s%s", p->name, delimiter);
 			else if (output_format == FORMAT_JSON) {
-				if (add_json_node(JSON_OBJECT, JSON_NULL, JSON_NOVALUE, p->name, NULL)
-						== NULL)
+				if (add_json_node(JSON_OBJECT, JSON_NULL, JSON_NOVALUE, p->name, NULL) == NULL)
 					return 1;
 			}
 			a = p->attribs;
@@ -1536,17 +1535,20 @@ display_statque(struct batch_status *status, int prtheader, int full, int alt_op
 							alt_opt & ALT_DISPLAY_w);
 				}
 				a = a->next;
-				if ((a || output_format == FORMAT_DEFAULT))
+				if (a)
 					printf("%s", delimiter);
-				else if (output_format == FORMAT_JSON)
-					if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL, NULL)
-							== NULL)
-						return 1;
 			}
-			/* end the resource node, if it exists */
-			if (output_format == FORMAT_JSON && prev_resc_name != NULL)
+			if (output_format == FORMAT_DEFAULT) {
+				printf("%s", delimiter);
+			}
+			else if (output_format == FORMAT_JSON) {
+				/* end the resource node, if it exists */
+				if (prev_resc_name != NULL)
+					if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL, NULL) == NULL)
+						return 1;
 				if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL, NULL) == NULL)
 					return 1;
+			}
 		} else {
 			if (p->name != NULL) {
 				l = strlen(p->name);

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -1,4 +1,4 @@
-# coding: utf - 8
+# coding: utf-8
 
 # Copyright (C) 1994-2019 Altair Engineering, Inc.
 # For more information, contact Altair at www.altair.com.
@@ -579,3 +579,28 @@ class TestQstatFormats(TestFunctional):
             json.loads(qstat_out)
         except ValueError:
             self.assertTrue(False)
+
+    def test_qstat_json_valid_multiple_queues(self):
+        """
+        Test json output of qstat -f is in valid format when multiple jobs are
+        queried and make sure that all attributes are displayed in qstat are
+        present in the output
+        """
+        a = {'queue_type': 'Execution', 'resources_max.walltime': '10:00:00'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq3')
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq4')
+        qstat_cmd_json = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
+                                      'qstat') + ' -Q -f -F json'
+        ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
+        qstat_out = "\n".join(ret['out'])
+        try:
+            qs = json.loads(qstat_out)
+        except ValueError:
+            self.assertTrue(False, "Invalid JSON, failed to load")
+
+        self.assertIn('Queue', qs)
+        self.assertIn('workq', qs['Queue'])
+        self.assertIn('workq2', qs['Queue'])
+        self.assertIn('workq3', qs['Queue'])
+        self.assertIn('workq4', qs['Queue'])

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -516,7 +516,6 @@ class TestQstatFormats(TestFunctional):
         we query multiple queues
         """
         a = {'queue_type': 'Execution', 'resources_max.walltime': '10:00:00'}
-        self.server.manager(MGR_CMD_DELETE, QUEUE, id='workq')
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq3')
         qstat_cmd_json = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
@@ -529,6 +528,7 @@ class TestQstatFormats(TestFunctional):
             self.assertTrue(False, "Invalid JSON, failed to load")
 
         self.assertIn('Queue', qs)
+        self.assertIn('workq', qs['Queue'])
         self.assertIn('workq2', qs['Queue'])
         self.assertIn('resources_max', qs['Queue']['workq2'])
         self.assertIn('workq3', qs['Queue'])

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -515,17 +515,24 @@ class TestQstatFormats(TestFunctional):
         Test json output of qstat -Qf is in valid format when
         we query multiple queues
         """
-        q_attr = {'queue_type': 'execution', 'enabled': 'True'}
-        self.server.manager(MGR_CMD_CREATE, QUEUE, q_attr, id='workq1')
-        self.server.manager(MGR_CMD_CREATE, QUEUE, q_attr, id='workq2')
-        qstat_cmd_json = os.path.join(self.server.pbs_conf[
-            'PBS_EXEC'], 'bin', 'qstat') + ' -Qf -F json workq1 workq2'
+        a = {'queue_type': 'Execution', 'resources_max.walltime': '10:00:00'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq3')
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq4')
+        qstat_cmd_json = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
+                                      'qstat') + ' -Q -f -F json'
         ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
         qstat_out = "\n".join(ret['out'])
         try:
-            json.loads(qstat_out)
-        except ValueError, e:
-            self.assertTrue(False)
+            qs = json.loads(qstat_out)
+        except ValueError:
+            self.assertTrue(False, "Invalid JSON, failed to load")
+
+        self.assertIn('Queue', qs)
+        self.assertIn('workq', qs['Queue'])
+        self.assertIn('workq2', qs['Queue'])
+        self.assertIn('workq3', qs['Queue'])
+        self.assertIn('workq4', qs['Queue'])
 
     def test_qstat_json_valid_job_special_env(self):
         """
@@ -579,28 +586,3 @@ class TestQstatFormats(TestFunctional):
             json.loads(qstat_out)
         except ValueError:
             self.assertTrue(False)
-
-    def test_qstat_json_valid_multiple_queues(self):
-        """
-        Test json output of qstat -f is in valid format when multiple jobs are
-        queried and make sure that all attributes are displayed in qstat are
-        present in the output
-        """
-        a = {'queue_type': 'Execution', 'resources_max.walltime': '10:00:00'}
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq3')
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq4')
-        qstat_cmd_json = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
-                                      'qstat') + ' -Q -f -F json'
-        ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
-        qstat_out = "\n".join(ret['out'])
-        try:
-            qs = json.loads(qstat_out)
-        except ValueError:
-            self.assertTrue(False, "Invalid JSON, failed to load")
-
-        self.assertIn('Queue', qs)
-        self.assertIn('workq', qs['Queue'])
-        self.assertIn('workq2', qs['Queue'])
-        self.assertIn('workq3', qs['Queue'])
-        self.assertIn('workq4', qs['Queue'])

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -519,7 +519,6 @@ class TestQstatFormats(TestFunctional):
         self.server.manager(MGR_CMD_DELETE, QUEUE, id='workq')
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq3')
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq4')
         qstat_cmd_json = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
                                       'qstat') + ' -Q -f -F json'
         ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
@@ -531,8 +530,9 @@ class TestQstatFormats(TestFunctional):
 
         self.assertIn('Queue', qs)
         self.assertIn('workq2', qs['Queue'])
+        self.assertIn('resources_max', qs['Queue']['workq2'])
         self.assertIn('workq3', qs['Queue'])
-        self.assertIn('workq4', qs['Queue'])
+        self.assertIn('resources_max', qs['Queue']['workq3'])
 
     def test_qstat_json_valid_job_special_env(self):
         """

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -516,6 +516,7 @@ class TestQstatFormats(TestFunctional):
         we query multiple queues
         """
         a = {'queue_type': 'Execution', 'resources_max.walltime': '10:00:00'}
+        self.server.manager(MGR_CMD_DELETE, QUEUE, id='workq')
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq3')
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq4')
@@ -529,7 +530,6 @@ class TestQstatFormats(TestFunctional):
             self.assertTrue(False, "Invalid JSON, failed to load")
 
         self.assertIn('Queue', qs)
-        self.assertIn('workq', qs['Queue'])
         self.assertIn('workq2', qs['Queue'])
         self.assertIn('workq3', qs['Queue'])
         self.assertIn('workq4', qs['Queue'])


### PR DESCRIPTION
#### Bug/feature Description
* JSON formatting with queues were creating invalid json.


#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* The JSON node creation was not refreshing on a per-queue basis. When the node was dumped, it created invalid json.

#### Solution Description
* `prev_resc_name` held the name of the previous resource list attribute, but it is only valid per-queue. When the queue changes, it should be cleared.
* Cleaned up the order of writing, so that the node is closed before the queue is closed.

#### Testing logs/output
[after-fix-new2.txt](https://github.com/PBSPro/pbspro/files/2954609/after-fix-new2.txt)

[after-fix-new.txt](https://github.com/PBSPro/pbspro/files/2947900/after-fix-new.txt)
[before-fix-new.txt](https://github.com/PBSPro/pbspro/files/2947901/before-fix-new.txt)

[before-fix.txt](https://github.com/PBSPro/pbspro/files/2947809/before-fix.txt)
[after-fix.txt](https://github.com/PBSPro/pbspro/files/2947810/after-fix.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
