### PR TITLE
LogUtils.convert_date_time() doesn't handle DST properly

### DIFF
--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -236,6 +236,9 @@ class PBSLogUtils(object):
         if dt is None:
             return None
 
+        offset = 0
+        if time.daylight:
+            offset = 3600
         micro = False
         if fmt is None:
             if '.' in dt:
@@ -250,7 +253,7 @@ class PBSLogUtils(object):
             # Get timedelta object of epoch time
             t -= epoch_datetime
             # get epoch time from timedelta object
-            tm = t.total_seconds()
+            tm = t.total_seconds() - offset
         except:
             cls.logger.debug("could not convert date time: " + str(datetime))
             return None

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -38,7 +38,7 @@
 import re
 import time
 import sys
-import datetime
+from datetime import tzinfo, timedelta, datetime
 import logging
 import traceback
 import math
@@ -209,7 +209,7 @@ PARSER_OK_STOP = 1
 PARSER_ERROR_CONTINUE = 2
 PARSER_ERROR_STOP = 3
 
-epoch_datetime = datetime.datetime.fromtimestamp(0)
+epoch_datetime = datetime.fromtimestamp(0)
 
 
 class PBSLogUtils(object):
@@ -225,7 +225,8 @@ class PBSLogUtils(object):
     def convert_date_time(cls, dt=None, fmt=None):
         """
         convert a date time string of the form given by fmt into
-        number of seconds since epoch (with possible microseconds)
+        number of seconds since epoch (with possible microseconds).
+        it considers the current system's timezone to convert the datetime to epoch time
 
         :param dt: the datetime string to convert
         :type dt: str or None
@@ -236,9 +237,9 @@ class PBSLogUtils(object):
         if dt is None:
             return None
 
-        offset = 0
+        offset = timedelta(seconds = -time.timezone)
         if time.daylight:
-            offset = 3600
+            offset = timedelta(seconds = -time.altzone) - offset
         micro = False
         if fmt is None:
             if '.' in dt:
@@ -249,11 +250,11 @@ class PBSLogUtils(object):
 
         try:
             # Get datetime object
-            t = datetime.datetime.strptime(dt, fmt)
+            t = datetime.strptime(dt, fmt)
             # Get timedelta object of epoch time
             t -= epoch_datetime
             # get epoch time from timedelta object
-            tm = t.total_seconds() - offset
+            tm = t.total_seconds() - offset.total_seconds()
         except:
             cls.logger.debug("could not convert date time: " + str(datetime))
             return None
@@ -459,7 +460,7 @@ class PBSLogUtils(object):
     @staticmethod
     def _duration(val=None):
         if val is not None:
-            return str(datetime.timedelta(seconds=int(val)))
+            return str(timedelta(seconds=int(val)))
 
     @staticmethod
     def get_day(tm=None):

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -226,7 +226,8 @@ class PBSLogUtils(object):
         """
         convert a date time string of the form given by fmt into
         number of seconds since epoch (with possible microseconds).
-        it considers the current system's timezone to convert the datetime to epoch time
+        it considers the current system's timezone to convert 
+        the datetime to epoch time
 
         :param dt: the datetime string to convert
         :type dt: str or None
@@ -237,9 +238,9 @@ class PBSLogUtils(object):
         if dt is None:
             return None
 
-        offset = timedelta(seconds = -time.timezone)
+        offset = timedelta(seconds=-time.timezone)
         if time.daylight:
-            offset = timedelta(seconds = -time.altzone) - offset
+            offset = timedelta(seconds=-time.altzone) - offset
         micro = False
         if fmt is None:
             if '.' in dt:

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -238,9 +238,12 @@ class PBSLogUtils(object):
         if dt is None:
             return None
 
-        offset = timedelta(seconds=-time.timezone)
+        stdoffset = timedelta(seconds=-time.timezone)
         if time.daylight:
-            offset = timedelta(seconds=-time.altzone) - offset
+            dstoffset = timedelta(seconds=-time.altzone)
+        else:
+            dstoffset = stdoffset
+        offsetdiff = dstoffset - stdoffset
         micro = False
         if fmt is None:
             if '.' in dt:
@@ -255,7 +258,7 @@ class PBSLogUtils(object):
             # Get timedelta object of epoch time
             t -= epoch_datetime
             # get epoch time from timedelta object
-            tm = t.total_seconds() - offset.total_seconds()
+            tm = t.total_seconds() - offsetdiff.total_seconds()
         except:
             cls.logger.debug("could not convert date time: " + str(datetime))
             return None

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -226,7 +226,7 @@ class PBSLogUtils(object):
         """
         convert a date time string of the form given by fmt into
         number of seconds since epoch (with possible microseconds).
-        it considers the current system's timezone to convert 
+        it considers the current system's timezone to convert
         the datetime to epoch time
 
         :param dt: the datetime string to convert


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
LogUtils.convert_date_time() doesn't handle DST properly

#### Affected Platform(s)
All

#### Cause / Analysis / Design
* The convert_date_time() function was recently rewritten to handle microsecond logging.  The original method of converting times to epoch times was using the time object.  The time object doesn't support microseconds.  The newer datetime object does support microseconds.  The new convert_date_time() function uses the datetime object.  Unfortunately it does not handle DST properly.  For example, converting to PDT will convert to PST and be off by an hour.

#### Solution Description
* Updated LogUtils.convert_date_time() to deduct extra 3600 sec if DST

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [ ] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
