### PR TITLE
setting preempt_targets to none fails during qalter

### DIFF
--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -452,7 +452,6 @@ fi
 %postun %{pbs_devel}
 ldconfig %{_libdir}
 
-
 %posttrans %{pbs_server}
 # The %preun section of 14.x unconditially removes /etc/init.d/pbs
 # because it does not check whether the package is being removed

--- a/src/server/resc_attr.c
+++ b/src/server/resc_attr.c
@@ -428,7 +428,7 @@ preempt_targets_action(resource *presc, attribute *pattr, void *pobject, int typ
 
 		if (!strncasecmp(name, TARGET_NONE, strlen(TARGET_NONE)))
 		{
-			if (presc->rs_value.at_val.at_arst->as_npointers > 1)
+			if (presc->rs_value.at_val.at_arst->as_usedptr > 1)
 			    return PBSE_BADATVAL;
 			return PBSE_NONE;
 		}

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -126,3 +126,26 @@ exit 0
         marked as "Job will never run"
         """
         self.submit_and_preempt_jobs(preempt_order='R')
+
+    def test_qalter_preempt_targets_to_none(self):
+        """
+        Test that a job requesting preempt targets set to two different queues
+        can be altered to set preempt_targets as NONE
+        """
+
+        # create an addition queue
+        a = {'queue_type': 'execution',
+             'started': 'True',
+             'enabled': 'True'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, "workq2")
+
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'False'})
+        # submit a job in expressq with preempt targets set to workq, workq2
+        a = {'Resource_List.preempt_targets': 'queue=workq,queue=workq2'}
+        j = Job(TEST_USER, a)
+        jid = self.server.submit(j)
+
+        self.server.alterjob(jobid=jid,
+                             attrib={'Resource_List.preempt_targets': 'None'})
+        self.server.expect(JOB, id=jid,
+                           attrib={'Resource_List.preempt_targets': 'None'})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
If a job is submitted with more than one preempt_targets (like -lpreempt_targets='queue=a,queue=b') and then this job is altered to set as "None" then qalter command fails.

#### Affected Platform(s)
All

#### Cause / Analysis / Design
The problem is there because we reuse the string array structures when we update the resource "preempt_targets" but in function preempt_targets_action while trying validate that "None" is not given with two different options (like -lpreempt_targets="None,queue=b") we check the number of pointers that are set in string array.
But we were checking the wrong number of pointers. Instead of checking used pointers we were checking total number of pointers every used by string array.

#### Solution Description
Updated the code to check the right number of pointers.

#### NOTE: This pull also addressed the discrepancy in pbspro.spec and pbspro.spec.in which were out of sync.

#### Testing logs/output
[test_preempt_targets.txt](https://github.com/PBSPro/pbspro/files/3020285/test_preempt_targets.txt)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [x] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
