### PR TITLE
Failed calendared job took up a top job slot

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2054,14 +2054,9 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 			bjob->name, log_buf);
 	} else if (start_time == 0) {
-		/* In the case where start_time = 0, we don't want mark the job as
-		 * can_never_run because there are transient cases (like node state)
-		 * that we don't handle in our simulation that can fix themselves in
-		 * real life.  Reconsider this decision once the simulation is more
-		 * robust
-		 */
 		schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_WARNING, topjob->name,
 			"Error in calculation of start time of top job");
+		return 0;
 	}
 	free_server(nsinfo, 1);
 	

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -140,7 +140,7 @@ class TestCalendaring(TestFunctional):
 
     def test_topjob_fail(self):
         """
-        Test that when we fail to add a job to the calendar it doesn't 
+        Test that when we fail to add a job to the calendar it doesn't
         take up a topjob slot.  The server's backfill_depth is 1 by default,
         so we just need to submit a job that can never run and a job that can.
         The can never run job will fail to be added to the calendar and the

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -146,6 +146,12 @@ class TestCalendaring(TestFunctional):
         The can never run job will fail to be added to the calendar and the
         second job will be.
         """
+
+        # We need two nodes to create the situation where a job can never run.
+        # We need to create this situation in such a way that the scheduler
+        # doesn't detect it.  If the scheduler detects that a job can't run,
+        # it won't try and add it to the calendar.  To do this, we ask for
+        # 1 node with 2 cpus.  There are 2 nodes with 1 cpu each.
         attrs = {'resources_available.ncpus': 1}
         self.server.create_vnodes('vn', attrib=attrs, num=2,
                                   mom=self.mom, sharednode=False)

--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -137,3 +137,45 @@ class TestCalendaring(TestFunctional):
         self.assertIn('estimated.start_time', job_arr[0])
         errmsg = jid + ";Error in calculation of start time of top job"
         self.scheduler.log_match(errmsg, existence=False, max_attempts=10)
+
+    def test_topjob_fail(self):
+        """
+        Test that when we fail to add a job to the calendar it doesn't 
+        take up a topjob slot.  The server's backfill_depth is 1 by default,
+        so we just need to submit a job that can never run and a job that can.
+        The can never run job will fail to be added to the calendar and the
+        second job will be.
+        """
+        attrs = {'resources_available.ncpus': 1}
+        self.server.create_vnodes('vn', attrib=attrs, num=2,
+                                  mom=self.mom, sharednode=False)
+
+        self.scheduler.set_sched_config({'strict_ordering': 'True ALL'})
+
+        # Submit job to eat up all the resources
+        attrs = {'Resource_List.select': '2:ncpus=1',
+                 'Resource_List.walltime': '1:00:00'}
+        j1 = Job(TEST_USER, attrs)
+        jid1 = self.server.submit(j1)
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+
+        # submit job that can never run.
+        attrs['Resource_List.select'] = '1:ncpus=2'
+        j2 = Job(TEST_USER, attrs)
+        jid2 = self.server.submit(j2)
+
+        # submit a job that can run, but just not now
+        attrs['Resource_List.select'] = '1:ncpus=1'
+        j3 = Job(TEST_USER, attrs)
+        jid3 = self.server.submit(j3)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+
+        msg = jid2 + ';Error in calculation of start time of top job'
+        self.scheduler.log_match(msg)
+
+        msg = jid3 + ';Job is a top job and will run at'
+        self.scheduler.log_match(msg)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a topjob fails to be added to the calendar (usually since it can never run), it still takes up a topjob slot in the backfill_depth.

#### Describe Your Change
The function that adds jobs to the calendar returned success when a job failed to be added to the calendar.  We just needed to return the failure, and it no longer takes up a top job slot.

The other half of the top job code which didn't change is in main_sched_loop().  This might be helpful to look at when reviewing.

#### Attach Test Logs or Output
[topjob_before.log](https://github.com/PBSPro/pbspro/files/3061146/topjob_before.log)
[topjob_after.log](https://github.com/PBSPro/pbspro/files/3061148/topjob_after.log)