### PR TITLE
double free with multiple exechost_periodic mom hooks

### DIFF
--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -649,7 +649,8 @@ vnl_add_vnode_entries(vnl_t *vnl, vmpiprocs *vnode_entry, int num_vnodes,
  *
  */
 mom_process_hooks_params_t
-*duplicate_php(mom_process_hooks_params_t *php) {
+*duplicate_php(mom_process_hooks_params_t *php)
+{
 	mom_process_hooks_params_t *new_php;
 
 	if ((new_php = (mom_process_hooks_params_t *)malloc(

--- a/test/tests/functional/pbs_hook_exechost_periodic.py
+++ b/test/tests/functional/pbs_hook_exechost_periodic.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestHookExechostPeriodic(TestFunctional):
+    """
+    Tests to test exechost_periodic hook
+    """
+
+    def test_multiple_exechost_periodic_hooks(self):
+        """
+        This test sets two exechost_periodic hooks and restarts the mom,
+        which tests whether both the hooks will successfully run on node
+        startup and the mom not crashes.
+        """
+        self.attr = {'event': 'exechost_periodic',
+                     'enabled': 'True', 'freq': '30'}
+        self.hook_body1 = ("import pbs\n"
+                           "e = pbs.event()\n"
+                           "pbs.logmsg(pbs.EVENT_DEBUG,\n"
+                           "\t\"exechost_periodic hook1\")\n"
+                           "e.accept()\n")
+        self.hook_body2 = ("import pbs\n"
+                           "e = pbs.event()\n"
+                           "pbs.logmsg(pbs.EVENT_DEBUG,\n"
+                           "\t\"exechost_periodic hook2\")\n"
+                           "e.accept()\n")
+        self.server.create_import_hook("exechost_periodic1",
+                                       self.attr, self.hook_body1)
+        self.server.create_import_hook("exechost_periodic2",
+                                       self.attr, self.hook_body2)
+        self.mom.restart()
+        self.assertTrue(self.mom.isUp())
+        self.mom.log_match("exechost_periodic hook1",
+                           max_attempts=5, interval=5)
+        self.mom.log_match("exechost_periodic hook2",
+                           max_attempts=5, interval=5)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Mom crashes with two or more exechost_periodic hooks in one calling of mom_process_hooks(). The issue is #1080.

exechost_periodic hook can be processed in parallel. In the mom_process_hooks() each exechost_periodic hook is forked and the php structure is passed to each hook run and freed in each post_run_hook() call.

#### Describe Your Change
We can not use only one instance of php because we would not know where or when to freed. So, the php structure is duplicated after each exechost_periodic hook is started. This way each exechost_periodic calling has its own copy of php and it can be safely freed. Since the duplication is done after the calling we do not need the exception for not freeing php for exechost_periodic hook in the end of mom_process_hooks(). The php is always freed in this place.

<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
None

#### Attach Test Logs or Output
[ptl_php_double_free.txt](https://github.com/PBSPro/pbspro/files/3074233/ptl_php_double_free.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
