### PR TITLE
PP-848: Ability to include requested custom resources in mom hook input file.

### DIFF
--- a/src/lib/Libattr/attr_resc_func.c
+++ b/src/lib/Libattr/attr_resc_func.c
@@ -423,6 +423,8 @@ parse_resc_flags(char *val, int *flag_ir_p, int *resc_flag_p)
 			resc_flag |= ATR_DFLAG_ANASSN;
 		else if (*val == 'h')
 			resc_flag |= ATR_DFLAG_CVTSLT;
+		else if (*val == 'm')
+			resc_flag |= ATR_DFLAG_MOM;
 		else if (*val == 'r') {
 			if (flag_ir == 0) {
 				resc_flag &= ~READ_WRITE;

--- a/src/lib/Libattr/resc_map.c
+++ b/src/lib/Libattr/resc_map.c
@@ -224,6 +224,8 @@ find_resc_flag_map(int perms)
 		flags[i++] = 'i';
 	else if ((perms & ATR_DFLAG_USWR) == 0)
 		flags[i++] = 'r';
+	if (perms & ATR_DFLAG_MOM)
+		flags[i++] = 'm';
 
 	flags[i] = '\0';
 	return flags;

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -2645,7 +2645,7 @@ get_hook_results(char *input_file, int *accept_flag, int *reject_flag,
 				/* We're now passing type and flag so that if 'name_str' resource */
 				/* does not exist, then it will be dynamically allocated on the server */
 				/* side, essentially allowing hook scripts to define custom resource! */
-				rs_flag = READ_WRITE | ATR_DFLAG_CVTSLT;
+				rs_flag = READ_WRITE | ATR_DFLAG_CVTSLT | ATR_DFLAG_MOM;
 				if ((p2=strrchr(name_str, '.')) != NULL) {
 					p2++;
 					prdef = find_resc_def(svr_resc_def,

--- a/src/server/setup_resc.c
+++ b/src/server/setup_resc.c
@@ -624,11 +624,13 @@ setup_resc(int autocorrect)
 					ATR_DFLAG_ANASSN |
 					ATR_DFLAG_FNASSN |
 					ATR_DFLAG_CVTSLT |
+					ATR_DFLAG_MOM |
 					READ_WRITE );
 				presc->rs_flags &= ~( ATR_DFLAG_RASSN |
 						ATR_DFLAG_ANASSN |
 						ATR_DFLAG_FNASSN |
 						ATR_DFLAG_CVTSLT |
+						ATR_DFLAG_MOM |
 						READ_WRITE );
 				presc->rs_flags |= resc_flag;
 #ifndef PBS_MOM

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -946,12 +946,15 @@ class _PBSSnapUtils(object):
 
         :returns: numeric value of the resource flag
         """
+        # Variable assignments below mirrors definitions
+        # from src/include/pbs_internal.h
         ATR_DFLAG_USRD = 0x01
         ATR_DFLAG_USWR = 0x02
         ATR_DFLAG_OPRD = 0x04
         ATR_DFLAG_OPWR = 0x08
         ATR_DFLAG_MGRD = 0x10
         ATR_DFLAG_MGWR = 0x20
+        ATR_DFLAG_MOM = 0x400
         ATR_DFLAG_RASSN = 0x4000
         ATR_DFLAG_ANASSN = 0x8000
         ATR_DFLAG_FNASSN = 0x10000
@@ -971,6 +974,8 @@ class _PBSSnapUtils(object):
             resc_flag |= ATR_DFLAG_ANASSN
         if "h" in flag:
             resc_flag |= ATR_DFLAG_CVTSLT
+        if "m" in flag:
+            resc_flag |= ATR_DFLAG_MOM
         if "r" in flag:
             resc_flag &= ~READ_WRITE
             resc_flag |= NO_USER_SET

--- a/test/tests/functional/pbs_resc_custom_perm.py
+++ b/test/tests/functional/pbs_resc_custom_perm.py
@@ -1,0 +1,140 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class Test_Custom_Resource_Perm(TestFunctional):
+    rsc_list = ['foo_str', 'foo_strm', 'foo_strh']
+    hook_list = ["start", "begin"]
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        self.momA = self.moms.values()[0]
+        self.momA.delete_vnode_defs()
+        self.hostA = self.momA.shortname
+
+        rc = self.server.manager(MGR_CMD_DELETE, NODE, None, "")
+        self.assertEqual(rc, 0)
+
+        rc = self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
+        self.assertEqual(rc, 0)
+        self.server.expect(NODE, {'state': 'free'}, id=self.hostA)
+
+        # Next set custom resources with m flag and without m flag
+        # via qmgr -c 'create resource'
+        attr = {'type': 'string', 'flag': 'h'}
+        r = 'foo_str'
+        self.server.manager(
+            MGR_CMD_CREATE, RSC, attr, id=r, logerr=False)
+
+        attr = {'type': 'string', 'flag': 'hm'}
+        r = 'foo_strm'
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id=r, logerr=False)
+
+        # Create a custom resources via exechost_startup hook.
+        startup_hook_body = """
+import pbs
+e=pbs.event()
+localnode=pbs.get_local_nodename()
+e.vnode_list[localnode].resources_available['foo_strh'] = "str_hook"
+"""
+        hook_name = "start"
+        a = {'event': "exechost_startup", 'enabled': 'True'}
+        self.server.create_import_hook(
+            hook_name,
+            a,
+            startup_hook_body,
+            overwrite=True)
+
+        # Restart the MoM so that exechost_startup hook can run.
+        self.momA.restart()
+
+        # Give the moms a chance to receive the updated resource.
+        # Ensure the new resource is seen by all moms.
+        self.momA.log_match("resourcedef;copy hook-related file",
+                            max_attempts=20, interval=1)
+
+        # Create a exechost_begin hook.
+        begin_hook_body = """
+import pbs
+e=pbs.event()
+res_list = getattr(e.job, 'Resource_List')
+pbs.logjobmsg(e.job.id, "Resource_List is %s" % str(res_list))
+"""
+        hook_name = "begin"
+        a = {'event': "execjob_begin", 'enabled': 'True'}
+        self.server.create_import_hook(
+            hook_name,
+            a,
+            begin_hook_body,
+            overwrite=True)
+
+    def test_custom_resc_single_node(self):
+        """
+        Test permission flag of resources of a single node job
+        using a execjob_begin hook.
+        """
+        self.logger.info("test_custom_resc__single_node")
+
+        a = {'Resource_List.foo_str': 'str_noperm',
+             'Resource_List.foo_strm': 'str_perm',
+             'Resource_List.foo_strh': 'str_hook'
+             }
+        j = Job(TEST_USER, a)
+        j.set_sleep_time("100")
+        jid = self.server.submit(j)
+
+        self.server.expect(JOB, {
+            'job_state': 'R',
+            'Resource_List.foo_str': 'str_noperm',
+            'Resource_List.foo_strm': 'str_perm',
+            'Resource_List.foo_strh': 'str_hook'},
+            offset=1, id=jid)
+
+        # Match mom logs entry, only resoruces with "m" flag would show up.
+        msg = 'foo_strm=str_perm'
+        self.momA.log_match("Job;%s;.*%s.*" % (jid, msg),
+                            regexp=True, n=10, max_attempts=10, interval=2)
+        msg = 'foo_strh=str_hook'
+        self.momA.log_match("Job;%s;.*%s.*" % (jid, msg),
+                            regexp=True, n=10, max_attempts=10, interval=2)
+        msg = 'foo_str=str_noperm'
+        self.momA.log_match("Job;%s;.*%s.*" % (jid, msg),
+                            regexp=True, n=5, max_attempts=10, interval=2,
+                            existence=False)

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -48,7 +48,7 @@ class SmokeTest(PBSTestSuite):
     # Class variables
     resc_types = [None, 'long', 'float', 'boolean', 'size', 'string',
                   'string_array']
-    resc_flags = [None, 'n', 'h', 'nh', 'q', 'f', 'fh']
+    resc_flags = [None, 'n', 'h', 'nh', 'q', 'f', 'fh', 'm', 'mh']
     resc_flags_ctl = [None, 'r', 'i']
     objs = [QUEUE, SERVER, NODE, JOB, RESV]
     resc_name = "ptl_custom_res"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *Currently hook writers only get a limited amount of information in the hook input file. For example, if I request ngpus, I need to parse the exec_vnode attribute and then identify the node to find out if a gpu was requested for the node. If I want the software attribute or custom resources, I have to query the server for it. This can have a negative impact on the server and introduces potential hangs. I would like for all the information requested by the job or set by the server using defaults to be available in the hook input file.*
* *Issue ID: [PP-848](https://pbspro.atlassian.net/browse/PP-848)*

#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
* *PBS does not send custom resources associated with jobs to MoMs.*

#### Solution Description
* *Introduce a new flag "m" for custom resources which will allow PBS to send those custom resources defined with the aforementioned flag to MoMs*
* EDD can be found here: [EDD](https://pbspro.atlassian.net/wiki/spaces/PD/pages/1034158087/Ability+to+include+requested+custom+resources+in+mom+hook+input+file.)

#### Testing logs/output
[ptl_log.txt](https://github.com/PBSPro/pbspro/files/3020083/ptl_log.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [x] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [x] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
