### PR TITLE
Scheduler mem leak when job is suspended and added to calendar

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1975,8 +1975,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 					create_node_array_from_nspec(bjob->nspec_arr);
 				selectspec = create_select_from_nspec(bjob->nspec_arr);
 				if (selectspec != NULL) {
-					if (bjob->execselect)
-						free_selspec(bjob->execselect);
+					free_selspec(bjob->execselect);
 					bjob->execselect = parse_selspec(selectspec);
 					free(selectspec);
 				}

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1975,6 +1975,8 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 					create_node_array_from_nspec(bjob->nspec_arr);
 				selectspec = create_select_from_nspec(bjob->nspec_arr);
 				if (selectspec != NULL) {
+					if (bjob->execselect)
+						free_selspec(bjob->execselect);
 					bjob->execselect = parse_selspec(selectspec);
 					free(selectspec);
 				}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->
**Problem**
scheduler leaks memory when a job is suspended and added to the calendar-
2,160 (240 direct, 1,920 indirect) bytes in 10 blocks are definitely lost in loss record 1,407 of 1,488
   at 0x4C271B2: malloc (vg_replace_malloc.c:298)
   by 0x46342A: new_selspec (resource_resv.c:1862)
   by 0x45336F: parse_selspec (node_info.c:4160)
   by 0x443777: create_res_released (job_info.c:4804)
   by 0x448534: find_and_preempt_jobs (job_info.c:2879)
   by 0x441901: main_sched_loop (fifo.c:929)
   by 0x442825: scheduling_cycle (fifo.c:742)
   by 0x44283D: intermediate_schedule (fifo.c:614)
   by 0x43EBC1: main (pbs_sched.c:1455)

Steps to reproduce:
Execute the below PTL tests - 
TestReleaseLimitedResOnSuspend.test_if_node_gets_oversubscribed
TestReleaseLimitedResOnSuspend.test_suspended_job_gets_calendered

from pbs_release_limited_res_suspend.py

**Solution**
While adding a job to the calendar, the selspec created in create_res_released() is overwritten.
Freeing it before assigning a new value to it.

The mem leaks related to parse_config() are addressed through #1067 

**Logs**
[val_after.txt](https://github.com/PBSPro/pbspro/files/3084476/val_after.txt)
[val_before.txt](https://github.com/PBSPro/pbspro/files/3084477/val_before.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->