### PR TITLE
Bugfix: reading version correctly from multiline output of psql -V

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -240,7 +240,7 @@ upgrade_pbs_database() {
 		return 1
 	fi
 	
-	sys_pgsql_ver=$(echo `${PGSQL_DIR}/bin/psql -V` | awk 'NR==1 {print $NF}' | cut -d '.' -f 1,2)
+	sys_pgsql_ver=$(echo `${PGSQL_DIR}/bin/psql -V | awk 'NR==1 {print $NF}'` | cut -d '.' -f 1,2)
 	old_pgsql_ver=`cat ${data_dir}/PG_VERSION`
 
 	[ ${sys_pgsql_ver%.*} -eq ${old_pgsql_ver%.*} ] && [ ${sys_pgsql_ver#*.} \> ${old_pgsql_ver#*.} ] || [ ${sys_pgsql_ver%.*} -gt ${old_pgsql_ver%.*} ];


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/fix Description
RHEL/CentOS 6 is shipped with PostgreSQL 8, which outputs multiple lines when queried for version using `psql -v`. This fix corrects the behavior for reading the version in that case.

#### Steps to Reproduce
* Update from pbspro-ce 14.1.2 to 18.1.2 in CentOS/RHEL 6.
* Start pbs service, it fails at pbs_habitat script: 
   ```
    [root@foo ~]# service pbs start
    Starting PBS
    PBS Home directory /.../pbspro-ce/var/spool needs updating.
    Running /.../pbspro-ce/current/libexec/pbs_habitat to update it.
    ***
    /.../pbspro-ce/current/libexec/pbs_habitat: line 246: [: editing: integer expression expected
    /.../pbspro-ce/current/libexec/pbs_habitat: line 246: [: editing: integer expression expected
    Upgrade from version 8.4 unsupported
    Failed to upgrade PBS Datastore
    [root@foo ~]# psql -V
    psql (PostgreSQL) 8.4.20
    contains support for command-line editing
    [root@foo ~]# cat /etc/redhat-release
    CentOS release 6.10 (Final)
    ```

#### Affected Platform(s)
* CentOS/RHEL 6

#### Cause / Analysis / Design
* echo, when provided a command output, converts multiple lines into one line. This causes the script to read the wrong token as the version. 
* Simply moving the backtick (as suggested by this PR) will cause `psql -V` output to pipe to `awk`, which in turn will read the correct version token from the first line only.
* The fix also covers the scenario when there's only one line outputted by `psql -V`.
* I believe this script is out of the scope of PTL, so no PTL test case was written.

#### Solution Description
* Simply, read the version from the first line of `psql -V` output, no matter how many lines are there.

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [X] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [X] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.

[ptl_output.txt](https://github.com/PBSPro/pbspro/files/2988684/ptl_output.txt) (2 errors even in unchanged code)