### PR TITLE
Fix memory leak in query_nodes when partition unset

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -244,6 +244,7 @@ query_nodes(int pbs_sd, server_info *sinfo)
 	if (nidx == 0) {
 		snprintf(log_buffer, sizeof(log_buffer), "No nodes found in partitions serviced by scheduler");
 		schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SERVER, LOG_INFO, __func__, log_buffer);
+		pbs_statfree(nodes);
 		free(ninfo_arr);
 		return NULL;
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Scheduler leaks memory when its associated nodes unset their partition. Following is the snippet of valgrind logs.

sched_1551685724.log:==22633== 65,249 (256 direct, 64,993 indirect) bytes in 8 blocks are definitely lost in loss record 1,615 of 1,616
sched_1551685724.log-==22633== at 0x4C29C23: malloc (vg_replace_malloc.c:299)
sched_1551685724.log-==22633== by 0x4B550D: alloc_bs (int_status.c:167)
sched_1551685724.log-==22633== by 0x4B53E8: PBSD_status_get (int_status.c:126)
sched_1551685724.log-==22633== by 0x4B5314: PBSD_status (int_status.c:89)
sched_1551685724.log-==22633== by 0x4AD1FF: __pbs_statvnode (pbsD_statnode.c:104)
sched_1551685724.log-==22633== by 0x446CC8: query_nodes (node_info.c:184)
sched_1551685724.log-==22633== by 0x467DA8: query_server (server_info.c:267)
sched_1551685724.log-==22633== by 0x42F918: scheduling_cycle (fifo.c:676)
sched_1551685724.log-==22633== by 0x42F875: intermediate_schedule (fifo.c:614)
sched_1551685724.log-==22633== by 0x42F734: schedule (fifo.c:559)
sched_1551685724.log-==22633== by 0x42E60F: main (pbs_sched.c:1455)

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* When partition/s is/are unset for all the nodes that a Scheduler is handling and from then on words if a scheduling cycle is kicked off it keeps on leaking the memory in query_nodes until partition is set on one of the nodes that the Scheduler is handling.

#### Solution Description
* If the scheduler does not find nodes in its own partition/s then release/free the memory accumulated in query_nodes.

#### Testing logs/output
* Attached are the logs that tells about the scenario used to reproduce the leak, logs of the test case before and after the fix.
[AfterFix_testcase.log](https://github.com/PBSPro/pbspro/files/2960576/AfterFix_testcase.log)
[BeforeFix_Testcase.log](https://github.com/PBSPro/pbspro/files/2960577/BeforeFix_Testcase.log)
[query_nodes_valgnd_afterfix.log](https://github.com/PBSPro/pbspro/files/2960578/query_nodes_valgnd_afterfix.log)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__