### PR TITLE
Removing expect=True from manager()

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5106,7 +5106,7 @@ class Server(PBSService):
             hooks = self.status(HOOK, level=logging.DEBUG)
             hooks = [h['id'] for h in hooks]
             if len(hooks) > 0:
-                self.manager(MGR_CMD_DELETE, HOOK, id=hooks, expect=True)
+                self.manager(MGR_CMD_DELETE, HOOK, id=hooks)
         if delqueues:
             revertqueues = False
             queues = self.status(QUEUE, level=logging.DEBUG)
@@ -5120,11 +5120,11 @@ class Server(PBSService):
                                          node['id'])
                 except:
                     pass
-                self.manager(MGR_CMD_DELETE, QUEUE, id=queues, expect=True)
+                self.manager(MGR_CMD_DELETE, QUEUE, id=queues)
             a = {ATTR_qtype: 'Execution',
                  ATTR_enable: 'True',
                  ATTR_start: 'True'}
-            self.manager(MGR_CMD_CREATE, QUEUE, a, id='workq', expect=True)
+            self.manager(MGR_CMD_CREATE, QUEUE, a, id='workq')
             setdict.update({ATTR_dfltque: 'workq'})
         if delscheds:
             self.manager(MGR_CMD_LIST, SCHED)
@@ -5152,8 +5152,7 @@ class Server(PBSService):
             hooks = [h['id'] for h in hooks]
             a = {ATTR_enable: 'false'}
             if len(hooks) > 0:
-                self.manager(MGR_CMD_SET, MGR_OBJ_HOOK, a, hooks,
-                             expect=True)
+                self.manager(MGR_CMD_SET, MGR_OBJ_HOOK, a, hooks)
         if revertqueues:
             self.status(QUEUE, level=logging.DEBUG)
             queues = []
@@ -5166,10 +5165,10 @@ class Server(PBSService):
                 qobj.revert_to_defaults()
                 queues.append(qname)
                 a = {ATTR_enable: 'false'}
-                self.manager(MGR_CMD_SET, QUEUE, a, id=queues, expect=True)
+                self.manager(MGR_CMD_SET, QUEUE, a, id=queues)
             a = {ATTR_enable: 'True', ATTR_start: 'True'}
             self.manager(MGR_CMD_SET, MGR_OBJ_QUEUE, a,
-                         id=server_stat[ATTR_dfltque], expect=True)
+                         id=server_stat[ATTR_dfltque])
         if len(setdict) > 0:
             self.manager(MGR_CMD_SET, MGR_OBJ_SERVER, setdict)
         if revertresources:
@@ -5179,7 +5178,7 @@ class Server(PBSService):
             except:
                 rescs = []
             if len(rescs) > 0:
-                self.manager(MGR_CMD_DELETE, RSC, id=rescs, expect=True)
+                self.manager(MGR_CMD_DELETE, RSC, id=rescs)
         return True
 
     def save_configuration(self, outfile, mode='a'):
@@ -6425,8 +6424,7 @@ class Server(PBSService):
         return bs
 
     def manager(self, cmd, obj_type, attrib=None, id=None, extend=None,
-                expect=False, max_attempts=None, level=logging.INFO,
-                sudo=None, runas=None, logerr=True):
+                level=logging.INFO, sudo=None, runas=None, logerr=True):
         """
         issue a management command to the server, e.g to set an
         attribute
@@ -6447,13 +6445,6 @@ class Server(PBSService):
         :param extend: Optional extension to the IFL call. see
                        pbs_ifl.h
         :type extend: str or None
-        :param expect: If set to True, query the server expecting
-                       the value to be\ accurately reflected.
-                       Defaults to False
-        :type expect: bool
-        :param max_attempts: Sets a maximum number of attempts to
-                             call expect with.
-        :type max_attempts: int
         :param level: logging level
         :param sudo: If True, run the manager command as super user.
                      Defaults to None. Some attribute settings
@@ -6469,21 +6460,8 @@ class Server(PBSService):
                        i.e. silent mode
         :type logerr: bool
         :raises: PbsManagerError
-        :returns: On success:
-                - if expect is False, return code of qmgr/pbs_manager
-                - if expect is True, 0 for success
-        :raises: On Error/Failure:
                 - PbsManagerError if qmgr/pbs_manager() failed
-                - PtlExpectError if expect() failed
         """
-
-        # Currently, expect() doesn't validate the values being set for
-        # create operations.
-        # For unset operations, expect does not handle attributes that are
-        # reset to default after unset.
-        # So, only call expect automatically for set and delete operations.
-        if cmd in (MGR_CMD_SET, MGR_CMD_DELETE):
-            expect = True
 
         if isinstance(id, str):
             oid = id.split(',')
@@ -6676,44 +6654,15 @@ class Server(PBSService):
         if c is not None:
             self._disconnect(c)
 
-        if expect:
-            offset = None
-            attrop = PTL_OR
-            if obj_type in (NODE, HOST):
-                obj_type = VNODE
-            if obj_type in (VNODE, QUEUE):
-                offset = 0.5
-            if cmd in PBS_CMD_TO_OP:
-                op = PBS_CMD_TO_OP[cmd]
-            else:
-                op = EQ
-
-            # If scheduling is set to false then check for
-            # state to be idle
-            if attrib and isinstance(attrib,
-                                     dict) and 'scheduling' in attrib.keys():
-                if str(attrib['scheduling']) in PTL_FALSE:
-                    if obj_type == MGR_OBJ_SERVER:
-                        state_val = 'Idle'
-                        state_attr = ATTR_status
-                    else:   # SCHED object
-                        state_val = 'idle'
-                        state_attr = 'state'
-                    attrib[state_attr] = state_val
-                    attrop = PTL_AND
-
-            if oid is None:
-                self.expect(obj_type, attrib, op=op,
-                            max_attempts=max_attempts,
-                            attrop=attrop, offset=offset)
-
-            else:
-                for i in oid:
-                    self.expect(obj_type, attrib, i, op=op,
-                                max_attempts=max_attempts,
-                                attrop=attrop, offset=offset)
-            rc = 0  # If we've reached here then expect passed, so return 0
-
+        if cmd == MGR_CMD_SET and 'scheduling' in attrib:
+            if attrib['scheduling'] in PTL_FALSE:
+                if obj_type == SERVER:
+                    sname = 'default'
+                else:
+                    sname = id
+                # Default max cycle length is 1200 seconds (20m)
+                self.expect(SCHED, {'state': 'scheduling'}, op=NE, id=sname,
+                            interval=1, max_attempts=1200)
         return rc
 
     def sigjob(self, jobid=None, signal=None, extend=None, runas=None,
@@ -9493,7 +9442,7 @@ class Server(PBSService):
             self.logger.error('hook named ' + name + ' exists')
             return False
 
-        self.manager(MGR_CMD_SET, HOOK, attrs, id=name, expect=True)
+        self.manager(MGR_CMD_SET, HOOK, attrs, id=name)
         return True
 
     def import_hook(self, name, body):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6460,7 +6460,6 @@ class Server(PBSService):
                        i.e. silent mode
         :type logerr: bool
         :raises: PbsManagerError
-                - PbsManagerError if qmgr/pbs_manager() failed
         """
 
         if isinstance(id, str):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1239,8 +1239,7 @@ class PBSTestSuite(unittest.TestCase):
         current_user = pwd.getpwuid(os.getuid())[0]
         try:
             # Unset managers list
-            server.manager(MGR_CMD_UNSET, SERVER, 'managers', sudo=True,
-                           expect=True)
+            server.manager(MGR_CMD_UNSET, SERVER, 'managers', sudo=True)
         except PbsManagerError as e:
             self.logger.error(e.msg)
         a = {ATTR_managers: (INCR, current_user + '@*')}

--- a/test/tests/functional/pbs_Rrecord_resources_used.py
+++ b/test/tests/functional/pbs_Rrecord_resources_used.py
@@ -77,12 +77,9 @@ class Test_Rrecord_with_resources_used(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
 
         a = {'resources_available.ncpus': 4}
-        self.server.manager(MGR_CMD_SET, NODE, a,
-                            id=self.hostA, expect=True)
-        self.server.manager(MGR_CMD_SET, NODE, a,
-                            id=self.hostB, expect=True)
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostB)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
     def common(self, is_nonrerunnable, restart_mom):
 
@@ -180,8 +177,7 @@ class Test_Rrecord_with_resources_used(TestFunctional):
         self.server.accounting_match(
             msg='.*Resource_List.*', id=jid3s1, regexp=True)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
         if restart_mom == 's':
             # Start mom without any  option
@@ -280,8 +276,7 @@ class Test_Rrecord_with_resources_used(TestFunctional):
         self.server.expect(JOB, {ATTR_state: 'Q'}, jid2)
         self.server.expect(JOB, {ATTR_state: 'Q'}, jid3s1)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
         self.server.expect(JOB, {ATTR_substate: '42'}, jid1)
         self.server.expect(JOB, {ATTR_substate: '42'}, jid2)
@@ -299,8 +294,7 @@ class Test_Rrecord_with_resources_used(TestFunctional):
         self.server.accounting_match(
             msg='.*R;' + jid2 + '.*resources_used.*run_count=2', id=jid2,
             regexp=True)
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
     def test_Rrecord_with_multiple_reruns(self):
         """

--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -539,14 +539,11 @@ for jk in e.job_list.keys():
         self.assertTrue(rv)
 
         a = {'resources_available.ncpus': '2'}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.hostA,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.hostA)
 
-        self.server.manager(MGR_CMD_SET, NODE, a, self.hostB,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.hostB)
 
-        self.server.manager(MGR_CMD_SET, NODE, a, self.hostC,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.hostC)
 
         a = {'Resource_List.select': '3:ncpus=1',
              'Resource_List.place': 'scatter'}

--- a/test/tests/functional/pbs_acl_host_moms.py
+++ b/test/tests/functional/pbs_acl_host_moms.py
@@ -76,9 +76,8 @@ class Test_acl_host_moms(TestFunctional):
         self.assertTrue(self.remote_host)
 
         self.server.manager(MGR_CMD_SET, SERVER, {
-                            'acl_hosts': self.hostB}, expect=True)
-        self.server.manager(MGR_CMD_SET, SERVER, {
-                            'acl_host_enable': True}, expect=True)
+                            'acl_hosts': self.hostB})
+        self.server.manager(MGR_CMD_SET, SERVER, { 'acl_host_enable': True})
 
         self.pbsnodes_cmd = os.path.join(self.server.pbs_conf[
             'PBS_EXEC'], 'bin', 'pbsnodes') + ' -av'
@@ -93,8 +92,7 @@ class Test_acl_host_moms(TestFunctional):
         """
 
         self.server.manager(MGR_CMD_SET, SERVER, {
-                            'acl_host_moms_enable': True}, expect=True)
-
+                            'acl_host_moms_enable': True}) 
         ret = self.du.run_cmd(self.remote_host, cmd=self.pbsnodes_cmd)
         self.assertEqual(ret['rc'], 0)
 
@@ -107,7 +105,7 @@ class Test_acl_host_moms(TestFunctional):
         host is forbidden to run pbsnodes and qstat.
         """
         self.server.manager(MGR_CMD_SET, SERVER, {
-                            'acl_host_moms_enable': False}, expect=True)
+                            'acl_host_moms_enable': False})
 
         ret = self.du.run_cmd(self.remote_host, cmd=self.pbsnodes_cmd)
         self.assertNotEqual(ret['rc'], 0)
@@ -137,7 +135,7 @@ e.accept()
             hook_name, a, hook_body, overwrite=True)
 
         self.server.manager(MGR_CMD_SET, SERVER, {
-                            'acl_host_moms_enable': False}, expect=True)
+                            'acl_host_moms_enable': False})
 
         j = Job()
         j.set_sleep_time(10)
@@ -146,7 +144,7 @@ e.accept()
         self.server.expect(JOB, {'job_state': 'H'}, id=jid)
 
         self.server.manager(MGR_CMD_SET, SERVER, {
-                            'acl_host_moms_enable': True}, expect=True)
+                            'acl_host_moms_enable': True})
         j = Job()
         j.set_sleep_time(10)
         jid = self.server.submit(j)
@@ -165,12 +163,11 @@ e.accept()
         self.server.manager(MGR_CMD_CREATE, QUEUE, queue_params, id='tempq')
 
         self.server.manager(MGR_CMD_SET, SERVER, {
-                            'acl_host_moms_enable': True}, expect=True)
+                            'acl_host_moms_enable': True})
         # Setting acl_host_enable on queue overrides acl_host_moms_enable
         # on server and requires acl_hosts to include remote host's name.
 
-        self.server.manager(MGR_CMD_SET, SERVER, {
-                            'flatuid': True}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'flatuid': True})
         # Setting flatuid lets us submit jobs on server as a remote
         # host without creating a seperate user account there.
         qsub_cmd_on_queue = os.path.join(self.server.pbs_conf[

--- a/test/tests/functional/pbs_acl_host_moms.py
+++ b/test/tests/functional/pbs_acl_host_moms.py
@@ -77,7 +77,7 @@ class Test_acl_host_moms(TestFunctional):
 
         self.server.manager(MGR_CMD_SET, SERVER, {
                             'acl_hosts': self.hostB})
-        self.server.manager(MGR_CMD_SET, SERVER, { 'acl_host_enable': True})
+        self.server.manager(MGR_CMD_SET, SERVER, {'acl_host_enable': True})
 
         self.pbsnodes_cmd = os.path.join(self.server.pbs_conf[
             'PBS_EXEC'], 'bin', 'pbsnodes') + ' -av'
@@ -92,7 +92,7 @@ class Test_acl_host_moms(TestFunctional):
         """
 
         self.server.manager(MGR_CMD_SET, SERVER, {
-                            'acl_host_moms_enable': True}) 
+                            'acl_host_moms_enable': True})
         ret = self.du.run_cmd(self.remote_host, cmd=self.pbsnodes_cmd)
         self.assertEqual(ret['rc'], 0)
 

--- a/test/tests/functional/pbs_admin_suspend.py
+++ b/test/tests/functional/pbs_admin_suspend.py
@@ -758,7 +758,7 @@ class TestAdminSuspend(TestFunctional):
 
         # set preempt_order to R
         self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'R'},
-                            expect=True, runas=ROOT_USER)
+                            runas=ROOT_USER)
 
         # submit a job
         j = Job(TEST_USER)

--- a/test/tests/functional/pbs_basil_support.py
+++ b/test/tests/functional/pbs_basil_support.py
@@ -84,7 +84,7 @@ class TestBasilQuery(TestFunctional):
 
         self.server.manager(MGR_CMD_SET, PBS_HOOK,
                             {'enabled': 'true', 'freq': 10},
-                            id='PBS_alps_inventory_check', expect=True)
+                            id='PBS_alps_inventory_check')
 
         momA = self.moms.values()[0]
         if not momA.is_cray():
@@ -237,8 +237,7 @@ class TestBasilQuery(TestFunctional):
         for node in nodelist:
             a = {'provision_enable': 'true',
                  'resources_available.aoe': '%s' % node['current_aoe']}
-            self.server.manager(MGR_CMD_SET, NODE,
-                                a, id=node['id'], expect=True)
+            self.server.manager(MGR_CMD_SET, NODE, a, id=node['id'])
 
     def unset_provisioning(self):
         """
@@ -248,8 +247,7 @@ class TestBasilQuery(TestFunctional):
         for node in nodelist:
             a = ['provision_enable',
                  'resources_available.aoe']
-            self.server.manager(MGR_CMD_UNSET, NODE,
-                                a, id=node['id'], expect=True)
+            self.server.manager(MGR_CMD_UNSET, NODE, a, id=node['id'])
 
     def request_current_aoe(self):
         """
@@ -698,26 +696,22 @@ type=\"ENGINE\"/>" % (self.basil_version[1])
                 'user': 'pbsadmin', 'fail_action': 'none'}
 
         self.server.manager(MGR_CMD_LIST, PBS_HOOK,
-                            attr, id='PBS_xeon_phi_provision', expect=True)
+                            attr, id='PBS_xeon_phi_provision')
 
         self.server.manager(MGR_CMD_SET, PBS_HOOK, {'enabled': 'true',
                                                     'alarm': 1000},
-                            id='PBS_xeon_phi_provision',
-                            expect=True)
+                            id='PBS_xeon_phi_provision')
         self.server.manager(MGR_CMD_LIST, PBS_HOOK, {'enabled': 'true',
                                                      'alarm': 1000},
-                            id='PBS_xeon_phi_provision',
-                            expect=True)
+                            id='PBS_xeon_phi_provision')
 
         # Reset pbs_hook value to default PBS_xeon_phi_provision hook
         self.server.manager(MGR_CMD_SET, PBS_HOOK, {'enabled': 'false',
                                                     'alarm': 1800},
-                            id='PBS_xeon_phi_provision',
-                            expect=True)
+                            id='PBS_xeon_phi_provision')
 
         self.server.manager(MGR_CMD_LIST, PBS_HOOK,
-                            attr, id='PBS_xeon_phi_provision',
-                            expect=True)
+                            attr, id='PBS_xeon_phi_provision')
 
     def tearDown(self):
         TestFunctional.tearDown(self)
@@ -732,6 +726,6 @@ type=\"ENGINE\"/>" % (self.basil_version[1])
         # Restore hook freq to 300
         self.server.manager(MGR_CMD_SET, PBS_HOOK,
                             {'enabled': 'true', 'freq': 300},
-                            id='PBS_alps_inventory_check', expect=True)
+                            id='PBS_alps_inventory_check')
         # Do Mom HUP
         self.mom.signal('-HUP')

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -699,7 +699,7 @@ sleep 300
         Job.dflt_attributes[ATTR_k] = 'oe'
         # Increase the server log level
         a = {'log_events': '4095'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         # Configure the scheduler to schedule using vmem
         a = {'resources': 'ncpus,mem,vmem,host,vnode,ngpus,nmics'}
         self.scheduler.set_sched_config(a)

--- a/test/tests/functional/pbs_checkpoint.py
+++ b/test/tests/functional/pbs_checkpoint.py
@@ -136,7 +136,7 @@ exit 0
         in express queue which preempts a running job in the default queue.
         """
         self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'C'},
-                            expect=True, runas=ROOT_USER)
+                            runas=ROOT_USER)
         a = {'queue_type': 'execution',
              'started': 'True',
              'enabled': 'True',

--- a/test/tests/functional/pbs_complete_running_parent_job.py
+++ b/test/tests/functional/pbs_complete_running_parent_job.py
@@ -53,7 +53,7 @@ class Test_complete_running_parent_job(TestFunctional):
         TestFunctional.setUp(self)
 
         self.server.manager(MGR_CMD_SET, SERVER, {
-                            'eligible_time_enable': True}, expect=True)
+                            'eligible_time_enable': True})
 
     def test_parent_job_S_accounting_record(self):
         """

--- a/test/tests/functional/pbs_cray_vnode_pool.py
+++ b/test/tests/functional/pbs_cray_vnode_pool.py
@@ -249,7 +249,7 @@ class TestVnodePool(TestFunctional):
         attr_2 = {'vnode_pool': '2'}
         try:
             self.server.manager(
-                MGR_CMD_SET, NODE, id=self.hostA, attrib=attr_2, expect=False)
+                MGR_CMD_SET, NODE, id=self.hostA, attrib=attr_2)
         except PbsManagerError as e:
             self.assertTrue("Invalid request" in e.msg[0])
 
@@ -269,7 +269,7 @@ class TestVnodePool(TestFunctional):
         attr_2 = {'vnode_pool': '2'}
         try:
             self.server.manager(MGR_CMD_SET, NODE, id=self.hostB,
-                                attrib=attr_2, expect=False)
+                                attrib=attr_2)
         except PbsManagerError as e:
             self.assertTrue("Invalid request" in e.msg[0])
 
@@ -277,6 +277,6 @@ class TestVnodePool(TestFunctional):
                               max_attempts=5, starttime=start_time)
         try:
             self.server.manager(MGR_CMD_UNSET, NODE, id=self.hostB,
-                                attrib='vnode_pool', expect=False)
+                                attrib='vnode_pool')
         except PbsManagerError as e:
             self.assertTrue("Illegal value for node vnode_pool" in e.msg[0])

--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -338,8 +338,7 @@ class TestFairshare(TestFunctional):
 
         self.scheduler.set_fairshare_usage(TEST_USER1, 50)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         J3 = Job(TEST_USER)
         jid3 = self.server.submit(J3)
         J4 = Job(TEST_USER1)

--- a/test/tests/functional/pbs_hook_debug_nocrash.py
+++ b/test/tests/functional/pbs_hook_debug_nocrash.py
@@ -129,8 +129,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "hook %s executed" % (e.hook_name,))
             overwrite=True)
         self.assertTrue(rv)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
         for i in range(1000):
             j = Job(TEST_USER)

--- a/test/tests/functional/pbs_hook_timeout.py
+++ b/test/tests/functional/pbs_hook_timeout.py
@@ -80,8 +80,7 @@ class TestHookTimeout(TestFunctional):
         Test when the server doesn't receive an ACK from a mom for
         sending hooks he resends them
         """
-        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
         timeout_max_attempt = 7
 
         # Make momB unresponsive

--- a/test/tests/functional/pbs_hook_unset_res.py
+++ b/test/tests/functional/pbs_hook_unset_res.py
@@ -59,8 +59,7 @@ class TestHookUnsetRes(TestFunctional):
         rv = self.server.create_import_hook(
             hook_name, a, hook_body, overwrite=True)
         self.assertTrue(rv)
-        self.server.manager(MGR_CMD_SET, SERVER, {
-                            'log_events': 2047}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, { 'log_events': 2047})
         j = Job(TEST_USER, attrs={
                 'Resource_List.select': '1:ncpus=1', ATTR_h: None})
         jid = self.server.submit(j)

--- a/test/tests/functional/pbs_hook_unset_res.py
+++ b/test/tests/functional/pbs_hook_unset_res.py
@@ -59,7 +59,7 @@ class TestHookUnsetRes(TestFunctional):
         rv = self.server.create_import_hook(
             hook_name, a, hook_body, overwrite=True)
         self.assertTrue(rv)
-        self.server.manager(MGR_CMD_SET, SERVER, { 'log_events': 2047})
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
         j = Job(TEST_USER, attrs={
                 'Resource_List.select': '1:ncpus=1', ATTR_h: None})
         jid = self.server.submit(j)

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -682,6 +682,6 @@ class TestJobArray(TestFunctional):
                             {'scheduling': 'True'})
         # ensure the sched cycle is finished
         self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
-                            {'scheduling': 'False'}, expect=True)
+                            {'scheduling': 'False'})
         # ensure all the subjobs are running
         self.server.expect(JOB, {'job_state=R': 200}, extend='t')

--- a/test/tests/functional/pbs_job_requeue_timeout_error.py
+++ b/test/tests/functional/pbs_job_requeue_timeout_error.py
@@ -71,8 +71,7 @@ class TestJobRequeueTimeoutErrorMsg(TestFunctional):
         else:
             self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
 
-        self.server.manager(MGR_CMD_SET, SERVER,
-                            {'job_requeue_timeout': 1}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'job_requeue_timeout': 1})
 
     def test_error_message(self):
         j = Job(TEST_USER, attrs={ATTR_N: 'job_requeue_timeout'})

--- a/test/tests/functional/pbs_job_routing.py
+++ b/test/tests/functional/pbs_job_routing.py
@@ -55,11 +55,9 @@ class TestJobRouting(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
 
         a = {'resources_available.ncpus': 3}
-        self.server.manager(MGR_CMD_SET, NODE, a,
-                            id=self.hostA, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'})
 
     def test_t1(self):
         """
@@ -141,8 +139,7 @@ class TestJobRouting(TestFunctional):
 
         # Start scheduling cycle. This will move all 3 subjobs to R state.
         # And parent job state to B state.
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'true'},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'true'})
 
         self.server.expect(JOB, {ATTR_state + '=R': 3}, count=True,
                            id=jid, extend='t')
@@ -158,8 +155,7 @@ class TestJobRouting(TestFunctional):
         self.momA = self.moms.values()[0]
         self.hostA = self.momA.shortname
         a = {'state': 'offline'}
-        self.server.manager(MGR_CMD_SET, NODE, a,
-                            id=self.hostA, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
 
         # Rerun Third job, job will move to Q state.
         self.server.rerunjob(subjobs[3]['id'])

--- a/test/tests/functional/pbs_mom_dynamic_resource.py
+++ b/test/tests/functional/pbs_mom_dynamic_resource.py
@@ -57,8 +57,7 @@ class TestMomDynRes(TestFunctional):
 
         for i, name in enumerate(resc_name):
             attr = {"type": resc_type[i], "flag": resc_flag[i]}
-            self.server.manager(MGR_CMD_CREATE, RSC, attr,
-                                id=name, expect=True)
+            self.server.manager(MGR_CMD_CREATE, RSC, attr, id=name)
 
             dest_file = self.mom.add_mom_dyn_res(name, script_body[i],
                                                  prefix="mom_resc",
@@ -355,8 +354,7 @@ class TestMomDynRes(TestFunctional):
         """
 
         attr = {"type": "long", "flag": "h"}
-        self.server.manager(MGR_CMD_CREATE, RSC, attr,
-                            id="foo", expect=True)
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id="foo")
         scr_body = ['echo "10"', 'exit 0']
         home_dir = os.path.expanduser("~")
         fp = self.mom.add_mom_dyn_res("foo", script_body=scr_body,

--- a/test/tests/functional/pbs_mom_walltime.py
+++ b/test/tests/functional/pbs_mom_walltime.py
@@ -137,9 +137,9 @@ class TestMomWalltime(TestFunctional):
         # Make sure the sched cycle is completed before reading
         # the walltime
         self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
-                            {'scheduling': 'True'}, expect=True)
+                            {'scheduling': 'True'})
         self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
-                            {'scheduling': 'False'}, expect=True)
+                            {'scheduling': 'False'})
 
         jstat = self.server.status(JOB, id=jid1,
                                    attrib=['resources_used.walltime'])

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -54,7 +54,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].create_scheduler()
         self.scheds['sc1'].start()
         self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1", expect=True)
+                            {'scheduling': 'True'}, id="sc1")
         self.scheds['sc1'].set_sched_config({'log_filter': 2048})
 
     def setup_sc2(self):
@@ -71,7 +71,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc2'].create_scheduler(dir_path)
         self.scheds['sc2'].start(dir_path)
         self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc2", expect=True)
+                            {'scheduling': 'True'}, id="sc2")
 
     def setup_sc3(self):
         a = {'partition': 'P3',
@@ -82,7 +82,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc3'].create_scheduler()
         self.scheds['sc3'].start()
         self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc3", expect=True)
+                            {'scheduling': 'True'}, id="sc3")
 
     def setup_queues_nodes(self):
         a = {'queue_type': 'execution',
@@ -93,19 +93,19 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq3')
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq4')
         p1 = {'partition': 'P1'}
-        self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq1', expect=True)
+        self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq1')
         p2 = {'partition': 'P2'}
-        self.server.manager(MGR_CMD_SET, QUEUE, p2, id='wq2', expect=True)
+        self.server.manager(MGR_CMD_SET, QUEUE, p2, id='wq2')
         p3 = {'partition': 'P3'}
-        self.server.manager(MGR_CMD_SET, QUEUE, p3, id='wq3', expect=True)
+        self.server.manager(MGR_CMD_SET, QUEUE, p3, id='wq3')
         p4 = {'partition': 'P4'}
-        self.server.manager(MGR_CMD_SET, QUEUE, p4, id='wq4', expect=True)
+        self.server.manager(MGR_CMD_SET, QUEUE, p4, id='wq4')
         a = {'resources_available.ncpus': 2}
         self.server.create_vnodes('vnode', a, 5, self.mom)
-        self.server.manager(MGR_CMD_SET, NODE, p1, id='vnode[0]', expect=True)
-        self.server.manager(MGR_CMD_SET, NODE, p2, id='vnode[1]', expect=True)
-        self.server.manager(MGR_CMD_SET, NODE, p3, id='vnode[2]', expect=True)
-        self.server.manager(MGR_CMD_SET, NODE, p4, id='vnode[3]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, p1, id='vnode[0]')
+        self.server.manager(MGR_CMD_SET, NODE, p2, id='vnode[1]')
+        self.server.manager(MGR_CMD_SET, NODE, p3, id='vnode[2]')
+        self.server.manager(MGR_CMD_SET, NODE, p4, id='vnode[3]')
 
     def common_setup(self):
         self.setup_sc1()
@@ -220,7 +220,7 @@ class TestMultipleSchedulers(TestFunctional):
                             {'Scheduling': 'True'}, id="sc5")
         self.server.expect(SCHED, {'state': 'idle'}, id='sc5', max_attempts=10)
         a = {'resources_available.ncpus': 100}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[2]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[2]')
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'False'}, id="sc5")
         for _ in xrange(500):
@@ -275,13 +275,12 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'partition': (DECR, 'P4')}, id="sc1")
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
-                            id="sc1", expect=True)
+                            id="sc1")
         log_msg = "Scheduler does not contain a partition"
         self.scheds['sc1'].log_match(log_msg, max_attempts=10,
                                      starttime=self.server.ctime)
         # Blocked by PP-1202 will revisit once its fixed
-        # self.server.manager(MGR_CMD_UNSET, SCHED, 'partition',
-        #                    id="sc2", expect=True)
+        # self.server.manager(MGR_CMD_UNSET, SCHED, 'partition', id="sc2")
 
     def test_job_queue_partition(self):
         """
@@ -447,7 +446,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, RSC, a, id='gpus')
         self.scheds['sc3'].add_resource("gpus")
         a = {'resources_available.gpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='@default', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id='@default')
         j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
                                    'Resource_List.select': '1:gpus=2',
                                    'Resource_List.walltime': 60})
@@ -886,10 +885,10 @@ class TestMultipleSchedulers(TestFunctional):
              'started': 'True',
              'enabled': 'True',
              'partition': 'P1'}
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq1', expect=True)
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq1')
         a = {'partition': 'P1', 'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a,
-                            id=self.mom.shortname, expect=True)
+                            id=self.mom.shortname)
 
         self.scheds['sc1'].add_to_resource_group(TEST_USER,
                                                  11, 'root', 10)
@@ -1412,7 +1411,7 @@ class TestMultipleSchedulers(TestFunctional):
              'sched_log': os.path.join(dir_path, 'sched_logs_sc2'),
              'sched_host': self.server.hostname,
              'sched_port': '15051'}
-        self.server.manager(MGR_CMD_LIST, SCHED, a, id="sc2", expect=True)
+        self.server.manager(MGR_CMD_LIST, SCHED, a, id="sc2")
 
         self.server.manager(MGR_CMD_LIST, SCHED, id="sc3")
 
@@ -1462,16 +1461,15 @@ class TestMultipleSchedulers(TestFunctional):
              'started': 'True',
              'enabled': 'True'}
         a.update(p3)
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq1', expect=True)
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq1')
         a = {'resources_available.ncpus': 2}
         self.server.create_vnodes('vnode', a, 2, self.mom)
-        self.server.manager(MGR_CMD_SET, NODE, p3, id='vnode[0]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, p3, id='vnode[0]')
         # Set job_sort_formula on the server
         self.server.manager(MGR_CMD_SET, SERVER, {'job_sort_formula': 'ncpus'})
         # Set job_sort_formula_threshold on the multisched
         self.server.manager(MGR_CMD_SET, SCHED,
-                            {'job_sort_formula_threshold': '2'},
-                            id="sc3", expect=True)
+                            {'job_sort_formula_threshold': '2'}, id="sc3")
         # Submit job to multisched
         j1_attrs = {ATTR_queue: 'wq1', 'Resource_List.ncpus': '1'}
         J1 = Job(TEST_USER, j1_attrs)
@@ -1790,9 +1788,9 @@ class TestMultipleSchedulers(TestFunctional):
         self.setup_sc3()
 
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduler_iteration': 1},
-                            id="sc3", expect=True)
+                            id="sc3")
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
-                            id="sc3", expect=True)
+                            id="sc3")
 
         self.logger.info('The sleep is 15 seconds which will trigger required '
                          'number of scheduling cycles that are needed to '
@@ -1829,8 +1827,7 @@ class TestMultipleSchedulers(TestFunctional):
 
         self.du.mkdir(path=new_sched_log, sudo=True)
         self.server.manager(MGR_CMD_SET, SCHED,
-                            {'sched_log': new_sched_log},
-                            id="sc3", expect=True)
+                            {'sched_log': new_sched_log}, id="sc3")
 
         a = {'sched_log': new_sched_log}
         self.server.expect(SCHED, a, id='sc3', max_attempts=10)
@@ -1864,7 +1861,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.du.run_copy(src=dflt_sched_priv, dest=new_sched_priv,
                          recursive=True, sudo=True)
         self.server.manager(MGR_CMD_SET, SCHED, {'sched_priv': new_sched_priv},
-                            id="sc3", expect=True)
+                            id="sc3")
 
         a = {'sched_priv': new_sched_priv}
         self.server.expect(SCHED, a, id='sc3', max_attempts=10)
@@ -1923,7 +1920,7 @@ class TestMultipleSchedulers(TestFunctional):
         # queue associated to it. Expectation is in this case scheduler won't
         # crash
         a = {ATTR_queue: 'wq1'}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[0]', expect="True")
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[0]')
 
         self.scheds['sc1'].terminate()
 
@@ -1970,20 +1967,20 @@ class TestMultipleSchedulers(TestFunctional):
         self.setup_sc1()
         self.setup_queues_nodes()
         a = {'partition': 'P1'}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='@default', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id='@default')
         a = {'node_sort_key': '"ncpus HIGH " ALL'}
         self.scheds['sc1'].set_sched_config(a)
         a = {'resources_available.ncpus': 1}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[0]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[0]')
         a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[1]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[1]')
         a = {'resources_available.ncpus': 3}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[2]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[2]')
         a = {'resources_available.ncpus': 4}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[3]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[3]')
         # Offlining the node as we do not need for the test
         a = {'state': 'offline'}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[4]', expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[4]')
         a = {'Resource_List.select': '1:ncpus=1',
              'Resource_List.place': 'excl',
              ATTR_queue: 'wq1'}
@@ -2013,7 +2010,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
         for name in self.scheds:
             self.server.manager(MGR_CMD_SET, SCHED,
-                                {'scheduling': 'False'}, id=name, expect=True)
+                                {'scheduling': 'False'}, id=name)
         a = {ATTR_queue: 'wq1',
              'Resource_List.select': '1:ncpus=2',
              'Resource_List.walltime': 60}
@@ -2021,7 +2018,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.submit(j)
         t = int(time.time())
         self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id='sc1', expect=True)
+                            {'scheduling': 'True'}, id='sc1')
         self.server.log_match("processing priority socket", starttime=t)
         a = {ATTR_queue: 'wq2',
              'Resource_List.select': '1:ncpus=2',
@@ -2030,5 +2027,5 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.submit(j)
         t = int(time.time())
         self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id='sc2', expect=True)
+                            {'scheduling': 'True'}, id='sc2')
         self.server.log_match("processing priority socket", starttime=t)

--- a/test/tests/functional/pbs_multiple_execjob_launch_hook.py
+++ b/test/tests/functional/pbs_multiple_execjob_launch_hook.py
@@ -69,8 +69,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "environment var from execjob_hook2 is %s" % (e.env))
 
     def setUp(self):
         TestFunctional.setUp(self)
-        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
 
     def test_multi_execjob_hook(self):
         """

--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -444,7 +444,7 @@ class TestNodeBuckets(TestFunctional):
         self.mom.add_config(c)
 
         self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'C'},
-                            expect=True, runas=ROOT_USER)
+                            runas=ROOT_USER)
         attrs = {'Resource_List.select': '1430:ncpus=1:color=orange',
                  'Resource_List.place': 'scatter:excl'}
         j_c1 = Job(TEST_USER, attrs)
@@ -570,7 +570,7 @@ class TestNodeBuckets(TestFunctional):
         """
         a = {'node_group_key': 'shape', 'node_group_enable': 'True',
              'scheduling': 'False'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         chunk = '1430:ncpus=1'
         a = {'Resource_List.select': chunk,

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -324,8 +324,7 @@ class TestPbsNodeRampDown(TestFunctional):
         a = {'resources_available.ncpus': 2,
              'resources_available.mem': '2gb'}
         # set natural vnode of hostC
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostC,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostC)
 
         a = {'state': 'free', 'resources_available.ncpus': (GE, 1)}
         self.server.expect(VNODE, {'state=free': 11}, op=EQ, count=True,
@@ -599,7 +598,7 @@ return i\\n return fib(i-1) + fib(i-2)\\n\\nprint fib(400)\\\")"'
         TestFunctional.tearDown(self)
         # Delete managers and operators if added
         attrib = ['operators', 'managers']
-        self.server.manager(MGR_CMD_UNSET, SERVER, attrib, expect=True)
+        self.server.manager(MGR_CMD_UNSET, SERVER, attrib)
 
     def test_release_nodes_on_stageout_true(self):
         """
@@ -1870,8 +1869,7 @@ pbs.event().job.release_nodes_on_stageout=False
         # Set hostC node to be of cray type
         a = {'resources_available.vntype': 'cray_login'}
         # set natural vnode of hostC
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.n7,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.n7)
 
         # Run pbs_release_nodes
         cmd = [self.pbs_release_nodes_cmd, '-j', jid, self.n4, self.n5,
@@ -1975,8 +1973,7 @@ pbs.event().job.release_nodes_on_stageout=False
         # Set hostB to be of cpuset type
         a = {'resources_available.arch': 'linux_cpuset'}
         # set natural vnode of hostC
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.n7,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.n7)
 
         # Run pbs_release_nodes
         cmd = [self.pbs_release_nodes_cmd, '-j', jid, self.n4, self.n5,

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -948,7 +948,7 @@ e.env["LAUNCH_NONPRINT"] = "CD"
             self.assertTrue(rv)
             hk_name_esc = "h%sd" % self.npcat[ch]
             self.check_print_list_hook(hk_name, hk_name_esc)
-            self.server.manager(MGR_CMD_DELETE, HOOK, id=hk_name, expect=True)
+            self.server.manager(MGR_CMD_DELETE, HOOK, id=hk_name)
 
     def test_terminal_control_in_rsubH(self):
         """

--- a/test/tests/functional/pbs_offline_vnodes.py
+++ b/test/tests/functional/pbs_offline_vnodes.py
@@ -82,8 +82,7 @@ class TestOfflineVnode(TestFunctional):
 
     def create_multi_vnodes(self, num_moms, num_vnode=3):
         if num_moms != len(self.moms):
-            self.server.manager(MGR_CMD_DELETE, NODE, id="@default",
-                                expect=True)
+            self.server.manager(MGR_CMD_DELETE, NODE, id="@default")
         if self.is_cray is True:
             if num_moms == 1 and len(self.moms) != 1:
                 self.server.manager(MGR_CMD_CREATE, NODE,
@@ -132,8 +131,7 @@ class TestOfflineVnode(TestFunctional):
 
         # Restore original node setup for future test cases.
         self.server.cleanup_jobs(extend='force')
-        self.server.manager(MGR_CMD_DELETE, NODE, id="@default",
-                            expect=True)
+        self.server.manager(MGR_CMD_DELETE, NODE, id="@default")
         for m in self.moms.values():
             self.server.manager(MGR_CMD_CREATE, NODE,
                                 id=m.shortname)

--- a/test/tests/functional/pbs_only_small_files_over_tpp.py
+++ b/test/tests/functional/pbs_only_small_files_over_tpp.py
@@ -71,11 +71,9 @@ class TestOnlySmallFilesOverTPP(TestFunctional):
         else:
             self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
 
-        self.server.manager(MGR_CMD_SET, SERVER,
-                            {'job_requeue_timeout': 175}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'job_requeue_timeout': 175})
 
-        self.server.manager(MGR_CMD_SET, SERVER,
-                            {'log_events': 4095}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 4095})
 
     def test_small_job_file(self):
         """

--- a/test/tests/functional/pbs_pbsnodes.py
+++ b/test/tests/functional/pbs_pbsnodes.py
@@ -60,8 +60,7 @@ class TestPbsnodes(TestFunctional):
         Common setUp for tests test_pbsnodes_as_user and test_pbsnodes_as_root
         """
         TestFunctional.setUp(self)
-        self.server.manager(MGR_CMD_DELETE, NODE, id="",
-                            sudo=True, expect=True)
+        self.server.manager(MGR_CMD_DELETE, NODE, id="", sudo=True)
         self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom.shortname)
         self.server.expect(NODE, {'state': 'free'})
 

--- a/test/tests/functional/pbs_power_provisioning_cray.py
+++ b/test/tests/functional/pbs_power_provisioning_cray.py
@@ -470,9 +470,9 @@ e.accept()
         nodes = self.server.status(NODE)
         host = nodes[0]['id']
         self.server.manager(MGR_CMD_SET, NODE, {'poweroff_eligible': 'True'},
-                            expect=True, id=host)
+                            id=host)
         self.server.manager(MGR_CMD_SET, NODE, {'poweroff_eligible': 'False'},
-                            expect=True, id=host)
+                            id=host)
 
     def test_last_state_change_time(self):
         """
@@ -935,7 +935,7 @@ e.accept()
         self.setup_power_ramp_rate()
         self.scheduler.set_sched_config({'strict_ordering': 'True ALL'})
         self.server.manager(MGR_CMD_SET, NODE, {'poweroff_eligible': 'False'},
-                            expect=True, id=self.names[0])
+                            id=self.names[0])
         a = {"power_ramp_rate_enable": True, 'node_idle_limit': '30'}
         self.modify_hook_config(attrs=a, hook_id='PBS_power')
         a = {'freq': 60}

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -46,8 +46,7 @@ class TestPreemption(TestFunctional):
         TestFunctional.setUp(self)
 
         a = {'resources_available.ncpus': 1}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
 
         # create express queue
         a = {'queue_type': 'execution',
@@ -73,8 +72,7 @@ class TestPreemption(TestFunctional):
 
         # set preempt order
         self.server.manager(MGR_CMD_SET, SCHED,
-                            {'preempt_order': preempt_order},
-                            expect=True, runas=ROOT_USER)
+                            {'preempt_order': preempt_order}, runas=ROOT_USER)
 
         attrs = {ATTR_l + '.select': '1:ncpus=1'}
 

--- a/test/tests/functional/pbs_provisioning.py
+++ b/test/tests/functional/pbs_provisioning.py
@@ -101,12 +101,9 @@ class TestProvisioningJob(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
 
         a = {'provision_enable': 'true'}
-        self.server.manager(
-            MGR_CMD_SET, NODE, a, id=self.hostA, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
 
-        self.server.manager(
-            MGR_CMD_SET, SERVER, {
-                'log_events': 2047}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
         self.server.expect(NODE, {'state': 'free'}, id=self.hostA)
 
         a = {'event': 'execjob_begin', 'enabled': 'True'}
@@ -124,8 +121,7 @@ class TestProvisioningJob(TestFunctional):
             Test the execjob_begin hook is seen by OS provisioned job.
         """
         a = {'resources_available.aoe': 'osimage1'}
-        self.server.manager(
-            MGR_CMD_SET, NODE, a, id=self.hostA, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
 
         job = Job(TEST_USER1, attrs={ATTR_l: 'aoe=osimage1'})
         job.set_sleep_time(1)
@@ -165,8 +161,7 @@ class TestProvisioningJob(TestFunctional):
         Test application provisioning
         """
         a = {'resources_available.aoe': 'App1'}
-        self.server.manager(
-            MGR_CMD_SET, NODE, a, id=self.hostA, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
 
         job = Job(TEST_USER1, attrs={ATTR_l: 'aoe=App1'})
         job.set_sleep_time(1)

--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -108,14 +108,13 @@ e.reject()
              'resources_available.ncpus': '2',
              'resources_available.aoe': 'App1,osimage1'}
         self.server.manager(
-            MGR_CMD_SET, NODE, a, id=self.hostA, expect=True)
+            MGR_CMD_SET, NODE, a, id=self.hostA)
         self.server.manager(MGR_CMD_UNSET, NODE, id=self.hostA,
-                            attrib='current_aoe', expect=True)
+                            attrib='current_aoe')
 
         # Set hostB ncpus to 12
         a = {'resources_available.ncpus': '12'}
-        self.server.manager(
-            MGR_CMD_SET, NODE, a, id=self.hostB, expect=True)
+        self.server.manager( MGR_CMD_SET, NODE, a, id=self.hostB)
 
         # Setup provisioning hook.
         a = {'event': 'provision', 'enabled': 'True', 'alarm': '300'}
@@ -123,8 +122,7 @@ e.reject()
             'fake_prov_hook', a, self.fake_prov_hook, overwrite=True)
         self.assertTrue(rv)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
 
     def test_app_provisioning(self):
         """
@@ -371,7 +369,7 @@ e.reject()
         self.assertTrue(rv)
         # Set current aoe to App1
         self.server.manager(MGR_CMD_SET, NODE, id=self.hostA,
-                            attrib={'current_aoe': 'App1'}, expect=True)
+                            attrib={'current_aoe': 'App1'})
 
         # Turn on scheduling
         self.server.manager(MGR_CMD_SET,
@@ -405,7 +403,7 @@ e.reject()
 
         # Set current aoe to osimage1
         self.server.manager(MGR_CMD_SET, NODE, id=self.hostA,
-                            attrib={'current_aoe': 'osimage1'}, expect=True)
+                            attrib={'current_aoe': 'osimage1'})
 
         # submit one job that will run on local node
         a = {'Resource_List.select': '1:ncpus=10'}

--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -114,7 +114,7 @@ e.reject()
 
         # Set hostB ncpus to 12
         a = {'resources_available.ncpus': '12'}
-        self.server.manager( MGR_CMD_SET, NODE, a, id=self.hostB)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostB)
 
         # Setup provisioning hook.
         a = {'event': 'provision', 'enabled': 'True', 'alarm': '300'}

--- a/test/tests/functional/pbs_qrun.py
+++ b/test/tests/functional/pbs_qrun.py
@@ -46,8 +46,7 @@ class TestQrun(TestFunctional):
         TestFunctional.setUp(self)
         # set ncpus to a known value, 2 here
         a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a,
-                            self.mom.shortname, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         self.pbs_exec = self.server.pbs_conf['PBS_EXEC']
         self.qrun = os.path.join(self.pbs_exec, 'bin', 'qrun')
 
@@ -117,8 +116,7 @@ class TestQrun(TestFunctional):
         self.logger.info("Submitted 500 jobs with different walltime")
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'scheduling': 'True'})
-        self.server.manager(MGR_CMD_SET, SERVER,
-                            {'scheduling': 'False'}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         time.sleep(1)
         now = int(time.time())
         pid = os.fork()

--- a/test/tests/functional/pbs_qstat_count.py
+++ b/test/tests/functional/pbs_qstat_count.py
@@ -44,8 +44,7 @@ class TestqstatStateCount(TestFunctional):
         TestFunctional.setUp(self)
         # set ncpus to a known value, 2 here
         a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a,
-                            self.mom.shortname, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
 
     def submit_waiting_job(self, timedelta):
         """
@@ -164,8 +163,7 @@ class TestqstatStateCount(TestFunctional):
                 'queue_type': 'Execution',
                 'enabled': 'True',
                 'started': 'True'}
-            self.server.manager(MGR_CMD_CREATE, QUEUE,
-                                a, que, expect=True)
+            self.server.manager(MGR_CMD_CREATE, QUEUE, a, que)
 
         q1_attr = {ATTR_queue: 'workq1'}
         q2_attr = {ATTR_queue: 'workq2'}
@@ -199,8 +197,7 @@ class TestqstatStateCount(TestFunctional):
                 'queue_type': 'Execution',
                 'enabled': 'True',
                 'started': 'True'}
-            self.server.manager(MGR_CMD_CREATE, QUEUE,
-                                a, que, expect=True)
+            self.server.manager(MGR_CMD_CREATE, QUEUE, a, que)
 
         q1_attr = {ATTR_queue: 'workq1'}
         q2_attr = {ATTR_queue: 'workq2'}

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -70,7 +70,7 @@ class TestPbsResvAlter(TestFunctional):
         self.server.create_vnodes('vnode', a, num=2, mom=self.mom,
                                   usenatvnode=True)
 
-        self.server.manager(MGR_CMD_SET, SERVER, { 'log_events': 4095})
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 4095})
 
     def submit_and_confirm_reservation(self, offset, duration, standing=False,
                                        select="1:ncpus=4",

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -70,8 +70,7 @@ class TestPbsResvAlter(TestFunctional):
         self.server.create_vnodes('vnode', a, num=2, mom=self.mom,
                                   usenatvnode=True)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {
-            'log_events': 4095}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, { 'log_events': 4095})
 
     def submit_and_confirm_reservation(self, offset, duration, standing=False,
                                        select="1:ncpus=4",

--- a/test/tests/functional/pbs_release_limited_res_suspend.py
+++ b/test/tests/functional/pbs_release_limited_res_suspend.py
@@ -63,7 +63,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Set restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
@@ -100,7 +100,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Set restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
@@ -133,7 +133,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Set restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
@@ -152,7 +152,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Change restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'mem'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         rc = 0
         try:
@@ -181,7 +181,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Set restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
@@ -212,7 +212,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Set restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         vn_attrs = {ATTR_rescavail + '.ncpus': 8,
                     ATTR_rescavail + '.mem': '1024mb'}
@@ -255,7 +255,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Set restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
@@ -290,7 +290,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Set restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus,mem'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
@@ -326,7 +326,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Set restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus,mem'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
@@ -358,7 +358,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Set restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus,mem'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         vn_attrs = {ATTR_rescavail + '.ncpus': 8,
                     ATTR_rescavail + '.mem': '1024mb'}
@@ -401,7 +401,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # Set restrict_res_to_release_on_suspend server attribute
         a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Submit a low priority job
         j1 = Job(TEST_USER)
@@ -947,8 +947,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         self.server.manager(MGR_CMD_SET, SCHED,
-                            {'preempt_order': preempt_method},
-                            expect=True, runas=ROOT_USER)
+                            {'preempt_order': preempt_method}, runas=ROOT_USER)
 
         # Set 1gb mem available on the node
         a = {ATTR_rescavail + '.ncpus': "2"}

--- a/test/tests/functional/pbs_reliable_job_startup.py
+++ b/test/tests/functional/pbs_reliable_job_startup.py
@@ -283,8 +283,7 @@ class TestPbsReliableJobStartup(TestFunctional):
         a = {'resources_available.ncpus': 2,
              'resources_available.mem': '2gb'}
         # set natural vnode of hostC
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostC,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostC)
 
         # set node momD
         # This one has no vnode definition.
@@ -295,8 +294,7 @@ class TestPbsReliableJobStartup(TestFunctional):
         a = {'resources_available.ncpus': 5,
              'resources_available.mem': '5gb'}
         # set natural vnode of hostD
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostD,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostD)
 
         # set node momE
         self.hostE = self.momE.shortname
@@ -1198,7 +1196,7 @@ if e.job.in_ms_mom():
         TestFunctional.tearDown(self)
         # Delete managers and operators if added
         attrib = ['operators', 'managers']
-        self.server.manager(MGR_CMD_UNSET, SERVER, attrib, expect=True)
+        self.server.manager(MGR_CMD_UNSET, SERVER, attrib)
 
     @timeout(400)
     def test_t1(self):

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -197,7 +197,7 @@ class TestReservations(TestFunctional):
         """
         a = {'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname,
-                            expect=True, sudo=True)
+                            sudo=True)
 
         now = int(time.time())
         a = {'Resource_List.select': "1:ncpus=2",

--- a/test/tests/functional/pbs_resv_end_hook.py
+++ b/test/tests/functional/pbs_resv_end_hook.py
@@ -74,8 +74,7 @@ if e.type == pbs.RESV_END:
         attrs = {'event': 'resv_end'}
         self.server.create_hook(self.hook_name, attrs)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
 
     def submit_resv(self, offset, duration, select='1:ncpus=1', rrule=''):
         """
@@ -536,7 +535,7 @@ if e.type == pbs.RESV_END:
 
         node_attrs = {'resources_available.ncpus': 1}
         self.server.manager(MGR_CMD_SET, NODE, node_attrs,
-                            id=self.mom.shortname, expect=True)
+                            id=self.mom.shortname)
         offset = 10
         duration = 10
         rid = self.submit_resv(offset, duration)

--- a/test/tests/functional/pbs_runjob_hook.py
+++ b/test/tests/functional/pbs_runjob_hook.py
@@ -147,10 +147,8 @@ e.job.Resource_List['site'] = 'site_value'
         msg = "Not Running: PBS Error: runjob hook rejected the job"
         self.server.expect(JOB, {'job_state': 'Q', 'comment': msg}, id=jid)
         a = {'enabled': 'false'}
-        self.server.manager(MGR_CMD_SET, HOOK, a, id=hook_name,
-                            expect=True, sudo=True)
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, HOOK, a, id=hook_name, sudo=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {'job_state': 'B'}, id=jid)
         self.server.expect(JOB, {'job_state=R': 3}, count=True,
                            id=jid, extend='t')

--- a/test/tests/functional/pbs_sched_subjob_badstate.py
+++ b/test/tests/functional/pbs_sched_subjob_badstate.py
@@ -57,11 +57,10 @@ class TestSchedSubjobBadstate(TestFunctional):
         self.mom.signal('-KILL')
 
         attr = {'state': 'free', 'resources_available.ncpus': '2'}
-        self.server.manager(MGR_CMD_SET, NODE, attr, self.mom.shortname,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, attr, self.mom.shortname)
 
         attr = {'scheduling': 'False'}
-        self.server.manager(MGR_CMD_SET, SERVER, attr, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
 
         j1 = Job(TEST_USER)
         j1.set_attributes({'Resource_List.ncpus': '2', ATTR_J: '1-3'})
@@ -70,7 +69,7 @@ class TestSchedSubjobBadstate(TestFunctional):
         now = time.time()
 
         attr = {'scheduling': 'True'}
-        self.server.manager(MGR_CMD_SET, SERVER, attr, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
 
         self.scheduler.log_match("Leaving Scheduling Cycle",
                                  starttime=now,

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -307,7 +307,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
             msg = "Able to set freq to zero"
             self.assertTrue(False, msg)
         attrs = {'enabled': "False", 'event': "periodic", 'freq': '120'}
-        self.server.manager(MGR_CMD_SET, HOOK, attrs, hook_name, expect=True)
+        self.server.manager(MGR_CMD_SET, HOOK, attrs, hook_name)
         attrs = {'freq': "-1"}
         match_str1 = "set_hook_freq: freq value '-1'"
         match_str1 += " of a hook must be > 0"
@@ -402,7 +402,5 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         else:
             msg = "Able to create hook as other user"
             self.assertTrue(False, msg)
-        self.server.manager(MGR_CMD_SET, HOOK, attrs, hook_name,
-                            expect=True)
-        self.server.manager(MGR_CMD_LIST, HOOK, {'freq': '120'}, hook_name,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, HOOK, attrs, hook_name)
+        self.server.manager(MGR_CMD_LIST, HOOK, {'freq': '120'}, hook_name)

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -58,9 +58,7 @@ class TestPBSSnapshot(TestFunctional):
         # Create a custom resource called 'ngpus'
         # This will help us test parts of PBSSnapUtils which handle resources
         attr = {"type": "long", "flag": "nh"}
-        self.server.manager(MGR_CMD_CREATE, RSC, attr,
-                            id="ngpus", expect=True,
-                            sudo=True)
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id="ngpus", sudo=True)
 
         # Check whether pbs_snapshot is accessible
         try:
@@ -114,7 +112,7 @@ class TestPBSSnapshot(TestFunctional):
             self.scheds[sched_id].create_scheduler()
             self.scheds[sched_id].start()
         self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id=sched_id, expect=True)
+                            {'scheduling': 'True'}, id=sched_id)
 
     def setup_queues_nodes(self, num_partitions):
         """
@@ -147,7 +145,7 @@ class TestPBSSnapshot(TestFunctional):
             id_n = "vnode[" + str(i) + "]"
             nodes.append(id_n)
             a = {"partition": partition_id}
-            self.server.manager(MGR_CMD_SET, NODE, a, id=id_n, expect=True)
+            self.server.manager(MGR_CMD_SET, NODE, a, id=id_n)
 
         return (queues, nodes)
 

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -71,7 +71,7 @@ class TestSoftWalltime(TestFunctional):
         self.server.manager(
             MGR_CMD_UNSET, SERVER, 'Resources_default.soft_walltime')
         # Delete operators if added
-        self.server.manager(MGR_CMD_UNSET, SERVER, 'operators', expect=True)
+        self.server.manager(MGR_CMD_UNSET, SERVER, 'operators')
 
     def stat_job(self, job):
         """
@@ -680,8 +680,7 @@ e.accept()
         to calculate percent done and also if the soft_walltime is exceeded,
         the percent done should remain at 100%
         """
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'preempt_order': '"R 10 S"'}, expect=True,
+        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': '"R 10 S"'},
                             runas=ROOT_USER)
         a = {'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)

--- a/test/tests/functional/pbs_stf.py
+++ b/test/tests/functional/pbs_stf.py
@@ -439,7 +439,7 @@ class TestSTF(TestFunctional):
         self.scheduler.set_sched_config(a)
 
         a = {'backfill_depth': '20'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'Resource_List.select': '1:ncpus=2',
              'Resource_List.place': 'free',
@@ -557,7 +557,7 @@ class TestSTF(TestFunctional):
         """
         a = {'resources_min.walltime': '00:10:00',
              'resources_max.walltime': '10:00:00'}
-        self.server.manager(MGR_CMD_SET, QUEUE, a, id="workq", expect=True)
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id="workq")
 
         a = {'Resource_List.max_walltime': '10:00:00',
              'Resource_List.min_walltime': '00:09:00'}

--- a/test/tests/functional/pbs_strict_ordering.py
+++ b/test/tests/functional/pbs_strict_ordering.py
@@ -60,7 +60,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         self.assertTrue(rv)
 
         a = {'backfill_depth': 0}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         j1 = Job(TEST_USER)
         a = {'Resource_List.select': '1:ncpus=2',
@@ -102,7 +102,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         self.assertTrue(rv)
         a = {'backfill_depth': 2}
         self.server.manager(
-            MGR_CMD_SET, QUEUE, a, id='workq', expect=True)
+            MGR_CMD_SET, QUEUE, a, id='workq')
         a = {
             'queue_type': 'execution',
             'started': 't',
@@ -116,17 +116,10 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
             'backfill_depth': 0}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq3')
         a = {'backfill_depth': 0}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'resources_available.ncpus': 5}
-        self.server.manager(
-            MGR_CMD_SET,
-            NODE,
-            a,
-            self.mom.shortname,
-            expect=True)
-        self.server.manager(
-            MGR_CMD_SET, SERVER, {
-                'scheduling': 'False'}, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        self.server.manager( MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'workq'}
         j = Job(TEST_USER, a)
         j.set_sleep_time(100)
@@ -141,9 +134,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         j = Job(TEST_USER, a)
         j.set_sleep_time(100)
         j5id = self.server.submit(j)
-        self.server.manager(
-            MGR_CMD_SET, SERVER, {
-                'scheduling': 'True'}, expect=True)
+        self.server.manager( MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB,
                            {'job_state': 'R'},
                            id=j1id,

--- a/test/tests/functional/pbs_strict_ordering.py
+++ b/test/tests/functional/pbs_strict_ordering.py
@@ -119,7 +119,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'resources_available.ncpus': 5}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
-        self.server.manager( MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'workq'}
         j = Job(TEST_USER, a)
         j.set_sleep_time(100)
@@ -134,7 +134,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         j = Job(TEST_USER, a)
         j.set_sleep_time(100)
         j5id = self.server.submit(j)
-        self.server.manager( MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB,
                            {'job_state': 'R'},
                            id=j1id,

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -47,8 +47,7 @@ class TestServerDynRes(TestFunctional):
         TestFunctional.setUp(self)
         # Setup node
         a = {'resources_available.ncpus': 4}
-        self.server.manager(MGR_CMD_SET, NODE, a,
-                            id=self.mom.shortname, expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
 
     def check_access_log(self, fp, exist=True):
         """
@@ -78,8 +77,7 @@ class TestServerDynRes(TestFunctional):
         attr = {}
         for i, name in enumerate(resname):
             attr["type"] = restype[i]
-            self.server.manager(MGR_CMD_CREATE, RSC, attr, id=name,
-                                expect=True)
+            self.server.manager(MGR_CMD_CREATE, RSC, attr, id=name)
             # Add resource to sched_config's 'resources' line
             self.scheduler.add_resource(name)
             dest_file = self.scheduler.add_server_dyn_res(name,

--- a/test/tests/functional/pbs_test_entity_limits.py
+++ b/test/tests/functional/pbs_test_entity_limits.py
@@ -56,8 +56,7 @@ class TestEntityLimits(TestFunctional):
         TestFunctional.setUp(self)
 
         a = {'resources_available.ncpus': 1}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
 
     def common_limit_test(self, server, entstr, job_attr={}, queued=False,
                           exp_err=''):

--- a/test/tests/functional/pbs_trillion_jobid.py
+++ b/test/tests/functional/pbs_trillion_jobid.py
@@ -243,12 +243,7 @@ exit 0
             self.assertTrue('Unauthorized Request' in e.msg[0])
 
         # Set as Admin User and also check the value after server restart
-        self.server.manager(
-            MGR_CMD_SET,
-            SERVER,
-            seq_id,
-            runas=ROOT_USER,
-            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, seq_id, runas=ROOT_USER)
         self.server.expect(SERVER, seq_id)
         self.server.log_match('svr_max_job_sequence_id set to '
                               'val %d' % (seq_id[ATTR_max_job_sequence_id]),
@@ -271,12 +266,8 @@ exit 0
             self.assertTrue('Unauthorized Request' in e.msg[0])
 
         # Unset as Admin user
-        self.server.manager(
-            MGR_CMD_UNSET,
-            SERVER,
-            'max_job_sequence_id',
-            runas=ROOT_USER,
-            expect=True)
+        self.server.manager(MGR_CMD_UNSET, SERVER, 'max_job_sequence_id', 
+                            runas=ROOT_USER)
         self.server.log_match('svr_max_job_sequence_id reverting back '
                               'to default val 9999999',
                               starttime=self.server.ctime)
@@ -311,12 +302,7 @@ exit 0
         valid_values = [9999999, 123456789, 100000000000, 999999999999]
         for val in valid_values:
             seq_id = {ATTR_max_job_sequence_id: val}
-            self.server.manager(
-                MGR_CMD_SET,
-                SERVER,
-                seq_id,
-                runas=ROOT_USER,
-                expect=True)
+            self.server.manager(MGR_CMD_SET, SERVER, seq_id, runas=ROOT_USER)
 
     def test_max_job_sequence_id_wrap(self):
         """
@@ -339,12 +325,7 @@ exit 0
         # Check max limit (999999999999) and wrap it 0
         sv_jobidnumber = 999999999999  # max limit
         seq_id = {ATTR_max_job_sequence_id: sv_jobidnumber}
-        self.server.manager(
-            MGR_CMD_SET,
-            SERVER,
-            seq_id,
-            runas=ROOT_USER,
-            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, seq_id, runas=ROOT_USER)
         self.server.expect(SERVER, seq_id)
         self.submit_job(verify=True)
         self.submit_job(lower=1, upper=2, verify=True)
@@ -359,12 +340,7 @@ exit 0
         # wrap it 0
         sv_jobidnumber = 1234567890
         seq_id = {ATTR_max_job_sequence_id: sv_jobidnumber}
-        self.server.manager(
-            MGR_CMD_SET,
-            SERVER,
-            seq_id,
-            runas=ROOT_USER,
-            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, seq_id, runas=ROOT_USER)
         self.server.expect(SERVER, seq_id)
         sv_jobidnumber = 123456789
         self.set_svr_sv_jobidnumber(sv_jobidnumber)
@@ -374,12 +350,7 @@ exit 0
         # Set smaller(12345678) than current jobid(123456790)
         sv_jobidnumber = 12345678
         seq_id = {ATTR_max_job_sequence_id: sv_jobidnumber}
-        self.server.manager(
-            MGR_CMD_SET,
-            SERVER,
-            seq_id,
-            runas=ROOT_USER,
-            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, seq_id, runas=ROOT_USER)
         self.server.expect(SERVER, seq_id)
         self.submit_job(job_id='0', verify=True)  # wrap it to zero
         self.submit_job(lower=1, upper=2, job_id='1[]', verify=True)
@@ -427,12 +398,7 @@ exit 0
                 jobs with the same id's are still running
         """
         seq_id = {ATTR_max_job_sequence_id: 99999999}
-        self.server.manager(
-            MGR_CMD_SET,
-            SERVER,
-            seq_id,
-            runas=ROOT_USER,
-            expect=True)
+        self.server.manager( MGR_CMD_SET, SERVER, seq_id, runas=ROOT_USER)
         self.set_svr_sv_jobidnumber(0)
         self.submit_job(sleep=1000, job_id='0')
         self.submit_job(sleep=1000, lower=1, upper=2, job_id='1[]')

--- a/test/tests/functional/pbs_trillion_jobid.py
+++ b/test/tests/functional/pbs_trillion_jobid.py
@@ -266,7 +266,7 @@ exit 0
             self.assertTrue('Unauthorized Request' in e.msg[0])
 
         # Unset as Admin user
-        self.server.manager(MGR_CMD_UNSET, SERVER, 'max_job_sequence_id', 
+        self.server.manager(MGR_CMD_UNSET, SERVER, 'max_job_sequence_id',
                             runas=ROOT_USER)
         self.server.log_match('svr_max_job_sequence_id reverting back '
                               'to default val 9999999',
@@ -398,7 +398,7 @@ exit 0
                 jobs with the same id's are still running
         """
         seq_id = {ATTR_max_job_sequence_id: 99999999}
-        self.server.manager( MGR_CMD_SET, SERVER, seq_id, runas=ROOT_USER)
+        self.server.manager(MGR_CMD_SET, SERVER, seq_id, runas=ROOT_USER)
         self.set_svr_sv_jobidnumber(0)
         self.submit_job(sleep=1000, job_id='0')
         self.submit_job(sleep=1000, lower=1, upper=2, job_id='1[]')

--- a/test/tests/functional/pbs_unset_exectime.py
+++ b/test/tests/functional/pbs_unset_exectime.py
@@ -60,8 +60,7 @@ else:
 """
         a = {'event': 'queuejob', 'enabled': 'True'}
         self.server.create_import_hook(hook_name, a, hook_body)
-        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
         j = Job(TEST_USER)
         self.server.submit(j)
         msg = "Error evaluating Python script, "

--- a/test/tests/interfaces/pbs_node_partition.py
+++ b/test/tests/interfaces/pbs_node_partition.py
@@ -63,7 +63,7 @@ class TestNodePartition(TestInterfaces):
         """
         attr = {'partition': partition}
         if mgr_cmd is "MGR_CMD_SET":
-            self.server.manager(MGR_CMD_SET, NODE, attr, id=n_name,runas=user)
+            self.server.manager(MGR_CMD_SET, NODE, attr, id=n_name, runas=user)
         elif mgr_cmd is "MGR_CMD_UNSET":
             self.server.manager(MGR_CMD_UNSET, NODE,
                                 "partition", id=n_name, runas=user)

--- a/test/tests/interfaces/pbs_node_partition.py
+++ b/test/tests/interfaces/pbs_node_partition.py
@@ -63,12 +63,10 @@ class TestNodePartition(TestInterfaces):
         """
         attr = {'partition': partition}
         if mgr_cmd is "MGR_CMD_SET":
-            self.server.manager(MGR_CMD_SET, NODE, attr,
-                                id=n_name, expect=True, runas=user)
+            self.server.manager(MGR_CMD_SET, NODE, attr, id=n_name,runas=user)
         elif mgr_cmd is "MGR_CMD_UNSET":
             self.server.manager(MGR_CMD_UNSET, NODE,
-                                "partition", id=n_name, expect=True,
-                                runas=user)
+                                "partition", id=n_name, runas=user)
         else:
             msg = ("Error: test_set_node_partition_attr function takes only "
                    "MGR_CMD_SET/MGR_CMD_UNSET value for mgr_cmd")
@@ -113,19 +111,15 @@ class TestNodePartition(TestInterfaces):
         """
         attr = {'queue_type': "execution", 'enabled': "True",
                 'started': "True", 'partition': "P1"}
-        self.server.manager(MGR_CMD_CREATE,
-                            QUEUE, attr,
-                            id="Q1", expect=True)
+        self.server.manager(MGR_CMD_CREATE, QUEUE, attr, id="Q1")
         self.set_node_partition_attr()
         attr = {'queue_type': "execution", 'enabled': "True",
                 'started': "True", 'partition': "P2"}
-        self.server.manager(MGR_CMD_CREATE,
-                            QUEUE, attr,
-                            id="Q2", expect=True)
+        self.server.manager(MGR_CMD_CREATE, QUEUE, attr, id="Q2")
 
         self.set_node_partition_attr(mgr_cmd="MGR_CMD_UNSET")
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': "Q2"}, id=self.host_name, expect=True)
+                            'queue': "Q2"}, id=self.host_name)
         self.set_node_partition_attr(partition="P2")
 
     def test_mismatch_of_partition_on_node_and_queue(self):

--- a/test/tests/interfaces/pbs_partition.py
+++ b/test/tests/interfaces/pbs_partition.py
@@ -84,8 +84,8 @@ class TestPartition(TestInterfaces):
                                     QUEUE, attr, id=name, runas=user)
             elif mgr_cmd == MGR_CMD_SET:
                 attr = {'partition': partition}
-                self.server.manager(MGR_CMD_SET, QUEUE, attr, id=name,
-                    runas=user)
+                self.server.manager(MGR_CMD_SET, QUEUE,
+                                    attr, id=name, runas=user)
             elif mgr_cmd == MGR_CMD_UNSET:
                 self.server.manager(MGR_CMD_UNSET, QUEUE,
                                     "partition", id=name, runas=user)

--- a/test/tests/interfaces/pbs_partition.py
+++ b/test/tests/interfaces/pbs_partition.py
@@ -81,21 +81,14 @@ class TestPartition(TestInterfaces):
                         'started': start,
                         'partition': partition}
                 self.server.manager(MGR_CMD_CREATE,
-                                    QUEUE, attr,
-                                    id=name, expect=True, runas=user)
+                                    QUEUE, attr, id=name, runas=user)
             elif mgr_cmd == MGR_CMD_SET:
                 attr = {'partition': partition}
-                self.server.manager(
-                    MGR_CMD_SET,
-                    QUEUE,
-                    attr,
-                    id=name,
-                    expect=True,
+                self.server.manager(MGR_CMD_SET, QUEUE, attr, id=name,
                     runas=user)
             elif mgr_cmd == MGR_CMD_UNSET:
                 self.server.manager(MGR_CMD_UNSET, QUEUE,
-                                    "partition", id=name, expect=True,
-                                    runas=user)
+                                    "partition", id=name, runas=user)
             else:
                 msg = ("Error: partition_attr function takes only "
                        "MGR_CMD_[CREATE/SET/UNSET] value for mgr_cmd when "
@@ -107,11 +100,10 @@ class TestPartition(TestInterfaces):
             attr = {'partition': partition}
             if mgr_cmd == MGR_CMD_SET:
                 self.server.manager(MGR_CMD_SET, NODE, attr,
-                                    id=name, expect=True, runas=user)
+                                    id=name, runas=user)
             elif mgr_cmd == MGR_CMD_UNSET:
                 self.server.manager(MGR_CMD_UNSET, NODE,
-                                    "partition", id=name, expect=True,
-                                    runas=user)
+                                    "partition", id=name, runas=user)
             else:
                 msg = ("Error: partition_attr function takes only "
                        "MGR_CMD_SET/MGR_CMD_UNSET value for mgr_cmd when "
@@ -256,8 +248,7 @@ class TestPartition(TestInterfaces):
             partition="P2")
         self.partition_attr(mgr_cmd=MGR_CMD_UNSET, obj_name="NODE")
         self.server.manager(MGR_CMD_SET, NODE, {
-                            'queue': "Q2"}, id=self.server.shortname,
-                            expect=True)
+                            'queue': "Q2"}, id=self.server.shortname)
         self.partition_attr(obj_name="NODE", partition="P2")
 
     def test_mismatch_of_partition_on_node_and_queue(self):

--- a/test/tests/interfaces/pbs_preempt_params.py
+++ b/test/tests/interfaces/pbs_preempt_params.py
@@ -98,8 +98,7 @@ class TestPreemptParamsQmgr(TestInterfaces):
                             runas=ROOT_USER)
 
         a = {param: 150}
-        self.server.manager(MGR_CMD_LIST, SCHED, a,
-                            expect=True, runas=ROOT_USER)
+        self.server.manager(MGR_CMD_LIST, SCHED, a, runas=ROOT_USER)
 
     def test_set_unset_preempt_prio(self):
         """
@@ -128,16 +127,14 @@ class TestPreemptParamsQmgr(TestInterfaces):
 
         p = 'starving_jobs, normal_jobs, starving_jobs+fairshare,fairshare'
         a = {param: p}
-        self.server.manager(MGR_CMD_LIST, SCHED, a,
-                            expect=True, runas=ROOT_USER)
+        self.server.manager(MGR_CMD_LIST, SCHED, a, runas=ROOT_USER)
 
         self.server.manager(MGR_CMD_UNSET, SCHED, param,
                             runas=ROOT_USER)
 
         p = 'express_queue, normal_jobs'
         a = {param: p}
-        self.server.manager(MGR_CMD_LIST, SCHED, a,
-                            expect=True, runas=ROOT_USER)
+        self.server.manager(MGR_CMD_LIST, SCHED, a, runas=ROOT_USER)
 
     def test_set_unset_preempt_order(self):
         """
@@ -174,8 +171,7 @@ class TestPreemptParamsQmgr(TestInterfaces):
 
         self.server.manager(MGR_CMD_UNSET, SCHED, param, runas=ROOT_USER)
 
-        self.server.manager(MGR_CMD_LIST, SCHED, a,
-                            expect=True, runas=ROOT_USER)
+        self.server.manager(MGR_CMD_LIST, SCHED, a, runas=ROOT_USER)
 
     def test_set_unset_preempt_sort(self):
         """
@@ -199,5 +195,4 @@ class TestPreemptParamsQmgr(TestInterfaces):
         self.server.manager(MGR_CMD_SET, SCHED, a, runas=ROOT_USER)
 
         self.server.manager(MGR_CMD_UNSET, SCHED, param, runas=ROOT_USER)
-        self.server.manager(MGR_CMD_LIST, SCHED, a,
-                            expect=False, runas=ROOT_USER)
+        self.server.manager(MGR_CMD_LIST, SCHED, a, runas=ROOT_USER)

--- a/test/tests/interfaces/pbs_sched_interface_test.py
+++ b/test/tests/interfaces/pbs_sched_interface_test.py
@@ -139,12 +139,9 @@ class TestSchedulerInterface(TestInterfaces):
                 self.assertTrue(
                     'qmgr: Error (15007) returned from server' in e.msg[1])
 
-        self.server.manager(MGR_CMD_SET,
-                            SCHED,
+        self.server.manager(MGR_CMD_SET, SCHED,
                             {'sched_cycle_length': 12000},
-                            id="TestCommonSched",
-                            runas=ROOT_USER,
-                            expect=True)
+                            id="TestCommonSched", runas=ROOT_USER)
 
     def test_delete_default_sched(self):
         """
@@ -164,11 +161,8 @@ class TestSchedulerInterface(TestInterfaces):
         Set and unset an attribute of a scheduler object .
         """
         # Set an attribute of a scheduler object.
-        self.server.manager(MGR_CMD_SET,
-                            SCHED,
-                            {'sched_cycle_length': 1234},
-                            id="TestCommonSched",
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'sched_cycle_length': 1234}, id="TestCommonSched")
 
         # Unset an attribute of a scheduler object.
         self.server.manager(MGR_CMD_UNSET,

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -165,8 +165,7 @@ class SmokeTest(PBSTestSuite):
         """
         Test to alter job
         """
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
@@ -192,8 +191,7 @@ class SmokeTest(PBSTestSuite):
         Test for backfilling
         """
         a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         self.scheduler.set_sched_config({'strict_ordering': 'True'})
         a = {'Resource_List.select': '1:ncpus=1',
              'Resource_List.walltime': 3600}
@@ -249,7 +247,7 @@ class SmokeTest(PBSTestSuite):
         except PbsManagerError:
             pass
         a = {'queue_type': 'Execution', 'enabled': 'True', 'started': 'True'}
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, qname, expect=True)
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, qname)
         self.server.manager(MGR_CMD_DELETE, QUEUE, id=qname)
 
     def test_create_routing_queue(self):
@@ -262,7 +260,7 @@ class SmokeTest(PBSTestSuite):
         except PbsManagerError:
             pass
         a = {'queue_type': 'Route', 'started': 'True'}
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, qname, expect=True)
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, qname)
         self.server.manager(MGR_CMD_DELETE, QUEUE, id=qname)
 
     @skipOnCpuSet
@@ -294,7 +292,7 @@ class SmokeTest(PBSTestSuite):
         a = {'resources_available.ncpus': 4}
         self.server.create_vnodes('lt', a, 2, self.mom)
         a = {'max_run_res.ncpus': '[u:' + str(TEST_USER) + '=1]'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         for _ in range(3):
             j = Job(TEST_USER)
             self.server.submit(j)
@@ -309,10 +307,9 @@ class SmokeTest(PBSTestSuite):
         Test for finished jobs
         """
         a = {'resources_available.ncpus': '4'}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         a = {'job_history_enable': 'True'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'Resource_List.walltime': '10', ATTR_k: 'oe'}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(5)
@@ -326,7 +323,7 @@ class SmokeTest(PBSTestSuite):
         """
         proj = 'testproject'
         a = {'max_run': '[p:' + proj + '=1]'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         for _ in range(5):
             j = Job(TEST_USER, attrs={ATTR_project: proj})
             self.server.submit(j)
@@ -339,21 +336,20 @@ class SmokeTest(PBSTestSuite):
         Test for job scheduling order
         """
         a = {'backfill_depth': 5}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         self.scheduler.set_sched_config({'strict_ordering': 'True'})
         a = {'resources_available.ncpus': '1'}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         a = {'state=free': 1}
         self.server.expect(VNODE, a, attrop=PTL_AND)
         a = {'scheduling': 'False'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         for _ in range(6):
             j = Job(TEST_USER, attrs={'Resource_List.select': '1:ncpus=1',
                                       'Resource_List.walltime': 3600})
             self.server.submit(j)
         a = {'scheduling': 'True'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'server_state': 'Scheduling'}
         self.server.expect(SERVER, a, op=NE)
         self.server.expect(JOB, {'estimated.start_time': 5},
@@ -367,8 +363,7 @@ class SmokeTest(PBSTestSuite):
         a = {'log_filter': 2048}
         self.scheduler.set_sched_config(a)
         a = {'resources_available.ncpus': '1'}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         self.server.status(QUEUE)
         if 'expressq' in self.server.queues.keys():
             self.server.manager(MGR_CMD_DELETE, QUEUE, None, 'expressq')
@@ -460,8 +455,7 @@ class SmokeTest(PBSTestSuite):
         hook_body = "import pbs\npbs.event().reject('my custom message')\n"
         a = {'event': 'queuejob', 'enabled': 'True'}
         self.server.create_import_hook(hook_name, a, hook_body)
-        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047},
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
         j = Job(TEST_USER)
         now = int(time.time())
         try:
@@ -537,11 +531,10 @@ class SmokeTest(PBSTestSuite):
         Test for job sort formula
         """
         a = {'resources_available.ncpus': 8}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         self.scheduler.set_sched_config({'log_filter': '2048'})
         a = {'job_sort_formula': 'ncpus'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         # purposely submitting a job that is highly unlikely to run so
         # it stays Q'd
         j = Job(TEST_USER, attrs={'Resource_List.select': '1:ncpus=128'})
@@ -626,8 +619,7 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, SERVER, a)
         self.scheduler.set_sched_config({'by_queue': 'True'})
         a = {'resources_available.ncpus': 8}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         a = {'Resource_List.select': '1:ncpus=1', ATTR_queue: 'p1'}
         j = Job(TEST_USER, a)
         j1id = self.server.submit(j)
@@ -647,9 +639,9 @@ class SmokeTest(PBSTestSuite):
         j = Job(TEST_USER, a)
         j6id = self.server.submit(j)
         a = {'scheduling': 'True'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'scheduling': 'False'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         # Given node configuration of 8 cpus the only jobs that could run are
         # j4id j1id and j3id
         self.server.expect(JOB, {'job_state=R': 3})
@@ -684,8 +676,7 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, SERVER, a)
         self.scheduler.set_sched_config({'round_robin': 'true   ALL'})
         a = {'resources_available.ncpus': 9}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname,
-                            expect=True)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         jids = []
         queues = ['p1', 'p2', 'p3']
         queue = queues[0]
@@ -915,7 +906,7 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         a = {'job_sort_formula':
              'ceil(fabs(-ncpus*(mem/100.00)*sqrt(walltime)))'}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'job_sort_formula_threshold': '7'}
         self.server.manager(MGR_CMD_SET, SCHED, a)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
@@ -1283,7 +1274,7 @@ class SmokeTest(PBSTestSuite):
                 self.assertNotEqual(jid, None)
             else:
                 self.server.manager(MGR_CMD_SET, obj_type, {ar: val},
-                                    id=obj_id, expect=True)
+                                    id=obj_id)
             try:
                 rc = self.server.manager(MGR_CMD_DELETE, RSC, id=r,
                                          logerr=False)

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -71,10 +71,10 @@ exit 0
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, 'workq2')
 
         a = {'max_run_res_soft.ncpus': "[u:PBS_GENERIC=2]"}
-        self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq', expect=True)
+        self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq')
 
         a = {'max_run_res.mem': "[u:" + str(TEST_USER) + "=1500mb]"}
-        self.server.manager(MGR_CMD_SET, SERVER, a, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'Resource_List.select': '1:ncpus=3:mem=90mb',
              'Resource_List.walltime': 9999}
@@ -89,7 +89,7 @@ exit 0
             self.server.submit(j)
 
         sched_off = {'scheduling': 'False'}
-        self.server.manager(MGR_CMD_SET, SERVER, sched_off, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, sched_off)
 
         a = {'Resource_List.select': '1:ncpus=3',
              'Resource_List.walltime': 9999}
@@ -104,7 +104,7 @@ exit 0
             self.server.submit(j)
 
         sched_on = {'scheduling': 'True'}
-        self.server.manager(MGR_CMD_SET, SERVER, sched_on, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, sched_on)
 
         self.server.expect(JOB, {'job_state=R': 1590},
                            offset=15, interval=20)
@@ -150,8 +150,7 @@ exit 0
         self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
         p = '"express_queue, normal_jobs, server_softlimits, queue_softlimits"'
         a = {'preempt_prio': p}
-        self.server.manager(MGR_CMD_SET, SCHED, a, expect=True,
-                            runas=ROOT_USER)
+        self.server.manager(MGR_CMD_SET, SCHED, a, runas=ROOT_USER)
 
         self.create_workload_and_preempt()
 
@@ -168,8 +167,7 @@ exit 0
         self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
         p = '"express_queue, normal_jobs, server_softlimits, queue_softlimits"'
         a = {'preempt_prio': p}
-        self.server.manager(MGR_CMD_SET, SCHED, a, expect=True,
-                            runas=ROOT_USER)
+        self.server.manager(MGR_CMD_SET, SCHED, a, runas=ROOT_USER)
 
         self.create_workload_and_preempt()
 
@@ -211,7 +209,7 @@ exit 0
         # Add qlist to the resources scheduler checks for
         self.scheduler.add_resource('qlist')
         self.server.manager(MGR_CMD_UNSET, SCHED, 'preempt_sort',
-                            expect=False, runas=ROOT_USER)
+                            runas=ROOT_USER)
 
         jid = self.server.submit(j)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
@@ -300,7 +298,7 @@ exit 0
         # Add qlist to the resources scheduler checks for
         self.scheduler.add_resource('qlist')
         self.server.manager(MGR_CMD_UNSET, SCHED, 'preempt_sort',
-                            expect=True, runas=ROOT_USER)
+                            runas=ROOT_USER)
 
         jid = self.server.submit(j)
         jid2 = self.server.submit(j2)
@@ -374,7 +372,7 @@ exit 0
         # Add foo to the resources scheduler checks for
         self.scheduler.add_resource('foo')
         self.server.manager(MGR_CMD_UNSET, SCHED, 'preempt_sort',
-                            expect=True, runas=ROOT_USER)
+                            runas=ROOT_USER)
 
         a = {ATTR_l + '.select': '1:ncpus=1', ATTR_l + '.foo': 25}
         j = Job(TEST_USER, attrs=a)

--- a/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
+++ b/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
@@ -62,11 +62,9 @@ class JobRerunFileTransferPerf(TestPerformance):
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
 
-        self.server.manager(MGR_CMD_SET, SERVER,
-                            {'log_events': 4095}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 4095})
 
-        self.server.manager(MGR_CMD_SET, SERVER,
-                            {'job_requeue_timeout': 1000}, expect=True)
+        self.server.manager(MGR_CMD_SET, SERVER, {'job_requeue_timeout': 1000})
 
     @timeout(600)
     def test_huge_job_file(self):

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -46,8 +46,7 @@ class TestSchedPerf(TestPerformance):
     def setUp(self):
         TestPerformance.setUp(self)
         self.server.manager(MGR_CMD_CREATE, RSC,
-                            {'type': 'string', 'flag': 'h'}, id='color',
-                            expect=True)
+                            {'type': 'string', 'flag': 'h'}, id='color')
         self.colors = \
             ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet']
         a = {'resources_available.ncpus': 1, 'resources_available.mem': '8gb'}
@@ -76,7 +75,7 @@ class TestSchedPerf(TestPerformance):
         jids = []
 
         self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
-                            {'scheduling': 'False'}, expect=True)
+                            {'scheduling': 'False'})
 
         for i in range(num):
             job_wt = wt_start + (i * step)
@@ -97,7 +96,7 @@ class TestSchedPerf(TestPerformance):
                             {'scheduling': 'True'})
         self.server.expect(SERVER, {'server_state': 'Scheduling'})
         self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
-                            {'scheduling': 'False'}, expect=True)
+                            {'scheduling': 'False'})
 
         # 600 * 2sec = 20m which is the max cycle length
         self.server.expect(SERVER, {'server_state': 'Scheduling'}, op=NE,
@@ -122,7 +121,7 @@ class TestSchedPerf(TestPerformance):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid_yellow)
 
         self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
-                            {'scheduling': 'False'}, expect=True)
+                            {'scheduling': 'False'})
 
         # Shared jobs use standard code path
         a = {'Resource_List.select':

--- a/test/tests/selftest/pbs_expect.py
+++ b/test/tests/selftest/pbs_expect.py
@@ -57,7 +57,7 @@ class TestExpect(TestSelf):
         # Set the Priority attribute on the queue but provide 'p' lowercase
         # Set other attributes normally
         a = {'enabled': 'True', 'started': 'True', 'priority': 150}
-        self.server.manager(MGR_CMD_SET, QUEUE, a, 'expressq', expect=True)
+        self.server.manager(MGR_CMD_SET, QUEUE, a, 'expressq')
 
     def test_unsupported_operator(self):
         """

--- a/test/tests/selftest/pbs_expect.py
+++ b/test/tests/selftest/pbs_expect.py
@@ -58,6 +58,7 @@ class TestExpect(TestSelf):
         # Set other attributes normally
         a = {'enabled': 'True', 'started': 'True', 'priority': 150}
         self.server.manager(MGR_CMD_SET, QUEUE, a, 'expressq')
+        self.server.expect(QUEUE, a, id='expressq')
 
     def test_unsupported_operator(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* PTL's manager() call has an argument called expect.  It was thought that if you set it to true, it would make sure your values were set properly.  All it was really doing was checking if the values are set to anything.  This functionality was not all that useful to begin with.  An exception is raised if manager() fails.  We should trust PBS to correctly set the value if it succeeds.

It also tried to wait until a scheduling cycle ended if you set scheduling=False.  It wouldn't work properly because it tried to check if server_state != scheduling.  Since op=SET instead of op=EQ, it only really checked if server_state was set.  Which it was, it was set to 'scheduling'

#### Cause / Analysis / Design
manager() was passing op=SET into expect() instead of op=EQ.  We can't just change this to op=EQ since there are many ways the server morphs the input to different output (e.g. queue_type=e turns into Execution or scheduling=1 turns into scheduling=True).

#### Solution Description
Remove the call expect and max_attempts arguments and the call to expect() except for scheduling=False.  When scheduling is set to False, we wait for the cycle to end.  Since a cycle can take up to 20m, max_attempts is set to 1200 and interval is set to 1.

Forum Discussion: http://community.pbspro.org/t/ptl-manager-with-expect-true/1427/28

#### Testing logs/output
[manager_test.log](https://github.com/PBSPro/pbspro/files/2973262/manager_test.log)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
