### PR TITLE
PTL setUp takes too long when there's large no. of vnodes

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5031,7 +5031,8 @@ class Server(PBSService):
 
     def revert_to_defaults(self, reverthooks=True, revertqueues=True,
                            revertresources=True, delhooks=True,
-                           delqueues=True, delscheds=True, server_stat=None):
+                           delqueues=True, delscheds=True, delnodes=True,
+                           server_stat=None):
         """
         reset server attributes back to out of box defaults.
 
@@ -5060,6 +5061,8 @@ class Server(PBSService):
                           The sched_priv and sched_logs directories will be
                           deleted.
         :type delscheds: bool
+        :param delnodes: If True all vnodes are deleted
+        :type delnodes: bool
         :returns: True upon success and False if an error is
                   encountered.
         :raises: PbsStatusError or PbsManagerError
@@ -5141,6 +5144,12 @@ class Server(PBSService):
                                recursive=True, force=True)
                     self.manager(MGR_CMD_DELETE, SCHED, id=name)
 
+        if delnodes:
+            try:
+                self.manager(MGR_CMD_DELETE, VNODE, id="@default")
+            except PbsManagerError as e:
+                if "Unknown node" not in e.msg[0]:
+                    raise
         if reverthooks:
             if self.platform == 'cray' or self.platform == 'craysim':
                 if self.du.cmp(self.hostname, self.dflt_mpp_hook,

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -477,11 +477,11 @@ class PBSTestSuite(unittest.TestCase):
             return
         self.log_enter_setup()
         self.init_proc_mon()
-        self.revert_pbsconf()
         self.revert_servers()
+        self.revert_moms()
         self.revert_comms()
         self.revert_schedulers()
-        self.revert_moms()
+        self.revert_pbsconf()
         self.log_end_setup()
         self.measurements = []
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* PTL's setUp() was taking to long (15+ minutes) when there are large number of nodes (~10k) in the system (reference testsuite: TestSchedPerf)

#### Affected Platform(s)
* Linux

#### Cause / Analysis
* There were 2 bottlenecks:
  1) pbs_init.d restart: This was taking 10+ minutes. Cause: the server function check_and_set_multivnode() takes too long when there are that many nodes in the system
  2) delete custom resource: Deleting just one custom resource was taking 4+ minutes. Cause: when PBS deletes a resource, it has to unset it from all the PBS objects where it is set

#### Solution Description
* Modified Server's revert_to_default() to delete all nodes before deleting all custom resources
* Reordered the revert_to_defaults calls in setUp() so that revert_server is called first, this makes sure that we don't restart pbs before all the nodes have been deleted from the server

#### Testing logs/output
* I saw a performance improvement of around 51 minutes (~39%) when running TestSchedPerf. The run time went down from 2 hours 11 mins to 1 hour 20 mins. Logs here:
[testschedperf_log.tar.gz](https://github.com/PBSPro/pbspro/files/2964010/testschedperf_log.tar.gz)

Please note that one of the test fails in both the original and after changes logs, so it has nothing to do with these changes. Hopefully we can run performance tests more often with this performance boost.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
