### PR TITLE
Sched crash when array job and reservation is submitted

### DIFF
--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -858,11 +858,21 @@ create_events(server_info *sinfo)
 	int		errflag = 0;
 	int		i = 0;
 	time_t 		end = 0;
+	resource_resv	**all_resresv_copy;
+	int		all_resresv_len;
 
-	/* all_resresv is sorted such that the timed events are in the front of
-	 * the array.  Once the first non-timed event is reached, we're done
+	/* create a temporary copy of all_resresv array which is sorted such that
+	 * the timed events are in the front of the array.
+	 * Once the first non-timed event is reached, we're done
 	 */
-	all = sinfo->all_resresv;
+	all_resresv_len = count_array((void **)sinfo->all_resresv);
+	all_resresv_copy = (resource_resv **)malloc((all_resresv_len + 1) * sizeof(resource_resv *));
+	if (all_resresv_copy == NULL)
+		return 0;
+	for (i = 0; sinfo->all_resresv[i] != NULL; i++)
+		all_resresv_copy[i] = sinfo->all_resresv[i];
+	all_resresv_copy[i] = NULL;
+	all = all_resresv_copy;
 
 	/* sort the all resersv list so all the timed events are in the front */
 	qsort(all, count_array((void **)all), sizeof(resource_resv *), cmp_events);
@@ -901,8 +911,10 @@ create_events(server_info *sinfo)
 		if (node->is_sleeping) {
 			te = create_event(TIMED_NODE_UP_EVENT, sinfo->server_time + PROVISION_DURATION,
 					(event_ptr_t *) node, (event_func_t) node_up_event, NULL);
-			if (te == NULL)
+			if (te == NULL) {
+				free(all_resresv_copy);
 				return 0;
+			}
 			events = add_timed_event(events, te);
 		}
 	}
@@ -910,9 +922,11 @@ create_events(server_info *sinfo)
 	/* A malloc error was encountered, free all allocated memory and return */
 	if (errflag > 0) {
 		free_timed_event_list(events);
+		free(all_resresv_copy);
 		return 0;
 	}
 
+	free(all_resresv_copy);
 	return events;
 }
 

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -866,7 +866,7 @@ create_events(server_info *sinfo)
 	 * Once the first non-timed event is reached, we're done
 	 */
 	all_resresv_len = count_array((void **)sinfo->all_resresv);
-	all_resresv_copy = (resource_resv **)malloc((all_resresv_len + 1) * sizeof(resource_resv *));
+	all_resresv_copy = malloc((all_resresv_len + 1) * sizeof(resource_resv *));
 	if (all_resresv_copy == NULL)
 		return 0;
 	for (i = 0; sinfo->all_resresv[i] != NULL; i++)
@@ -912,8 +912,8 @@ create_events(server_info *sinfo)
 			te = create_event(TIMED_NODE_UP_EVENT, sinfo->server_time + PROVISION_DURATION,
 					(event_ptr_t *) node, (event_func_t) node_up_event, NULL);
 			if (te == NULL) {
-				free(all_resresv_copy);
-				return 0;
+				errflag++;
+				break;
 			}
 			events = add_timed_event(events, te);
 		}

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -77,6 +77,7 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, {'job_state=R': 3}, count=True,
                            id=jid, extend='t')
 
+    @skipOnCpuSet
     def test_advance_reservation(self):
         """
         Test to submit an advanced reservation and submit jobs to that
@@ -88,21 +89,22 @@ class SmokeTest(PBSTestSuite):
         r = Reservation(TEST_USER)
         now = int(time.time())
         a = {'Resource_List.select': '1:ncpus=4',
-             'reserve_start': now + 5,
-             'reserve_end': now + 105}
+             'reserve_start': now + 10,
+             'reserve_end': now + 110}
         r.set_attributes(a)
         rid = self.server.submit(r)
+        rid_q = rid.split('.')[0]
         a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
         self.server.expect(RESV, a, id=rid)
 
         # submit a normal job and an array job to the reservation
         a = {'Resource_List.select': '1:ncpus=1',
-             ATTR_q: rid.split('.')[0]}
+             ATTR_q: rid_q}
         j1 = Job(TEST_USER, attrs=a)
         jid1 = self.server.submit(j1)
 
         a = {'Resource_List.select': '1:ncpus=1',
-             ATTR_q: rid.split('.')[0], ATTR_J: '1-2'}
+             ATTR_q: rid_q, ATTR_J: '1-2'}
         j2 = Job(TEST_USER, attrs=a)
         jid2 = self.server.submit(j2)
 

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -79,14 +79,37 @@ class SmokeTest(PBSTestSuite):
 
     def test_advance_reservation(self):
         """
-        Test to submit an advanced reservation
+        Test to submit an advanced reservation and submit jobs to that
+        reservation. Check if the reservation gets confimed and the jobs
+        inside the reservation starts running when the reservation runs.
         """
-        r = Reservation()
-        a = {'Resource_List.select': '1:ncpus=1'}
+        a = {'resources_available.ncpus': 4}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+        r = Reservation(TEST_USER)
+        now = int(time.time())
+        a = {'Resource_List.select': '1:ncpus=4',
+             'reserve_start': now + 5,
+             'reserve_end': now + 105}
         r.set_attributes(a)
         rid = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
         self.server.expect(RESV, a, id=rid)
+
+        # submit a normal job and an array job to the reservation
+        a = {'Resource_List.select': '1:ncpus=1',
+             ATTR_q: rid.split('.')[0]}
+        j1 = Job(TEST_USER, attrs=a)
+        jid1 = self.server.submit(j1)
+
+        a = {'Resource_List.select': '1:ncpus=1',
+             ATTR_q: rid.split('.')[0], ATTR_J: '1-2'}
+        j2 = Job(TEST_USER, attrs=a)
+        jid2 = self.server.submit(j2)
+
+        a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
+        self.server.expect(RESV, a, id=rid, interval=1)
+        self.server.expect(JOB, {'job_state': 'R'}, jid1)
+        self.server.expect(JOB, {'job_state': 'B'}, jid2)
 
     def test_standing_reservation(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Scheduler crashes when it encounters an array job and a reservation in the same scheduling cycle.


#### Describe Your Change
As part of speeding up scheduler, we added a way to find a job/reservation based on their indexes in the all_resresv array.
But after these indexes are created, all_resresv array gets sorted to bring timed events in from in order to create a calendar. This sort messes up the indexes and causes the crash. While the sort is needed there is no reason to have all_resresv sorted. 
As part of the fix, create_events code which creates the calendar will create a local copy of the array and sort that local copy instead of sorting all_resresv array.


#### Link to Design Doc
None


#### Attach Test Logs or Output
[sched_dump_valgrind.txt](https://github.com/PBSPro/pbspro/files/3136152/sched_dump_valgrind.txt)
[test_out.txt](https://github.com/PBSPro/pbspro/files/3136153/test_out.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
