### PR TITLE
session of postmaster is same as the shell triggering pbs start

### DIFF
--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -258,13 +258,13 @@ start_dataservice() {
 			if [ -n "$NASMODE" ] ; then
 				su - ${PGUSR} -s /bin/sh -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -W start -l $log_file > /dev/null'"
 			else
-				su - ${PGUSR} -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -W start -l $log_file > /dev/null'"
+				su - ${PGUSR} -c "/bin/sh -c '${PGSQL_LIBSTR} setsid ${PG_CTL} -o \"-p ${PGPORT}\" -W start -l $log_file > /dev/null'"
 			fi
 		else
 			if [ -n "$NASMODE" ] ; then
 				su - ${PGUSR} -s /bin/sh -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -w start -l $log_file > /dev/null'"
 			else
-				su - ${PGUSR} -c "/bin/sh -c '${PGSQL_LIBSTR} ${PG_CTL} -o \"-p ${PGPORT}\" -w start -l $log_file > /dev/null'"
+				su - ${PGUSR} -c "/bin/sh -c '${PGSQL_LIBSTR} setsid ${PG_CTL} -o \"-p ${PGPORT}\" -w start -l $log_file > /dev/null'"
 			fi
 		fi
 		ret=$?


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
Postgres processes started by PBS init script is getting killed when the shell started the init script is killed 

#### Affected Platform(s)
* *SLES11*

#### Cause / Analysis / Design
* session id of postmaster process in sles11 is the same as that of the parent triggering the installation/start. There by it is getting killed when the session it has initiated dies.

* postgres 9.3 is also getting killed when session gets killed but the writer process continues to exists which will write data to pbs database and everything will look normal. Where as in 9.6 all the children are also getting killed along with postmaster.

* Inorder to avoid this we are already launching postmaster in a different shell process. However this is not working in sles11.

#### Solution Description
* *The situation can be avoided by launching postmaster using setsid.*

#### Testing logs/output
[rhel7_log.txt](https://github.com/PBSPro/pbspro/files/2981671/rhel7_log.txt)
[sles12_Cray_logs.txt](https://github.com/PBSPro/pbspro/files/2981672/sles12_Cray_logs.txt)
[test_logs.txt](https://github.com/PBSPro/pbspro/files/2981673/test_logs.txt)
[pbs_dataservice in async mode.txt](https://github.com/PBSPro/pbspro/files/2981731/pbs_dataservice.in.async.mode.txt)



* *Steps:*
* start pbs using `/etc/init.d/pbs start`
* check the session id of postmaster using `ps -o sid pid` command
* check processes having same sessions using `ps -s sid` command and make sure the shell which has spawned postgres processes is not one of them.

* PTL test case is not added as it is a rare scenario.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
