### PR TITLE
memory leaks when creating nodes from a vnodedef file

### DIFF
--- a/src/resmom/vnode_storage.c
+++ b/src/resmom/vnode_storage.c
@@ -135,6 +135,7 @@ find_vmapent_byID(void *ctx, const char *vnid)
 #endif	/* DEBUG */
 	}
 
+	free (pe);
 	return NULL;
 }
 
@@ -165,12 +166,14 @@ add_vmapent_byID(void *ctx, const char *vnid, void *data)
 			(void) sprintf(log_buffer, "avl_add_key IX_OK");
 			log_event(PBSEVENT_DEBUG, 0, LOG_DEBUG, __func__, log_buffer);
 #endif	/* DEBUG */
+			free (pe);
 			return (1);
 		} else {
 #ifdef	DEBUG
 			(void) sprintf(log_buffer, "avl_add_key not IX_OK");
 			log_event(PBSEVENT_DEBUG, 0, LOG_DEBUG, __func__, log_buffer);
 #endif	/* DEBUG */
+			free (pe);
 			return (0);
 		}
 	} else


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* There are two memory leaks when the mom creates nodes from a vnodedef file:
==20757== 1,120 bytes in 10 blocks are definitely lost in loss record 49 of 55
==20757== at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==20757== by 0x482BED: find_vmapent_byID (vnode_storage.c:124)
==20757== by 0x46C894: vnid2mominfo (mom_vnode.c:983)
==20757== by 0x46C7B6: vn_callback (mom_vnode.c:936)
==20757== by 0x4375F8: vn_addvnr (vnparse.c:627)
==20757== by 0x4371C7: vn_parse_stream (vnparse.c:421)
==20757== by 0x45D00B: config_versionhandler (mom_main.c:4379)
==20757== by 0x45CED2: parse_config (mom_main.c:4310)
==20757== by 0x45D773: do_addconfigs (mom_main.c:4608)
==20757== by 0x45DCC8: read_config (mom_main.c:4754)
==20757== by 0x464579: main (mom_main.c:8592)
 
==20757== 1,120 bytes in 10 blocks are definitely lost in loss record 51 of 55
==20757== at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==20757== by 0x482C76: add_vmapent_byID (vnode_storage.c:157)
==20757== by 0x46C51B: add_mominfo (mom_vnode.c:819)
==20757== by 0x46CB33: new_vnid (mom_vnode.c:1044)
==20757== by 0x46C92E: vnid2mominfo (mom_vnode.c:990)
==20757== by 0x46C7B6: vn_callback (mom_vnode.c:936)
==20757== by 0x4375F8: vn_addvnr (vnparse.c:627)
==20757== by 0x4371C7: vn_parse_stream (vnparse.c:421)
==20757== by 0x45D00B: config_versionhandler (mom_main.c:4379)
==20757== by 0x45CED2: parse_config (mom_main.c:4310)
==20757== by 0x45D773: do_addconfigs (mom_main.c:4608)
==20757== by 0x45DCC8: read_config (mom_main.c:4754)



#### Affected Platform(s)
* Platform: All

#### Cause / Analysis / Design
How to reproduce the leak:
Delete all existing nodes (qmgr -c "d n @default")
Create and import a vnode definition file, and the leaks will happen.


#### Solution Description
Free when the key is not found in the avltree or after it's been added to the tree.

#### Testing logs/output
[before_fix.txt](https://github.com/PBSPro/pbspro/files/2963615/before_fix.txt)
[after_fix.txt](https://github.com/PBSPro/pbspro/files/2963618/after_fix.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__