### PR TITLE
pbs_snapshot --obfuscate breaks when there are illegal characters in accounting logs

### DIFF
--- a/test/fw/ptl/utils/pbs_anonutils.py
+++ b/test/fw/ptl/utils/pbs_anonutils.py
@@ -1087,6 +1087,8 @@ class PBSAnonymizer(object):
             # accounting log format is
             # %Y/%m/%d %H:%M:%S;<Key>;<Id>;<key1=val1> <key2=val2> ...
             curr = data.split(";", 3)
+            if curr is None or len(curr) < 4:
+                continue
             if curr[1] in ("A", "L"):
                 anon_data.append(data.strip())
                 continue
@@ -1095,6 +1097,11 @@ class PBSAnonymizer(object):
             skip_record = False
             # Split the attribute list into key value pairs
             kvl_list = map(lambda n: n.split("=", 1), buf)
+            if kvl_list is None:
+                self.num_bad_acct_records += 1
+                self.logger.debug("Bad accounting record found:\n" +
+                                  data)
+                continue
             for kvl in kvl_list:
                 try:
                     k, v = kvl


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/Cause/Analysis
* pbs_snapshot fails when used with --obfuscate if there are illegal characters in the accounting logs. This happens because while reading accounting records in pbs_anonutils, we don't check for bad records

#### Affected Platform(s)
* Linux

#### Solution Description
* Added some error checking in pbs_anonutils when parsing accounting log files

#### Testing logs/output
Added a new test called "test_obfuscate_acct_bad" that inserts garbage in accounting logs and validates pbs_snapshot run with --obfuscate. Results:
[before_fix.log](https://github.com/PBSPro/pbspro/files/3022071/before_fix.log)
[after_fix.log](https://github.com/PBSPro/pbspro/files/3042201/testobfacctbad.log)



#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [X] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [X] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [X] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [ ] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [X] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__
