### PR TITLE
Failed to start PBS via init script

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -717,6 +717,24 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 		fi
 		${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 			create queue workq
+		EOF
+		ret=$?
+		if [ $ret -ne 0 ]; then
+			tries=3
+			while [ $tries -ge 0 ]
+			do
+				sleep 2
+				${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+					create queue workq
+				EOF
+				ret=$?
+				if [ $ret -eq 0 ]; then
+					break
+				fi
+				tries=$((tries-1))
+			done
+		fi
+		${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 			set queue workq queue_type = Execution
 			set queue workq enabled = True
 			set queue workq started = True

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -715,25 +715,19 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 				set server restrict_res_to_release_on_suspend = ncpus
 			EOF
 		fi
-		${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
-			create queue workq
-		EOF
-		ret=$?
-		if [ $ret -ne 0 ]; then
-			tries=3
-			while [ $tries -ge 0 ]
-			do
-				sleep 2
-				${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
-					create queue workq
-				EOF
-				ret=$?
-				if [ $ret -eq 0 ]; then
-					break
-				fi
-				tries=$((tries-1))
-			done
-		fi
+		tries=3
+		while [ $tries -ge 0 ]
+		do
+			${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
+				create queue workq
+			EOF
+			ret=$?
+			if [ $ret -eq 0 ]; then
+				break
+			fi
+			tries=$((tries-1))
+			sleep 2
+		done
 		${PBS_EXEC}/bin/qmgr <<-EOF > /dev/null
 			set queue workq queue_type = Execution
 			set queue workq enabled = True


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
On slower systems after installing PBS. When we try to start PBS '/etc/init.d/pbs start' some times PBS fails to start via init script.

Failed scenario  output 
--------------
```
***
*** Setting default queue and resource limits.
***
Connecting to PBS dataservice....connected to PBS dataservice@x3776-0.x3776.th.svc.cluster.local
Connection refused
qmgr: cannot connect to server
*** Setting license file location(s).
***
Connection refused
qmgr: cannot connect to server
Connection refused
qmgr: cannot connect to server
Connection refused
qterm: could not connect to server  (111)
*** End of /opt/pbs/libexec/pbs_habitat

.....

at the end of script

+ '[' -f /opt/pbs/lib/init.d/limits.pbs_server ']'
+ /opt/pbs/sbin/pbs_server
pbs_server: another server running
+ ret_val=1
+ '[' 1 -eq 4 ']'
+ echo 'pbs_server startup failed, exit 1 aborting.'
pbs_server startup failed, exit 1 aborting.
+ return 1
+ exit 1
```


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Updated pbs_habitat script to retry first qmgr command command 3 times incase it fails to connect  server while creating default queue.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
