### PR TITLE
pbs_snapshot --with-sudo captures all system commands with sudo

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -1397,7 +1397,6 @@ quit()
         sudo_cmds = [PBS_PROBE_OUT, LSOF_PBS_OUT, DMESG_OUT]
         as_script_cmds = [PROCESS_INFO, LSOF_PBS_OUT]
         pbs_cmds = [PBS_PROBE_OUT, PBS_HOSTN_OUT]
-        sudo = False
 
         host_platform = self.du.get_platform()
         win_platform = False
@@ -1406,6 +1405,7 @@ quit()
 
         # Capture information that's dependent on commands
         for (key, values) in self.sys_info.iteritems():
+            sudo = False
             (path, cmd_list) = values
             if cmd_list is None:
                 continue


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
pbs_snapshot, when run with the "--with-sudo" option, is only supposed to capture the following commands with sudo:

lsof

dmesg

pbs_probe

But it seems to capture all system commands with sudo:

2019-04-22 06:40:45,020 INFOCLI2 pbspro: which vmstat
2019-04-22 06:40:45,028 INFOCLI2 pbspro: sudo -H /usr/bin/vmstat
2019-04-22 06:40:45,049 INFOCLI2 pbspro: which df
2019-04-22 06:40:45,054 INFOCLI2 pbspro: sudo -H /usr/bin/df -h
2019-04-22 06:40:45,076 INFOCLI2 pbspro: which dmesg
2019-04-22 06:40:45,081 INFOCLI2 pbspro: sudo -H /usr/bin/dmesg
2019-04-22 06:40:45,103 INFOCLI2 pbspro: sudo -H /usr/bin/ps -leaf


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Local variable 'sudo' once set to True was not being reset to False for the following commands, and we run a sudo command first, so all commands following it were being run with sudo=True.
- So, I just moved the local variable's initialization inside the loop so it gets reset for every iteration


#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
pbs_snapshot's logs post bugfix should suffice as proof of testing:

```
2019-04-22 07:07:09,861 INFO     capturing system information
2019-04-22 07:07:09,862 INFOCLI2 pbspro: sudo -H /opt/pbs/sbin/pbs_probe -v
2019-04-22 07:07:09,877 INFOCLI2 pbspro: /opt/pbs/bin/pbs_hostn -v pbspro
2019-04-22 07:07:09,881 INFOCLI2 pbspro: which ps
2019-04-22 07:07:09,884 INFOCLI2 pbspro: /tmp/PtlPbsR94Den
Contents of /tmp/PtlPbsR94Den:
----------------------------------------
#!/bin/bash
/usr/bin/ps aux | grep [p]bs
----------------------------------------
2019-04-22 07:07:09,894 INFOCLI2 pbspro: which rm
2019-04-22 07:07:09,897 INFOCLI2 pbspro: /usr/bin/rm /tmp/PtlPbsR94Den
2019-04-22 07:07:09,902 INFOCLI2 pbspro: which lsof
2019-04-22 07:07:09,906 INFOCLI2 pbspro: /tmp/PtlPbsJHFrFy
Contents of /tmp/PtlPbsJHFrFy:
----------------------------------------
#!/bin/bash
sudo /usr/sbin/lsof | grep [p]bs
----------------------------------------
2019-04-22 07:07:10,464 INFOCLI2 pbspro: /usr/bin/rm /tmp/PtlPbsJHFrFy
2019-04-22 07:07:10,473 INFOCLI2 pbspro: /usr/bin/cat /etc/hosts
2019-04-22 07:07:10,476 INFOCLI2 pbspro: /usr/bin/cat /etc/nsswitch.conf
2019-04-22 07:07:10,479 INFOCLI2 pbspro: which vmstat
2019-04-22 07:07:10,482 INFOCLI2 pbspro: /usr/bin/vmstat
2019-04-22 07:07:10,487 INFOCLI2 pbspro: which df
2019-04-22 07:07:10,489 INFOCLI2 pbspro: /usr/bin/df -h
2019-04-22 07:07:10,494 INFOCLI2 pbspro: which dmesg
2019-04-22 07:07:10,496 INFOCLI2 pbspro: sudo -H /usr/bin/dmesg
2019-04-22 07:07:10,515 INFOCLI2 pbspro: /usr/bin/ps -leaf
2019-04-22 07:07:10,521 INFO     capturing OS information
2019-04-22 07:07:10,526 INFO     capturing pbs_environment
```