### PR TITLE
Fixed race condition in test_pbsfs

### DIFF
--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -313,11 +313,8 @@ class TestFairshare(TestFunctional):
         J2 = Job(TEST_USER1)
         jid2 = self.server.submit(J2)
 
-        t = int(time.time())
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-
-        self.scheduler.log_match('Leaving Scheduling Cycle', starttime=t,
-                                 max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
         c = self.scheduler.cycles(lastN=1)[0]
         job_order = [jid2, jid1]
@@ -328,9 +325,13 @@ class TestFairshare(TestFunctional):
         self.server.deljob(id=jid2, wait=True)
         self.scheduler.revert_to_defaults()
 
+        # revert_to_defaults() will set the default scheduler's scheduling
+        # back to true.  Need to turn it off again
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+
         # Set TEST_USER1 to 50.  If revert_to_defaults() has affected the
         # scheduler's view of the fairshare usage, it's the only entity with
-        # usage.  It's job will run second.  If revert_to_defaults() did
+        # usage.  Its job will run second.  If revert_to_defaults() did
         # nothing, 50 is less than 100, so TEST_USER1's job will run first
         self.scheduler.add_to_resource_group(TEST_USER, 11, 'root', 10)
         self.scheduler.add_to_resource_group(TEST_USER1, 12, 'root', 10)
@@ -338,17 +339,13 @@ class TestFairshare(TestFunctional):
 
         self.scheduler.set_fairshare_usage(TEST_USER1, 50)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         J3 = Job(TEST_USER)
         jid3 = self.server.submit(J3)
         J4 = Job(TEST_USER1)
         jid4 = self.server.submit(J4)
 
-        t = int(time.time())
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-
-        self.scheduler.log_match('Leaving Scheduling Cycle', starttime=t,
-                                 max_attempts=10)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
         c = self.scheduler.cycles(lastN=1)[0]
         job_order = [jid3, jid4]


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* This test had a race condition because it did the following:
1) Run a cycle
2) wait for the cycle to finish by looking in the log for the 'Leaving scheduling cycle' message
3) Look at the order of jobs that ran in the last cycle.
--> One ran, one didn't.

#### Cause / Analysis / Design
The race condition is that a second cycle can run after 2 and before 3.  Since one job is running, only the second job is considered in the new cycle.

#### Solution Description
What needed to happen is to turn scheduling false immediately after turning scheduling to true.  Now that PTL will wait for the cycle to finish when you turn scheduling to false, this should remove the race condition.

#### Testing logs/output
[pbsfs.log](https://github.com/PBSPro/pbspro/files/2994381/pbsfs.log)
