### PR TITLE
Fix requeueing job stuck in E state.

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -830,6 +830,12 @@ post_discard_job(job *pjob, mominfo_t *pmom, int newstate)
 		return;
 	}
 
+	if ((pjob->ji_qs.ji_state == JOB_STATE_HELD) && (pjob->ji_qs.ji_substate == JOB_SUBSTATE_HELD)) {
+		log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO,
+			pjob->ji_qs.ji_jobid, "Leaving job in held state");
+		return;
+	}
+
 	if (pjob->ji_qs.ji_substate == JOB_SUBSTATE_RERUN3) {
 		static char ndreque[] = "Job requeued, execution node %s down";
 
@@ -2720,8 +2726,9 @@ discard_job(job *pjob, char *txt, int noack)
 		/* must be already discarding */
 		log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 			pjob->ji_qs.ji_jobid,
-			"in discard_job and has ji_discard");
-		return;
+			"cancel previous discard_job tracking for new discard_job request");
+		free(pjob->ji_discard);
+		pjob->ji_discard = NULL;
 	}
 
 	/* first count up number of vnodes in exec_vnode to size the	*/


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* When a multinode job is requeueing due to, say an execjob_prologue hook has rejected a job continuously by a sister mom, it can get stuck in "E" state. The job could only be deleted by qdel -Wforce.
#### Affected Platform(s)
* all
#### Cause / Analysis / Design
* When the bug happens, it is usually accompanied by the following server_logs message:
    03/01/2019 16:28:04;0100;Server@corretja;Job;1656.corretja;in discard_job and has ji_discard
* When a job is about to be requeued, a discard_job() request is sent to all the moms
to have them discard/delete the job. pjob->ji_discard structure tracks which moms
have already responded to the request. When primary mom sends multiple obits to the
server for the same job, which happens as job is exiting at the same time multiple sister
moms are reporting errors to the primary mom, server would see the following in the server_logs:

    02/28/2019 12:50:30;0080;Server@x52-rhel7;Job;16.x52-rhel7;Obit received momhop:6 serverhop:6 
    state:4 substate:42
    02/28/2019 12:50:30;0080;Server@x52-rhel7;Job;16.x52-rhel7;Obit received momhop:6 serverhop:6 
    state:5 substate:63

* Job eventually requeues but the pjob->ji_discard structure lingers for awhile.
As soon as the job runs again, and then tries to requeue by calling discard_job() first,
the presence of a lingering pjob->ji_discard would prevent the actual discard job action
to take place, causing job to get stuck in an "E" state indefinitely. Thus, we see the
message:
02/28/2019 12:50:30;0100;Server@x52-rhel7;Job;16.x52-rhel7;in discard_job and has ji_discard
.
* A secondary problem that is also observed is that when job is requeued/rerun 21 times, some timing condition can occur when the post_discard_job() function is called causing a job, that is already held, to get deleted.



#### Solution Description
*  Under discard_job(), the fix is to cancel/free up the previous pjob->ji_discard structure to make way for this new discard_job() action, which will re-track mom discard job responses in a new instance of pjob->ji_discard.
* Under post_discard_job(), if a job is found to be already held, leave its state as is and not delete the job.

#### Testing logs/output
* [ptl.PASS.txt](https://github.com/PBSPro/pbspro/files/2969242/ptl.PASS.txt)
* [ptl.FAIL.txt](https://github.com/PBSPro/pbspro/files/2969243/ptl.FAIL.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
