### PR TITLE
Overlay upgrade fails due to failure in PBS datastore upgrade on SLES 12 & SLES 15

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -184,8 +184,13 @@ utf8_to_sql_ascii() {
 		fi
 	fi
 
-	locale=`${PGSQL_INST_DIR}/bin/psql -A -t -p ${PBS_DATA_SERVICE_PORT} -d pbs_datastore -U ${PBS_DATA_SERVICE_USER} -c "SHOW LC_COLLATE"`
-	if [ ! -z ${locale} -a ${locale} != "C" ]; then
+	locale_collate=`${PGSQL_INST_DIR}/bin/psql -A -t -p ${PBS_DATA_SERVICE_PORT} -d pbs_datastore -U ${PBS_DATA_SERVICE_USER} -c "SHOW LC_COLLATE"`
+	if [ ! -z ${locale_collate} -a ${locale_collate} != "C" ]; then
+		change_locale=1
+	fi
+
+	locale_ctype=`${PGSQL_INST_DIR}/bin/psql -A -t -p ${PBS_DATA_SERVICE_PORT} -d pbs_datastore -U ${PBS_DATA_SERVICE_USER} -c "SHOW LC_CTYPE"`
+	if [ ! -z ${locale_ctype} -a ${locale_ctype} != "C" ]; then
 		change_locale=1
 	fi
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Problem description
Issue while performing overlay upgrade from 18.*.* to 19.*.* in SLES 12 & SLES 15 platforms only.
Upgrades on rest of the GNU/Linux platforms are working fine.

#### Cause / Analysis
Database related scripts are checking only the LC_COLLATE type, not checking the LC_CTYPE of the older DB instance. Thus the difference in DB instance attributes, pg_upgrade fails to upgrade.
The cause for this issue observed only in SLES 12 & SLES 15 is the default locale for 9.3 & 9.6 DMBS is different. Below we can see different values for 9.3 DB in two different platform

![image](https://user-images.githubusercontent.com/17980660/54346546-484d9600-466b-11e9-9434-52c5da3334d2.png)
#### Affected Platform(s)
* SLES 12 & SLES 15

#### Solution Description
* In General, database scripts will check the older db instance attributes, (say LC_COLLATE)
if the older db has non-C type LC_COLLATE, script will execute initdb without C type character locale for newer DBMS cluster creation. 
* Proceeds to upgrade the "pbs_datastore" db instance using pg_upgrade tools, since both the older & newer db instance types are retained same, it succeed to upgrade. Then will change the type to "C" in pbs_habitat.
* Now, we are adding the check for LC_CTYPE also before calling initdb by setting the appropriate flags. (change locale) 

#### Testing logs/output:

[SLES15_Overlay_upgrade_18.2_to_19.4.txt](https://github.com/PBSPro/pbspro/files/3016239/SLES15_Overlay_upgrade_18.2_to_19.4.txt)

[CentOS7_overlay_upgrade_18.txt](https://github.com/PBSPro/pbspro/files/3016241/CentOS7_overlay_upgrade_18.txt)

[sles12_arm_platform-testresults.txt](https://github.com/PBSPro/pbspro/files/3052609/sles12_arm_platform-testresults.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
- [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
- [x] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.

__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
