### PR TITLE
PBS Installation fails on Open SUSE Leap 15.0 with libical dependency

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -137,16 +137,12 @@ Requires: tcl
 Requires: tk
 %if %{defined suse_version}
 Requires: smtp_daemon
-%if %{suse_version} >= 1500
-Requires: libical3
-Requires: hostname
-%else
-Requires: libical1
-%endif
 %else
 Requires: smtpdaemon
 Requires: libical
 %endif
+Requires: hostname
+Requires: libical
 Autoreq: 1
 
 %description %{pbs_server}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
PBS 18.1.4 fails installation on opensuse 15 due to wrong libical dependency listed in pbspro.spec

#### Affected Platform(s)
* *Opensuse 15*

#### Cause / Analysis / Design

- There's a requirement in pbspro.spec file file suse version > 1500 for libical3.
- OpenSUSE Leap 15.0 comes up with libical2 which was installed as part of libical-devel package

#### Solution Description
* *Made a generic rule in pbspro.spec file*

#### Testing logs/output
[install.log](https://github.com/PBSPro/pbspro/files/3010190/install.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [ ] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
