### PR TITLE
Remove member 'pid' from PBSService objects

### DIFF
--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -1925,11 +1925,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].terminate()
 
         self.scheds['sc1'].start()
-        # Ideally the following statement is not requried. start() method
-        # itself should take care of updating the PID in its cache. I have
-        # created a new bug to fix in this framework. For the time being
-        # the following statement is required as a work around.
-        self.scheds['sc1']._update_pid(self.scheds['sc1'])
 
         j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
                                    'Resource_List.select': '1:ncpus=1'})

--- a/test/tests/selftest/pbs_initservices.py
+++ b/test/tests/selftest/pbs_initservices.py
@@ -1,0 +1,58 @@
+# coding: utf-8
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.selftest import *
+
+
+class TestPbsInitServices(TestSelf):
+    """
+    Contains tests related to PBSInitServices class
+    """
+    def test_init_services_pid(self):
+        """
+        Test if the pid of PBS daemons are updated correctly
+        after a restart via PBSInitServices's functions
+        """
+        self.server.pi.stop()
+        self.server.pi.start_server()
+        self.server.pi.start_mom()
+        self.server.pi.start_comm()
+        self.server.pi.start_sched()
+
+        self.assertTrue(self.server.signal('-HUP'))
+        self.assertTrue(self.mom.signal('-HUP'))
+        self.assertTrue(self.scheduler.signal('-HUP'))
+        self.assertTrue(self.comm.signal('-HUP'))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a test writer uses PTL’s PBSInitServices’s functions directly (instead of daemon’s wrapper functions) (for example self.server.pi.restart()) in tests, followed by any operation that needs the latest pid like a self.server.signal(‘HUP”) PTL will fail because the newer pid is not updated in the daemon objects.

#### Describe Your Change
Fetch the daemon process ids, using _get_pid() rather than relying on the internal cache ‘pid’. _get_pid() gets pid from daemon’s lock file. Hence there is no need for the member ‘pid’ in the daemon objects. It is better to remove this variable to avoid access to incorrect (not latest) pid. 

#### Link to Design Doc
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1219985428/Remove+member+variable+pid+and+function+update+pid+from+PTL+s+daemon+objects 
http://community.pbspro.org/t/remove-member-variable-pid-and-function-update-pid-from-ptls-daemon-objects/1544

#### Attach Test Logs or Output
~~[test_multisched_not_crash.txt](https://github.com/PBSPro/pbspro/files/3074410/test_multisched_not_crash.txt)~~
~~[pbs_init_script_afterfix.txt](https://github.com/PBSPro/pbspro/files/3074411/pbs_init_script_afterfix.txt)~~


[pbs_initservices.txt](https://github.com/PBSPro/pbspro/files/3075370/pbs_initservices.txt)
[test_multisched_not_crash.txt](https://github.com/PBSPro/pbspro/files/3075371/test_multisched_not_crash.txt)

[beforefix.txt](https://github.com/PBSPro/pbspro/files/3074413/beforefix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->