### PR TITLE
pbs_snapshot --obfuscate doesn't obfuscate everything

### DIFF
--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -171,9 +171,12 @@ def remotesnap_thread(logger, host):
     du.rm(hostname=host, path=snap_home, recursive=True, force=True)
 
 
-def capture_local_snap():
+def capture_local_snap(sudo_val):
     """
     Helper method to capture snapshot of the local host
+
+    :param sudo_val - Value of the --with-sudo option
+    :type sudo_val - bool
 
     :returns Name of the snapshot directory/tar file captured
     """
@@ -185,12 +188,12 @@ def capture_local_snap():
 
     with PBSSnapUtils(out_dir, acct_logs=acct_logs,
                       daemon_logs=daemon_logs, create_tar=create_tar,
-                      log_path=log_path, with_sudo=with_sudo) as snap_utils:
+                      log_path=log_path, with_sudo=sudo_val) as snap_utils:
         snap_name = snap_utils.capture_all()
 
     if obfuscate:
         obj = ObfuscateSnapshot()
-        obj.obfuscate_snapshot(snap_name, map_file)
+        obj.obfuscate_snapshot(snap_name, map_file, sudo_val)
         if additional_hosts is None:
             # Now create the tar
             outtar = snap_name + ".tgz"
@@ -319,7 +322,7 @@ if __name__ == '__main__':
             thread_p.start()
         else:
             # Capture a local snapshot
-            main_snap = capture_local_snap()
+            main_snap = capture_local_snap(with_sudo)
 
         if thread_p is not None:
             # Let's get the main host's snapshot first
@@ -368,7 +371,7 @@ if __name__ == '__main__':
         du.rm(path=p_snappath, force=True)
     else:
         # Capture snapshot of the local host
-        outtar = capture_local_snap()
+        outtar = capture_local_snap(with_sudo)
 
     if outtar is not None:
         print "Snapshot available at: " + outtar

--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -49,7 +49,7 @@ from getopt import GetoptError
 from threading import Thread
 
 from ptl.lib.pbs_testlib import PtlConfig
-from ptl.utils.pbs_snaputils import PBSSnapUtils
+from ptl.utils.pbs_snaputils import PBSSnapUtils, ObfuscateSnapshot
 from ptl.utils.pbs_cliutils import CliUtils
 from ptl.utils.pbs_dshutils import DshUtils
 
@@ -136,7 +136,7 @@ def remotesnap_thread(logger, host):
     cmd = [host_pbssnappath, "-o", snap_home,
            "--daemon-logs=" + str(daemon_logs),
            "--accounting-logs=" + str(acct_logs)]
-    if anonymize:
+    if obfuscate:
         cmd.extend(["--obfuscate", "--map=" + map_file])
     if with_sudo:
         cmd.append("--with-sudo")
@@ -171,6 +171,38 @@ def remotesnap_thread(logger, host):
     du.rm(hostname=host, path=snap_home, recursive=True, force=True)
 
 
+def capture_local_snap():
+    """
+    Helper method to capture snapshot of the local host
+
+    :returns Name of the snapshot directory/tar file captured
+    """
+    if obfuscate or additional_hosts is not None:
+        # We will need to the captured snapshot directory in these 2 cases
+        create_tar = False
+    else:
+        create_tar = True
+
+    with PBSSnapUtils(out_dir, acct_logs=acct_logs,
+                      daemon_logs=daemon_logs, create_tar=create_tar,
+                      log_path=log_path, with_sudo=with_sudo) as snap_utils:
+        snap_name = snap_utils.capture_all()
+
+    if obfuscate:
+        obj = ObfuscateSnapshot()
+        obj.obfuscate_snapshot(snap_name, map_file)
+        if additional_hosts is None:
+            # Now create the tar
+            outtar = snap_name + ".tgz"
+            with tarfile.open(outtar, "w:gz") as tar:
+                tar.add(snap_name, arcname=os.path.basename(snap_name))
+            # Delete the snapshot directory itself
+            du.rm(path=snap_name, recursive=True, force=True)
+            snap_name = outtar
+
+    return snap_name
+
+
 if __name__ == '__main__':
 
     # Arguments to PBSSnapUtils
@@ -181,7 +213,7 @@ if __name__ == '__main__':
     daemon_logs = 5   # Capture 5 days of daemon logs by default
     additional_hosts = None
     map_file = None
-    anonymize = False
+    obfuscate = False
     log_file = "pbs_snapshot.log"
     with_sudo = False
     du = DshUtils()
@@ -226,7 +258,7 @@ if __name__ == '__main__':
         elif o == "--map":
             map_file = val
         elif o == "--obfuscate":
-            anonymize = True
+            obfuscate = True
         elif o == "--with-sudo":
             with_sudo = True
         elif o == "--version":
@@ -260,7 +292,7 @@ if __name__ == '__main__':
     ptl_logger.addHandler(stream_hdlr)
     ptl_logger.setLevel(level_int)
 
-    if anonymize is True:
+    if obfuscate is True:
         # find the parent directory of the snapshot
         # This will be used to store the map file
         out_abspath = os.path.abspath(out_dir)
@@ -287,12 +319,7 @@ if __name__ == '__main__':
             thread_p.start()
         else:
             # Capture a local snapshot
-            with PBSSnapUtils(out_dir, acct_logs=acct_logs,
-                              daemon_logs=daemon_logs, map_file=map_file,
-                              anonymize=anonymize, create_tar=False,
-                              log_path=log_path,
-                              with_sudo=with_sudo) as snap_utils:
-                main_snap = snap_utils.capture_all()
+            main_snap = capture_local_snap()
 
         if thread_p is not None:
             # Let's get the main host's snapshot first
@@ -341,13 +368,7 @@ if __name__ == '__main__':
         du.rm(path=p_snappath, force=True)
     else:
         # Capture snapshot of the local host
-
-        with PBSSnapUtils(out_dir, acct_logs=acct_logs,
-                          daemon_logs=daemon_logs, map_file=map_file,
-                          anonymize=anonymize, create_tar=True,
-                          log_path=log_path,
-                          with_sudo=with_sudo) as snap_utils:
-            outtar = snap_utils.capture_all()
+        outtar = capture_local_snap()
 
     if outtar is not None:
         print "Snapshot available at: " + outtar

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -315,21 +315,17 @@ class ObfuscateSnapshot(object):
                     attrval = attrval.strip()
 
                     # Check if this attribute needs to be deleted
-                    for attr in attrs_to_del:
-                        if attrname == attr:
-                            delete_line = True
-                            val_del = attrval
-                            break
+                    if attrname in attrs_to_del:
+                        delete_line = True
+                        val_del = attrval
 
                     if delete_line is True:
                         continue
 
                     # Check if this attribute needs to be obfuscated
-                    for attr in attrs_to_obf:
-                        if attrname == attr:
-                            val_obf = attrval
-                            key_obf = attrname
-                            break
+                    if attrname in attrs_to_obf:
+                        val_obf = attrval
+                        key_obf = attrname
 
                 if val_obf is None:
                     fdout.write(line)
@@ -455,13 +451,11 @@ class ObfuscateSnapshot(object):
         # will get obfuscated
         custom_rscs = []
         custrscs_path = os.path.join(snap_dir, "server_priv", "resourcedef")
-        with open(custrscs_path, "r") as fd:
-            for line in fd:
-                try:
+        if os.path.isfile(custrscs_path):
+            with open(custrscs_path, "r") as fd:
+                for line in fd:
                     rscs_name = line.split(" ", 1)[0]
-                except IndexError:
-                    continue
-                custom_rscs.append(rscs_name.strip())
+                    custom_rscs.append(rscs_name.strip())
         for rscs in custom_rscs:
             if rscs not in self.val_obf_map:
                 obf = self.bu.random_str(length=random.randint(8, 30))
@@ -480,7 +474,7 @@ class ObfuscateSnapshot(object):
         db_logs = os.path.join(snap_dir, PG_LOGS_PATH)
         sched_logs = []
         for dirname in os.listdir(snap_dir):
-            if str(dirname).startswith(DFLT_SCHED_LOGS_PATH):
+            if dirname.startswith(DFLT_SCHED_LOGS_PATH):
                 dirpath = os.path.join(snap_dir, str(dirname))
                 sched_logs.append(dirpath)
         dirs_to_del = [svr_logs, mom_logs, comm_logs, db_logs] + sched_logs

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -241,7 +241,7 @@ class ObfuscateSnapshot(object):
                       ATTR_rescavail + ".vnode"]
     sched_attrs_obf = [ATTR_SchedHost]
     queue_attrs_obf = [ATTR_acluser, ATTR_aclgroup, ATTR_aclhost]
-    skip_vals = ["_pbs_project_default", "*"]
+    skip_vals = ["_pbs_project_default", "*", "pbsadmin", "pbsuser"]
 
     def _obfuscate_stat(self, file_path, attrs_to_obf, attrs_to_del):
         """

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -40,13 +40,18 @@ import time
 import tarfile
 import logging
 import socket
+import random
+import shutil
+import re
+import pprint
+import shlex
 
 from subprocess import STDOUT
 from ptl.lib.pbs_testlib import Server, Scheduler, SCHED
 from ptl.lib.pbs_ifl_mock import *
 from ptl.utils.pbs_dshutils import DshUtils
 from ptl.utils.pbs_logutils import PBSLogUtils
-from ptl.utils.pbs_anonutils import PBSAnonymizer
+from ptl.lib.pbs_testlib import BatchUtils
 
 
 # Define an enum which is used to label various pieces of information
@@ -212,11 +217,305 @@ PBS_RSTAT_CMD = os.path.join("bin", "pbs_rstat")
 PBS_PROBE_CMD = os.path.join("sbin", "pbs_probe")
 PBS_HOSTN_CMD = os.path.join("bin", "pbs_hostn")
 
-# A global list of files which contain data in tabular form
-FILE_TABULAR = ["qstat.out", "qstat_t.out", "qstat_x.out", "qstat_ns.out",
-                "pbsnodes_aS.out", "pbsnodes_aSj.out", "pbsnodes_avS.out",
-                "pbsnodes_avSj.out", "qstat_Q.out", "qstat_B.out",
-                "pbs_rstat.out"]
+
+class ObfuscateSnapshot(object):
+    val_obf_map = {}
+    vals_to_del = []
+    bu = BatchUtils()
+    du = DshUtils()
+    logger = logging.getLogger(__name__)
+
+    job_attrs_del = [ATTR_v, ATTR_e, ATTR_jobdir,
+                     ATTR_submit_arguments, ATTR_o, ATTR_S]
+    resv_attrs_del = [ATTR_v]
+    svr_attrs_del = [ATTR_mailfrom]
+    job_attrs_obf = [ATTR_euser, ATTR_egroup, ATTR_project, ATTR_A,
+                     ATTR_g, ATTR_M, ATTR_u, ATTR_owner, ATTR_name]
+    resv_attrs_obf = [ATTR_A, ATTR_g, ATTR_M, ATTR_auth_u, ATTR_auth_g,
+                      ATTR_auth_h, ATTR_resv_owner]
+    svr_attrs_obf = [ATTR_SvrHost, ATTR_acluser, ATTR_aclResvuser,
+                     ATTR_aclResvhost, ATTR_aclhost, ATTR_operators,
+                     ATTR_managers]
+    node_attrs_obf = [ATTR_NODE_Host, ATTR_NODE_Mom, ATTR_rescavail + ".host",
+                      ATTR_rescavail + ".vnode"]
+    sched_attrs_obf = [ATTR_SchedHost]
+    queue_attrs_obf = [ATTR_acluser, ATTR_aclgroup, ATTR_aclhost]
+    skip_vals = ["_pbs_project_default"]
+
+    def _obfuscate_stat(self, file_path, attrs_to_obf, attrs_to_del):
+        """
+        Helper function to obfuscate qstat/rstat -f & pbsnodes -av outputs
+
+        :param file_path - path to the qstat output file in snapshot
+        :type file_path - str
+        :param attrs_to_obf - attribute list to obfuscate
+        :type list
+        :param attrs_to_del- attribute list to delete
+        :type list
+        """
+        fout = self.du.create_temp_file()
+
+        with open(file_path, "r") as fdin, open(fout, "w") as fdout:
+            delete_line = False
+            val_obf = None
+            val_del = None
+            for line in fdin:
+                # Check if this is a line extension for an attr being deleted
+                if line[0] == "\t":
+                    if delete_line:
+                        val_del += line.strip()
+                        continue
+                    elif val_obf is not None:
+                        val_obf += line.strip()
+                        continue
+
+                delete_line = False
+                if val_del is not None:
+                    self.vals_to_del.append(val_del)
+                    val_del = None
+
+                if val_obf is not None:
+                    # Write the previous, obfuscated attribute first
+                    val_to_write = []
+                    for val in val_obf.split(","):
+                        val = val.strip()
+                        val = val.split("@")
+                        out_val = []
+                        for _val in val:
+                            if _val in self.skip_vals:
+                                obf = _val
+                            elif _val not in self.val_obf_map:
+                                obf = self.bu.random_str(
+                                    length=random.randint(8, 30))
+                                self.val_obf_map[_val] = obf
+                            else:
+                                obf = self.val_obf_map[_val]
+                            out_val.append(obf)
+                        out_val = "@".join(out_val)
+                        val_to_write.append(out_val)
+
+                    # Some PBS outputs have inconsistent whitespaces
+                    # e.g - pbs_rstat -f doesn't print leading spaces
+                    # So, extract the lead from the original line
+                    lead = ""
+                    for c in line:
+                        if not c.isspace():
+                            break
+                        lead += c
+
+                    obf_line = lead + key_obf + " = " + \
+                        ",".join(val_to_write) + "\n"
+                    fdout.write(obf_line)
+                    val_obf = None
+                    key_obf = None
+
+                if "=" in line:
+                    attrname, attrval = line.split("=", 1)
+                    attrname = attrname.strip()
+                    attrval = attrval.strip()
+
+                    # Check if this attribute needs to be deleted
+                    for attr in attrs_to_del:
+                        if attrname == attr:
+                            delete_line = True
+                            val_del = attrval
+                            break
+
+                    if delete_line is True:
+                        continue
+
+                    # Check if this attribute needs to be obfuscated
+                    for attr in attrs_to_obf:
+                        if attrname == attr:
+                            val_obf = attrval
+                            key_obf = attrname
+                            break
+
+                if val_obf is None:
+                    fdout.write(line)
+
+        shutil.move(fout, file_path)
+
+    def _obfuscate_acct_file(self, attrs_obf, file_path):
+        """
+        Helper function to anonymize
+
+        :param attrs_obf - list of attributes to obfuscate
+        :type attrs_obf - list
+        :param file_path - path of acct log file
+        :type file_path - str
+        """
+        fout = self.du.create_temp_file()
+
+        with open(file_path, "r") as fd, open(fout, "w") as fdout:
+            for line in fd:
+                # accounting log format is
+                # %Y/%m/%d %H:%M:%S;<Key>;<Id>;<key1=val1> <key2=val2> ...
+                curr = line.split(";", 3)
+                if curr is None or len(curr) < 4:
+                    continue
+                if curr[1] in ("A", "L"):
+                    fdout.write(line)
+                    continue
+                buf = shlex.split(curr[3].strip())
+
+                skip_record = False
+                kvl_list = map(lambda n: n.split("=", 1), buf)
+                if kvl_list is None:
+                    self.num_bad_acct_records += 1
+                    self.logger.debug("Bad accounting record found:\n" + line)
+                    continue
+                for kvl in kvl_list:
+                    try:
+                        k, v = kvl
+                    except ValueError:
+                        self.num_bad_acct_records += 1
+                        self.logger.debug("Bad accounting record found:\n" +
+                                          line)
+                        skip_record = True
+                        break
+
+                    if k in attrs_obf:
+                        val = v.split("@")
+                        obf = []
+                        for _val in val:
+                            if _val == "_pbs_project_default":
+                                obf.append(_val)
+                            elif _val not in self.val_obf_map:
+                                obf_v = self.bu.random_str(
+                                    length=random.randint(8, 30))
+                                self.val_obf_map[_val] = obf_v
+                                obf.append(obf_v)
+                            else:
+                                obf.append(self.val_obf_map[_val])
+                        kvl[1] = "@".join(obf)
+
+                if not skip_record:
+                    line = ";".join(curr[:3]) + ";" + \
+                        " ".join(["=".join(n) for n in kvl_list])
+                    fdout.write(line + "\n")
+
+        shutil.move(fout, file_path)
+
+    def obfuscate_acct_logs(self, snap_dir):
+        """
+        Helper function to obfuscate accounting logs
+
+        :param snap_dir - the snapshot directory path
+        :type snap_dir - str
+        """
+        attrs_to_obf = self.job_attrs_obf + self.resv_attrs_obf +\
+            self.svr_attrs_obf + self.queue_attrs_obf + self.node_attrs_obf +\
+            self.sched_attrs_obf
+
+        # Some accounting record attributes are named differently
+        acct_extras = ["user", "requestor", "group", "account"]
+        attrs_to_obf += acct_extras
+
+        acct_path = os.path.join(snap_dir, "server_priv", "accounting")
+        acct_fnames = os.listdir(acct_path)
+        for acct_fname in acct_fnames:
+            acct_fpath = os.path.join(acct_path, acct_fname)
+            self._obfuscate_acct_file(attrs_to_obf, acct_fpath)
+
+    def obfuscate_snapshot(self, snap_dir, map_file):
+        """
+        Helper function to obfuscate a snapshot
+
+        :param snap_dir - path to snapshot directory to obfsucate
+        :type snap_dir - str
+        :param map_file - path to the map file to create
+        :type map_file - str
+        """
+        if not os.path.isdir(snap_dir):
+            raise ValueError("Snapshot directory path not accessible"
+                             " for obfuscation")
+
+        # Let's go through the qmgr, qstat, pbsnodes and resourcedef file
+        # Get the values associated with attributes to obfuscate and
+        # obfuscate them everywhere in the snapshot
+        # Delete the attribute-value pair in the delete lists
+        stat_f_files = {
+            QSTAT_BF_PATH: [self.svr_attrs_obf, self.svr_attrs_del],
+            QSTAT_F_PATH: [self.job_attrs_obf, self.job_attrs_del],
+            QSTAT_TF_PATH: [self.job_attrs_obf, self.job_attrs_del],
+            QSTAT_XF_PATH: [self.job_attrs_obf, self.job_attrs_del],
+            QSTAT_QF_PATH: [self.queue_attrs_obf, []],
+            PBSNODES_VA_PATH: [self.node_attrs_obf, []],
+            PBS_RSTAT_F_PATH: [self.resv_attrs_obf, self.resv_attrs_del]
+        }
+        for s_f_file, attrs in stat_f_files.iteritems():
+            qstat_f_path = os.path.join(snap_dir, s_f_file)
+            if os.path.isfile(qstat_f_path):
+                self._obfuscate_stat(qstat_f_path, attrs[0], attrs[1])
+
+        # Parse resourcedef file and add custom resources to obfuscation map
+        # We will later do a sed on the whole snapshot, that's when these
+        # will get obfuscated
+        custom_rscs = []
+        custrscs_path = os.path.join(snap_dir, "server_priv", "resourcedef")
+        with open(custrscs_path, "r") as fd:
+            for line in fd:
+                try:
+                    rscs_name = line.split(" ", 1)[0]
+                except IndexError:
+                    continue
+                custom_rscs.append(rscs_name.strip())
+        for rscs in custom_rscs:
+            if rscs not in self.val_obf_map:
+                obf = self.bu.random_str(length=random.randint(8, 30))
+                self.val_obf_map[rscs] = obf
+
+        # Obfuscate accounting logs
+        # Note: We can't rely on sed to do this because there might be logs
+        # From long back which have usernames & hostnames that didn't get
+        # captured in the qstat/pbs_rstat/pbsnodes outputs
+        self.obfuscate_acct_logs(snap_dir)
+
+        # Until we can support obfuscating daemon logs, delete them
+        svr_logs = os.path.join(snap_dir, SVR_LOGS_PATH)
+        mom_logs = os.path.join(snap_dir, MOM_LOGS_PATH)
+        comm_logs = os.path.join(snap_dir, COMM_LOGS_PATH)
+        db_logs = os.path.join(snap_dir, PG_LOGS_PATH)
+        sched_logs = []
+        for dir in os.listdir(snap_dir):
+            if str(dir).startswith(DFLT_SCHED_LOGS_PATH):
+                dirpath = os.path.join(snap_dir, str(dir))
+                sched_logs.append(dirpath)
+        dirs_to_del = [svr_logs, mom_logs, comm_logs, db_logs] + sched_logs
+        for dir in dirs_to_del:
+            self.du.rm(path=dir, recursive=True, force=True)
+
+        # Now, go through the obfuscation map and replace all other instances
+        # of the sensitive values in the snapshot with their obfuscated values
+        sed_path = self.du.which(exe="sed")
+        if sed_path is None or sed_path == "sed":
+            raise IOError("Couldn't find path to sed command, aborting .. ")
+        for root, _, fnames in os.walk(snap_dir):
+            for fname in fnames:
+                fpath = os.path.join(root, fname)
+
+                # Obfuscate values from val_obf_map
+                for key, val in self.val_obf_map.iteritems():
+                    sedcmd = r"%s -i 's/\b%s\b/%s/g' %s" % (sed_path, key,
+                                                            val, fpath)
+                    self.du.run_cmd(cmd=sedcmd, as_script=True,
+                                    level=logging.DEBUG, logerr=False)
+
+                # Remove the attr values from vals_to_del list
+                fout = self.du.create_temp_file()
+                with open(fpath, "r") as fd, open(fout, "w") as fdout:
+                    data = fd.read()
+                    for val in self.vals_to_del:
+                        data = data.replace(val, "")
+                    fdout.write(data)
+                shutil.move(fout, fpath)
+
+        with open(map_file, "w") as fd:
+            fd.write("Attributes Obfuscated:\n")
+            fd.write(pprint.pformat(self.val_obf_map) + "\n")
+            fd.write("Attributes Deleted:\n")
+            fd.write("\n".join(self.vals_to_del) + "\n")
 
 
 class PBSSnapUtils(object):
@@ -226,13 +525,10 @@ class PBSSnapUtils(object):
     """
 
     def __init__(self, out_dir, acct_logs=None, daemon_logs=None,
-                 map_file=None, anonymize=None, create_tar=False,
-                 log_path=None, with_sudo=False):
+                 create_tar=False, log_path=None, with_sudo=False):
         self.out_dir = out_dir
         self.acct_logs = acct_logs
         self.srvc_logs = daemon_logs
-        self.map_file = map_file
-        self.anonymize = anonymize
         self.create_tar = create_tar
         self.log_path = log_path
         self.with_sudo = with_sudo
@@ -240,8 +536,7 @@ class PBSSnapUtils(object):
 
     def __enter__(self):
         self.utils_obj = _PBSSnapUtils(self.out_dir, self.acct_logs,
-                                       self.srvc_logs, self.map_file,
-                                       self.anonymize, self.create_tar,
+                                       self.srvc_logs, self.create_tar,
                                        self.log_path, self.with_sudo)
         return self.utils_obj
 
@@ -259,8 +554,7 @@ class _PBSSnapUtils(object):
     """
 
     def __init__(self, out_dir, acct_logs=None, daemon_logs=None,
-                 map_file=None, anonymize=False, create_tar=False,
-                 log_path=None, with_sudo=False):
+                 create_tar=False, log_path=None, with_sudo=False):
         """
         Initialize a PBSSnapUtils object with the arguments specified
 
@@ -270,10 +564,6 @@ class _PBSSnapUtils(object):
         :type acct_logs: int or None
         :param daemon_logs: number of daemon logs to capture
         :type daemon_logs: int or None
-        :param map_file: Path to map file for anonymization map
-        :type map_file str or None
-        :param anonymize: anonymize data?
-        :type anonymize: bool
         :param create_tar: Create a tarball of the output snapshot?
         :type create_tar: bool or None
         :param log_path: Path to pbs_snapshot's log file
@@ -292,7 +582,6 @@ class _PBSSnapUtils(object):
         self.resv_info = {}
         self.sys_info = {}
         self.core_info = {}
-        self.anon_obj = None
         self.all_hosts = []
         self.server = None
         self.mom = None
@@ -335,8 +624,6 @@ class _PBSSnapUtils(object):
         else:
             self.num_daemon_logs = 0
 
-        self.mapfile = map_file
-
         # Check which of the PBS daemons' information is available
         self.server = Server()
         self.scheduler = None
@@ -372,29 +659,6 @@ class _PBSSnapUtils(object):
 
         # Create the snapshot directory tree
         self.__initialize_snapshot()
-
-        # Create a PBSAnonymizer object
-        self.anonymize = anonymize
-
-        if self.anonymize:
-            del_attrs = [ATTR_v, ATTR_e, ATTR_mailfrom, ATTR_m, ATTR_name,
-                         ATTR_jobdir, ATTR_submit_arguments, ATTR_o, ATTR_S]
-            obf_attrs = [ATTR_euser, ATTR_egroup, ATTR_project, ATTR_A,
-                         ATTR_operators, ATTR_managers, ATTR_g, ATTR_M,
-                         ATTR_u, ATTR_SvrHost, ATTR_aclgroup, ATTR_acluser,
-                         ATTR_aclResvgroup, ATTR_aclResvuser, ATTR_SchedHost,
-                         ATTR_aclResvhost, ATTR_aclhost, ATTR_owner,
-                         ATTR_exechost, ATTR_NODE_Host, ATTR_NODE_Mom,
-                         ATTR_rescavail + ".host", ATTR_rescavail + ".vnode",
-                         ATTR_auth_u, ATTR_auth_g, ATTR_resv_owner]
-            obf_rsc_attrs = []
-            if self.custom_rscs is not None:
-                for rsc in self.custom_rscs.keys():
-                    obf_rsc_attrs.append(rsc)
-
-            self.anon_obj = PBSAnonymizer(attr_delete=del_attrs,
-                                          attr_val=obf_attrs,
-                                          resc_key=obf_rsc_attrs)
 
     def __init_cmd_path_map(self):
         """
@@ -576,8 +840,8 @@ class _PBSSnapUtils(object):
             rel_path = os.path.join(self.snapdir, item)
             os.makedirs(rel_path, 0755)
 
-    def __capture_cmd_output(self, out_path, cmd, skip_anon=False,
-                             as_script=False, ret_out=False, sudo=False):
+    def __capture_cmd_output(self, out_path, cmd, as_script=False,
+                             ret_out=False, sudo=False):
         """
         Run a command and capture its output
 
@@ -585,8 +849,6 @@ class _PBSSnapUtils(object):
         :type out_path: str
         :param cmd: The command to execute
         :type cmd: list
-        :param skip_anon: Skip anonymization even though anonymize is True?
-        :type skip_anon: bool
         :param as_script: Passed to run_cmd()
         :type as_Script: bool
         :param ret_out: Return output of the command?
@@ -606,9 +868,6 @@ class _PBSSnapUtils(object):
                 # Just log and return
                 self.logger.error(str(e))
                 return
-
-            if self.anonymize and not skip_anon:
-                self.__anonymize_file(out_path)
 
         if self.create_tar:
             self.__add_to_archive(out_path)
@@ -775,14 +1034,6 @@ quit()
                 self.du.chown(path=snap_logfile, uid=os.getuid(),
                               gid=os.getgid(), sudo=self.with_sudo)
 
-            # Anonymize accounting logs
-            if self.anonymize and "accounting" in snap_logdir:
-                anon = self.anon_obj.anonymize_accounting_log(snap_logfile)
-                if anon is not None:
-                    anon_fd = open(snap_logfile, "w")
-                    anon_fd.write("\n".join(anon))
-                    anon_fd.close()
-
             if self.create_tar:
                 self.__add_to_archive(snap_logfile)
 
@@ -836,36 +1087,6 @@ quit()
             os.remove(file_path)
 
         return True
-
-    def __anonymize_file(self, file_path):
-        """
-        Anonymize/obfuscate a file to remove sensitive information
-
-        :param file_path: path to the file to anonymize
-        :type file_path: str
-        """
-        if not self.anonymize or self.anon_obj is None:
-            return
-
-        self.logger.debug("Anonymizing " + file_path)
-
-        # Anonymizing a file requires editing it, so make sure the user owns it
-        self.du.chown(path=file_path, uid=os.getuid(),
-                      gid=os.getgid(), sudo=self.with_sudo)
-
-        file_name = os.path.basename(file_path)
-        if file_name == "sched_config":
-            self.anon_obj.anonymize_sched_config(self.scheduler)
-            self.scheduler.apply_config(path=file_path, validate=False)
-        elif file_name == "resource_group":
-            anon = self.anon_obj.anonymize_resource_group(file_path)
-            if anon is not None:
-                with open(file_path, "w") as rgfd:
-                    rgfd.write("\n".join(anon))
-        elif file_name in FILE_TABULAR:
-            self.anon_obj.anonymize_file_tabular(file_path, inplace=True)
-        else:
-            self.anon_obj.anonymize_file_kv(file_path, inplace=True)
 
     def __copy_dir_with_core(self, src_path, dest_path, core_dir,
                              except_list=None, only_core=False, sudo=False):
@@ -959,8 +1180,7 @@ quit()
                     os.remove(item_dest_path)
                 else:
                     # This was not a core file, and 'only_core' is not True
-                    # So, we need to capture & anonymize this file
-                    self.__anonymize_file(item_dest_path)
+                    # So, we need to capture this file
                     if self.create_tar:
                         self.__add_to_archive(item_dest_path)
 
@@ -1445,8 +1665,7 @@ quit()
 
             snap_path = os.path.join(self.snapdir, path)
             self.__capture_cmd_output(snap_path, cmd_list_cpy,
-                                      skip_anon=True, as_script=as_script,
-                                      sudo=sudo)
+                                      as_script=as_script, sudo=sudo)
 
         # Capture platform dependent information
         if win_platform:
@@ -1576,20 +1795,6 @@ quit()
             return
 
         self.finalized = True
-
-        if self.anonymize:
-            # Print out number of bad accounting records:
-            if self.anon_obj.num_bad_acct_records > 0:
-                self.logger.error("Number of bad accounting records found: " +
-                                  str(self.anon_obj.num_bad_acct_records))
-            if self.mapfile is not None:
-                # Print out obfuscation map
-                try:
-                    with open(self.mapfile, "w") as mapfd:
-                        mapfd.write(str(self.anon_obj))
-                except Exception:
-                    self.logger.error("Error writing out the map file " +
-                                      self.mapfile)
 
         # Record timestamp of the snapshot
         snap_ctimepath = os.path.join(self.snapdir, CTIME_PATH)

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -418,7 +418,7 @@ class ObfuscateSnapshot(object):
             self._obfuscate_acct_file(attrs_to_obf, acct_fpath)
         if self.num_bad_acct_records > 0:
             self.logger.info("Total bad records found: " +
-                str(self.num_bad_acct_records))
+                             str(self.num_bad_acct_records))
 
     def _replace_str_in_file(self, key, val, fpath):
         """
@@ -511,7 +511,7 @@ class ObfuscateSnapshot(object):
                 printjob = None
         if printjob is None:
             self.logger.error("printjob not found, so .JB files will "
-            "simply be deleted")
+                              "simply be deleted")
         jobspath = os.path.join(snap_dir, MOM_PRIV_PATH, "jobs")
         jbcontent = {}
         for name in os.listdir(jobspath):
@@ -521,10 +521,10 @@ class ObfuscateSnapshot(object):
                 if printjob is not None:
                     cmd = [printjob, fpath]
                     ret = self.du.run_cmd(cmd=cmd, sudo=sudo_val,
-                                        as_script=True)
+                                          as_script=True)
                 self.du.rm(path=fpath)
                 if ret is not None and ret["out"] is not None:
-                    jbcontent[name] =  "\n".join(ret["out"])
+                    jbcontent[name] = "\n".join(ret["out"])
             # Also delete any other files/directories inside mom_priv/jobs
             else:
                 path = os.path.join(jobspath, name)

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -818,15 +818,14 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
 
         operator = str(OPER_USER) + '@*'
         self.server.manager(MGR_CMD_SET, SERVER,
-                            {ATTR_operators: (INCR, operator)},
-                            sudo=True)
+                            {ATTR_operators: (INCR, operator)})
         real_values[ATTR_operators] = [operator]
 
         real_values[ATTR_SvrHost] = [self.server.hostname]
 
         # Create a queue with acls set
-        a = {ATTR_qtype: 'execution', ATTR_start: 't', ATTR_enable: 't',
-             ATTR_aclgren: 't', ATTR_aclgroup: TSTGRP0,
+        a = {ATTR_qtype: 'execution', ATTR_start: 'True', ATTR_enable: 'True',
+             ATTR_aclgren: 'True', ATTR_aclgroup: TSTGRP0,
              ATTR_acluser: TEST_USER}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
         real_values[ATTR_aclgroup] = [TSTGRP0]

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -854,7 +854,7 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
 
         # Submit a reservation with Authorized_Users & Authorized_Groups set
         a = {ATTR_auth_u: TEST_USER, ATTR_auth_g: TSTGRP0}
-        r = Reservation(TEST_USER, a)
+        Reservation(TEST_USER, a)
         real_values[ATTR_auth_u] = [TEST_USER]
         real_values[ATTR_auth_g] = [TSTGRP0]
         real_values[ATTR_resv_owner] = [TEST_USER, self.server.hostname]
@@ -869,7 +869,7 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
              ATTR_l + ".walltime": "00:01:00", ATTR_S: "/bin/bash"}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(1000)
-        j1 = self.server.submit(j)
+        self.server.submit(j)
 
         # Add job's attributes to the list
         # TEST_USER belongs to group TESTGRP0


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
pbs_snapshot --obfuscate has many issues: it doesn’t obfuscate everything, there are bugs with obfuscating special attributes (like it only obfuscates the first entry in managers, acl attributes etc.), the obfuscated string has the same length as the original string, which could be decrypted back to the original, etc.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Suggesting a redesign of pbs_snapshot --obfuscate. Please refer to the linked design for more details.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1233125400/Redesigning+pbs+snapshot+--obfuscate

#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
Ran pbs_snapshot.unittest.py
Single node test results:
[snapshot_test.log](https://github.com/PBSPro/pbspro/files/3152131/snapshot_test.log)



Will post multi-node results soon.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
