### PR TITLE
revert_pbsconf() need to be updated to wait for pbs daemons to be up and ready

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4373,7 +4373,12 @@ class Comm(PBSService):
         """
         Check for comm up
         """
-        return super(Comm, self)._isUp(self)
+        for _ in range(10):
+            rv = super(Comm, self)._isUp(self)
+            if rv:
+                break
+            time.sleep(1)
+        return rv
 
     def signal(self, sig):
         """
@@ -10642,7 +10647,12 @@ class Scheduler(PBSService):
         """
         Check for PBS scheduler up
         """
-        return super(Scheduler, self)._isUp(self)
+        for _ in range(10):
+            rv = super(Scheduler, self)._isUp(self)
+            if rv:
+                break
+            time.sleep(1)
+        return rv
 
     def signal(self, sig):
         """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1168,15 +1168,39 @@ class PBSTestSuite(unittest.TestCase):
                 if restart_pbs:
                     # Restart all
                     server.pi.restart(server.hostname)
-                    if not server.isUp():
-                        self.fail("Server is not up")
-                    if not self.mom.isUp():
-                        self.fail("Mom is not up")
-                    if not self.scheduler.isUp():
-                        self.fail("Scheduler is not up")
-                    if not self.comm.isUp():
-                        self.fail("comm is not up")
-
+                    rv = server.isUp()
+                    if not rv:
+                        self.logger.error('Server '
+                                          + comm.hostname
+                                          + ' is down')
+                        msg = 'Failed to restart server '
+                        msg += server.hostname
+                        self.assertTrue(rv, msg)
+                    if new_pbsconf["PBS_START_MOM"] == "1":
+                        rv = server.moms.values()[0].isUp()
+                        if not rv:
+                            self.logger.error('mom '
+                                              + server.moms.values()[0]
+                                              + ' is down')
+                            msg = 'Failed to restart mom '
+                            msg += server.moms.values()[0]
+                            self.assertTrue(rv, msg)
+                    rv = server.schedulers['default'].isUp()
+                    if not rv:
+                        self.logger.error('Scheduler is down')
+                        msg = 'Failed to restart scheduler '
+                        msg += server.scheduler.hostname
+                        self.assertTrue(rv, msg)
+                    if self.du.is_localhost(server.hostname):
+                        if new_pbsconf["PBS_START_COMM"] == "1":
+                            rv = self.comm.isUp()
+                            if not rv:
+                                self.logger.error('comm '
+                                                  + self.comm.hostname
+                                                  + ' is down')
+                                msg = 'Failed to restart comm '
+                                msg += self.comm.hostname
+                                self.assertTrue(rv, msg)
                 else:
                     for initcmd in cmds_to_exec:
                         # start/stop the particular daemon
@@ -1184,17 +1208,40 @@ class PBSTestSuite(unittest.TestCase):
                                         daemon=initcmd[0])
                         if initcmd[1] == "start":
                             if initcmd[0] == "server":
-                                if not server.isUp():
-                                    self.fail("Server is not up")
-                            if initcmd[1] == "sched":
-                                if not self.sched.isUp():
-                                    self.fail("Scheduler is not up")
+                                rv = server.isUp()
+                                if not rv:
+                                    self.logger.error('Server '
+                                                      + comm.hostname
+                                                      + ' is down')
+                                    msg = 'Failed to restart server '
+                                    msg += server.hostname
+                                    self.assertTrue(rv, msg)
+                            if initcmd[0] == "sched":
+                                rv = server.schedulers['default'].isUp()
+                                if not rv:
+                                    self.logger.error('Scheduler is down')
+                                    msg = 'Failed to restart scheduler '
+                                    msg += server.scheduler.hostname
+                                    self.assertTrue(rv, msg)
                             if initcmd[0] == "mom":
-                                if not self.mom.isUp():
-                                    self.fail("Mom is not up")
+                                rv = server.moms.values()[0].isUp()
+                                if not rv:
+                                        self.logger.error('mom '
+                                                          + server.mom.hostname
+                                                          + ' is down')
+                                        msg = 'Failed to restart mom '
+                                        msg += server.mom.hostname
+                                        self.assertTrue(rv, msg)
                             if initcmd[0] == "comm":
-                                if not self.comm.isUp():
-                                    self.fail("comm is not running")
+                                if self.du.is_localhost(server.hostname):
+                                    rv = self.comm.isUp()
+                                    if not rv:
+                                        self.logger.error('comm '
+                                                          + comm.hostname
+                                                          + ' is down')
+                                        msg = 'Failed to restart comm '
+                                        msg += comm.hostname
+                                        self.assertTrue(rv, msg)
 
     def revert_pbsconf(self):
         """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -989,7 +989,8 @@ class PBSTestSuite(unittest.TestCase):
                 self.du.set_pbs_config(comm.hostname, confs=new_pbsconf)
                 comm.pbs_conf = new_pbsconf
                 comm.pi.initd(comm.hostname, "restart", daemon="comm")
-                comm.isUp()
+                if not comm.isUp():
+                    self.fail("comm is not up")
 
     def _revert_pbsconf_mom(self, primary_server, vals_to_set):
         """
@@ -1063,7 +1064,8 @@ class PBSTestSuite(unittest.TestCase):
                                        append=False)
                 mom.pbs_conf = new_pbsconf
                 mom.pi.initd(mom.hostname, "restart", daemon="mom")
-                mom.isUp()
+                if not mom.isUp():
+                    self.fail("Mom is not up")
 
     def _revert_pbsconf_server(self, vals_to_set):
         """
@@ -1166,12 +1168,33 @@ class PBSTestSuite(unittest.TestCase):
                 if restart_pbs:
                     # Restart all
                     server.pi.restart(server.hostname)
+                    if not server.isUp():
+                        self.fail("Server is not up")
+                    if not self.mom.isUp():
+                        self.fail("Mom is not up")
+                    if not self.scheduler.isUp():
+                        self.fail("Scheduler is not up")
+                    if not self.comm.isUp():
+                        self.fail("comm is not up")
+
                 else:
                     for initcmd in cmds_to_exec:
                         # start/stop the particular daemon
                         server.pi.initd(server.hostname, initcmd[1],
                                         daemon=initcmd[0])
-                server.isUP()
+                        if initcmd[1] == "start":
+                            if initcmd[0] == "server":
+                                if not server.isUp():
+                                    self.fail("Server is not up")
+                            if initcmd[1] == "sched":
+                                if not self.sched.isUp():
+                                    self.fail("Scheduler is not up")
+                            if initcmd[0] == "mom":
+                                if not self.mom.isUp():
+                                    self.fail("Mom is not up")
+                            if initcmd[0] == "comm":
+                                if not self.comm.isUp():
+                                    self.fail("comm is not running")
 
     def revert_pbsconf(self):
         """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -989,6 +989,7 @@ class PBSTestSuite(unittest.TestCase):
                 self.du.set_pbs_config(comm.hostname, confs=new_pbsconf)
                 comm.pbs_conf = new_pbsconf
                 comm.pi.initd(comm.hostname, "restart", daemon="comm")
+                comm.isUp()
 
     def _revert_pbsconf_mom(self, primary_server, vals_to_set):
         """
@@ -1062,6 +1063,7 @@ class PBSTestSuite(unittest.TestCase):
                                        append=False)
                 mom.pbs_conf = new_pbsconf
                 mom.pi.initd(mom.hostname, "restart", daemon="mom")
+                mom.isUp()
 
     def _revert_pbsconf_server(self, vals_to_set):
         """
@@ -1169,6 +1171,7 @@ class PBSTestSuite(unittest.TestCase):
                         # start/stop the particular daemon
                         server.pi.initd(server.hostname, initcmd[1],
                                         daemon=initcmd[0])
+                server.isUP()
 
     def revert_pbsconf(self):
         """


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PTL test cases sometimes used to fail with error "'Connection refused', 'qmgr: cannot connect to server '" due to server was not up when pbs.conf file is reverted and restarted all the daemons.
revert_pbsconf() reverts pbs.conf file and restarts the daemons if any changes are made in pbs.conf file.

#### Describe Your Change
Wait for all the daemons to be up and running after PBS restart.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
