### PR TITLE
Suspended job fails to resume if high priority job runs beyond its end time

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -796,8 +796,12 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 						convert_duration_to_str(duration, timebuf, 128);
 						update_job_attr(pbs_sd, resresv, ATTR_estimated, "soft_walltime", timebuf, NULL, UPDATE_NOW);
 					}
-				} else /* Job has exceeded its walltime.  It'll soon be killed and be put into the exiting state */
-					duration += EXITING_TIME;
+				} else 
+					/* Job has exceeded its walltime.  It'll soon be killed and be put into the exiting state.
+					 * Change the duration of the job to match the current situation and assume it will end in
+					 * now + EXITING_TIME
+					 */
+					duration =  server_time - start + EXITING_TIME;
 				end = start + duration;
 			}
 			resresv->start = start;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When sched_preempt_enforce_resumption option is set to True on the scheduler, PBS makes sure that a preempted job resumes as soon its preemptor (or any other higher priority job running on its resources) ends.
This works fine but it was failing in one corner case. When the high priority job that preempted a low priority job is running past its duration (or walltime). In such a case scheduler assumes that the job ends in the past and also assumes that the preempted job will start in the past. This results in nondeserving filler jobs running on resources which were needed for the preempted job to resume.


#### Describe Your Change
The change is to calculate the end time of the high priority job correctly and set it in future.

#### Link to Design Doc
None

#### Attach Test Logs or Output
There is no PTL test for it. This is a timing issue and requires debugger to reproduce the issue.
[resume_issue_after_fix.txt](https://github.com/PBSPro/pbspro/files/3119069/resume_issue_after_fix.txt)
[resume_issue_before_fix.txt](https://github.com/PBSPro/pbspro/files/3119085/resume_issue_before_fix.txt)
[job2.txt](https://github.com/PBSPro/pbspro/files/3119086/job2.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
