### PR TITLE
Scheduler leaks memory while suspending job

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -4800,6 +4800,7 @@ void create_res_released(status *policy, resource_resv *pjob)
 		pjob->job->resreq_rel = create_resreq_rel_list(policy, pjob);
 	}
 	selectspec = create_select_from_nspec(pjob->job->resreleased);
+	free_selspec(pjob->execselect);
 	pjob->execselect = parse_selspec(selectspec);
 	free(selectspec);
 	return;

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -1037,7 +1037,8 @@ resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resr
 				INSUFFICIENT_RESOURCE, err) == 0) {
 		if ((flags & RETURN_ALL_ERR)) {
 			can_fit = 0;
-			for (; err->next != NULL; err = err->next);
+			for (; err->next != NULL; err = err->next)
+			;
 			err->next = new_schd_error();
 			prev_err = err;
 			err = err->next;
@@ -1063,7 +1064,8 @@ resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resr
 					INSUFFICIENT_RESOURCE, err) == 0) {
 			if ((flags & RETURN_ALL_ERR)) {
 				can_fit = 0;
-				for (; err->next != NULL; err = err->next);
+				for (; err->next != NULL; err = err->next)
+				;
 				err->next = new_schd_error();
 				prev_err = err;
 				err = err->next;

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -1037,6 +1037,7 @@ resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resr
 				INSUFFICIENT_RESOURCE, err) == 0) {
 		if ((flags & RETURN_ALL_ERR)) {
 			can_fit = 0;
+			for (; err->next != NULL; err = err->next);
 			err->next = new_schd_error();
 			prev_err = err;
 			err = err->next;
@@ -1062,6 +1063,7 @@ resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resr
 					INSUFFICIENT_RESOURCE, err) == 0) {
 			if ((flags & RETURN_ALL_ERR)) {
 				can_fit = 0;
+				for (; err->next != NULL; err = err->next);
 				err->next = new_schd_error();
 				prev_err = err;
 				err = err->next;
@@ -1069,7 +1071,7 @@ resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resr
 				return 0;
 		}
 	}
-	if((flags&RETURN_ALL_ERR)) {
+	if ((flags & RETURN_ALL_ERR)) {
 		if(prev_err != NULL) {
 			prev_err->next = NULL;
 			free(err);

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -1038,7 +1038,7 @@ resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resr
 		if ((flags & RETURN_ALL_ERR)) {
 			can_fit = 0;
 			for (; err->next != NULL; err = err->next)
-			;
+				;
 			err->next = new_schd_error();
 			prev_err = err;
 			err = err->next;
@@ -1065,7 +1065,7 @@ resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *resr
 			if ((flags & RETURN_ALL_ERR)) {
 				can_fit = 0;
 				for (; err->next != NULL; err = err->next)
-				;
+					;
 				err->next = new_schd_error();
 				prev_err = err;
 				err = err->next;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Scheduler leaks memory in two cases - 
1 - When a running job is suspended, we create execselect for the suspended job based on resources held by the job and overwrite the previously created execselect without freeing it.
2 - When we try to check whether the queued job can fit node partition, it calls check_available_resources() on the node partition but the additional errors returned by check_available_resources is overwritten by the calling function.


#### Describe Your Change
free execselect before rewriting the pointer.
do not overwrite the error returned by check_available_resources() function and move to the end of error list and then append the new error.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
[sched_leak_without_fix.txt](https://github.com/PBSPro/pbspro/files/3045697/sched_leak_without_fix.txt)
[sched_leak_with_fix.txt](https://github.com/PBSPro/pbspro/files/3045698/sched_leak_with_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
