### PR TITLE
qsub -a argument causes duplicate job entry in datastore in 18.x or before and gets rejected in 19.x

### DIFF
--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -856,6 +856,7 @@ create_subjob(job *parent, char *newjid, int *rc)
 		*rc = PBSE_SYSTEM;
 		return NULL;
 	}
+	subj->ji_newjob = 1; /* help to save in db as a new job */
 	subj->ji_qs = parent->ji_qs;	/* copy the fixed save area */
 	parent->ji_ajtrk->tkm_tbl[indx].trk_psubjob = subj;
 	subj->ji_qhdr     = parent->ji_qhdr;
@@ -904,8 +905,6 @@ create_subjob(job *parent, char *newjid, int *rc)
 
 	subj->ji_qs.ji_svrflags &= ~JOB_SVFLG_ArrayJob;
 	subj->ji_qs.ji_svrflags |=  JOB_SVFLG_SubJob;
-	subj->ji_modified = 0;  /* to avoid db save in svr_setjobstate()*/
-	subj->ji_newjob = 1;    /* Hack to use ji_newjob to mean SAVEJOB_NEW for subjobs */
 	subj->ji_qs.ji_substate = JOB_SUBSTATE_TRANSICM;
 	(void)svr_setjobstate(subj, JOB_STATE_QUEUED, JOB_SUBSTATE_QUEUED);
 	subj->ji_modified = 1;  /* to force a SAVEJOB_NEW db save in svr_setjobstate() for subjobs */

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -856,7 +856,7 @@ create_subjob(job *parent, char *newjid, int *rc)
 		*rc = PBSE_SYSTEM;
 		return NULL;
 	}
-	subj->ji_newjob = 1; /* help to save in db as a new job */
+	subj->ji_newjob = 1; /* flag to indicate a new job is being added to the db */
 	subj->ji_qs = parent->ji_qs;	/* copy the fixed save area */
 	parent->ji_ajtrk->tkm_tbl[indx].trk_psubjob = subj;
 	subj->ji_qhdr     = parent->ji_qhdr;

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -378,6 +378,7 @@ job_alloc(void)
 	pj->ji_terminated = 0;
 	pj->ji_deletehistory = 0;
 	pj->ji_newjob = 0;
+	pj->ji_modified = 0;
 	pj->ji_script = NULL;
 #endif
 	pj->ji_qs.ji_jsversion = JSVERSION;

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -383,10 +383,9 @@ job_save_db(job *pjob, int updatetype)
 		return (0);
 
 	if (updatetype == SAVEJOB_NEW && pjob->ji_newjob == 0) {
-		/* If new_job flag is not set but still try to save as a new job, changed to SAVEJOB_FULL*/
 		updatetype = SAVEJOB_FULL;
-		sprintf(log_buffer,"job has already been saved earlier as a new job, thus changing to SAVEJOB_FULL");
-		log_joberr(-1, "job_save_db", log_buffer,  pjob->ji_qs.ji_jobid);
+		sprintf(log_buffer, "job already saved to db, so changing updatetype to SAVEJOB_FULL");
+		log_joberr(-1, "job_save_db", log_buffer, pjob->ji_qs.ji_jobid);
 #ifndef WIN32
 		print_backtrace(pjob->ji_qs.ji_jobid);
 #endif
@@ -819,15 +818,15 @@ print_backtrace(char *jobid) {
 	total_frames = backtrace(bt_buffer, BACKTRACE_BUF_SIZE);
 	if (total_frames != 0) {
 		log_err(-1, "job_save_db", "----- BACKTRACE START -----");
-		sprintf(log_buffer,"backtrace() has returned %d addresses",total_frames);
-		log_joberr(-1, "job_save_db", log_buffer,  jobid);
+		sprintf(log_buffer, "backtrace() has returned %d addresses", total_frames);
+		log_joberr(-1, "job_save_db", log_buffer, jobid);
 		/* backtrace_symbols() resolve addresses into strings containing "filename(function+address)",
 		 * this array must be free()-ed at the end.
 		 */
 		bt_strings = backtrace_symbols(bt_buffer, total_frames);
 		if (bt_strings == NULL) {
-			sprintf(log_buffer,"no backtrace_symbols() found");
-			log_joberr(-1, "job_save_db", log_buffer,  jobid);
+			sprintf(log_buffer, "no backtrace symbols found");
+			log_joberr(-1, "job_save_db", log_buffer, jobid);
 		} else {
 			for (frame_num = 0; frame_num < total_frames; frame_num++) {
 				snprintf(log_buffer, LOG_BUF_SIZE-1, "%s", bt_strings[frame_num]);
@@ -837,8 +836,8 @@ print_backtrace(char *jobid) {
 		free(bt_strings);
 		log_err(-1, "job_save_db", "----- BACKTRACE END -----");
 	} else {
-		sprintf(log_buffer,"backtrace() has not returned any address, might be corrupted");
-		log_joberr(-1, "job_save_db", log_buffer,  jobid);
+		sprintf(log_buffer, "No backtrace symbols present");
+		log_joberr(-1, "job_save_db", log_buffer, jobid);
 	}
 #endif /*-- GLIBC --*/
 #endif /*-- GNUC  --*/

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -68,6 +68,8 @@
 
 #ifndef WIN32
 #include <sys/param.h>
+#include <execinfo.h>
+#define BACKTRACE_BUF_SIZE 50
 #endif
 
 #include "pbs_ifl.h"
@@ -375,6 +377,46 @@ job_save_db(job *pjob, int updatetype)
 	 */
 	if (pjob->ji_newjob == 1 && updatetype != SAVEJOB_NEW)
 		return (0);
+
+	if (updatetype == SAVEJOB_NEW && pjob->ji_newjob == 0) {
+		/* If new_job flag is not set but still try to save as a new job, changed to SAVEJOB_FULL*/
+		updatetype = SAVEJOB_FULL;
+		sprintf(log_buffer,"job has already been saved earlier as a new job, thus changing to SAVEJOB_FULL");
+		log_joberr(-1, "job_save_db", log_buffer,  pjob->ji_qs.ji_jobid);
+#ifndef WIN32
+		/* let's print the backtrace to identify the faulty scenario */
+		int total_frames; /* total number of frames returned by backtrace() */
+		int frame_num;
+		void *bt_buffer[BACKTRACE_BUF_SIZE];
+		char **bt_strings;
+
+		/* backtrace() returns current stack addresses */
+		total_frames = backtrace(bt_buffer, BACKTRACE_BUF_SIZE);
+		if (total_frames != 0) {
+			log_err(-1, "job_save_db", "----- BACKTRACE START -----");
+			sprintf(log_buffer,"backtrace() has returned %d addresses",total_frames);
+			log_joberr(-1, "job_save_db", log_buffer,  pjob->ji_qs.ji_jobid);
+			/* backtrace_symbols() resolve addresses into strings containing "filename(function+address)",
+			 * this array must be free()-ed at the end.
+			 */
+			bt_strings = backtrace_symbols(bt_buffer, total_frames);
+			if (bt_strings == NULL) {
+				sprintf(log_buffer,"no backtrace_symbols() found");
+				log_joberr(-1, "job_save_db", log_buffer,  pjob->ji_qs.ji_jobid);
+			} else {
+				for (frame_num = 0; frame_num < total_frames; frame_num++) {
+					snprintf(log_buffer, LOG_BUF_SIZE-1, "%s", bt_strings[frame_num]);
+					log_err(-1, "job_save_db", log_buffer);
+				}
+			}
+			free(bt_strings);
+			log_err(-1, "job_save_db", "----- BACKTRACE END -----");
+		} else {
+			sprintf(log_buffer,"backtrace() has not returned any address, might be corrupted");
+			log_joberr(-1, "job_save_db", log_buffer,  pjob->ji_qs.ji_jobid);
+		}
+#endif
+	}
 
 	/* if ji_modified is set, ie an attribute changed, then update mtime */
 	if (pjob->ji_modified) {

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -383,7 +383,11 @@ job_save_db(job *pjob, int updatetype)
 		updatetype = SAVEJOB_FULL;
 		sprintf(log_buffer,"job has already been saved earlier as a new job, thus changing to SAVEJOB_FULL");
 		log_joberr(-1, "job_save_db", log_buffer,  pjob->ji_qs.ji_jobid);
+
 #ifndef WIN32
+#ifdef __GNUC__
+/* backtrace() functionality provided in glibc since from version 2.1 */
+#if (__GLIBC__ >= 2 && __GLIBC_MINOR__ >= 1)
 		/* let's print the backtrace to identify the faulty scenario */
 		int total_frames; /* total number of frames returned by backtrace() */
 		int frame_num;
@@ -415,7 +419,9 @@ job_save_db(job *pjob, int updatetype)
 			sprintf(log_buffer,"backtrace() has not returned any address, might be corrupted");
 			log_joberr(-1, "job_save_db", log_buffer,  pjob->ji_qs.ji_jobid);
 		}
-#endif
+#endif /*-- GLIBC --*/
+#endif /*-- GNUC --*/
+#endif /*-- WIN32 --*/
 	}
 
 	/* if ji_modified is set, ie an attribute changed, then update mtime */

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -70,7 +70,6 @@
 #ifndef WIN32
 #include <sys/param.h>
 #include <execinfo.h>
-#define BACKTRACE_BUF_SIZE 50
 #endif
 
 #include "pbs_ifl.h"
@@ -108,12 +107,8 @@
 #ifndef PBS_MOM
 extern pbs_db_conn_t	*svr_db_conn;
 #ifndef WIN32
-#ifdef __GNUC__
-/* backtrace() functionality provided in glibc since from version 2.1 */
-#if (__GLIBC__ >= 2 && __GLIBC_MINOR__ >= 1)
+#define BACKTRACE_BUF_SIZE 50
 void print_backtrace(char *);
-#endif
-#endif
 #endif
 #endif
 
@@ -392,14 +387,8 @@ job_save_db(job *pjob, int updatetype)
 		updatetype = SAVEJOB_FULL;
 		sprintf(log_buffer,"job has already been saved earlier as a new job, thus changing to SAVEJOB_FULL");
 		log_joberr(-1, "job_save_db", log_buffer,  pjob->ji_qs.ji_jobid);
-
 #ifndef WIN32
-#ifdef __GNUC__
-/* backtrace() functionality provided in glibc since from version 2.1 */
-#if (__GLIBC__ >= 2 && __GLIBC_MINOR__ >= 1)
 		print_backtrace(pjob->ji_qs.ji_jobid);
-#endif
-#endif
 #endif
 	}
 
@@ -815,13 +804,11 @@ job_or_resv_recov_db(char *id, int objtype)
  * @param[in]	jobid - Print call trace of the job
  *
  */
-#ifndef WIN32
+void
+print_backtrace(char *jobid) {
 #ifdef __GNUC__
 /* backtrace() functionality provided in glibc since from version 2.1 */
 #if (__GLIBC__ >= 2 && __GLIBC_MINOR__ >= 1)
-void
-print_backtrace(char *jobid) {
-
 	/* let's print the backtrace to identify the faulty scenario */
 	int total_frames; /* total number of frames returned by backtrace() */
 	int frame_num;
@@ -853,9 +840,8 @@ print_backtrace(char *jobid) {
 		sprintf(log_buffer,"backtrace() has not returned any address, might be corrupted");
 		log_joberr(-1, "job_save_db", log_buffer,  jobid);
 	}
-}
 #endif /*-- GLIBC --*/
 #endif /*-- GNUC  --*/
-#endif /*-- WIN32 --*/
+}
 
 #endif

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -1845,7 +1845,6 @@ req_commit(struct batch_request *preq)
 	delete_link(&pj->ji_alljobs);
 
 	svr_evaljobstate(pj, &newstate, &newsub, 1);
-	pj->ji_modified = 0; /* don't save from svr_setjobstate, we will save soon after */
 	(void)svr_setjobstate(pj, newstate, newsub);
 
 #ifdef WIN32

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -613,14 +613,9 @@ req_runjob2(struct batch_request *preq, job *pjob)
 	/* Check if prov is required, if so, reply_ack and let prov finish */
 	/* else follow normal flow */
 	prov_rc = check_and_provision_job(preq, pjob, &need_prov);
-	if (prov_rc) { /* problem with the request */
-		free_nodes(pjob);
-		req_reject(prov_rc, 0, preq);
-		return;
-	}
 
-	/* In case of subjob, it was never saved to the database so far.
-	 * Save it now, before a possiblity to return from the routine
+	/* In case of subjob, save it to the database now because
+	 * not saved to the database so far.
 	 */
 	if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) {
 		if (job_save(pjob, SAVEJOB_NEW)) {
@@ -630,7 +625,11 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		}
 	}
 
-	if (need_prov == 1) { /* prov required and request is fine */
+	if (prov_rc) { /* problem with the request */
+		free_nodes(pjob);
+		req_reject(prov_rc, 0, preq);
+		return;
+	} else if (need_prov == 1) { /* prov required and request is fine */
 		/* allocate resources right away */
 		set_resc_assigned((void *)pjob, 0,  INCR);
 

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -613,8 +613,13 @@ req_runjob2(struct batch_request *preq, job *pjob)
 	/* Check if prov is required, if so, reply_ack and let prov finish */
 	/* else follow normal flow */
 	prov_rc = check_and_provision_job(preq, pjob, &need_prov);
+	if (prov_rc) { /* problem with the request */
+		free_nodes(pjob);
+		req_reject(prov_rc, 0, preq);
+		return;
+	}
 
-	/* in case of subjob, it was never saved to the database so far.
+	/* In case of subjob, it was never saved to the database so far.
 	 * Save it now, before a possiblity to return from the routine
 	 */
 	if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) {
@@ -625,12 +630,7 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		}
 	}
 
-	if (prov_rc) { /* problem with the request */
-		free_nodes(pjob);
-		req_reject(prov_rc, 0, preq);
-		return;
-	}
-	else if (need_prov == 1) { /* prov required and request is fine */
+	if (need_prov == 1) { /* prov required and request is fine */
 		/* allocate resources right away */
 		set_resc_assigned((void *)pjob, 0,  INCR);
 
@@ -639,8 +639,8 @@ req_runjob2(struct batch_request *preq, job *pjob)
 		reply_ack(preq);
 		return;
 	}
-	/* if need_prov ==0 then no prov required, so continue normal flow */
 
+	/* if need_prov ==0 then no prov required, so continue normal flow */
 	dest = preq->rq_ind.rq_run.rq_destin;
 	if ((dest == NULL) || (*dest == '\0') || ((*dest == '-') && (*(dest + 1) == '\0'))) {
 		if (pjob->ji_wattr[(int)JOB_ATR_exec_vnode].at_flags & ATR_VFLAG_SET) {

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -713,14 +713,10 @@ svr_setjobstate(job *pjob, int newstate, int newsubstate)
 		}
 	}
 
-	if (pjob->ji_modified) {
-		if (pjob->ji_newjob)	/* Hack to use ji_newjob to mean SAVEJOB_NEW for subjobs */
-			return (job_save(pjob, SAVEJOB_NEW));
-		else
-			return (job_save(pjob, SAVEJOB_FULL));
-	} else if (changed)
+	if (pjob->ji_modified)
+		return (job_save(pjob, SAVEJOB_FULL));
+	else if(changed)
 		return (job_save(pjob, SAVEJOB_QUICK));
-
 	return (0);
 }
 

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -126,3 +126,37 @@ bhtiusabsdlg' % (os.environ['HOME'])
         cmd = [self.qsub_cmd, '-V', self.fn]
         rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
         self.assertEquals(rv['rc'], 0, 'qsub failed')
+
+    def test_qsub_with_option_a(self):
+        """
+        submit a job with an option 'a' with time (past and future) and should
+        accept
+        """
+        self.server.manager(MGR_CMD_SET, NODE,
+                            {'resources_available.ncpus': 2},
+                            self.mom.shortname)
+        # submit a job with future time and should start whenever time hits
+        present_tm = int(time.time())
+        future_tm = time.strftime(
+            "%Y%m%d%H%M", time.localtime(
+                present_tm + 60))
+        qsub_cmd = [self.qsub_cmd, '-a', future_tm, '--', '/bin/sleep', '100']
+        rv = self.du.run_cmd(self.server.hostname, cmd=qsub_cmd)
+        if rv['rc'] != 0:
+            self.fail("ERROR in submitting a job with future time: %s" % rv)
+        self.server.expect(JOB, {'job_state': 'W'}, id=str(rv['out'][0]))
+        self.logger.info(
+            'waiting for 60 seconds to run the job as it is a future job...')
+        time.sleep(60)
+        self.server.expect(JOB, {'job_state': 'R'}, id=str(rv['out'][0]))
+
+        # submit a job with past time and should start right away
+        past_tm = time.strftime(
+            "%Y%m%d%H%M", time.localtime(
+                present_tm - 3600))
+        qsub_cmd = [self.qsub_cmd, '-a', past_tm, '--', '/bin/sleep', '100']
+        ret_msg = 'Failed to save job/resv, refer server logs for details'
+        rv_1 = self.du.run_cmd(self.server.hostname, cmd=qsub_cmd)
+        if rv_1['rc'] != 0:
+            self.assertFalse(rv_1['err'][0], ret_msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=str(rv_1['out'][0]))

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -143,8 +143,7 @@ bhtiusabsdlg' % (os.environ['HOME'])
 
     def test_qsub_with_option_a(self):
         """
-        submit a job with an option 'a' with time (past and future) and should
-        accept
+        submit a job with an execution time and should accept
         """
         self.server.manager(MGR_CMD_SET, NODE,
                             {'resources_available.ncpus': 2},
@@ -162,8 +161,7 @@ bhtiusabsdlg' % (os.environ['HOME'])
         self.server.expect(JOB, {'job_state': 'W'}, id=jid_1)
         self.logger.info(
             'waiting for 60 seconds to run the job as it is a future job...')
-        time.sleep(60)
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid_1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid_1, offset=60)
 
         # submit a job with past time and should start right away
         past_tm = time.strftime(

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -60,16 +60,13 @@ class TestQsubOptionsArguments(TestFunctional):
         # PBS returns 15161 error code when it fails to save the job in db
         # but in PTL_CLI mode it returns modulo of the error code.
 
-        # for PTL_API mode
-        if e.rc == 15161:
-            self.assertFalse(e.msg[0], ret_msg)
-        # for PTL_CLI mode
-        elif 15161 % 256 == e.rc:
-            self.assertFalse(e.msg[0], ret_msg)
+        # PTL_API and PTL_CLI mode returns 15161 and 57 error code respectively
+        if err.rc == 15161 or err.rc == 15161 % 256:
+            self.assertFalse(err.msg[0], ret_msg)
         else:
             self.fail(
                 "ERROR in submitting a job with future time: %s" %
-                e.msg[0])
+                err.msg[0])
 
     def test_qsub_with_script_with_long_TMPDIR(self):
         """

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -143,7 +143,7 @@ bhtiusabsdlg' % (os.environ['HOME'])
 
     def test_qsub_with_option_a(self):
         """
-        submit a job with an execution time and should accept
+        Test submission of job with execution time(future and past)
         """
         self.server.manager(MGR_CMD_SET, NODE,
                             {'resources_available.ncpus': 2},


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* job submitted with qsub -a argument in the past causes duplicate job and job_attr rows in datastore and ultimately server crash in 18.x and before, causes job to be rejected in 19.x
* In 18.x PBS saves the job in job_wait_over as a new job and later again save the same job through job_or_resv_save as a fresh job resulting duplication in datastore happens.
* In 19.x this thing is not happening because jobid has been guarded with primary key so PBS doesn't accept the job.

**Steps to Reproduce**:(18.x or older)
1. submit a job with past time using qsub 'a' option.
   e.g. 
   [root@centos7_2 PBSPro_18.2.3]# date
   Thu Apr 25 16:11:59 IST 2019
    [root@centos7_2 PBSPro_18.2.3]# qsub -a 201904251500 -- /bin/sleep 100
    0.centos7_2
2. Restart the PBS complex (/etc/init.d/pbs restart)
3. Run qstat and can see two jobs with the same name.
4. qdel \<jobid\>, server will be crashed here. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* PBS will use job_or_resv_save() only to save a new job.
* If PBS tries to save a same job twice as a new job then PBS will dump backtrace in server logs.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
[ptl_job_array.txt](https://github.com/PBSPro/pbspro/files/3161766/ptl_job_array.txt)
[ptl_qsub_opt_args.txt](https://github.com/PBSPro/pbspro/files/3161767/ptl_qsub_opt_args.txt)
valgrind report: [server_multi_job_save_val.txt](https://github.com/PBSPro/pbspro/files/3171794/server_multi_job_save_val.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
