### PR TITLE
Tests of 'TestMomDynRes' are failing while verifying the job substate

### DIFF
--- a/test/tests/functional/pbs_mom_dynamic_resource.py
+++ b/test/tests/functional/pbs_mom_dynamic_resource.py
@@ -124,7 +124,7 @@ class TestMomDynRes(TestFunctional):
         jid = self.server.submit(j)
 
         # The job should run
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'R'}, interval=1, id=jid)
 
         # Submit a job that requests different mom dynamic resource
         # not return from script
@@ -168,7 +168,7 @@ class TestMomDynRes(TestFunctional):
         jid = self.server.submit(j)
 
         # The job should run
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'R'}, interval=1, id=jid)
 
     def test_res_string_correct_value(self):
         """
@@ -189,7 +189,7 @@ class TestMomDynRes(TestFunctional):
         jid = self.server.submit(j)
 
         # The job should run
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'R'}, interval=1, id=jid)
 
     def test_res_float_value(self):
         """
@@ -224,7 +224,7 @@ class TestMomDynRes(TestFunctional):
         # The job should run
         self.server.expect(JOB, {'job_state': 'R',
                            'Resource_List.'+resc_name[0]: '2'},
-                           id=jid, attrop=PTL_AND)
+                           id=jid, attrop=PTL_AND, interval=1)
 
     def test_multiple_res_valid_value(self):
         """
@@ -247,7 +247,7 @@ class TestMomDynRes(TestFunctional):
         jid = self.server.submit(j)
 
         # The job should run
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'R'}, interval=1, id=jid)
 
         # Submit a job that requests more value
         # than available for both mom resources.
@@ -307,7 +307,7 @@ class TestMomDynRes(TestFunctional):
         jid = self.server.submit(j)
 
         # The job should run
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'R'}, interval=1, id=jid)
 
         # Check for the expected error message throwing by PBS
         try:
@@ -334,7 +334,7 @@ class TestMomDynRes(TestFunctional):
         jid = self.server.submit(j)
 
         # The job should run
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'R'}, interval=1, id=jid)
 
         # Change script during job run
         change_res = "/bin/echo 1"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Tests of 'TestMomDynRes' are failing while verifying the job substate

#### Affected Platform(s)
* ARM_centos7.0

#### Cause / Analysis / Design
* Test failed while verifying the job's substate(Expected job substate=42,Observed =41). Job started running after the test failed on validating the job's substate

#### Solution Description
* Increase the interval time in the test while checking for the job's state(expect())

#### Testing logs/output
* [Execution_logs_TestMomDynRes.txt](https://github.com/PBSPro/pbspro/files/2962081/Execution_logs_TestMomDynRes.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.

__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
