### PR TITLE
PP-1328: @requirements data in PTL json test report

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_report_json.py
+++ b/test/fw/ptl/utils/plugins/ptl_report_json.py
@@ -37,7 +37,6 @@
 
 import re
 from ptl.utils.pbs_dshutils import DshUtils
-from ptl.utils.pbs_testsuite import default_requirements
 
 
 class PTLJsonData(object):

--- a/test/fw/ptl/utils/plugins/ptl_report_json.py
+++ b/test/fw/ptl/utils/plugins/ptl_report_json.py
@@ -118,7 +118,7 @@ class PTLJsonData(object):
             'end_time': str(data['end_time']),
             'measurements': []
         }
-        tcshort['requirements'] = {}
+        tcshort['requirements'] = data['requirements']
         if 'measurements' in data:
             tcshort['results']['measurements'] = data['measurements']
         data_json['testsuites'][tsname]['testcases'][tcname] = tcshort

--- a/test/fw/ptl/utils/plugins/ptl_report_json.py
+++ b/test/fw/ptl/utils/plugins/ptl_report_json.py
@@ -119,8 +119,7 @@ class PTLJsonData(object):
             'end_time': str(data['end_time']),
             'measurements': []
         }
-        tcshort['requirements'] = getattr(data, 'requirements',
-                                          default_requirements)
+        tcshort['requirements'] = data['requirements']
         if 'measurements' in data:
             tcshort['results']['measurements'] = data['measurements']
         data_json['testsuites'][tsname]['testcases'][tcname] = tcshort

--- a/test/fw/ptl/utils/plugins/ptl_report_json.py
+++ b/test/fw/ptl/utils/plugins/ptl_report_json.py
@@ -37,6 +37,7 @@
 
 import re
 from ptl.utils.pbs_dshutils import DshUtils
+from ptl.utils.pbs_testsuite import default_requirements
 
 
 class PTLJsonData(object):
@@ -118,7 +119,8 @@ class PTLJsonData(object):
             'end_time': str(data['end_time']),
             'measurements': []
         }
-        tcshort['requirements'] = data['requirements']
+        tcshort['requirements'] = getattr(data, 'requirements',
+                                          default_requirements)
         if 'measurements' in data:
             tcshort['results']['measurements'] = data['measurements']
         data_json['testsuites'][tsname]['testcases'][tcname] = tcshort

--- a/test/fw/ptl/utils/plugins/ptl_test_db.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_db.py
@@ -50,6 +50,7 @@ from ptl.lib.pbs_testlib import PbsTypeDuration
 from ptl.utils.plugins.ptl_test_tags import TAGKEY
 from ptl.utils.pbs_dshutils import DshUtils
 from ptl.utils.plugins.ptl_report_json import PTLJsonData
+from ptl.utils.pbs_testsuite import default_requirements
 
 # Following dance require because PTLTestDb().process_output() from this file
 # is used in pbs_loganalyzer script which is shipped with PBS package
@@ -1731,6 +1732,8 @@ class PTLTestDb(Plugin):
         testdata['end_time'] = getattr(test, 'end_time', cur_time)
         testdata['duration'] = getattr(test, 'duration', 0)
         testdata['tags'] = getattr(_test, TAGKEY, [])
+        testdata['requirements'] = getattr(_test, 'requirements',
+                                           default_requirements)
         measurements_dic = getattr(_test, 'measurements', {})
         if measurements_dic:
             testdata['measurements'] = measurements_dic

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -652,6 +652,7 @@ class PTLTestRunner(Plugin):
             if not ts_requirements:
                 return None
         eff_tc_req = get_effective_reqs(ts_requirements, tc_requirements)
+        setattr(test.test, 'requirements', eff_tc_req)
         for key in ['servers', 'moms', 'comms', 'clients']:
             param_count['num_' + key] = len(param_dic[key])
         for pk in param_count:

--- a/test/tests/selftest/pbs_json_test_report.py
+++ b/test/tests/selftest/pbs_json_test_report.py
@@ -99,13 +99,25 @@ class TestJSONReport(TestSelf):
         }
         field_values = {
             'machine_info_name': test_data['machinfo'].keys()[0],
-            'testresult_status': test_data['status']
+            'testresult_status': test_data['status'],
+            'requirements': {
+                "num_moms": 1,
+                "no_comm_on_mom": True,
+                "no_comm_on_server": False,
+                "num_servers": 1,
+                "no_mom_on_server": False,
+                "num_comms": 1,
+                "num_clients": 1
+            }
         }
         faulty_fields = []
         faulty_values = []
         test_cmd = "pbs_benchpress -t SmokeTest.test_submit_job"
         jsontest = PTLJsonData(command=test_cmd)
         jdata = jsontest.get_json(data=test_data, prev_data=None)
+        tsname = test_data['suite']
+        tcname = test_data['testcase']
+        vdata = jdata['testsuites'][tsname]['testcases'][tcname]
         for k in verify_data['test_keys']:
             if k not in jdata:
                 faulty_fields.append(k)
@@ -127,10 +139,6 @@ class TestJSONReport(TestSelf):
             for t in jdata['testsuites'][s]:
                 for u in jdata['testsuites'][s]['testcases']:
                     for r in verify_data['test_cases_info']:
-                        if r == 'requirements':
-                            if (jdata['testsuites'][s]['testcases'][u][r] !=
-                                    test_data[r]):
-                                faulty_values.append(r)
                         if r not in jdata['testsuites'][s]['testcases'][u]:
                             faulty_fields.append(r)
         for s in jdata['testsuites']:
@@ -144,11 +152,11 @@ class TestJSONReport(TestSelf):
                 if jdata['machine_info'].keys()[0] != v:
                     faulty_values.append(k)
             if k == 'testresult_status':
-                tsname = test_data['suite']
-                tcname = test_data['testcase']
-                vdata = jdata['testsuites'][tsname]['testcases'][tcname]
                 if vdata['results']['status'] != v:
                     faulty_values.append(k)
+            if k == 'requirements':
+                if vdata['requirements'] != v:
+                    faulty_values.append(r)
         if (faulty_fields or faulty_values):
             raise AssertionError("Faulty fields or values",
                                  (faulty_fields, faulty_values))

--- a/test/tests/selftest/pbs_json_test_report.py
+++ b/test/tests/selftest/pbs_json_test_report.py
@@ -70,7 +70,16 @@ class TestJSONReport(TestSelf):
             'suitedoc': '\n    This test suite contains smoke tests of PBS\n',
             'tags': ['smoke'],
             'file': 'tests/pbs_smoketest.py',
-            'module': 'tests.pbs_smoketest'
+            'module': 'tests.pbs_smoketest',
+            'requirements': {
+                "num_moms": 1,
+                "no_comm_on_mom": True,
+                "no_comm_on_server": False,
+                "num_servers": 1,
+                "no_mom_on_server": False,
+                "num_comms": 1,
+                "num_clients": 1
+             }
         }
         verify_data = {
             'test_keys': ["command", "user", "product_version", "run_id",
@@ -118,6 +127,10 @@ class TestJSONReport(TestSelf):
             for t in jdata['testsuites'][s]:
                 for u in jdata['testsuites'][s]['testcases']:
                     for r in verify_data['test_cases_info']:
+                        if r == 'requirements':
+                            if (jdata['testsuites'][s]['testcases'][u][r] !=
+                                    test_data[r]):
+                                faulty_values.append(r)
                         if r not in jdata['testsuites'][s]['testcases'][u]:
                             faulty_fields.append(r)
         for s in jdata['testsuites']:

--- a/test/tests/selftest/pbs_json_test_report.py
+++ b/test/tests/selftest/pbs_json_test_report.py
@@ -79,7 +79,7 @@ class TestJSONReport(TestSelf):
                 "no_mom_on_server": False,
                 "num_comms": 1,
                 "num_clients": 1
-             }
+            }
         }
         verify_data = {
             'test_keys': ["command", "user", "product_version", "run_id",

--- a/test/tests/selftest/pbs_requirements_decorator.py
+++ b/test/tests/selftest/pbs_requirements_decorator.py
@@ -89,3 +89,19 @@ class TestRequirementsDecorator(TestSelf):
         due to no_mom_on_server flag
         """
         self.server.expect(SERVER, {'server_state': 'Active'})
+
+    @requirements(num_servers=1, num_comms=1, no_comm_on_mom=True)
+    def test_skip_no_comm_on_mom(self):
+        """
+        Test to verify test skip when requirements are not satisfied
+        due to no_comm_on_mom flag set true
+        """
+        self.server.expect(SERVER, {'server_state': 'Active'})
+
+    @requirements(num_comms=2, num_moms=2, no_comm_on_server=True)
+    def test_skip_no_comm_on_server(self):
+        """
+        Test to verify test skip when requirements are not satisfied
+        due to no_comm_on_server flag set true
+        """
+        self.server.expect(SERVER, {'server_state': 'Active'})


### PR DESCRIPTION
#### Bug/feature Description
* *[PP-1328](https://pbspro.atlassian.net/browse/PP-1328)*

* Data relating to Test case requirements specified in @requirements decorator needs to be included in PTL's json test report's "requirements" field.
* Currently it lists a blank dictionary as below 
{
"testsuites": {
"TestRequirementsDecorator": {
"testcases": {
"test_tc_run": {
"docstring": "Test to verify test run when requirements are satisfied test suite requirements overridden by test case requirements",
"requirements": {},
"results":

{ "status": "PASS", "start_time": "2019-02-11 00:24:15.497798", "measurements": [], "status_data": "", "end_time": "2019-02-11 00:24:17.992014", "duration": "0:00:02.494216" }


#### Affected Platform(s)
* All

#### Solution Description
*  Include data related to @requirements decorator at test suite and test case level into json report.

#### Testing logs/output
* [ptl_execution_logs.txt](https://github.com/PBSPro/pbspro/files/2956477/ptl_execution_logs.txt)
* [ptl_test_results_json.txt](https://github.com/PBSPro/pbspro/files/2959937/ptl_test_results_json.txt)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
