### PR TITLE
TestResourceUsageLog.test_acclog_force_requeue failed in checking node state

### DIFF
--- a/test/tests/functional/pbs_resource_usage_log.py
+++ b/test/tests/functional/pbs_resource_usage_log.py
@@ -300,7 +300,7 @@ class TestResourceUsageLog(TestFunctional):
         self.mom.signal('-KILL')
 
         # Verify that nodes are reported to be down.
-        self.server.expect(NODE, {ATTR_NODE_state: 'down'},
+        self.server.expect(NODE, {ATTR_NODE_state: (MATCH_RE, 'down')},
                            id=self.mom.shortname, offset=15)
         self.server.rerunjob(jid1, extend='force')
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
TestResourceUsageLog.test_acclog_force_requeue failed in checking node state. Test expected node state to be 'down' but got a 'down/job-busy'.

#### Affected Platform(s)
All linux

#### Cause / Analysis / Design
Test expects node state to be 'down' after the mom was killed. But in scenarios when all cpus are in use, (test ran a job before killing the mom), the node state would be 'down/job-busy'. 

#### Solution Description
Add a regular expression match in expect() to see if the node state text contained 'down' instead of an exact match. 

#### Testing logs/output
[beforefix.txt](https://github.com/PBSPro/pbspro/files/2953916/beforefix.txt)
[afterfix.txt](https://github.com/PBSPro/pbspro/files/2953917/afterfix.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [ ] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__