### PR TITLE
Add quotes to string attributes when printing in qmgr

### DIFF
--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -2189,7 +2189,14 @@ display(int otype, int ptype, char *oname, struct batch_status *status,
 								}
 							}
 							if((attrdef_l != NULL) && (attrdef_l[i].at_type == ATR_TYPE_STR)) {
-								printf(" = %s\n", show_nonprint_chars(c));
+								if (strpbrk(c, "\"' ,") != NULL) {
+									if (strchr(c, (int)'"'))
+										q = '\'';
+									else
+										q = '"';
+									printf(" = %c%s%c\n", q, show_nonprint_chars(c), q);
+								} else
+									printf(" = %s\n", show_nonprint_chars(c));
 								break;
 							}
 							else {

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5071,7 +5071,7 @@ class Server(PBSService):
         ignore_attrs += [ATTR_status, ATTR_total, ATTR_count]
         ignore_attrs += [ATTR_rescassn, ATTR_FLicenses, ATTR_SvrHost]
         ignore_attrs += [ATTR_license_count, ATTR_version, ATTR_managers]
-        ignore_attrs += [ATTR_pbs_license_info,  ATTR_power_provisioning]
+        ignore_attrs += [ATTR_pbs_license_info, ATTR_power_provisioning]
         unsetlist = []
         setdict = {}
         skip_site_hooks = ['pbs_cgroups']
@@ -6523,8 +6523,13 @@ class Server(PBSService):
                                 op = '='
                             # handle string arrays as double quotes if
                             # not already set:
-                            if isinstance(v, str) and ',' in v and v[0] != '"':
-                                v = '"' + v + '"'
+                            if isinstance(v, str):
+                                if ',' in v and v[0] != '"':
+                                    v = '"' + v + '"'
+                                elif any((c in v) for c in set(", \n'")):
+                                    v = '"%s"' % v
+                                elif '"' in v:
+                                    v = "'%s'" % v
                             kvpairs += [str(k) + op + str(v)]
                         if kvpairs:
                             execcmd += [",".join(kvpairs)]

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6526,10 +6526,11 @@ class Server(PBSService):
                             if isinstance(v, str):
                                 if ',' in v and v[0] != '"':
                                     v = '"' + v + '"'
-                                elif any((c in v) for c in set(", \n'")):
-                                    v = '"%s"' % v
-                                elif '"' in v:
-                                    v = "'%s'" % v
+                                elif any((c in v) for c in set(', \'\n"')):
+                                    if '"' in v:
+                                        v = "%s'" % v
+                                    else:
+                                        v = '"%s"' % v
                             kvpairs += [str(k) + op + str(v)]
                         if kvpairs:
                             execcmd += [",".join(kvpairs)]

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6528,7 +6528,7 @@ class Server(PBSService):
                                     v = '"' + v + '"'
                                 elif any((c in v) for c in set(', \'\n"')):
                                     if '"' in v:
-                                        v = "%s'" % v
+                                        v = "'%s'" % v
                                     else:
                                         v = '"%s"' % v
                             kvpairs += [str(k) + op + str(v)]

--- a/test/tests/functional/pbs_qmgr.py
+++ b/test/tests/functional/pbs_qmgr.py
@@ -170,13 +170,11 @@ class TestQmgr(TestFunctional):
         qmgr_cmd = \
             os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin', 'qmgr') + \
             " -c '%s'"
-        qmgr_cmd_print = qmgr_cmd % ('p s @default default_qsub_arguments')
+        qmgr_cmd_print = qmgr_cmd % ('p s default_qsub_arguments')
         ret = self.du.run_cmd(self.server.hostname,
                               cmd=qmgr_cmd_print, as_script=True)
         self.assertEqual(ret['rc'], 0)
         for line in ret['out']:
-            if 'server' not in line:
-                continue
             if '#' in line:
                 continue
             qmgr_cmd_check = qmgr_cmd % (line)


### PR DESCRIPTION
#### Describe Bug or Feature
* [1] When string attribute values with spaces or quotes are printed with qmgr, it does not quote them. When the output is used as input into qmgr, qmgr can't parse the input and fails.
* [2] When PTL tries to set an string attribute with a value with spaces, it does not quote it, and PTL fails to set the attribute.

#### Describe Your Change
* [1] When qmgr prints a string attribute that needs to be quoted, it will quote it.
* [2] When `server.manager()` is called with an attrval with spaces, it will quote it.

#### Link to Design Doc
None


#### Attach Test Logs or Output
new:
[after-fix3.txt](https://github.com/PBSPro/pbspro/files/3082120/after-fix3.txt)



[before-fix.txt](https://github.com/PBSPro/pbspro/files/3065676/before-fix.txt)
[after-fix.txt](https://github.com/PBSPro/pbspro/files/3065677/after-fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
