### PR TITLE
remove group name validation in pbs_munge_validate()

### DIFF
--- a/src/lib/Libutil/munge_supp.c
+++ b/src/lib/Libutil/munge_supp.c
@@ -252,7 +252,7 @@ pbs_munge_validate(void *auth_data, int *fromsvr, char *ebuf, int ebufsz)
 	if (*p == '1')
 		*fromsvr = 1; /* connection was from a server */
 
-	p = strtok(recv_payload + 2, ":");
+	p = strtok(p + 2, ":");
 
 	if (p && (strncmp(pwent->pw_name, p, PBS_MAXUSER) == 0)) /* inline with current pbs_iff we compare with username only */
 		rc = 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* *[git issue #1068](https://github.com/PBSPro/pbspro/issues/1068)*

*Steps to reproduce*
1. have two machines/vms, one being server (including mom) and another being just client
2. create same user on both having same GID but differing group name.
In my test set up I had:
```
[pbsuser@server]$ id pbsuser
uid=1002(pbsuser) gid=1002(pbsgroup1) groups=1002(pbsgroup1)
-------
[pbsuser@client]$ id pbsuser
uid=1002(pbsuser) gid=1002(pbsgroup2) groups=1002(pbsgroup2)

```
3. configure same munge key and start the munge service
4. qmgr -c 'set server flatuid=true'
5. from client as pbsuser submit a job to server. **BUG:** qsub will fail with message `No Permission.` and in server log we can see `authenticate_external, User credentials do not match`  followed by `req_reject;Reject reply code=15019, aux=0, type=88, from pbsuser@client`

6. if the same steps are executed without configuring munge, the qsub works


#### Affected Platform(s)
* *All*

#### Cause / Analysis / Design
* *Current MUNGE authentication functionality transmits group name from qsub to pbs_server and the server will reject a job if the qsub host's primary group NAME does not match the primary group name on the server host*

#### Solution Description
* *We actually do not need to consider group name or GID when authenticating*

#### Testing logs/output
[client_output.txt](https://github.com/PBSPro/pbspro/files/3037635/client_output.txt)
[server_log_without_fix.txt](https://github.com/PBSPro/pbspro/files/3037642/server_log_without_fix.txt)
[server_log_with_fix.txt](https://github.com/PBSPro/pbspro/files/3037644/server_log_with_fix.txt)


