### PR TITLE
Fix for invalid cache in getgids and register rshd in execution mode

### DIFF
--- a/src/cmds/scripts/win_postinstall.py
+++ b/src/cmds/scripts/win_postinstall.py
@@ -413,14 +413,14 @@ def register_and_start_services(username, password):
                      username, password)
         __svc_helper(os.path.join(pbs_sbin, 'pbs_server.exe'),
                      username, password)
-        rshd_path = os.path.join(pbs_sbin, 'pbs_rshd.exe')
-        if os.path.isfile(rshd_path):
-            __svc_helper(rshd_path, username, password)
         set_svr_defaults()
     if installtype in ('server', 'comm'):
         __svc_helper(os.path.join(pbs_sbin, 'pbs_comm.exe'),
                      username, password)
     if installtype in ('server', 'execution'):
+        rshd_path = os.path.join(pbs_sbin, 'pbs_rshd.exe')
+        if os.path.isfile(rshd_path):
+            __svc_helper(rshd_path, username, password)
         __svc_helper(os.path.join(pbs_sbin, 'pbs_mom.exe'), username, password)
 
 
@@ -433,7 +433,7 @@ def usage():
     _msg += ['    -p|--passwd=<password>\t- ']
     _msg += ['specify PBS Service/database user\'s password\n']
     _msg += ['    -t|--type=<type>\t\t- specify PBS installation type \n']
-    _msg += ['\t\t\t\t  (server\execution\client\comm)\n']
+    _msg += ['\t\t\t\t  (server/execution/client/comm)\n']
     _msg += ['    -s|--server=<server>\t- ']
     _msg += ['specify PBS Server value\n']
     _msg += ['    -h|--help\t\t\t- print help message\n']

--- a/src/lib/Libwin/passwd.c
+++ b/src/lib/Libwin/passwd.c
@@ -1928,7 +1928,7 @@ getdefgrpname(char *user)
 		NetApiBufferFree(groups);
 
 		strcpy(c_data_[0], group);
-		cache_data(__func__, user, (char *)c_data_, 1, GNLEN);
+		cache_data(__func__, user, (char *)c_data_, 1, GNLEN+1);
 
 		return (group);
 	}
@@ -1939,7 +1939,7 @@ getdefgrpname(char *user)
 		NetApiBufferFree(groups);
 
 		strcpy(c_data_[0], group);
-		cache_data(__func__, user, (char *)c_data_, 1, GNLEN);
+		cache_data(__func__, user, (char *)c_data_, 1, GNLEN+1);
 
 		return (group);
 	}
@@ -1947,7 +1947,7 @@ getdefgrpname(char *user)
 	(void)free(group);
 
 	strcpy(c_data_[0], "Everyone");
-	cache_data(__func__, user, (char *)c_data_, 1, GNLEN);
+	cache_data(__func__, user, (char *)c_data_, 1, GNLEN+1);
 
 	return (strdup("Everyone"));
 }
@@ -2302,7 +2302,7 @@ getgids(char *user, SID *grp[], DWORD rids[])
 		NetApiBufferFree(groups);
 		groups = NULL;
 	}
-	cache_data(__func__, user, (char *)c_data_, j, GNLEN);
+	cache_data(__func__, user, (char *)c_data_, j, GNLEN+1);
 
 	return (j);
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* While adding group names in cache getgids/getdefgrpname passes invalid group name buffer length so catch_data() caches invalid group name and in next call to getgids/getdefgrpname uses that invalid group name which leads to failure to create user token in LogonNoPass() and which leads to "Failed to Impersonate user" error

* While installing Execution only, even if pbs_rshd binary exists, win_postinstall.py doesn't register PBS_RSHD service.

#### Describe Your Change
* Pass correct group name buffer length in catch_data()
* Register pbs_rshd service in execution mode


#### Link to Design Doc
* None

#### Attach Test Logs or Output
* [before_fix.txt](https://github.com/PBSPro/pbspro/files/3046530/before_fix.txt)
* [after_fix.txt](https://github.com/PBSPro/pbspro/files/3046531/after_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
