### PR TITLE
Fix qstat json output for jobs

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -1264,6 +1264,7 @@ display_statjob(struct batch_status *status, struct batch_status *prtheader, int
 		state = NULL;
 		location = NULL;
 		hpcbp_executable = NULL;
+		prev_resc_name = NULL;
 		if (full) {
 			if (output_format == FORMAT_DSV || output_format == FORMAT_DEFAULT)
 				printf("Job Id: %s%s", p->name, delimiter);
@@ -1329,17 +1330,17 @@ display_statjob(struct batch_status *status, struct batch_status *prtheader, int
 					}
 				}
 				a = a->next;
-				if ((a || output_format == FORMAT_DEFAULT))
+				if (a)
 					printf("%s", delimiter);
-				else if (output_format == FORMAT_JSON) {
-					if (prev_resc_name != NULL)
-						if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL,
-								NULL) == NULL)
-							return 1;
-					if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL, NULL)
-							== NULL)
+			}
+			if (output_format == FORMAT_DEFAULT)
+					printf("%s", delimiter);
+			else if (output_format == FORMAT_JSON) {
+				if (prev_resc_name != NULL)
+					if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL, NULL) == NULL)
 						return 1;
-				}
+				if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL, NULL) == NULL)
+					return 1;
 			}
 		} else {
 			if (p->name != NULL) {

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -1334,7 +1334,7 @@ display_statjob(struct batch_status *status, struct batch_status *prtheader, int
 					printf("%s", delimiter);
 			}
 			if (output_format == FORMAT_DEFAULT)
-					printf("%s", delimiter);
+				printf("%s", delimiter);
 			else if (output_format == FORMAT_JSON) {
 				if (prev_resc_name != NULL)
 					if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL, NULL) == NULL)

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -419,6 +419,8 @@ class TestQstatFormats(TestFunctional):
         jid = self.server.submit(j)
         jid2 = self.server.submit(j)
         jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': "R"}, id=jid)
+        self.server.expect(JOB, {'job_state': "R"}, id=jid2)
         self.server.expect(JOB, {'job_state': "R"}, id=jid3)
         qstat_cmd_json = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
                                       'qstat') + ' -fp -F json '

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -412,7 +412,10 @@ class TestQstatFormats(TestFunctional):
     def test_qstat_json_valid_multiple_jobs_p(self):
         """
         Test json output of qstat -f is in valid format when multiple jobs are
-        queried and make sure that attributes are displayed with `p` option
+        queried and make sure that attributes are displayed with `p` option.
+        When -p is passed, then only the Resource_List is requested. An
+        attribute with type resource list has to be the last attribute
+        in order to hit the bug.
         """
         j = Job(TEST_USER)
         j.set_sleep_time(100)

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -411,7 +411,7 @@ class TestQstatFormats(TestFunctional):
 
     def test_qstat_json_valid_multiple_jobs_p(self):
         """
-        Test json output of qstat -f is in valid format when array jobs are
+        Test json output of qstat -f is in valid format when multiple jobs are
         queried and make sure that attributes are displayed with `p` option
         """
         j = Job(TEST_USER)

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -409,6 +409,34 @@ class TestQstatFormats(TestFunctional):
         except ValueError:
             self.assertTrue(False)
 
+    def test_qstat_json_valid_multiple_jobs_p(self):
+        """
+        Test json output of qstat -f is in valid format when array jobs are
+        queried and make sure that attributes are displayed with `p` option
+        """
+        j = Job(TEST_USER)
+        j.set_sleep_time(100)
+        jid = self.server.submit(j)
+        jid2 = self.server.submit(j)
+        jid3 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': "R"}, id=jid3)
+        qstat_cmd_json = os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin',
+                                      'qstat') + ' -fp -F json '
+        ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_json)
+        qstat_out = '\n'.join(ret['out'])
+        try:
+            js = json.loads(qstat_out)
+        except ValueError:
+            self.assertTrue(False, 'JSON failed to load.')
+
+        self.assertIn('Jobs', js)
+        self.assertIn(jid, js['Jobs'])
+        self.assertIn('Resource_List', js['Jobs'][jid])
+        self.assertIn(jid2, js['Jobs'])
+        self.assertIn('Resource_List', js['Jobs'][jid2])
+        self.assertIn(jid3, js['Jobs'])
+        self.assertIn('Resource_List', js['Jobs'][jid3])
+
     def test_qstat_json_valid_user(self):
         """
         Test json output of qstat -f is in valid format when queried as


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* JSON formatting with jobs were creating invalid json.

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* The JSON node creation was not refreshing on a per-job basis. When the node was dumped, it created invalid json.


#### Solution Description
* `prev_resc_name` held the name of the previous resource list attribute, but it is only valid per-job. When a new job is ready to be added, it should be cleared.
* Cleaned up the order of writing, so that the the object node is closed before the job node is closed.

#### Testing logs/output
[after-fix.txt](https://github.com/PBSPro/pbspro/files/2963765/after-fix.txt)
[before-fix.txt](https://github.com/PBSPro/pbspro/files/2963766/before-fix.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
