### PR TITLE
Revert Mom configuration settings to defaults in setUp

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -12907,6 +12907,8 @@ class MoM(PBSService):
                     return False
                 self.delete_vnodes()
             if cmp(self.config, self.dflt_config) != 0:
+                # Clear older mom configuration. Apply default.
+                self.config = {}
                 self.apply_config(self.dflt_config, hup=False, restart=False)
             if restart:
                 self.restart()

--- a/test/tests/selftest/pbs_pbstestsuite.py
+++ b/test/tests/selftest/pbs_pbstestsuite.py
@@ -268,3 +268,22 @@ class TestPBSTestSuite(TestSelf):
         # Confirm that the variable was set again
         pbs_conf_val = self.du.parse_pbs_config(self.server.hostname)
         self.assertIn("PBS_CORE_LIMIT", pbs_conf_val)
+
+    def test_revert_moms_default_conf(self):
+        """
+        Test if PBSTestSuite.revert_moms() reverts the mom configuration
+        setting to defaults
+        """
+        c1 = self.mom.parse_config()
+        # Save a copy of default config to check it was reverted
+        # correctly later
+        c2 = c1.copy()
+
+        a = {'$prologalarm': '280'}
+        self.mom.add_config(a)
+        c1.update(a)
+        self.assertEqual(self.mom.parse_config(), c1)
+        self.mom.revert_to_defaults()
+
+        # Make sure the default config is back
+        self.assertEqual(self.mom.parse_config(), c2)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
PTL_framework doesn't revert default mom configuration file as part of setUp. As a result, when multiple tests are run,  tests run with non-default mom configuration (when the previous test added a new mom configuration). This leads to the test failures.
[PP-1225](https://pbspro.atlassian.net/browse/PP-1225)

#### Affected Platform(s)
All Linux

#### Cause / Analysis / Design
mom.revert_to_defaults() does not clear the older config before applying the default mom configuration.

#### Solution Description
Clear the older mom configuration in mom.revert_to_defaults() before calling apply_config() to set the default mom configuration 

#### Testing logs/output
[beforefix.txt](https://github.com/PBSPro/pbspro/files/3005334/beforefix.txt)
~~[afterfix.txt](https://github.com/PBSPro/pbspro/files/3005335/afterfix.txt)~~

[afterfix.txt](https://github.com/PBSPro/pbspro/files/3005945/afterfix.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__