### PR TITLE
issues related to preemption

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1899,7 +1899,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		 * Note: We only ever look from now into the future
 		 */
 		nexte = get_next_event(sinfo->calendar);
-		if (find_timed_event(nexte, topjob->name, TIMED_NOEVENT, 0) != NULL)
+		if (find_timed_event(nexte, IGNORE_DISABLED_EVENTS, topjob->name, TIMED_NOEVENT, 0) != NULL)
 			return 1;
 	}
 	if ((nsinfo = dup_server_info(sinfo)) == NULL)

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3234,7 +3234,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 		update_universe_on_end(npolicy, pjob,  "S", NO_ALLPART);
 		rjobs_count--;
 		if ( nsinfo->calendar != NULL ) {
-			te = find_timed_event(nsinfo->calendar->events, pjob->name, TIMED_END_EVENT, 0);
+			te = find_timed_event(nsinfo->calendar->events, 0, pjob->name, TIMED_END_EVENT, 0);
 			if (te != NULL) {
 				if (delete_event(nsinfo, te, DE_NO_FLAGS) == 0)
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO, pjob->name, "Failed to delete end event for job.");

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -114,6 +114,7 @@
 #include "check.h"
 #include "fifo.h"
 #include "range.h"
+#include "simulate.h"
 
 
 /**
@@ -1270,6 +1271,9 @@ update_resresv_on_end(resource_resv *resresv, char *job_state)
 	int ret;
 	int i;
 
+	/* used for calendar correction */
+	timed_event *te;
+
 	if (resresv == NULL)
 		return;
 
@@ -1313,6 +1317,12 @@ update_resresv_on_end(resource_resv *resresv, char *job_state)
 			}
 			free_selspec(resresv->execselect);
 			resresv->execselect = NULL;
+		}
+		/* We need to correct our calendar */
+		if (resresv->server->calendar != NULL) {
+			te = find_timed_event(resresv->server->calendar->events, 0, resresv->name, TIMED_END_EVENT, 0);
+			if (te != NULL)
+				set_timed_event_disabled(te, 1);
 		}
 	}
 	else if (resresv->is_resv && resresv->resv !=NULL) {

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1180,13 +1180,13 @@ disable_reservation_occurrence(timed_event *events,
 {
 	timed_event *te;
 
-	te = find_timed_event(events, resv->name, TIMED_RUN_EVENT, resv->start);
+	te = find_timed_event(events, 0, resv->name, TIMED_RUN_EVENT, resv->start);
 	if (te != NULL)
 		set_timed_event_disabled(te, 1);
 	else
 		return 0;
 
-	te = find_timed_event(events, resv->name, TIMED_END_EVENT, resv->end);
+	te = find_timed_event(events, 0, resv->name, TIMED_END_EVENT, resv->end);
 	if (te != NULL)
 		set_timed_event_disabled(te, 1);
 	else

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -480,6 +480,7 @@ set_timed_event_disabled(timed_event *te, int disabled)
  *		differentiate between similar events.
  *
  * @param[in]	te_list 	- timed_event list to search in
+ * @param[in] 	ignore_disabled - ignore disabled events
  * @param[in] 	name    	- name of timed_event to search or NULL to ignore
  * @param[in] 	event_type 	- event_type or TIMED_NOEVENT to ignore
  * @param[in] 	event_time 	- time or 0 to ignore
@@ -493,7 +494,7 @@ set_timed_event_disabled(timed_event *te, int disabled)
  *
  */
 timed_event *
-find_timed_event(timed_event *te_list, char *name,
+find_timed_event(timed_event *te_list, int ignore_disabled, char *name,
 	enum timed_event_types event_type, time_t event_time)
 {
 	timed_event *te;
@@ -505,6 +506,8 @@ find_timed_event(timed_event *te_list, char *name,
 		return NULL;
 
 	for (te = te_list; te != NULL; te = find_next_timed_event(te, 0, ALL_MASK)) {
+		if (ignore_disabled && te->disabled)
+			continue;
 		found_name = found_type = found_time = 0;
 		if (name == NULL || strcmp(te->name, name) == 0)
 			found_name = 1;
@@ -973,7 +976,7 @@ dup_event_list(event_list *oelist, server_info *nsinfo)
 	}
 
 	if (oelist->next_event != NULL) {
-		nelist->next_event = find_timed_event(nelist->events,
+		nelist->next_event = find_timed_event(nelist->events, 0,
 			oelist->next_event->name,
 			oelist->next_event->event_type,
 			oelist->next_event->event_time);
@@ -1132,7 +1135,7 @@ dup_te_list(te_list *ote, timed_event *new_timed_event_list)
 	if(nte == NULL)
 		return NULL;
 	
-	nte->event = find_timed_event(new_timed_event_list, ote->event->name, ote->event->event_type, ote->event->event_time);
+	nte->event = find_timed_event(new_timed_event_list, 0, ote->event->name, ote->event->event_type, ote->event->event_time);
 	
 	return nte;
 }
@@ -1412,7 +1415,7 @@ add_event(event_list *calendar, timed_event *te)
 				calendar->next_event = te;
 			else if (te->event_time == calendar->next_event->event_time) {
 				calendar->next_event =
-					find_timed_event(calendar->events, NULL,
+					find_timed_event(calendar->events, 0, NULL,
 					TIMED_NOEVENT, te->event_time);
 			}
 		}

--- a/src/scheduler/simulate.h
+++ b/src/scheduler/simulate.h
@@ -124,6 +124,7 @@ void set_timed_event_disabled(timed_event *te, int disabled);
  *			   different types
  *
  *	  te_list - timed_event list to search in
+ *	  ignore_disabled - ignore disabled events
  *	  name    - name of timed_event to search for
  *	  event_type - event_type or TIMED_LOW to ignore
  *	  event_time - time or 0 to ignore
@@ -132,7 +133,7 @@ void set_timed_event_disabled(timed_event *te, int disabled);
  *
  */
 timed_event *
-find_timed_event(timed_event *te_list, char *name,
+find_timed_event(timed_event *te_list, int ignore_disabled, char *name,
 	enum timed_event_types event_type, time_t event_time);
 
 

--- a/src/server/req_preemptjob.c
+++ b/src/server/req_preemptjob.c
@@ -180,6 +180,7 @@ reply_preempt_jobs_request(int code, int aux, struct batch_request *local_preq)
 		/* successful preemption */
 		long old_hold;
 		pjob->ji_wattr[(int)JOB_ATR_sched_preempted].at_val.at_long = time(0);
+		pjob->ji_wattr[(int)JOB_ATR_sched_preempted].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
 		switch (aux) {
 			case 1:
 				strcpy(preempt_jobs_list[index].order, "S");

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -167,6 +167,7 @@ req_signaljob(struct batch_request *preq)
 			req_reject(PBSE_BADSTATE, 0, preq);
 			return;
 		}
+		return;
 
 	} else if (jt == IS_ARRAY_ArrayJob) {
 

--- a/test/tests/functional/pbs_sched_preempt_enforce_resumption.py
+++ b/test/tests/functional/pbs_sched_preempt_enforce_resumption.py
@@ -1,0 +1,360 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestSchedPreemptEnforceResumption(TestFunctional):
+    """
+    Test sched_preempt_enforce_resumption working
+    """
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        a = {ATTR_qtype: 'Execution', ATTR_enable: 'True',
+             ATTR_start: 'True', ATTR_p: '151'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, "expressq")
+
+        a = {ATTR_sched_preempt_enforce_resumption: True}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+
+        a = {'job_history_enable': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+    def test_filler_job_higher_walltime(self):
+        """
+        This test confirms that the filler job does not run if it conflicts
+        with running of a suspended job.
+        """
+        a = {ATTR_rescavail + '.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        j1 = Job(TEST_USER)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=2',
+                           ATTR_l + '.walltime': 80})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        j2 = Job(TEST_USER)
+        j2.set_attributes({ATTR_l + '.select': '1:ncpus=1',
+                           ATTR_q: 'expressq',
+                           ATTR_l + '.walltime': 30})
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+
+        j3 = Job(TEST_USER)
+        j3.set_attributes({ATTR_l + '.select': '1:ncpus=1',
+                           ATTR_l + '.walltime': 90})
+        jid3 = self.server.submit(j3)
+        logmsg = ";Job would conflict with reservation or top job"
+        self.scheduler.log_match(jid3 + logmsg)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid3)
+
+    def test_suspended_job_ded_time_calendared(self):
+        """
+        This test confirms that a suspended job becomes top job when unable to
+        resume due to conflict with dedicated time.
+        """
+        a = {ATTR_rescavail + '.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        now = int(time.time())
+        temp = 60 - now % 60
+        start = now + 180 + temp
+        end = start + 120
+        self.scheduler.add_dedicated_time(start=start, end=end)
+
+        temp += 180
+        j1 = Job(TEST_USER)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=2',
+                           ATTR_l + '.walltime': temp})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        j2 = Job(TEST_USER)
+        j2.set_attributes({ATTR_l + '.select': '1:ncpus=1',
+                           ATTR_l + '.walltime': 60,
+                           ATTR_q: 'expressq'})
+        j2.set_sleep_time(60)
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+
+        self.server.tracejob_match(
+            msg='Job is a top job and will run at', id=jid1)
+
+        attr = 'estimated.start_time'
+        stat = self.server.status(JOB, attr, id=jid1)
+        est_val = stat[0][attr]
+        est_str = time.strptime(est_val, '%c')
+        est_start_time = int(time.mktime(est_str))
+
+        self.assertGreaterEqual(est_start_time, end)
+
+    def test_filler_job_lesser_walltime(self):
+        """
+        This test confirms that the filler job does run when the walltime does
+        not conflict with running of a suspended job.
+        """
+        a = {ATTR_rescavail + '.ncpus': 4}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        j1 = Job(TEST_USER)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4',
+                           ATTR_l + '.walltime': 50})
+        jid1 = self.server.submit(j1)
+
+        j2 = Job(TEST_USER)
+        j2.set_attributes({ATTR_l + '.select': '1:ncpus=1',
+                           ATTR_l + '.walltime': 80})
+        jid2 = self.server.submit(j2)
+
+        j3 = Job(TEST_USER)
+        j3.set_attributes({ATTR_l + '.select': '1:ncpus=1',
+                           ATTR_l + '.walltime': 50})
+        jid3 = self.server.submit(j3)
+
+        j4 = Job(TEST_USER)
+        j4.set_attributes({ATTR_l + '.select': '1:ncpus=1',
+                           ATTR_l + '.walltime': 150})
+        jid4 = self.server.submit(j4)
+
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid3)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid4)
+
+        j5 = Job(TEST_USER)
+        j5.set_attributes({ATTR_l + '.select': '1:ncpus=1',
+                           ATTR_q: 'expressq',
+                           ATTR_l + '.walltime': 100})
+        jid5 = self.server.submit(j5)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid4)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid5)
+
+        logmsg = ";Job would conflict with reservation or top job"
+        self.scheduler.log_match(jid4 + logmsg)
+
+    def test_filler_job_suspend(self):
+        """
+        This test confirms that the filler gets suspended by a high
+        priority job.
+        """
+        a = {ATTR_rescavail + '.ncpus': 4}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        j1 = Job(TEST_USER)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4',
+                           ATTR_l + '.walltime': 30})
+        jid1 = self.server.submit(j1)
+
+        j2 = Job(TEST_USER)
+        j2.set_attributes({ATTR_l + '.select': '1:ncpus=2',
+                           ATTR_l + '.walltime': 18})
+        jid2 = self.server.submit(j2)
+
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid2)
+
+        j3 = Job(TEST_USER)
+        j3.set_attributes({ATTR_l + '.select': '1:ncpus=2',
+                           ATTR_q: 'expressq',
+                           ATTR_l + '.walltime': 20})
+        jid3 = self.server.submit(j3)
+
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
+
+        j4 = Job(TEST_USER)
+        j4.set_attributes({ATTR_l + '.select': '1:ncpus=2',
+                           ATTR_q: 'expressq',
+                           ATTR_l + '.walltime': 5})
+        jid4 = self.server.submit(j4)
+
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid4)
+
+        self.server.expect(JOB, {ATTR_state: 'F'}, id=jid4, extend='x',
+                           offset=5, interval=2)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
+
+        logmsg = ";Job would conflict with reservation or top job"
+        self.scheduler.log_match(jid2 + logmsg)
+
+        self.server.expect(JOB, {ATTR_state: 'F'}, id=jid3, extend='x',
+                           offset=15, interval=2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid2)
+
+        self.server.expect(JOB, {ATTR_state: 'F'}, id=jid1, extend='x',
+                           offset=30, interval=2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+
+    def test_preempted_job_server_soft_limits(self):
+        """
+        This test confirms that a preempted job remains suspended if it has
+        violated server soft limits
+        """
+        a = {ATTR_rescavail + '.ncpus': 4}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        a = {'max_run_res_soft.ncpus': "[u:" + str(TEST_USER1) + "=2]"}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        p = '"express_queue, normal_jobs, server_softlimits"'
+        a = {'preempt_prio': p}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+
+        j1 = Job(TEST_USER1)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4',
+                           ATTR_l + '.walltime': 50})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        j2 = Job(TEST_USER)
+        j2.set_attributes({ATTR_l + '.select': '1:ncpus=2',
+                           ATTR_q: 'expressq',
+                           ATTR_l + '.walltime': 20})
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+
+        j3 = Job(TEST_USER)
+        j3.set_attributes({ATTR_l + '.select': '1:ncpus=2',
+                           ATTR_l + '.walltime': 25})
+        jid3 = self.server.submit(j3)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid3)
+
+        self.server.expect(JOB, {ATTR_state: 'F'}, id=jid2, extend='x',
+                           offset=30, interval=2)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
+
+        self.server.expect(JOB, {ATTR_state: 'F'}, id=jid3, extend='x',
+                           offset=30, interval=2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+    def test_preempted_job_queue_soft_limits(self):
+        """
+        This test confirms that a preempted job remains suspended if it has
+        violated queue soft limits
+        """
+        a = {ATTR_rescavail + '.ncpus': 4}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        a = {'max_run_res_soft.ncpus': "[u:" + str(TEST_USER1) + "=2]"}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq')
+
+        p = '"express_queue, normal_jobs, queue_softlimits"'
+        a = {'preempt_prio': p}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+
+        j1 = Job(TEST_USER1)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4',
+                           ATTR_l + '.walltime': 50})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        j2 = Job(TEST_USER)
+        j2.set_attributes({ATTR_l + '.select': '1:ncpus=2',
+                           ATTR_q: 'expressq',
+                           ATTR_l + '.walltime': 20})
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+
+        j3 = Job(TEST_USER)
+        j3.set_attributes({ATTR_l + '.select': '1:ncpus=2',
+                           ATTR_l + '.walltime': 25})
+        jid3 = self.server.submit(j3)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid3)
+
+        self.server.expect(JOB, {ATTR_state: 'F'}, id=jid2, extend='x',
+                           offset=30, interval=2)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
+
+        self.server.expect(JOB, {ATTR_state: 'F'}, id=jid3, extend='x',
+                           offset=30, interval=2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+    def test_filler_jobs_with_no_walltime(self):
+        """
+        This test confirms that filler jobs with no walltime remain queued
+        """
+        a = {ATTR_rescavail + '.ncpus': 4}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        j1 = Job(TEST_USER1)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4',
+                           ATTR_l + '.walltime': 20})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        j2 = Job(TEST_USER)
+        j2.set_attributes({ATTR_l + '.select': '1:ncpus=2',
+                           ATTR_q: 'expressq',
+                           ATTR_l + '.walltime': 8})
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+
+        j3 = Job(TEST_USER)
+        j3.set_attributes({ATTR_l + '.select': '1:ncpus=2'})
+        jid3 = self.server.submit(j3)
+
+        j4 = Job(TEST_USER)
+        j4.set_attributes({ATTR_l + '.select': '1:ncpus=2'})
+        jid4 = self.server.submit(j4)
+
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid3)
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid4)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* **Issue 1** - qsig -s suspend array_job_id[some_valid_index] was failing.
* **Issue 2** - "sched_preemption_enforce_resumption" was not working as expected - 
Steps to reproduce:
single node cluster with 2 ncpus
1. set sched sched_preempt_enforce_resumption = True
2. create an express queue
3. Sumit a job to the default queue needing 2 ncpus, confirm that job starts running.
4. Submit a job to the express queue needing 1 ncpus, confirm that this jobs runs and 1st job is suspended.
5. Submit a filler job needing 1 ncpus to the default qqueue, with walltime greater than express job
The filler job should not run, but starts running.
* **Issue 3** - With sched_preempt_enforce_resumption set, a suspended job is not getting calendared when unable to resume due to dedicated time.
Steps to reproduce:
1. set sched sched_preempt_enforce_resumption = True
2. create an express queue
3. set dedicated time from current time + 3x minutes for duration of y minutes.
4. submit a job to the default queue with walltime=2x minutes and ncpus=2. Confirm that the job runs.
5. submit a job to the express queue with walltime=x minutes and ncpus=1. Confirm that the job runs and the other job is suspended.
6. wait for the high priority job to finish running.
7. Check the state of the low priority job.
The suspended low priority job should not resume since it conflicts with dedicated time, but it does resume.
* **Issue 4** - With sched_preempt_enforce_resumption set, a low priority queued job that becomes a filler job after a high priority job is submitted starts running even though it conflicts with a suspended low priority job.
#### Affected Platform(s)
* All
#### Cause / Analysis / Design
* For **Issue 1** - In #903 a "return" was removed from req_signaljob() by mistake. This made the server return "Invalid state" to the qsig request.
* For **Issue 2, 3** - In #903, we moved setting of JOB_ATR_sched_preempted to the server, but did not set the flags to that effect. When the scheduler queried the job, this attribute was not sent by the server, hence the flow in scheduler was disturbed.
* For **Issue 4** - In #903 - we removed the function preempt_job() which removed the timed end event of the suspended job from the calendar in server_info. As the suspended job becomes a top job, it's run and end events are added to the calendar. When running the filler jobs, when this run event is found, the scheduler understands the conflict with a filler job with higher walltime and does not run the filler job. As this function was removed, we were only deleting the end event of the suspended job from a copy of the server info. 

#### Solution Description
* For **Issue 1** - added back the return statement.
* For **Issue 2, 3** - flags set to appropriate values.
* For **Issue 4** -  remove the end event of the suspended job from the server info after the job is suspended.

#### Testing logs/output
* New tests for Issues 2, 3 and 4 are added.
* For Issue 1, PTL test cases TestJobArray.test_suspended_subjob_survive_restart and TestJobArray.test_suspended_subjob_survive_restart_with_history were run.
* Two new test cases for preempt_sort are also added.
[after_fix_test_suspended_subjob_survive_restart.txt](https://github.com/PBSPro/pbspro/files/3019389/after_fix_test_suspended_subjob_survive_restart.txt)
[after_fix_test_suspended_subjob_survive_restart_with_history.txt](https://github.com/PBSPro/pbspro/files/3019390/after_fix_test_suspended_subjob_survive_restart_with_history.txt)
[before_fix_test_suspended_subjob_survive_restart.txt](https://github.com/PBSPro/pbspro/files/3019391/before_fix_test_suspended_subjob_survive_restart.txt)
[before_fix_test_suspended_subjob_survive_restart_with_history.txt](https://github.com/PBSPro/pbspro/files/3019392/before_fix_test_suspended_subjob_survive_restart_with_history.txt)
[after_fix_sched_preempt_enforce_resumption.txt](https://github.com/PBSPro/pbspro/files/3019395/after_fix_sched_preempt_enforce_resumption.txt)
[before_fix_sched_preempt_enforce_resumption.txt](https://github.com/PBSPro/pbspro/files/3019396/before_fix_sched_preempt_enforce_resumption.txt)
[test_preempt_sort.txt](https://github.com/PBSPro/pbspro/files/3019397/test_preempt_sort.txt)

#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
