### PR TITLE
pbs_snapshot help message has incorrect information about -o option

### DIFF
--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -78,7 +78,7 @@ sys.excepthook = trap_exceptions
 
 def usage():
     msg = """
-Usage: pbs_snapshot -o <path to existing staging directory> [OPTION]
+Usage: pbs_snapshot -o <path to existing output directory> [OPTION]
 
     Take snapshot of a PBS system and optionally capture logs for diagnostics
 

--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -78,7 +78,7 @@ sys.excepthook = trap_exceptions
 
 def usage():
     msg = """
-Usage: pbs_snapshot -o <path to output tar file> [OPTION]
+Usage: pbs_snapshot -o <path to existing staging directory> [OPTION]
 
     Take snapshot of a PBS system and optionally capture logs for diagnostics
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
pbs_snapshot -h option gives the usage as:

Usage: pbs_snapshot -o \<**path to output tar file\**> [OPTION]
.....

The -o option is written as "path to output tar file" this is not correct, it's actually path to a pre-existing  staging directory where the snapshot tar file is created.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Just changed the help message to say:
/opt/pbs/sbin/pbs_snapshot -h

Usage: pbs_snapshot -o **\<path to existing output directory\>** [OPTION]

....


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
Updated the snapshot design doc with the latest help message:
https://pbspro.atlassian.net/wiki/spaces/PD/pages/51614810/PP-758+Add+pbs+snapshot+tool+to+capture+state+logs+from+PBS

#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
