### PR TITLE
PP-774: Ability to create file and directory as a user in PTL needs enhancement

### DIFF
--- a/test/tests/functional/pbs_cray_hyperthread.py
+++ b/test/tests/functional/pbs_cray_hyperthread.py
@@ -93,7 +93,7 @@ class TestCrayHyperthread(TestFunctional):
         scr += ['/bin/sleep 5\n']
         scr += ['aprun -b %s /bin/hostname\n' % aprun_args]
 
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         j1.create_script(scr)
         jid1 = self.server.submit(j1, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)

--- a/test/tests/functional/pbs_cray_smoketest.py
+++ b/test/tests/functional/pbs_cray_smoketest.py
@@ -112,7 +112,7 @@ class TestCraySmokeTest(TestFunctional):
         scr += ['echo Hello World\n']
         scr += ['/bin/sleep 5\n']
 
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         j1.create_script(scr)
         jid1 = self.server.submit(j1, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
@@ -155,7 +155,7 @@ class TestCraySmokeTest(TestFunctional):
         scr += ['/bin/sleep 5\n']
         scr += ['aprun -b -B /bin/sleep 10\n']
 
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         j1.create_script(scr)
         jid1 = self.server.submit(j1, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -644,7 +644,7 @@ class TestJobArray(TestFunctional):
         Test that subjobs standard error and out files are generated
         in the custom directory provided with oe qsub options
         """
-        tmp_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)
         a = {ATTR_e: tmp_dir, ATTR_o: tmp_dir, ATTR_J: '1-4'}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(2)

--- a/test/tests/functional/pbs_mom_dynamic_resource.py
+++ b/test/tests/functional/pbs_mom_dynamic_resource.py
@@ -387,7 +387,8 @@ class TestMomDynRes(TestFunctional):
         # This should make loading of this file fail in all cases.
         # Create the dirctory name with a space in it, to make sure PBS parses
         # it correctly.
-        dir_temp = self.du.mkdtemp(mode=0766, dir=home_dir, suffix=' tmp')
+        dir_temp = self.du.create_temp_dir(mode=0766, dirname=home_dir,
+                                           suffix=' tmp')
         fp = self.mom.add_mom_dyn_res("foo", script_body=scr_body,
                                       dirname=dir_temp)
 

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -59,8 +59,8 @@ class TestQsub_direct_write(TestFunctional):
         """
         j = Job(TEST_USER, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})
@@ -110,8 +110,8 @@ class TestQsub_direct_write(TestFunctional):
         """
         j = Job(TEST_USER, attrs={ATTR_k: 'do'})
         j.set_sleep_time(10)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})
@@ -138,8 +138,8 @@ class TestQsub_direct_write(TestFunctional):
         """
         j = Job(TEST_USER, attrs={ATTR_k: 'de'})
         j.set_sleep_time(10)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})
@@ -164,14 +164,14 @@ class TestQsub_direct_write(TestFunctional):
         are getting directly written to the custom path
         provided in -e and -o option even when -doe is set.
         """
-        tmp_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)
         err_file = os.path.join(tmp_dir, 'error_file')
         out_file = os.path.join(tmp_dir, 'output_file')
         a = {ATTR_e: err_file, ATTR_o: out_file, ATTR_k: 'doe'}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(10)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})
@@ -190,12 +190,12 @@ class TestQsub_direct_write(TestFunctional):
         are getting directly written to the custom dir
         provided in -e and -o option even when -doe is set.
         """
-        tmp_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)
         a = {ATTR_e: tmp_dir, ATTR_o: tmp_dir, ATTR_k: 'doe'}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(10)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})
@@ -218,8 +218,8 @@ class TestQsub_direct_write(TestFunctional):
         j.set_sleep_time(10)
         self.server.manager(MGR_CMD_SET, SERVER, {
                             'default_qsub_arguments': '-kdoe'})
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})
@@ -241,7 +241,7 @@ class TestQsub_direct_write(TestFunctional):
         """
         j = Job(TEST_USER, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.logger.info(self.msg)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
@@ -302,8 +302,8 @@ class TestQsub_direct_write(TestFunctional):
         self.mom.add_config({'$logevent': '0xffffffff'})
         j = Job(TEST_USER, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})
@@ -331,7 +331,7 @@ class TestQsub_direct_write(TestFunctional):
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         j = Job(TEST_USER, attrs={ATTR_k: 'doe', ATTR_J: '1-4'})
         j.set_sleep_time(10)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_state: 'B'}, id=jid)
         self.server.expect(JOB, {ATTR_state + '=R': 4}, count=True,
@@ -356,12 +356,12 @@ class TestQsub_direct_write(TestFunctional):
         """
         a = {'resources_available.ncpus': 4}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
-        tmp_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)
         a = {ATTR_e: tmp_dir, ATTR_o: tmp_dir, ATTR_k: 'doe', ATTR_J: '1-4'}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(10)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})

--- a/test/tests/functional/pbs_qsub_remove_files.py
+++ b/test/tests/functional/pbs_qsub_remove_files.py
@@ -50,7 +50,7 @@ class TestQsub_remove_files(TestFunctional):
         """
         j = Job(TEST_USER, attrs={ATTR_R: 'oe'})
         j.set_sleep_time(1)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_R: 'oe'}, id=jid)
         self.server.expect(JOB, 'job_state', op=UNSET, id=jid)
@@ -66,7 +66,7 @@ class TestQsub_remove_files(TestFunctional):
         """
         j = Job(TEST_USER, attrs={ATTR_R: 'oe', ATTR_sandbox: 'private'})
         j.set_sleep_time(1)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_R: 'oe'}, id=jid)
         self.server.expect(JOB, 'job_state', op=UNSET, id=jid)
@@ -81,7 +81,7 @@ class TestQsub_remove_files(TestFunctional):
         """
         j = Job(TEST_USER, attrs={ATTR_R: 'o'})
         j.set_sleep_time(1)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_R: 'o'}, id=jid)
         self.server.expect(JOB, 'job_state', op=UNSET, id=jid)
@@ -102,8 +102,8 @@ class TestQsub_remove_files(TestFunctional):
         """
         j = Job(TEST_USER, attrs={ATTR_k: 'de', ATTR_R: 'e'})
         j.set_sleep_time(1)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        mapping_dir = self.du.create_temp_dir(asuser=TEST_USER)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})
@@ -127,13 +127,13 @@ class TestQsub_remove_files(TestFunctional):
         are getting deleted from custom path provided in
         -e and -o option when -Roe is set.
         """
-        tmp_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)
         err_file = os.path.join(tmp_dir, 'error_file')
         out_file = os.path.join(tmp_dir, 'output_file')
         a = {ATTR_e: err_file, ATTR_o: out_file, ATTR_R: 'oe'}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(1)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_R: 'oe'}, id=jid)
         self.server.expect(JOB, 'job_state', op=UNSET, id=jid)
@@ -147,11 +147,11 @@ class TestQsub_remove_files(TestFunctional):
         are getting deleted from custom directory path
         provided in -e and -o option when -Roe is set.
         """
-        tmp_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)
         a = {ATTR_e: tmp_dir, ATTR_o: tmp_dir, ATTR_R: 'oe'}
         j = Job(TEST_USER, attrs=a)
         j.set_sleep_time(1)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_R: 'oe'}, id=jid)
         self.server.expect(JOB, 'job_state', op=UNSET, id=jid)
@@ -169,7 +169,7 @@ class TestQsub_remove_files(TestFunctional):
         j.set_sleep_time(1)
         self.server.manager(MGR_CMD_SET, SERVER, {
                             'default_qsub_arguments': '-Roe'})
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_R: 'oe'}, id=jid)
         self.server.expect(JOB, 'job_state', op=UNSET, id=jid)
@@ -185,7 +185,7 @@ class TestQsub_remove_files(TestFunctional):
         """
         j = Job(TEST_USER, attrs={ATTR_R: 'oe'})
         j.set_execargs('sleep', 1)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, 'job_state', op=UNSET, id=jid)
         file_count = len([name for name in os.listdir(
@@ -248,7 +248,7 @@ class TestQsub_remove_files(TestFunctional):
         j = Job(TEST_USER, attrs={ATTR_R: 'oe', ATTR_J: '1-3'},
                 jobname='JOB_NAME')
         j.create_script(script)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_state: 'B'}, id=jid)
         self.server.expect(JOB, ATTR_state, op=UNSET, id=jid)
@@ -274,11 +274,11 @@ class TestQsub_remove_files(TestFunctional):
             "/bin/sleep 3;\n"\
             "if [ $PBS_ARRAY_INDEX -eq 2 ]; then\n"\
             "exit 1; fi; exit 0;"
-        tmp_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        tmp_dir = self.du.create_temp_dir(asuser=TEST_USER)
         j = Job(TEST_USER, attrs={ATTR_e: tmp_dir, ATTR_o: tmp_dir,
                                   ATTR_R: 'oe', ATTR_J: '1-3'})
         j.create_script(script)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER.uid)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER)
         jid = self.server.submit(j, submit_dir=sub_dir)
         self.server.expect(JOB, {ATTR_state: 'B'}, id=jid)
         self.server.expect(JOB, ATTR_state, op=UNSET, id=jid)

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -561,7 +561,8 @@ class TestServerDynRes(TestFunctional):
         # This should make loading of this file fail in all cases
         # Create the dirctory name with a space in it, to make sure PBS parses
         # it correctly.
-        dir_temp = self.du.mkdtemp(mode=0766, dir=home_dir, suffix=' tmp')
+        dir_temp = self.du.create_temp_dir(mode=0766, dirname=home_dir,
+                                           suffix=' tmp')
         fp = self.scheduler.add_server_dyn_res("foo", scr_body,
                                                dirname=dir_temp,
                                                validate=False)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
 Currently, mkdtemp is not working as how it should work when user is trying to create a directory as another user. It creates the directory and do a chown to the specified user. However, it may fail as only root can run chown. We also need to make this interface consistent with create_temp_file().

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
the new implementation of the given function where it can be fed the argument “asuser” to create the directory as the given user rather than trying to modify it at a later stage.

#### [Link to Design Doc](https://pbspro.atlassian.net/wiki/spaces/PD/pages/1086619651/Address+PP-774+Ability+to+create+directory+and+file+as+a+user+in+PTL+needs+enhancement)


#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
