### PR TITLE
Scheduler memory leak while parsing its general or fairshare configur…

### DIFF
--- a/src/scheduler/config.h
+++ b/src/scheduler/config.h
@@ -167,8 +167,6 @@
 #define PARSE_OPT_BACKFILL_FUZZY_TIME "opt_backfill_fuzzy_time"
 
 /* deprecated */
-#define PARSE_SORT_BY "sort_by"
-#define PARSE_KEY "key"
 #define PARSE_PREEMPT_STARVING "preempt_starving"
 #define PARSE_PREEMPT_FAIRSHARE "preempt_fairshare"
 #define PARSE_LOAD_BALANCING_RR "load_balancing_rr"

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -576,6 +576,13 @@ enum bucket_flags {
 	NO_PRINT_BUCKETS
 };
 
+enum sort_info_type {
+	PRIME_SORT,
+	NON_PRIME_SORT,
+	PRIME_NODE_SORT,
+	NON_PRIME_NODE_SORT
+};
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -562,11 +562,7 @@ schedule(int cmd, int sd, char *runjobid)
 		case SCH_CONFIGURE:
 			schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_INFO,
 				"reconfigure", "Scheduler is reconfiguring");
-			free_fairshare_head(conf.fairshare);
 			reset_global_resource_ptrs();
-			free(conf.prime_sort);
-			free(conf.non_prime_sort);
-
 			if(schedinit() != 0) {
 				return 0;
 			}

--- a/src/scheduler/parse.h
+++ b/src/scheduler/parse.h
@@ -95,6 +95,8 @@ int valid_config(void);
 /* Check if string is a valid special case sorting string */
 int is_speccase_sort(char *sort_res, int sort_type);
 
+void free_sort_info(enum sort_info_type si_type);
+
 #ifdef	__cplusplus
 }
 #endif


### PR DESCRIPTION
…ation

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* Scheduler leaks huge amount of memory when the frequency of SIGHUP is more. Most of these leaks are related to the scheduler's general and fairshare configuration.

#### Affected Platform(s)
* All

#### Cause / Analysis / Design
* Whenever SIGHUP is issued Scheduler rereads its configuration present in sched_config file and then proceeds further with this new configuration. But before it rereads the new configuration it is not freeing most of the memory allocated for the conf(of type struct config used to read scheduler's configuration) data structure/s and hence the memory leak.

#### Solution Description
* As most of the leaks are related to the parsing of scheduler configuration and fairshare, started running various scenarios relating to these in Valgrind and proceeded towards fixing the “definitely lost” leaks.
* Well freeing of some of these leaks is not straight forward. This is because at some places where we parse the configuration in Scheduler we sometimes are using the read-only memory and at other times we are using dynamically allocated memory for example for conf.fairshare_res and conf.fairshare_ent. The solution here is to allocate memory dynamically all the times wherever required.
* Some of the data structures are pointing to the same memory location. If  we free one data structure then we can get core dump while freeing this memory from another data structure. As there is no reference counting mechanism we should make sure that whenever we free the memory we should not free the same memory again even though it is part of another data structure.

#### Testing logs/output
* Have run all the required automated test cases under valgrind before and after the fix. This is to make sure that the leaks identified are indeed fixed. Attached are the detailed logs. Valgrind logs after before and after testing are huge and since we cannot attach a tar.gz file not adding the same here. 
[test_fairshare_and_enhanced.log](https://github.com/PBSPro/pbspro/files/3027960/test_fairshare_and_enhanced.log)
[TestFairshareJobSortKeys_ext.log](https://github.com/PBSPro/pbspro/files/3027961/TestFairshareJobSortKeys_ext.log)
[TestMultipleSchedulers.log](https://github.com/PBSPro/pbspro/files/3027962/TestMultipleSchedulers.log)
[TestSchedulerInterface.log](https://github.com/PBSPro/pbspro/files/3027963/TestSchedulerInterface.log)


#### Checklist:
<!--- Use the preview button to see the checkboxes/links properly. -->
<!--- Go over the following points, and put an `x` (without spaces around it) in the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have joined the **[pbspro community forum](http://community.pbspro.org/)**.
- [x] My pull request contains a **single, signed** commit. See **[setting up gpg signature](https://pbspro.atlassian.net/wiki/display/DG/Signing+Your+Git+Commits)**.
- [x] My code follows the **[coding style](https://pbspro.atlassian.net/wiki/display/DG/Coding+Standards)** of this project.
- [ ] My change requires project documentation. See **[required documentation checklist](https://pbspro.atlassian.net/wiki/display/DG/Checklist+for+Developing+Features+and+Bug+Fixes)** for details.
   - [ ] I have added documentation in the **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)**.
- [ ] I have added new **PTL test(s) to my commit**. (See **[using PTL for testing](https://pbspro.atlassian.net/wiki/display/DG/Using+PTL+for+Testing)**) *(or)*
   - [ ] I have added  **manual test(s) to this pull request and explained why PTL is not appropriate** for this case.
- [x] All new and existing automated tests have passed. (See **[running automated PTL tests](https://pbspro.atlassian.net/wiki/display/DG/PTL+Quick+Start+Guide)**).
- [x] I have attached **test logs to this pull request** as evidence of testing/verification.


__***For further information please visit the [Developer Guide Home](https://pbspro.atlassian.net/wiki/display/DG/Developer+Guide+Home).***__