### PR TITLE
Sched mem leak when estimating for top job fails

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1148,7 +1148,7 @@ end_cycle_tasks(server_info *sinfo)
 	 */
 	if (sinfo != NULL) {
 		sinfo->fairshare = NULL;
-		free_server(sinfo, 1);	/* free server and queues and jobs */
+		free_server(sinfo);	/* free server and queues and jobs */
 	}
 
 	/* close any open connections to peers */
@@ -1906,7 +1906,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		return 0;
 
 	if ((njob = find_resource_resv_by_indrank(nsinfo->jobs, topjob->rank, topjob->resresv_ind)) == NULL) {
-		free_server(nsinfo, 1);
+		free_server(nsinfo);
 		return 0;
 	}
 
@@ -1933,7 +1933,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 		if (topjob->job->is_array) {
 			tjob = queue_subjob(topjob, sinfo, topjob->job->queue);
 			if (tjob == NULL) {
-				free_server(nsinfo, 1);
+				free_server(nsinfo);
 				return 0;
 			}
 
@@ -1942,7 +1942,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 			if (njob == NULL) {
 				schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_DEBUG, __func__,
 					"Can't find new subjob in simulated universe");
-				free_server(nsinfo, 1);
+				free_server(nsinfo);
 				return 0;
 			}
 			/* The subjob is just for the calendar, not for running */
@@ -1980,11 +1980,11 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 					free(selectspec);
 				}
 			} else {
-				free_server(nsinfo, 1);
+				free_server(nsinfo);
 				return 0;
 			}
 		} else {
-			free_server(nsinfo, 1);
+			free_server(nsinfo);
 			return 0;
 		}
 
@@ -1998,14 +1998,14 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 
 		te_start = create_event(TIMED_RUN_EVENT, bjob->start, bjob, NULL, NULL);
 		if (te_start == NULL) {
-			free_server(nsinfo, 1);
+			free_server(nsinfo);
 			return 0;
 		}
 		add_event(sinfo->calendar, te_start);
 
 		te_end = create_event(TIMED_END_EVENT, bjob->end, bjob, NULL, NULL);
 		if (te_end == NULL) {
-			free_server(nsinfo, 1);
+			free_server(nsinfo);
 			return 0;
 		}
 		add_event(sinfo->calendar, te_end);
@@ -2057,10 +2057,10 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 	} else if (start_time == 0) {
 		schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_WARNING, topjob->name,
 			"Error in calculation of start time of top job");
-		free_server(nsinfo, 1);
+		free_server(nsinfo);
 		return 0;
 	}
-	free_server(nsinfo, 1);
+	free_server(nsinfo);
 	
 	return 1;
 }

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2057,6 +2057,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 	} else if (start_time == 0) {
 		schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_WARNING, topjob->name,
 			"Error in calculation of start time of top job");
+		free_server(nsinfo, 1);
 		return 0;
 	}
 	free_server(nsinfo, 1);

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3157,7 +3157,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 			sprintf(log_buf, "Limited running jobs used for preemption from %d to 0: No jobs to preempt",
 				nsinfo->sc.running);
 			schdlog(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG, nhjob->name, log_buf);
-			free_server(nsinfo, 1);
+			free_server(nsinfo);
 			free_schd_error_list(full_err);
 			free(pjobs);
 			free(prjobs);
@@ -3188,7 +3188,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 	err = dup_schd_error(full_err);	/* only first element */
 	if(err == NULL) {
 		free_schd_error_list(full_err);
-		free_server(nsinfo, 1);
+		free_server(nsinfo);
 		free(pjobs);
 		free(prjobs);
 		log_err(errno, __func__, MEM_ERR_MSG);
@@ -3199,7 +3199,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 	if (rjobs_subset == NULL) {
 		schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO, nhjob->name, "Found no preemptable candidates");
 		free_schd_error_list(full_err);
-		free_server(nsinfo, 1);
+		free_server(nsinfo);
 		free(pjobs);
 		free(prjobs);
 		return NULL;
@@ -3211,7 +3211,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 
 		if (indexfound == ERR_IN_SELECT) {
 			/* System error occurred, no need to proceed */
-			free_server(nsinfo, 1);
+			free_server(nsinfo);
 			free(pjobs);
 			free(prjobs);
 			free_schd_error_list(full_err);
@@ -3265,7 +3265,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 				nj = queue_subjob(nhjob, nsinfo, nhjob->job->queue);
 
 				if (nj == NULL) {
-					free_server(nsinfo, 1);
+					free_server(nsinfo);
 					free(pjobs);
 					free(prjobs);
 					free_schd_error_list(full_err);
@@ -3305,7 +3305,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 			if (rjobs_subset == NULL) {
 				schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO, nhjob->name, "Found no preemptable candidates");
 				free_schd_error_list(full_err);
-				free_server(nsinfo, 1);
+				free_server(nsinfo);
 				free(pjobs);
 				free(prjobs);
 				free_schd_error(err);
@@ -3349,7 +3349,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 
 	if (rc > 0) {
 		if ((pjobs_list = calloc((j + 1), sizeof(int))) == NULL) {
-			free_server(nsinfo, 1);
+			free_server(nsinfo);
 			free(pjobs);
 			free(prjobs);
 			free_schd_error_list(full_err);
@@ -3390,7 +3390,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 			*no_of_jobs = i;
 	}
 
-	free_server(nsinfo, 1);
+	free_server(nsinfo);
 	free(pjobs);
 	free(prjobs);
 	free_schd_error_list(full_err);

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -180,7 +180,7 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 		if ((qinfo = query_queue_info(policy, cur_queue, sinfo)) == NULL) {
 			free_schd_error(sch_err);
 			pbs_statfree(queues);
-			free_queues(qinfo_arr, 1);
+			free_queues(qinfo_arr);
 			return NULL;
 		}
 
@@ -327,7 +327,7 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 	free_schd_error(sch_err);
 	if (err) {
 		if (qinfo_arr != NULL)
-			free_queues(qinfo_arr, 1);
+			free_queues(qinfo_arr);
 
 		return NULL;
 	}
@@ -595,23 +595,20 @@ new_queue_info(int limallocflag)
  *		free_queues - free an array of queues
  *
  * @param[in,out]	qarr	-	qinfo array to delete
- * @param[in]	free_jobs_too	-	free the jobs in the queue also
  *
  * @return	nothing
  *
  */
 
 void
-free_queues(queue_info **qarr, char free_jobs_too  )
+free_queues(queue_info **qarr)
 {
 	int i;
 	if (qarr == NULL)
 		return;
 
 	for (i = 0; qarr[i] != NULL; i++) {
-		if (free_jobs_too)
-			free_resource_resv_array(qarr[i]->jobs);
-
+		free_resource_resv_array(qarr[i]->jobs);
 		free_queue_info(qarr[i]);
 	}
 
@@ -890,7 +887,7 @@ dup_queues(queue_info **oqueues, server_info *nsinfo)
 
 	for (i = 0; oqueues[i] != NULL; i++) {
 		if ((new_queues[i] = dup_queue_info(oqueues[i], nsinfo)) == NULL) {
-			free_queues(new_queues, 1);
+			free_queues(new_queues);
 			return NULL;
 		}
 	}

--- a/src/scheduler/queue_info.h
+++ b/src/scheduler/queue_info.h
@@ -66,7 +66,7 @@ queue_info *new_queue_info(int limallocflag);
 /*
  *      free_queues - frees the memory for an array
  */
-void free_queues(queue_info **qinfo, char free_jobs_too);
+void free_queues(queue_info **qinfo);
 
 /*
  *      update_queue_on_run - update the information kept in a qinfo structure

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -954,7 +954,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 					sinfo->resvs[i]->name,
 					"Error determining if reservation can be confirmed: "
 					"Resource not found.");
-				free_server(nsinfo, 1);
+				free_server(nsinfo);
 				return -1;
 			}
 
@@ -993,7 +993,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						schdlog(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
 							sinfo->resvs[i]->name,
 							"Error unrolling standing reservation.");
-						free_server(nsinfo, 1);
+						free_server(nsinfo);
 						return -1;
 					}
 				}
@@ -1004,7 +1004,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 					 */
 					occr_execvnodes_arr = malloc(sizeof(char *));
 					if (occr_execvnodes_arr == NULL) {
-						free_server(nsinfo, 1);
+						free_server(nsinfo);
 						log_err(errno, "check_new_reservations", MEM_ERR_MSG);
 						return -1;
 					}
@@ -1152,7 +1152,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 			occr_execvnodes_arr = NULL;
 
 			/* Clean up simulated server info */
-			free_server(nsinfo, 1);
+			free_server(nsinfo);
 		}
 		/* Something went wrong with reservation confirmation, retry later */
 		if (pbsrc == RESV_CONFIRM_RETRY)

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -280,7 +280,7 @@ query_server(status *pol, int pbs_sd)
 	if ((sinfo->queues = query_queues(policy, pbs_sd, sinfo)) == NULL) {
 		pbs_statfree(server);
 		sinfo->fairshare = NULL;
-		free_server(sinfo, 0);
+		free_server(sinfo, 1);
 		return NULL;
 	}
 

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -125,7 +125,7 @@ schd_resource *create_resource(char *name, char *value, enum resource_fields fie
 /*
  *	free_server - free a list of server_info structs
  */
-void free_server(server_info *sinfo, int free_queues_too);
+void free_server(server_info *sinfo);
 
 /*
  *      update_server_on_run - update server_info strucutre when a job is run


### PR DESCRIPTION
**Problem**
Scheduler leaks memory when estimating for top job fails - 
==24836== 78,274 (2,928 direct, 75,346 indirect) bytes in 6 blocks are definitely lost in loss record 1,723 of 1,724
==24836== at 0x4C27BE3: malloc (vg_replace_malloc.c:299)
==24836== by 0x459043: new_server_info (server_info.c:1244)
==24836== by 0x45AFCF: dup_server_info (server_info.c:2235)
==24836== by 0x4207D0: add_job_to_calendar (fifo.c:1905)
==24836== by 0x41EB3F: main_sched_loop (fifo.c:963)
==24836== by 0x41E57A: scheduling_cycle (fifo.c:742)
==24836== by 0x41E20C: intermediate_schedule (fifo.c:614)
==24836== by 0x41E0CB: schedule (fifo.c:559)
==24836== by 0x41CFD8: main (pbs_sched.c:1455)

Steps to reproduce:
Execute the below PTL tests -
TestCalendaring.test_topjob_fail
from pbs_multi_sched.py

A return statement was added through #1087 which caused this leak.

**Solution**
Free the duped server_info before returning from add_job_to_calendar().
Once this is done - we see another mem leak being reported - 
==395== 3,630 (32 direct, 3,598 indirect) bytes in 1 blocks are definitely lost in loss record 1,568 of 1,595
==395==    at 0x4C27BE3: malloc (vg_replace_malloc.c:299)
==395==    by 0x435644: query_nodes (node_info.c:197)
==395==    by 0x456813: query_server (server_info.c:267)
==395==    by 0x41E2AF: scheduling_cycle (fifo.c:676)
==395==    by 0x41E20C: intermediate_schedule (fifo.c:614)
==395==    by 0x41E0CB: schedule (fifo.c:559)
==395==    by 0x41CFD8: main (pbs_sched.c:1455)

For this - we need to pass 1 to free_server when query_queues() fail.

**Logs**
[val_sched_final.txt](https://github.com/PBSPro/pbspro/files/3107072/val_sched_final.txt)
[val_sched_no_changes.txt](https://github.com/PBSPro/pbspro/files/3107073/val_sched_no_changes.txt)
[val_sched_one_change.txt](https://github.com/PBSPro/pbspro/files/3107074/val_sched_one_change.txt)
