### PR TITLE
libical1a is not in Debian stretch/current stable

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -46,7 +46,7 @@ How to install PBS Pro using the configure script.
   For Debian systems you should run the following command as root:
 
     apt-get install expat libedit2 postgresql python postgresql-contrib sendmail-bin \
-      sudo tcl tk libical1a
+      sudo tcl tk libical2
 
 3. Open a terminal as a normal (non-root) user, unpack the PBS Pro
   tarball, and cd to the package directory.

--- a/INSTALL
+++ b/INSTALL
@@ -43,10 +43,16 @@ How to install PBS Pro using the configure script.
     zypper install expat libedit postgresql-server postgresql-contrib python \
       sendmail sudo tcl tk libical1
 
-  For Debian systems you should run the following command as root:
+  For Debian (jessie) systems you should run the following command as root:
+
+    apt-get install expat libedit2 postgresql python postgresql-contrib sendmail-bin \
+      sudo tcl tk libical1a
+
+  For Debian (stretch) systems you should run the following command as root:
 
     apt-get install expat libedit2 postgresql python postgresql-contrib sendmail-bin \
       sudo tcl tk libical2
+
 
 3. Open a terminal as a normal (non-root) user, unpack the PBS Pro
   tarball, and cd to the package directory.


### PR DESCRIPTION
#### Describe Bug or Feature
in current debian stable (stretch) `libical1a` does not exist,  `libical2` does (yes it builds). I believe this will change when buster releases in the coming months as well...

#### Describe Your Change
This is install text/doc change only

#### Link to Design Doc
n/a

#### Attach Test Logs or Output
n/a