### PR TITLE
Fix script error in client rpm

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -255,7 +255,7 @@ Summary: PBS Test Lab for testing PBS Professional
 Group: System Environment/Base
 Requires: python-nose
 Requires: python-beautifulsoup
-%if 0%{?rhel} 
+%if 0%{?rhel}
 Requires: pexpect
 %else
 Requires: python-pexpect
@@ -356,8 +356,6 @@ fi
 if [ $imps -eq 0 ]; then
 ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_postinstall client \
 	%{version} ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}
-else
-        install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
 fi
 
 %post %{pbs_devel}

--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -255,7 +255,7 @@ Summary: PBS Test Lab for testing PBS Professional
 Group: System Environment/Base
 Requires: python-nose
 Requires: python-beautifulsoup
-%if 0%{?rhel} 
+%if 0%{?rhel}
 Requires: pexpect
 %else
 Requires: python-pexpect
@@ -356,8 +356,6 @@ fi
 if [ $imps -eq 0 ]; then
 ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}/libexec/pbs_postinstall client \
 	%{version} ${RPM_INSTALL_PREFIX:=%{pbs_prefix}}
-else
-        install -D %{pbs_prefix}/libexec/pbs_init.d /etc/init.d/pbs
 fi
 
 %post %{pbs_devel}


### PR DESCRIPTION
#### Describe Bug or Feature
The installation of a pbspro-client rpm on a CLE6+ machine prints a warning while trying to copy `pbs_init.d` to `/etc/init.d/pbs`.

#### Describe Your Change
Do not copy `pbs_init.d` in a pbspro-client rpm install.

#### Attach Test Logs or Output
```
[vstumpf@x104-c7p5 PBSPro_19.4.1]$ sudo rpm -ivh pbspro-client-19.4.1.20190408215119-0.el7.x86_64.rpm 
Preparing...                          ################################# [100%]
Installation of PBS Professional

Terms of use for the software are available online at
http://www.pbspro.com/UserArea/agreement.html

Updating / installing...
   1:pbspro-client-19.4.1.201904082151################################# [100%]
*** PBS Installation Summary
***
*** Postinstall script called as follows:
*** /opt/pbs/libexec/pbs_postinstall client 19.4.1.20190408215119 /opt/pbs 
***
*** No configuration file found.
*** Creating new configuration file: /etc/pbs.conf
*** =======
*** NOTICE:
*** =======
*** The value of PBS_SERVER in /etc/pbs.conf is invalid.
*** PBS_SERVER should be set to the PBS Pro server hostname.
*** Update this value before starting PBS Pro.
***
*** Replacing /etc/pbs.conf with /etc/pbs.conf.19.4.1.20190408215119
*** /etc/pbs.conf has been created.
***
***
*** The PBS commands have been installed in /opt/pbs/bin.
***
*** End of /opt/pbs/libexec/pbs_postinstall
```