### PR TITLE
preempt retry not working

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2862,7 +2862,6 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 
 		if ((preempt_jobs_reply = pbs_preempt_jobs(pbs_sd, preempt_jobs_list)) == NULL) {
 			free_string_array(preempt_jobs_list);
-			free(preempt_jobs_list);
 			free(preempted_list);
 			free(fail_list);
 			return -1;
@@ -2870,9 +2869,10 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 
 		for (i = 0; i < no_of_jobs; i++) {
 			job = find_resource_resv(sinfo->running_jobs, preempt_jobs_reply[i].job_id);
-			if (preempt_jobs_reply[i].order[0] == '0')
+			if (preempt_jobs_reply[i].order[0] == '0') {
+				done = 0;
 				fail_list[fail_count++] = job->rank;
-			else {
+			} else {
 				preempted_list[preempted_count++] = job->rank;
 				if (preempt_jobs_reply[i].order[0] == 'S') {
 					/* Set resources_released and execselect on the job */

--- a/src/server/req_preemptjob.c
+++ b/src/server/req_preemptjob.c
@@ -86,7 +86,6 @@ void
 req_preemptjobs(struct batch_request *preq)
 {
 	int			i = 0;
-	int			j = 0;
 	int			count = 0;
 	job			*pjob = NULL;
 	preempt_job_info	*ppj = NULL;
@@ -102,7 +101,7 @@ req_preemptjobs(struct batch_request *preq)
 
 		pjob->preempt_order = svr_get_preempt_order(pjob, psched);
 		pjob->preempt_order_index = 0;
-		switch((int)pjob->preempt_order[0].order[j]) {
+		switch((int)pjob->preempt_order[0].order[0]) {
 			case PREEMPT_METHOD_SUSPEND:
 				issue_signal(pjob, SIG_SUSPEND, post_signal_req, pjob, preq);
 				break;
@@ -173,6 +172,8 @@ reply_preempt_jobs_request(int code, int aux, struct batch_request *local_preq)
 				/* preemption failed */
 				preply->brp_code = 1;
 				strcpy(preempt_jobs_list[index].order, "000");
+				sprintf(preempt_jobs_list[index].job_id, "%s", pjob->ji_qs.ji_jobid);
+				index++;
 				break;
 		}
 		pjob->preempt_order_index++;

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -205,10 +205,10 @@ exit 0
         abort_script = """#!/bin/bash
 exit 3
 """
-        self.abort_file = self.du.create_temp_file(body=abort_script)
-        self.du.chmod(path=self.abort_file, mode=0755)
-        self.du.chown(path=self.abort_file, uid=0, gid=0, runas=ROOT_USER)
-        c = {'$action': 'checkpoint_abort 30 !' + self.abort_file + ' %sid'}
+        abort_file = self.du.create_temp_file(body=abort_script)
+        self.du.chmod(path=abort_file, mode=0755)
+        self.du.chown(path=abort_file, uid=0, gid=0, runas=ROOT_USER)
+        c = {'$action': 'checkpoint_abort 30 !' + abort_file}
         self.mom.add_config(c)
 
         # submit two jobs to regular queue
@@ -241,10 +241,10 @@ exit 3
 kill -9 $1
 exit 0
 """
-        self.abort_file = self.du.create_temp_file(body=abort_script)
-        self.du.chmod(path=self.abort_file, mode=0755)
-        self.du.chown(path=self.abort_file, uid=0, gid=0, runas=ROOT_USER)
-        c = {'$action': 'checkpoint_abort 30 !' + self.abort_file + ' %sid'}
+        abort_file = self.du.create_temp_file(body=abort_script)
+        self.du.chmod(path=abort_file, mode=0755)
+        self.du.chown(path=abort_file, uid=0, gid=0, runas=ROOT_USER)
+        c = {'$action': 'checkpoint_abort 30 !' + abort_file + ' %sid'}
         self.mom.add_config(c)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -194,3 +194,60 @@ exit 0
         self.server.expect(JOB, {ATTR_state: 'S'}, id=jid1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid3)
+
+    def test_preempt_retry(self):
+        """
+        Test to make sure that preemption is retried if it fails.
+        """
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+
+        abort_script = """#!/bin/bash
+exit 3
+"""
+        self.abort_file = self.du.create_temp_file(body=abort_script)
+        self.du.chmod(path=self.abort_file, mode=0755)
+        self.du.chown(path=self.abort_file, uid=0, gid=0, runas=ROOT_USER)
+        c = {'$action': 'checkpoint_abort 30 !' + self.abort_file + ' %sid'}
+        self.mom.add_config(c)
+
+        # submit two jobs to regular queue
+        j1 = Job(TEST_USER)
+        jid1 = self.server.submit(j1)
+
+        time.sleep(2)
+
+        j2 = Job(TEST_USER)
+        jid2 = self.server.submit(j2)
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+
+        # set preempt order
+        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'C'})
+
+        # submit a job to high priority queue
+        a = {ATTR_q: 'expressq'}
+        j3 = Job(TEST_USER, a)
+        jid3 = self.server.submit(j3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid3)
+
+        self.mom.log_match(jid2 + ";checkpoint failed:")
+        self.mom.log_match(jid1 + ";checkpoint failed:")
+
+        abort_script = """#!/bin/bash
+kill -9 $1
+exit 0
+"""
+        self.abort_file = self.du.create_temp_file(body=abort_script)
+        self.du.chmod(path=self.abort_file, mode=0755)
+        self.du.chown(path=self.abort_file, uid=0, gid=0, runas=ROOT_USER)
+        c = {'$action': 'checkpoint_abort 30 !' + self.abort_file + ' %sid'}
+        self.mom.add_config(c)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* scheduler tried only once to preempt jobs. If the server reported failure in preempting a job, scheduler will not try again.


#### Describe Your Change
* server was not sending the job id - made the change.
* scheduler flag "done" in find_and_preempt_jobs() was not getting unset when preemption failed for a job.

#### Attach Test Logs or Output
[ptl_after_fix.txt](https://github.com/PBSPro/pbspro/files/3060370/ptl_after_fix.txt)
[ptl_before_fix.txt](https://github.com/PBSPro/pbspro/files/3060371/ptl_before_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->