### PR TITLE
Add loglevel to create_import_hook() to enable/disable printing hook text

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -9453,7 +9453,7 @@ class Server(PBSService):
         self.manager(MGR_CMD_SET, HOOK, attrs, id=name)
         return True
 
-    def import_hook(self, name, body):
+    def import_hook(self, name, body, level=logging.INFO):
         """
         Helper function to import hook body into hook by name.
         The hook must have been created prior to calling this
@@ -9493,12 +9493,13 @@ class Server(PBSService):
         os.remove(rfile)
         if not self._is_local:
             self.du.rm(self.hostname, rfile)
-
-        self.logger.info('server ' + self.shortname +
-                         ': imported hook body\n---\n' + body + '---')
+        self.logger.log(level, 'server ' + self.shortname +
+                        ': imported hook body\n---\n' +
+                        body + '---')
         return True
 
-    def create_import_hook(self, name, attrs=None, body=None, overwrite=True):
+    def create_import_hook(self, name, attrs=None, body=None, overwrite=True,
+                           level=logging.INFO):
         """
         Helper function to create a hook, import content into it,
         set the event and enable it.
@@ -9542,7 +9543,7 @@ class Server(PBSService):
 
         # In 12.0 A MoM hook must be enabled and the event set prior to
         # importing, otherwise the MoM does not get the hook content
-        ret = self.import_hook(name, body)
+        ret = self.import_hook(name, body, level)
 
         # In case of mom hooks, make sure that the hook related files
         # are successfully copied to the MoM

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -856,7 +856,8 @@ if %s e.job.in_ms_mom():
         for _ in range(5):
             try:
                 self.server.create_import_hook(self.hook_name, a, script,
-                                               overwrite=True)
+                                               overwrite=True,
+                                               level=logging.DEBUG)
             except Exception:
                 time.sleep(2)
             else:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PTL’s create_import_hook(), by default, prints hook’s content in the test output. This is a useful information in the test output. But in scenarios where the hook body is very large, (For example cgroups hook with 4500+ lines) the test output becomes unmanageable.

#### Describe Your Change
A new parameter 'level'  will be added to create_import_hook() and import_hook() functions.  Default value for this parameter would be logging.INFO. Hook body will be printed out to the test output by default. Test writers can choose to set 'level' param to 'logging.DEBUG' or logging.DEBUG2 in create_import_hook() and import_hook() methods when dealing with hooks with large body. This will suppress printing of hook body to logs.

#### Link to Design Doc
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1201209353/Option+to+suppress+logging+of+hook+body+in+PTL+s+create+import+hook
http://community.pbspro.org/t/option-to-suppress-logging-of-hook-body-in-ptls-create-import-hook/1537/3

#### Attach Test Logs or Output
[beforefix.txt](https://github.com/PBSPro/pbspro/files/3049235/beforefix.txt)
[afterfix.txt](https://github.com/PBSPro/pbspro/files/3049250/afterfix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->