### PR TITLE
test_submit_job_with_script of SmokeTest is failing

### DIFF
--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -508,6 +508,8 @@ class SmokeTest(PBSTestSuite):
         """
         Test to submit job with job script
         """
+        a = {ATTR_rescavail + '.ncpus': '2'}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         j = Job(TEST_USER, attrs={ATTR_N: 'test'})
         j.create_script('sleep 120\n', hostname=self.server.client)
         jid = self.server.submit(j)
@@ -522,7 +524,7 @@ class SmokeTest(PBSTestSuite):
             self.assertNotIn('illegal -N value', e.msg[0],
                              'qsub: Not accepted "." in job name')
         else:
-            self.server.expect(JOB, {'job_state': (MATCH_RE, '[RQ]')}, id=jid)
+            self.server.expect(JOB, {'job_state': 'R'}, id=jid)
             self.logger.info('Job submitted successfully: ' + jid)
 
     @skipOnCpuSet


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/Cause/Analysis
* The test fails because it expects the second job to be in either states R or Q, and internally PTL checks for substate 42 when checking for a job in R state, so the test fails if the job is in Q state. The job can be in the Q state if the test is run on a machine with just 1 cpu (so that setUp creates a vnode with ncpus = 1)
* The bug was exposed by #1034 as it caused nodes to be reverted in setUp.

#### Affected Platform(s)
* Linux

#### Solution Description
* Changed the test to set ncpus to 2 and expect both jobs to run

#### Testing logs/output
* This was caught on our internal test machines as some of them have 1 cpu (which is necessary for this bug to show up). I've currently submitted a build with the fix, I'll post results once it's done. But here's the test logs from my machine to show that it still works on bigger machines:
[postfix_bigmachine.log](https://github.com/PBSPro/pbspro/files/3019806/postfix_bigmachine.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [ ] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
