### PR TITLE
Revert managers and operators in tearDown method

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8328,6 +8328,11 @@ class Server(PBSService):
             select_xt = 'x'
         job_ids = self.select(extend=select_xt)
 
+        revert_server_attribs = ['managers', 'operators']
+
+        for attrib in revert_server_attribs:
+            self.manager(MGR_CMD_UNSET, SERVER, attrib, sudo=True)
+
         # Make sure the current user is a manager. Some tests might have
         # unset the mangers attribute. Ignore 'Duplicate entry in the list'
         # error if the current user was already a manager

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5190,6 +5190,20 @@ class Server(PBSService):
                 self.manager(MGR_CMD_DELETE, RSC, id=rescs)
         return True
 
+    def revert_server_teardown(self):
+        """
+        Method to unset only server attributes during tearDown
+        """
+        unset_list = ['managers', 'operators']
+        self.manager(MGR_CMD_UNSET, SERVER, unset_list, sudo=True)
+
+        current_user = pwd.getpwuid(os.getuid())[0]
+        a = {ATTR_managers: (INCR, current_user + '@*')}
+        try:
+            self.manager(MGR_CMD_SET, SERVER, a, sudo=True)
+        except PbsManagerError:
+            pass
+
     def save_configuration(self, outfile, mode='a'):
         """
         Save a server configuration, this includes:
@@ -11158,20 +11172,6 @@ class Scheduler(PBSService):
         self.fairshare_tree = None
         self.resource_group = None
         return self.isUp()
-
-    def revert_server_attribs(self):
-        """
-        Method to unset only server attributes during tearDown
-        """
-        unset_list = ['managers', 'operators']
-        self.manager(MGR_CMD_UNSET, SERVER, unset_list, sudo=True)
-
-        current_user = pwd.getpwuid(os.getuid())[0]
-        a = {ATTR_managers: (INCR, current_user + '@*')}
-        try:
-            self.manager(MGR_CMD_SET, SERVER, a, sudo=True)
-        except PbsManagerError:
-            pass
 
     def create_scheduler(self, sched_home=None):
         """

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8328,11 +8328,6 @@ class Server(PBSService):
             select_xt = 'x'
         job_ids = self.select(extend=select_xt)
 
-        revert_server_attribs = ['managers', 'operators']
-
-        for attrib in revert_server_attribs:
-            self.manager(MGR_CMD_UNSET, SERVER, attrib, sudo=True)
-
         # Make sure the current user is a manager. Some tests might have
         # unset the mangers attribute. Ignore 'Duplicate entry in the list'
         # error if the current user was already a manager
@@ -11163,6 +11158,20 @@ class Scheduler(PBSService):
         self.fairshare_tree = None
         self.resource_group = None
         return self.isUp()
+
+    def revert_server_attribs(self):
+        """
+        Method to unset only server attributes during tearDown
+        """
+        unset_list = ['managers', 'operators']
+        self.manager(MGR_CMD_UNSET, SERVER, unset_list, sudo=True)
+
+        current_user = pwd.getpwuid(os.getuid())[0]
+        a = {ATTR_managers: (INCR, current_user + '@*')}
+        try:
+            self.manager(MGR_CMD_SET, SERVER, a, sudo=True)
+        except PbsManagerError:
+            pass
 
     def create_scheduler(self, sched_home=None):
         """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1473,6 +1473,7 @@ class PBSTestSuite(unittest.TestCase):
 
         for server in self.servers.values():
             server.cleanup_files()
+            server.revert_server_attribs()
 
         for mom in self.moms.values():
             mom.cleanup_files()

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1473,7 +1473,7 @@ class PBSTestSuite(unittest.TestCase):
 
         for server in self.servers.values():
             server.cleanup_files()
-            server.revert_server_attribs()
+            server.revert_server_teardown()
 
         for mom in self.moms.values():
             mom.cleanup_files()

--- a/test/tests/selftest/pbs_managers_operators_ext.py
+++ b/test/tests/selftest/pbs_managers_operators_ext.py
@@ -61,10 +61,10 @@ class ManagersOperators(TestSelf):
         TestSelf.setUp(self)
         self.server.expect(SERVER, attrib=attr)
 
-    def test_managers_unset_teardown(self):
+    def test_managers_operators_unset_teardown(self):
         """
-        Additional managers users, except current user should get unset
-        after tearDown run
+        Additional managers users except current user and operators
+        should get unset after tearDown run
         """
         runas = ROOT_USER
         current_usr = pwd.getpwuid(os.getuid())[0]
@@ -79,9 +79,4 @@ class ManagersOperators(TestSelf):
         self.logger.info("Calling test tearDown:")
         TestSelf.tearDown(self)
         self.server.expect(SERVER, attrib=attr)
-        try:
-            self.server.expect(SERVER, attrib=a, max_attempts=5)
-        except PtlExpectError:
-            pass
-        else:
-            self.fail("Error in unsetting operators attribute")
+        self.server.expect(SERVER, 'operators', max_attempts=5, op=UNSET)


### PR DESCRIPTION
#### Describe Bug or Feature
Currently PTL is not reverting server attributes "managers" and "operators" at the end of the test case. 


#### Describe Your Change
Unsetting server attributes "managers" and "operators" in cleanup_jobs method which is called in tearDown function.


#### Attach Test Logs or Output
[pbs_managers_operators_execution_logs.txt](https://github.com/PBSPro/pbspro/files/3043326/pbs_managers_operators_execution_logs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
