### PR TITLE
Strict ordering does not work if backfill_depth on queue is 0

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1071,6 +1071,10 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 				set_schd_error_arg(err, SPECMSG, "Job would conflict with starving job");
 				update_jobs_cant_run(sd, sinfo->jobs, NULL, err, START_WITH_JOB);
 			}
+			else if (policy->backfill && policy->strict_ordering && qinfo->backfill_depth == 0) {
+				set_schd_error_codes(err, NOT_RUN, STRICT_ORDERING);
+				update_jobs_cant_run(sd, qinfo->jobs, NULL, err, START_WITH_JOB);
+			}
 		}
 
 		time(&cur_time);

--- a/test/tests/functional/pbs_strict_ordering.py
+++ b/test/tests/functional/pbs_strict_ordering.py
@@ -54,8 +54,8 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
 
         rv = self.scheduler.set_sched_config(
-            {'round_robin': 'false all', 'by_queue': 'false prime',
-             'by_queue': 'false non_prime', 'strict_ordering': 'true all',
+            {'round_robin': 'false all', 'by_queue': 'false all',
+             'strict_ordering': 'true all',
              'help_starving_jobs': 'false all'})
         self.assertTrue(rv)
 
@@ -97,8 +97,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
 
     def test_t2(self):
         rv = self.scheduler.set_sched_config(
-            {'by_queue': 'false prime', 'by_queue': 'false non_prime',
-             'strict_ordering': 'true all'})
+            {'by_queue': 'false prime', 'strict_ordering': 'true all'})
         self.assertTrue(rv)
         a = {'backfill_depth': 2}
         self.server.manager(
@@ -164,3 +163,104 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
                            id=j5id,
                            max_attempts=30,
                            interval=2)
+
+    def test_zero_backfill_depth_on_queue(self):
+        """
+        Test if scheduler tries to run a job when strict ordering is enabled
+        and backfill_depth is set to 0 on the queue
+        """
+        a = {'resources_available.ncpus': 1}
+        self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
+
+        rv = self.scheduler.set_sched_config(
+            {'round_robin': 'false all', 'by_queue': 'false all',
+             'strict_ordering': 'true all',
+             'help_starving_jobs': 'false all'})
+        self.assertTrue(rv)
+
+        a = {'backfill_depth': 0}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id="workq")
+
+        a = {'scheduling': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        a = {'Resource_List.select': '1:ncpus=1'}
+        j1 = Job(TEST_USER)
+        j1.set_attributes(a)
+        self.server.submit(j1)
+
+        j2 = Job(TEST_USER)
+        j2.set_attributes(a)
+        self.server.submit(j2)
+
+        j3 = Job(TEST_USER)
+        j3.set_attributes(a)
+        jid3 = self.server.submit(j3)
+
+        a = {'scheduling': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        job_comment = "Not Running: Job would break strict sorted order"
+        self.server.expect(JOB, {'comment': job_comment}, id=jid3, offset=2,
+                           max_attempts=2, interval=2)
+
+    def test_zero_backfill_depth_on_one_queue(self):
+        """
+        Test if scheduler tries to run a job when strict ordering is enabled
+        and backfill_depth is set to 0 on one queue but backfill_depth is
+        enabled on another queue.
+        """
+        a = {'resources_available.ncpus': 1}
+        self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
+
+        rv = self.scheduler.set_sched_config(
+            {'round_robin': 'false all', 'by_queue': 'false all',
+             'strict_ordering': 'true all',
+             'help_starving_jobs': 'false all'})
+        self.assertTrue(rv)
+
+        a = {'backfill_depth': 0}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id="workq")
+
+        a = {'queue_type': 'execution', 'started': 'True', 'enabled': 'True',
+             'priority': '100'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id="workq2")
+
+        a = {'backfill_depth': 1}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id="workq2")
+
+        a = {'scheduling': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        a = {'Resource_List.select': '1:ncpus=1'}
+        j1 = Job(TEST_USER)
+        j1.set_attributes(a)
+        self.server.submit(j1)
+
+        j2 = Job(TEST_USER)
+        j2.set_attributes(a)
+        self.server.submit(j2)
+
+        j3 = Job(TEST_USER)
+        j3.set_attributes(a)
+        jid3 = self.server.submit(j3)
+
+        a = {'Resource_List.select': '1:ncpus=1', 'queue': 'workq2'}
+        j4 = Job(TEST_USER)
+        j4.set_attributes(a)
+        jid4 = self.server.submit(j4)
+
+        j5 = Job(TEST_USER)
+        j5.set_attributes(a)
+        self.server.submit(j5)
+
+        j6 = Job(TEST_USER)
+        j6.set_attributes(a)
+        self.server.submit(j6)
+
+        a = {'scheduling': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        job_comment = "Not Running: Job would break strict sorted order"
+        self.server.expect(JOB, {'comment': job_comment}, id=jid3, offset=2,
+                           max_attempts=2, interval=2)
+        self.scheduler.log_match(jid4 + ";Job is a top job")

--- a/test/tests/functional/pbs_strict_ordering.py
+++ b/test/tests/functional/pbs_strict_ordering.py
@@ -169,7 +169,7 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         Test if scheduler tries to run a job when strict ordering is enabled
         and backfill_depth is set to 0 on the queue
         """
-        a = {'resources_available.ncpus': 1}
+        a = {'resources_available.ncpus': 2}
         self.server.create_vnodes('vn', a, 1, self.mom, usenatvnode=True)
 
         rv = self.scheduler.set_sched_config(
@@ -187,12 +187,14 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         a = {'Resource_List.select': '1:ncpus=1'}
         j1 = Job(TEST_USER)
         j1.set_attributes(a)
-        self.server.submit(j1)
+        jid1 = self.server.submit(j1)
 
+        a = {'Resource_List.select': '1:ncpus=2'}
         j2 = Job(TEST_USER)
         j2.set_attributes(a)
-        self.server.submit(j2)
+        jid2 = self.server.submit(j2)
 
+        a = {'Resource_List.select': '1:ncpus=1'}
         j3 = Job(TEST_USER)
         j3.set_attributes(a)
         jid3 = self.server.submit(j3)
@@ -203,6 +205,42 @@ class TestStrictOrderingAndBackfilling(TestFunctional):
         job_comment = "Not Running: Job would break strict sorted order"
         self.server.expect(JOB, {'comment': job_comment}, id=jid3, offset=2,
                            max_attempts=2, interval=2)
+
+        # Now try the same scenario with backfilling set to one and check
+        # that first and third job runs but second gets calendared.
+        # since we want thrid job to backfill around second, we need to make
+        # sure that walltime of third job is less than the walltime of first
+        # job
+        a = {'scheduling': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.server.deljob([jid1, jid2, jid3])
+
+        a = {'backfill_depth': 1}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id="workq")
+
+        a = {'Resource_List.select': '1:ncpus=1',
+             'Resource_List.walltime': '100'}
+        j4 = Job(TEST_USER)
+        j4.set_attributes(a)
+        jid4 = self.server.submit(j4)
+
+        a = {'Resource_List.select': '1:ncpus=2'}
+        j5 = Job(TEST_USER)
+        j5.set_attributes(a)
+        jid5 = self.server.submit(j5)
+
+        a = {'Resource_List.select': '1:ncpus=1',
+             'Resource_List.walltime': '50'}
+        j6 = Job(TEST_USER)
+        j6.set_attributes(a)
+        jid6 = self.server.submit(j6)
+
+        a = {'scheduling': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid6)
+        self.scheduler.log_match(jid5 + ";Job is a top job")
 
     def test_zero_backfill_depth_on_one_queue(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
When strict_ordering is true and backfill_depth is set to 0, the scheduler should stop considering jobs to run when it can't run one.  This means it will run as many jobs as it can until it can't run one.  It will then end the cycle. 
This does not happen if backfill_depth on a queue is set to 0.

#### Affected Platform(s)
All

#### Cause / Analysis / Design
When backfill is enabled but backfill_depth on a queue is set to 0  and strict ordering is enabled, we do not mark the jobs in that queue as can-not-run. This results into considering all the jobs of the queue one after another.

#### Solution Description
When strict_ordering is true and backfill_depth on a queue is set to 0, mark all the jobs of that queue as can-not-run.


#### Testing logs/output
[test_strict_ordering.txt](https://github.com/PBSPro/pbspro/files/2985871/test_strict_ordering.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
