### PR TITLE
Measure hook performance infrastructure

### DIFF
--- a/src/include/hook.h
+++ b/src/include/hook.h
@@ -386,6 +386,17 @@ extern int set_alarm(int sec, void (*)(void));
 
 extern void hook_perf_stat_start(char *label, char *action, int);
 extern void hook_perf_stat_stop(char *label, char *action, int);
+#define HOOK_PERF_POPULATE "populate"
+#define HOOK_PERF_FUNC "hook_func"
+#define HOOK_PERF_RUN_CODE "run_code"
+#define HOOK_PERF_START_PYTHON "start_interpreter"
+#define HOOK_PERF_LOAD_INPUT "load_hook_input_file"
+#define HOOK_PERF_HOOK_OUTPUT "hook_output"
+#define HOOK_PERF_POPULATE_VNODELIST "populate:pbs.event().vnode_list"
+#define HOOK_PERF_POPULATE_VNODELIST_FAIL "populate:pbs.event().vnode_list_fail"
+#define HOOK_PERF_POPULATE_RESVLIST "populate:pbs.event().resv_list"
+#define HOOK_PERF_POPULATE_JOBLIST "populate:pbs.event().job_list"
+#define HOOK_PERF_LOAD_DATA "load_hook_data"
 #ifdef	__cplusplus
 }
 #endif

--- a/src/include/hook.h
+++ b/src/include/hook.h
@@ -384,6 +384,8 @@ extern void cleanup_hooks_workdir(struct work_task *);
 extern void catch_hook_alarm(ALARM_HANDLER_ARG);
 extern int set_alarm(int sec, void (*)(void));
 
+extern void hook_perf_stat_start(char *label, char *action, int);
+extern void hook_perf_stat_stop(char *label, char *action, int);
 #ifdef	__cplusplus
 }
 #endif

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -307,6 +307,12 @@ void
 perf_stat_start(char *instance);
 
 /**
+ * Remove a performance stats entry.
+ */
+void 
+perf_stat_remove(char *instance);
+
+/**
  * End collecting performance stats (e.g. walltime)
  */
 char *

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -300,6 +300,18 @@ void convert_duration_to_str(time_t duration, char* buf, int bufsize);
 struct preempt_ordering *
 get_preemption_order(struct preempt_ordering *porder, int req, int used);
 
+/**
+ * Begin collecting performance stats (e.g. walltime)
+ */
+void 
+perf_stat_start(char *instance);
+
+/**
+ * End collecting performance stats (e.g. walltime)
+ */
+char *
+perf_stat_stop(char *instance);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/src/include/pbs_python.h
+++ b/src/include/pbs_python.h
@@ -85,6 +85,7 @@
  * ====================== IMPORTANT =======================
  */
 
+#define PBS_PYTHON_PROGRAM "pbs_python"
 struct python_interpreter_data {
 	int data_initialized;     /* data initialized */
 	int interp_started;       /* status flag*/

--- a/src/include/pbs_python.h
+++ b/src/include/pbs_python.h
@@ -443,12 +443,13 @@ extern int  pbs_python_event_set(
 	unsigned int hook_event,
 	char *req_user,
 	char *req_host,
-	hook_input_param_t *req_params);
+	hook_input_param_t *req_params,
+	char *perf_label);
 
 extern void pbs_python_event_unset(void);
 
 extern int  pbs_python_event_to_request(unsigned int hook_event,
-	hook_output_param_t *req_params);
+	hook_output_param_t *req_params, char *perf_label, char *perf_action);
 
 extern int  pbs_python_event_set_attrval(char *name, char *value);
 

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -4199,7 +4199,7 @@ create_py_vnodelist(pbs_list_head *vnlist, char *perf_label, char *perf_action)
 				goto create_py_vnodelist_exit;
 			}
 
-			rc = pbs_python_populate_python_class_from_svrattrl(py_vn, &rqs.rq_attr, perf_label, perf_action);
+			rc = pbs_python_populate_python_class_from_svrattrl(py_vn, &rqs.rq_attr, NULL, NULL);
 
 			if (rc == -1) {
 				snprintf(log_buffer, sizeof(log_buffer),
@@ -4432,7 +4432,7 @@ create_py_joblist(pbs_list_head *joblist, char *perf_label, char *perf_action)
 				goto create_py_joblist_exit;
 			}
 
-			rc = pbs_python_populate_python_class_from_svrattrl(py_jn, &rqs.rq_attr, perf_label, perf_action);
+			rc = pbs_python_populate_python_class_from_svrattrl(py_jn, &rqs.rq_attr, NULL, NULL);
 
 			if (rc == -1) {
 				snprintf(log_buffer, sizeof(log_buffer),
@@ -4665,7 +4665,7 @@ create_py_resvlist(pbs_list_head *resvlist, char *perf_label, char *perf_action)
 				goto create_py_resvlist_exit;
 			}
 
-			rc = pbs_python_populate_python_class_from_svrattrl(py_rn, &rqs.rq_attr, perf_label, perf_action);
+			rc = pbs_python_populate_python_class_from_svrattrl(py_rn, &rqs.rq_attr, NULL, NULL);
 
 			if (rc == -1) {
 				snprintf(log_buffer, sizeof(log_buffer),

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -3346,7 +3346,7 @@ _pps_helper_get_queue(pbs_queue *pque, const char *que_name, char *perf_label)
 		que->qu_jobstbuf);
 	/* stuff all the attributes */
 	snprintf((char *)hook_debug.objname, HOOK_BUF_SIZE-1, "%s(%s)", SERVER_QUEUE_OBJECT, que->qu_qs.qu_name);
-	snprintf(perf_action, sizeof(perf_action), "populate:%s", hook_debug.objname);
+	snprintf(perf_action, sizeof(perf_action), "%s:%s", HOOK_PERF_POPULATE, hook_debug.objname);
 	tmp_rc = pbs_python_populate_attributes_to_python_class(py_que,
 		py_que_attr_types,
 		que->qu_attr,
@@ -3496,7 +3496,7 @@ _pps_helper_get_server(char *perf_label)
 
 	/* stuff all the attributes */
 	strncpy((char *)hook_debug.objname, SERVER_OBJECT, HOOK_BUF_SIZE-1);
-	snprintf(perf_action, sizeof(perf_action), "populate:%s", hook_debug.objname);
+	snprintf(perf_action, sizeof(perf_action), "%s:%s", HOOK_PERF_POPULATE, hook_debug.objname);
 	tmp_rc = pbs_python_populate_attributes_to_python_class(py_svr,
 		py_svr_attr_types,
 		server.sv_attr,
@@ -3622,7 +3622,7 @@ _pps_helper_get_job(job *pjob_o, const char *jobid, const char *qname, char *per
 	 * OK, At this point we need to start populating the job class.
 	 */
 	snprintf((char *)hook_debug.objname, HOOK_BUF_SIZE-1, "%s(%s)", SERVER_JOB_OBJECT, pjob->ji_qs.ji_jobid);
-	snprintf(perf_action, sizeof(perf_action), "populate:%s", hook_debug.objname);
+	snprintf(perf_action, sizeof(perf_action), "%s:%s", HOOK_PERF_POPULATE, hook_debug.objname);
 	tmp_rc = pbs_python_populate_attributes_to_python_class(py_job,
 		py_job_attr_types,
 		pjob->ji_wattr,
@@ -3758,7 +3758,7 @@ _pps_helper_get_resv(resc_resv *presv_o, const char *resvid, char *perf_label)
 	 * OK, At this point we need to start populating the resv class.
 	 */
 	snprintf((char *)hook_debug.objname, HOOK_BUF_SIZE-1, "%s(%s)", SERVER_RESV_OBJECT, presv->ri_qs.ri_resvID);
-	snprintf(perf_action, sizeof(perf_action), "populate:%s", hook_debug.objname);
+	snprintf(perf_action, sizeof(perf_action), "%s:%s", HOOK_PERF_POPULATE, hook_debug.objname);
 	tmp_rc = pbs_python_populate_attributes_to_python_class(py_resv,
 		py_resv_attr_types,
 		presv->ri_wattr,
@@ -3882,7 +3882,7 @@ _pps_helper_get_vnode(struct pbsnode *pvnode_o, const char *vname, char *perf_la
 	 * OK, At this point we need to start populating the vnode class.
 	 */
 	snprintf((char *)hook_debug.objname, HOOK_BUF_SIZE-1, "%s(%s)", SERVER_VNODE_OBJECT, pvnode->nd_name);
-	snprintf(perf_action, sizeof(perf_action), "populate:%s", hook_debug.objname);
+	snprintf(perf_action, sizeof(perf_action), "%s:%s", HOOK_PERF_POPULATE, hook_debug.objname);
 	tmp_rc = pbs_python_populate_attributes_to_python_class(py_vnode,
 		py_vnode_attr_types,
 		pvnode->nd_attr,
@@ -5342,7 +5342,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			goto event_set_exit;
 		}
 
-		snprintf(perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_JOB_OBJECT, rqj->rq_jid);
+		snprintf(perf_action, sizeof(perf_action), "%s:%s(%s)", HOOK_PERF_POPULATE, EVENT_JOB_OBJECT, rqj->rq_jid);
 		rc = pbs_python_populate_python_class_from_svrattrl(py_job,
 			&rqj->rq_attr, perf_label, perf_action);
 
@@ -5386,7 +5386,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 				PY_TYPE_EVENT,  PY_EVENT_PARAM_RESV);
 			goto event_set_exit;
 		}
-		snprintf(perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_RESV_OBJECT, rqj->rq_jid);
+		snprintf(perf_action, sizeof(perf_action), "%s:%s(%s)", HOOK_PERF_POPULATE, EVENT_RESV_OBJECT, rqj->rq_jid);
 		rc = pbs_python_populate_python_class_from_svrattrl(py_resv,
 			&rqj->rq_attr, perf_label, perf_action);
 
@@ -5432,7 +5432,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			goto event_set_exit;
 		}
 
-		snprintf(perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_JOB_OBJECT, rqj->rq_objname);
+		snprintf(perf_action, sizeof(perf_action), "%s:%s(%s)", HOOK_PERF_POPULATE, EVENT_JOB_OBJECT, rqj->rq_objname);
 		rc = pbs_python_populate_python_class_from_svrattrl(py_job,
 			&rqj->rq_attr, perf_label, perf_action);
 
@@ -5624,7 +5624,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 		/* SET VNODE_LIST param */
 		(void)PyDict_SetItemString(py_event_param, PY_EVENT_PARAM_VNODELIST,
 			Py_None);
-		py_vnodelist = create_py_vnodelist(vnlist, perf_label, "populate:pbs.event().vnode_list");
+		py_vnodelist = create_py_vnodelist(vnlist, perf_label, HOOK_PERF_POPULATE_VNODELIST);
 		if (py_vnodelist == NULL) {
 			LOG_ERROR_ARG2("%s: failed to create a Python vnodelist object for param['%s']",
 				PY_TYPE_EVENT, PY_EVENT_PARAM_VNODELIST);
@@ -5646,7 +5646,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 
 		(void)PyDict_SetItemString(py_event_param, PY_EVENT_PARAM_RESVLIST,
 			Py_None);
-		py_resvlist = create_py_resvlist(resvlist, perf_label, "populate:pbs.event().resv_list");
+		py_resvlist = create_py_resvlist(resvlist, perf_label, HOOK_PERF_POPULATE_RESVLIST);
 		if (py_resvlist == NULL) {
 			LOG_ERROR_ARG2("%s: failed to create a Python resvlist object for param['%s']",
 				PY_TYPE_EVENT, PY_EVENT_PARAM_RESVLIST);
@@ -5820,7 +5820,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			goto event_set_exit;
 		}
 
-		snprintf((char *)perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_JOB_OBJECT, rqj->rq_jid);
+		snprintf((char *)perf_action, sizeof(perf_action), "%s:%s(%s)", HOOK_PERF_POPULATE, EVENT_JOB_OBJECT, rqj->rq_jid);
 		rc = pbs_python_populate_python_class_from_svrattrl(py_job, &rqj->rq_attr, perf_label, perf_action);
 
 		if (rc == -1) {
@@ -5832,7 +5832,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 		py_vnodelist = create_hook_vnode_list_param(py_event_param,
 					PY_TYPE_EVENT, PY_EVENT_PARAM_VNODELIST,
 					(pbs_list_head *)req_params->vns_list,
-					perf_label, "populate:pbs.event().vnode_list");
+					perf_label, HOOK_PERF_POPULATE_VNODELIST);
 					
 		if (py_vnodelist == NULL) {
 			rc = -1;
@@ -5843,7 +5843,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 
 			py_vnodelist_fail = create_hook_vnode_list_param(py_event_param,
 						PY_TYPE_EVENT, PY_EVENT_PARAM_VNODELIST_FAIL,
-			    			(pbs_list_head *)req_params->vns_list_fail, perf_label, "populate:pbs.event().vnode_list_fail");
+			    			(pbs_list_head *)req_params->vns_list_fail, perf_label, HOOK_PERF_POPULATE_VNODELIST_FAIL);
 					
 			if (py_vnodelist_fail == NULL) {
 				rc = -1;
@@ -5915,7 +5915,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			goto event_set_exit;
 		}
 
-		snprintf((char *)perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_JOB_OBJECT, rqj->rq_jid);
+		snprintf((char *)perf_action, sizeof(perf_action), "%s:%s(%s)", HOOK_PERF_POPULATE, EVENT_JOB_OBJECT, rqj->rq_jid);
 		rc = pbs_python_populate_python_class_from_svrattrl(py_job, &rqj->rq_attr, perf_label, perf_action);
 
 		if (rc == -1) {
@@ -5927,7 +5927,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 		py_vnodelist =
 			   create_hook_vnode_list_param(py_event_param,
 					PY_TYPE_EVENT, PY_EVENT_PARAM_VNODELIST,
-					(pbs_list_head *)req_params->vns_list, perf_label, "populate:pbs.event().vnode_list");
+					(pbs_list_head *)req_params->vns_list, perf_label, HOOK_PERF_POPULATE_VNODELIST);
 					
 		if (py_vnodelist == NULL) {
 			rc = -1;
@@ -5937,7 +5937,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 		py_vnodelist_fail =
 			   create_hook_vnode_list_param(py_event_param,
 				PY_TYPE_EVENT, PY_EVENT_PARAM_VNODELIST_FAIL,
-			    	(pbs_list_head *)req_params->vns_list_fail, perf_label, "populate:pbs.event().vnode_list_fail");
+			    	(pbs_list_head *)req_params->vns_list_fail, perf_label, HOOK_PERF_POPULATE_VNODELIST_FAIL);
 					
 		if (py_vnodelist_fail == NULL) {
 			rc = -1;
@@ -6063,7 +6063,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 				PY_TYPE_EVENT,
 				PY_EVENT_PARAM_VNODELIST,
 			    (pbs_list_head *)req_params->vns_list,
-			    perf_label, "populate:pbs.event().vnode_list");
+			    perf_label, HOOK_PERF_POPULATE_VNODELIST);
 
 		if (py_vnodelist == NULL) {
 			rc = -1;
@@ -6077,7 +6077,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 
 			(void)PyDict_SetItemString(py_event_param, PY_EVENT_PARAM_JOBLIST,
 				Py_None);
-			py_joblist = create_py_joblist(joblist, perf_label, "populate:pbs.event().job_list");
+			py_joblist = create_py_joblist(joblist, perf_label, HOOK_PERF_POPULATE_JOBLIST);
 			if (py_joblist == NULL) {
 				LOG_ERROR_ARG2("%s: failed to create a Python joblist object for param['%s']",
 					PY_TYPE_EVENT, PY_EVENT_PARAM_JOBLIST);
@@ -6134,7 +6134,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			goto event_set_exit;
 		}
 
-		snprintf((char *)perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_JOB_OBJECT, rqj->rq_jid);
+		snprintf((char *)perf_action, sizeof(perf_action), "%s:%s(%s)", HOOK_PERF_POPULATE, EVENT_JOB_OBJECT, rqj->rq_jid);
 		rc = pbs_python_populate_python_class_from_svrattrl(py_job, &rqj->rq_attr, perf_label, perf_action);
 
 		if (rc == -1) {
@@ -6169,7 +6169,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 				PY_TYPE_EVENT,
 				PY_EVENT_PARAM_VNODELIST,
 			    (pbs_list_head *)req_params->vns_list,
-			    perf_label, "populate:pbs_event().vnode_list");
+			    perf_label, HOOK_PERF_POPULATE_VNODELIST);
 					
 		if (py_vnodelist == NULL) {
 			rc = -1;
@@ -6859,8 +6859,8 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 				"unexpected hook event type");
 			goto event_to_request_exit;
 	}
-event_to_request_exit:
 	rc = 0;
+event_to_request_exit:
 	hook_perf_stat_stop(perf_label, perf_action, 0);
 	return rc;
 }
@@ -7088,7 +7088,7 @@ pbsv1mod_meth_get_queue(PyObject *self, PyObject *args, PyObject *kwds)
 	}
 
 	hook_set_mode = C_MODE;
-	py_que = _pps_helper_get_queue(NULL, name, "hook_func");
+	py_que = _pps_helper_get_queue(NULL, name, HOOK_PERF_FUNC);
 	hook_set_mode = PY_MODE;
 
 	if (py_que != NULL)
@@ -7147,7 +7147,7 @@ pbsv1mod_meth_get_job(PyObject *self, PyObject *args, PyObject *kwds)
 	}
 
 	hook_set_mode = C_MODE;
-	py_job = _pps_helper_get_job(NULL, jname, qname, "hook_func");
+	py_job = _pps_helper_get_job(NULL, jname, qname, HOOK_PERF_FUNC);
 	hook_set_mode = PY_MODE;
 
 	if (py_job != NULL)
@@ -7202,7 +7202,7 @@ pbsv1mod_meth_get_resv(PyObject *self, PyObject *args, PyObject *kwds)
 	}
 
 	hook_set_mode = C_MODE;
-	py_resv = _pps_helper_get_resv(NULL, rname, "hook_func");
+	py_resv = _pps_helper_get_resv(NULL, rname, HOOK_PERF_FUNC);
 	hook_set_mode = PY_MODE;
 
 	if (py_resv != NULL)
@@ -7256,7 +7256,7 @@ pbsv1mod_meth_get_vnode(PyObject *self, PyObject *args, PyObject *kwds)
 	}
 
 	hook_set_mode = C_MODE;
-	py_vnode = _pps_helper_get_vnode(NULL, vname, "hook_func");
+	py_vnode = _pps_helper_get_vnode(NULL, vname, HOOK_PERF_FUNC);
 	hook_set_mode = PY_MODE;
 
 	if (py_vnode != NULL)
@@ -7307,7 +7307,7 @@ pbsv1mod_meth_server(void)
 {
 	PyObject *py_svr = NULL;
 	hook_set_mode = C_MODE;
-	py_svr = _pps_helper_get_server("hook_func");
+	py_svr = _pps_helper_get_server(HOOK_PERF_FUNC);
 	hook_set_mode = PY_MODE;
 	return (py_svr);
 }
@@ -8989,15 +8989,15 @@ pbsv1mod_meth_iter_nextfunc(PyObject *self, PyObject *args, PyObject *kwds)
 
 			hook_set_mode = C_MODE;
 			if (strcmp(obj_name, ITER_RESERVATIONS) == 0) {
-				py_object = _pps_helper_get_resv((resc_resv *)iter_entry->data, NULL, "hook_func");
+				py_object = _pps_helper_get_resv((resc_resv *)iter_entry->data, NULL, HOOK_PERF_FUNC);
 				iter_entry->data = (resc_resv *)GET_NEXT(\
 				((resc_resv *)iter_entry->data)->ri_allresvs);
 			} else if (strcmp(obj_name, ITER_QUEUES) == 0) {
-				py_object = _pps_helper_get_queue((pbs_queue *)iter_entry->data, NULL, "hook_func");
+				py_object = _pps_helper_get_queue((pbs_queue *)iter_entry->data, NULL, HOOK_PERF_FUNC);
 				iter_entry->data = (pbs_queue *)GET_NEXT(\
 				((pbs_queue *)iter_entry->data)->qu_link);
 			} else if (strcmp(obj_name, ITER_JOBS) == 0) {
-				py_object = _pps_helper_get_job((job *)iter_entry->data, NULL, NULL, "hook_func");
+				py_object = _pps_helper_get_job((job *)iter_entry->data, NULL, NULL, HOOK_PERF_FUNC);
 
 
 #ifdef NAS /* localmod 014 */
@@ -9033,7 +9033,7 @@ pbsv1mod_meth_iter_nextfunc(PyObject *self, PyObject *args, PyObject *kwds)
 				}
 			} else if (strcmp(obj_name, ITER_VNODES) == 0) {
 
-				py_object = _pps_helper_get_vnode((struct pbsnode *)iter_entry->data, NULL, "hook_func");
+				py_object = _pps_helper_get_vnode((struct pbsnode *)iter_entry->data, NULL, HOOK_PERF_FUNC);
 
 				iter_entry->data = NULL;
 				vi = iter_entry->data_index + 1;
@@ -10606,7 +10606,7 @@ py_get_server_static(void)
 
 	snprintf(perf_label, sizeof(perf_label), "hook_func:%s(%s)", SERVER_OBJECT, server_name);
 	tmp_rc = pbs_python_populate_python_class_from_svrattrl(py_svr,
-		server_data, perf_label, "populate");
+		server_data, perf_label, HOOK_PERF_POPULATE);
 
 	if (tmp_rc == -1) {
 		log_err(PBSE_INTERNAL, __func__,
@@ -10826,7 +10826,7 @@ py_get_queue_static(char *qname, char *svr_name)
 	}
 
 	snprintf(perf_label, sizeof(perf_label), "hook_func:%s(%s)", SERVER_QUEUE_OBJECT, qname);
-	rc = pbs_python_populate_python_class_from_svrattrl(py_queue, &queuel, perf_label, "populate");
+	rc = pbs_python_populate_python_class_from_svrattrl(py_queue, &queuel, perf_label, HOOK_PERF_POPULATE);
 
 	if (rc == -1) {
 		snprintf(log_buffer, sizeof(log_buffer),
@@ -11065,7 +11065,7 @@ py_get_vnode_static(char *vname, char *svr_name)
 	}
 
 	snprintf(perf_label, sizeof(perf_label), "hook_func:%s(%s)", SERVER_VNODE_OBJECT, vname);
-	rc = pbs_python_populate_python_class_from_svrattrl(py_vnode, &vnodel, perf_label, "populate");
+	rc = pbs_python_populate_python_class_from_svrattrl(py_vnode, &vnodel, perf_label, HOOK_PERF_POPULATE);
 	if (rc == -1) {
 		snprintf(log_buffer, sizeof(log_buffer),
 			"failed to fully populate Python"
@@ -11328,7 +11328,7 @@ py_get_job_static(char *jid, char *svr_name, char *queue_name)
 	}
 
 	snprintf(perf_label, sizeof(perf_label), "hook_func:%s(%s)", SERVER_JOB_OBJECT, jid);
-	rc = pbs_python_populate_python_class_from_svrattrl(py_job, &jobl, perf_label, "populate");
+	rc = pbs_python_populate_python_class_from_svrattrl(py_job, &jobl, perf_label, HOOK_PERF_POPULATE);
 
 	if (rc == -1) {
 		snprintf(log_buffer, sizeof(log_buffer),
@@ -11594,7 +11594,7 @@ py_get_resv_static(char *resvid, char *svr_name)
 	}
 
 	snprintf(perf_label, sizeof(perf_label), "hook_func:%s(%s)", SERVER_RESV_OBJECT, resvid);
-	rc = pbs_python_populate_python_class_from_svrattrl(py_resv, &resvl, perf_label, "populate");
+	rc = pbs_python_populate_python_class_from_svrattrl(py_resv, &resvl, perf_label, HOOK_PERF_POPULATE);
 
 	if (rc == -1) {
 		snprintf(log_buffer, sizeof(log_buffer),

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -1973,11 +1973,22 @@ py_resource_string_value(pbs_resource_value *resc_val)
  * @param[in] attr_data_array - array of actual attribute names/resources/values
  * @param[in] attr_def_array - array of attribute definitions (ex. job_attr_def)
  * @param[in] attr_def_array_size - size of attr_def_array.
+ * @param[in]	perf_label - passed on to hook_perf_stat* call.
+ * @param[in]	perf_action - passed on to hook_perf_stat* call.
  *
  * @return indication of whether or not 'py_instance' was completely
  *	   populated or not
  * @return 0	- completely populated
  * @return -1	- incompletely populated
+ *
+ * @note
+ *		This function calls a single hook_perf_stat_start()
+ *		that has some malloc-ed data that are freed in the
+ *		hook_perf_stat_stop() call, which is done at the end of
+ *		this function.
+ *		Ensure that after the hook_perf_stat_start(), all
+ *		program execution path lead to hook_perf_stat_stop()
+ *		call.
  */
 
 int
@@ -1985,7 +1996,7 @@ pbs_python_populate_attributes_to_python_class(PyObject *py_instance,
 	PyObject **attr_py_array,
 	attribute *attr_data_array,
 	attribute_def *attr_def_array,
-	int attr_def_array_size)
+	int attr_def_array_size, char *perf_label, char *perf_action)
 {
 	int i = 0; /* index */
 	int encode_rv = 0;  /* at_encode functions return value */
@@ -2001,6 +2012,7 @@ pbs_python_populate_attributes_to_python_class(PyObject *py_instance,
 	char *new_value_str = NULL;
 	pbs_resource_value *resc_val;
 
+	hook_perf_stat_start(perf_label, perf_action, 0);
 	for (i = 0; i < attr_def_array_size; i++) {
 		attr_p = attr_data_array + i;
 		attr_def_p = attr_def_array + i;
@@ -2207,6 +2219,7 @@ pbs_python_populate_attributes_to_python_class(PyObject *py_instance,
 			continue;
 		}
 	} /* for */
+	hook_perf_stat_stop(perf_label, perf_action, 0);
 	return ret_rc;
 }
 
@@ -2219,15 +2232,25 @@ pbs_python_populate_attributes_to_python_class(PyObject *py_instance,
  * @param[in] py_instance -  a Python object/class to populate
  * @param[in] svrattrl_list - a pbs_list_head with svrattrl entries whose
  *				values will be used to populate 'py_instance'
+ * @param[in]	perf_label - data passed on to hook_perf_stat* call
+ * @param[in]	perf_action - dat passed on to hook_perf_stat* call
  *
  * @return indication of whether or not 'py_instance' was completely
  *	   populated or not
  * @return 0	- completely populated
  * @return -1	- incompletely populated
+ *
+ * @note
+ *		This function calls a single hook_perf_stat_start()
+ *		that has some malloc-ed data that are freed in the
+ *		hook_perf_stat_stop() call, which is done at the end of
+ *		this function.
+ *		Ensure that after the hook_perf_stat_start(), all
+ *		program execution path lead to hook_perf_stat_stop()
+ *		call.
  */
 int
-pbs_python_populate_python_class_from_svrattrl(PyObject *py_instance,
-	pbs_list_head *svrattrl_list)
+pbs_python_populate_python_class_from_svrattrl(PyObject *py_instance, pbs_list_head *svrattrl_list, char *perf_label, char *perf_action)
 {
 	svrattrl	*plist = NULL;
 
@@ -2253,7 +2276,7 @@ pbs_python_populate_python_class_from_svrattrl(PyObject *py_instance,
 
 	print_svrattrl_list("pbs_python_populate_python_class_from_svrattrl==>",
 		svrattrl_list);
-
+	hook_perf_stat_start(perf_label, perf_action, 0);
 	plist = (svrattrl *)GET_NEXT(*svrattrl_list);
 
 	while (plist) {
@@ -2310,6 +2333,7 @@ pbs_python_populate_python_class_from_svrattrl(PyObject *py_instance,
 		plist = (svrattrl *)GET_NEXT(plist->al_link);
 	}
 
+	hook_perf_stat_stop(perf_label, perf_action, 0);
 	return (ret_rc);
 
 }
@@ -2569,7 +2593,7 @@ load_cached_resource_value(PyObject *py_resource_match)
  * @return int
  * @retval 0	for success
  * @retval != 0 for error
-
+ *
  */
 int
 pbs_python_populate_svrattrl_from_python_class(PyObject *py_instance,
@@ -2631,7 +2655,7 @@ pbs_python_populate_svrattrl_from_python_class(PyObject *py_instance,
 		snprintf(log_buffer, LOG_BUF_SIZE-1, "python object does not have '%s'", PY_ATTRIBUTES);
 		log_buffer[LOG_BUF_SIZE-1] = '\0';
 		log_err(PBSE_INTERNAL, __func__, log_buffer);
-		return (rc);
+		return rc;
 	}
 
 	py_attr_dict = PyObject_GetAttrString(py_instance, PY_ATTRIBUTES); /* NEW*/
@@ -3229,6 +3253,7 @@ mark_readonly_exit:
  * @param[in]   queue_name - if 'pque' is not set, then create a PBS Python
  *			      queue object mapping a pbs_queue structure in
  *			      the system that matches 'queue_name'.
+ * @param[in]	perf_label - passed on to hook_perf_stat* call.
  * @note
  *	This first returns any cached Python queue object found in
  *	'py_hook_pbsque[]' matching 'que_name' or pque's que_name.
@@ -3239,7 +3264,7 @@ mark_readonly_exit:
  *				queue.
  */
 static PyObject *
-_pps_helper_get_queue(pbs_queue *pque, const char *que_name)
+_pps_helper_get_queue(pbs_queue *pque, const char *que_name, char *perf_label)
 {
 	PyObject *py_que_class = NULL;
 	PyObject *py_que = NULL;
@@ -3247,6 +3272,7 @@ _pps_helper_get_queue(pbs_queue *pque, const char *que_name)
 	pbs_queue *que;
 	int tmp_rc = -1;
 	int i;
+	char perf_action[MAXBUFLEN];
 
 	if (pque != NULL) {
 		que = pque;
@@ -3320,11 +3346,12 @@ _pps_helper_get_queue(pbs_queue *pque, const char *que_name)
 		que->qu_jobstbuf);
 	/* stuff all the attributes */
 	snprintf((char *)hook_debug.objname, HOOK_BUF_SIZE-1, "%s(%s)", SERVER_QUEUE_OBJECT, que->qu_qs.qu_name);
+	snprintf(perf_action, sizeof(perf_action), "populate:%s", hook_debug.objname);
 	tmp_rc = pbs_python_populate_attributes_to_python_class(py_que,
 		py_que_attr_types,
 		que->qu_attr,
 		que_attr_def,
-		QA_ATR_LAST);
+		QA_ATR_LAST, perf_label, perf_action);
 	if (tmp_rc == -1) {
 		log_err(PBSE_INTERNAL, __func__,
 			"partially populated python queue object");
@@ -3403,6 +3430,9 @@ ERROR_EXIT:
  * @brief
  * 	Helper method returning a server Python Object representing the local
  *	(current) server.
+ *
+ * @param[in]	perf_label - passed on to hook_perf_stat* call.
+ *
  *  @note
  *	This marks the server object "read-only" in Python mode.
  *	Also, this first returns the cached 'py_hook_pbsserver' object.
@@ -3413,12 +3443,13 @@ ERROR_EXIT:
  *				local server values.
  */
 static PyObject *
-_pps_helper_get_server(void)
+_pps_helper_get_server(char *perf_label)
 {
 	PyObject *py_svr_class = NULL;
 	PyObject *py_svr = NULL;
 	PyObject *py_sargs = NULL;
 	int tmp_rc = -1;
+	char	perf_action[MAXBUFLEN];
 
 	if (py_hook_pbsserver != NULL) {
 		Py_INCREF(py_hook_pbsserver);
@@ -3465,11 +3496,12 @@ _pps_helper_get_server(void)
 
 	/* stuff all the attributes */
 	strncpy((char *)hook_debug.objname, SERVER_OBJECT, HOOK_BUF_SIZE-1);
+	snprintf(perf_action, sizeof(perf_action), "populate:%s", hook_debug.objname);
 	tmp_rc = pbs_python_populate_attributes_to_python_class(py_svr,
 		py_svr_attr_types,
 		server.sv_attr,
 		svr_attr_def,
-		SRV_ATR_LAST);
+		SRV_ATR_LAST, perf_label, perf_action);
 
 	if (tmp_rc == -1) {
 		log_err(PBSE_INTERNAL, __func__,
@@ -3510,6 +3542,7 @@ ERROR_EXIT:
  * @param[in] pjob_o - job info
  * @param[in] jobid - job identifier
  * @param[in] qname - queuename
+ * @param[in]	perf_label - data passed on to hook_perf_stat* call
  *
  * @return	PyObject*
  * @retval	job python object	success
@@ -3517,7 +3550,7 @@ ERROR_EXIT:
  *
  */
 static PyObject *
-_pps_helper_get_job(job *pjob_o, const char *jobid, const char *qname)
+_pps_helper_get_job(job *pjob_o, const char *jobid, const char *qname, char *perf_label)
 {
 	PyObject *py_job_class = NULL;
 	PyObject *py_job = NULL;
@@ -3527,6 +3560,7 @@ _pps_helper_get_job(job *pjob_o, const char *jobid, const char *qname)
 	job *pjob;
 	int tmp_rc = -1;
 	int t;
+	char	perf_action[MAXBUFLEN];
 
 	if (pjob_o != NULL) {
 		pjob = pjob_o;
@@ -3588,11 +3622,12 @@ _pps_helper_get_job(job *pjob_o, const char *jobid, const char *qname)
 	 * OK, At this point we need to start populating the job class.
 	 */
 	snprintf((char *)hook_debug.objname, HOOK_BUF_SIZE-1, "%s(%s)", SERVER_JOB_OBJECT, pjob->ji_qs.ji_jobid);
+	snprintf(perf_action, sizeof(perf_action), "populate:%s", hook_debug.objname);
 	tmp_rc = pbs_python_populate_attributes_to_python_class(py_job,
 		py_job_attr_types,
 		pjob->ji_wattr,
 		job_attr_def,
-		JOB_ATR_LAST);
+		JOB_ATR_LAST, perf_label, perf_action);
 
 	if (tmp_rc == -1) {
 		log_err(PBSE_INTERNAL, __func__,
@@ -3601,7 +3636,7 @@ _pps_helper_get_job(job *pjob_o, const char *jobid, const char *qname)
 
 	/* set job.queue to actual queue object */
 	if (pjob->ji_qs.ji_queue) {
-		py_que = _pps_helper_get_queue(NULL, pjob->ji_qs.ji_queue);/* NEW ref */
+		py_que = _pps_helper_get_queue(NULL, pjob->ji_qs.ji_queue, perf_label);/* NEW ref */
 		if (py_que) {
 			if (PyObject_HasAttrString(py_job, ATTR_queue)) {
 				/* py_que ref ct incremented as part of py_job */
@@ -3612,7 +3647,7 @@ _pps_helper_get_job(job *pjob_o, const char *jobid, const char *qname)
 	}
 
 	/* set job.server to actual server object */
-	py_server = _pps_helper_get_server(); /* NEW Ref */
+	py_server = _pps_helper_get_server(perf_label); /* NEW Ref */
 
 	if (py_server) {
 		if (PyObject_HasAttrString(py_job, ATTR_server)) {
@@ -3647,6 +3682,7 @@ ERROR_EXIT:
  *
  * @param[in] presv_o - reservation structure
  * @param[in] resvid - reservation name
+ * @param[in] perf_label - passed on to hook_perf_stat* call.
  *
  * @return	PyObject *
  * @retval	This returns a Python object that maps
@@ -3654,7 +3690,7 @@ ERROR_EXIT:
  * 		or to the struct returned by find_resv(<resvid>).
  */
 static PyObject *
-_pps_helper_get_resv(resc_resv *presv_o, const char *resvid)
+_pps_helper_get_resv(resc_resv *presv_o, const char *resvid, char *perf_label)
 {
 	PyObject *py_resv_class = NULL;
 	PyObject *py_resv = NULL;
@@ -3665,6 +3701,7 @@ _pps_helper_get_resv(resc_resv *presv_o, const char *resvid)
 	int tmp_rc = -1;
 	char resvid_out[PBS_MAXCLTJOBID];
 	char server_out[MAXSERVERNAME];
+	char perf_action[MAXBUFLEN];
 
 	if (presv_o != NULL) {
 		presv = presv_o;
@@ -3721,11 +3758,12 @@ _pps_helper_get_resv(resc_resv *presv_o, const char *resvid)
 	 * OK, At this point we need to start populating the resv class.
 	 */
 	snprintf((char *)hook_debug.objname, HOOK_BUF_SIZE-1, "%s(%s)", SERVER_RESV_OBJECT, presv->ri_qs.ri_resvID);
+	snprintf(perf_action, sizeof(perf_action), "populate:%s", hook_debug.objname);
 	tmp_rc = pbs_python_populate_attributes_to_python_class(py_resv,
 		py_resv_attr_types,
 		presv->ri_wattr,
 		resv_attr_def,
-		RESV_ATR_LAST);
+		RESV_ATR_LAST, perf_label, perf_action);
 
 	if (tmp_rc == -1) {
 		log_err(PBSE_INTERNAL, __func__,
@@ -3734,7 +3772,7 @@ _pps_helper_get_resv(resc_resv *presv_o, const char *resvid)
 
 	/* set resv.queue to actual queue object */
 	if (presv->ri_qs.ri_queue && PyObject_HasAttrString(py_resv, ATTR_queue)) {
-		py_que = _pps_helper_get_queue(NULL, presv->ri_qs.ri_queue); /* NEW */
+		py_que = _pps_helper_get_queue(NULL, presv->ri_qs.ri_queue, perf_label); /* NEW */
 		if (py_que) {
 			/* py_que ref ct incremented as part of py_resv */
 			(void)PyObject_SetAttrString(py_resv, ATTR_queue, py_que);
@@ -3743,7 +3781,7 @@ _pps_helper_get_resv(resc_resv *presv_o, const char *resvid)
 	}
 
 	/* set resv.server to actual server object */
-	py_server = _pps_helper_get_server(); /* NEW */
+	py_server = _pps_helper_get_server(perf_label); /* NEW */
 
 	if (py_server) {
 		if (PyObject_HasAttrString(py_resv, ATTR_server)) {
@@ -3783,11 +3821,13 @@ GR_ERROR_EXIT:
  *				  populate a Python vnode object.
  * @param[in]	vname		- name of a vnode to obtain "struct pbsnode *"
  *				  content to populate a Python vnode object.
+ * @param[in]	perf_label	- passed on to hook_perf_stat* call.
+ *
  * @return      PyObject *	- the Python vnode object corresponding to
  *				  'pvnode_o' or 'vname'.
  */
 static PyObject *
-_pps_helper_get_vnode(struct pbsnode *pvnode_o, const char *vname)
+_pps_helper_get_vnode(struct pbsnode *pvnode_o, const char *vname, char *perf_label)
 {
 	PyObject *py_vnode_class = NULL;
 	PyObject *py_vnode = NULL;
@@ -3796,6 +3836,7 @@ _pps_helper_get_vnode(struct pbsnode *pvnode_o, const char *vname)
 	struct pbsnode *pvnode;
 	int tmp_rc = -1;
 	char buf[512];
+	char perf_action[MAXBUFLEN];
 
 	if (pvnode_o != NULL) {
 		pvnode = pvnode_o;
@@ -3841,11 +3882,12 @@ _pps_helper_get_vnode(struct pbsnode *pvnode_o, const char *vname)
 	 * OK, At this point we need to start populating the vnode class.
 	 */
 	snprintf((char *)hook_debug.objname, HOOK_BUF_SIZE-1, "%s(%s)", SERVER_VNODE_OBJECT, pvnode->nd_name);
+	snprintf(perf_action, sizeof(perf_action), "populate:%s", hook_debug.objname);
 	tmp_rc = pbs_python_populate_attributes_to_python_class(py_vnode,
 		py_vnode_attr_types,
 		pvnode->nd_attr,
 		node_attr_def,
-		ND_ATR_LAST);
+		ND_ATR_LAST, perf_label, perf_action);
 
 	if (tmp_rc == -1) {
 		log_err(PBSE_INTERNAL, __func__,
@@ -3854,7 +3896,7 @@ _pps_helper_get_vnode(struct pbsnode *pvnode_o, const char *vname)
 
 	/* set vnode.queue to actual queue object */
 	if (pvnode->nd_pque && PyObject_HasAttrString(py_vnode, ATTR_queue)) {
-		py_que = _pps_helper_get_queue(pvnode->nd_pque, NULL); /* NEW */
+		py_que = _pps_helper_get_queue(pvnode->nd_pque, NULL, perf_label); /* NEW */
 		if (py_que) {
 			/* py_que ref ct incremented as part of py_vnode */
 			(void)PyObject_SetAttrString(py_vnode, ATTR_queue, py_que);
@@ -4007,15 +4049,26 @@ _pbs_python_set_mode(int mode)
  * @param[in]	plist->al_name = <node_name>.<attribute_name>
  * @param[in]	plist->al_resc =  <resource_name>,<type>
  * @param[in]	plist->al_value = <value>
+ * @param[in]	perf_label - data passed on to hook_perf_stat* call
+ * @param[in]	perf_action - dat passed on to hook_perf_stat* call
  *
  * @return 	PyObject *
  * @retval	<object>	- the Python dictionary object holding
  *			           the individual vnode objects, indexed by
  *				   vnode names.
  * @retval	NULL		- if an error occured.
+ *
+ * @note
+ *		This function calls a single hook_perf_stat_start()
+ *		that has some malloc-ed data that are freed in the
+ *		hook_perf_stat_stop() call, which is done at the end of
+ *		this function.
+ *		Ensure that after the hook_perf_stat_start(), all
+ *		program execution path lead to hook_perf_stat_stop()
+ *		call.
  */
 static PyObject *
-create_py_vnodelist(pbs_list_head *vnlist)
+create_py_vnodelist(pbs_list_head *vnlist, char *perf_label, char *perf_action)
 {
 	svrattrl	*plist, *plist_next;
 	PyObject	*py_vn = NULL;  /* class vnode arg list */
@@ -4044,6 +4097,8 @@ create_py_vnodelist(pbs_list_head *vnlist)
 			"failed to create a Vnodes list dictionary!");
 		return NULL;
 	}
+
+	hook_perf_stat_start(perf_label, perf_action, 0);
 
 	py_vnode_class = pbs_python_types_table[PP_VNODE_IDX].t_class;
 
@@ -4144,8 +4199,7 @@ create_py_vnodelist(pbs_list_head *vnlist)
 				goto create_py_vnodelist_exit;
 			}
 
-			rc = pbs_python_populate_python_class_from_svrattrl(\
-						       py_vn, &rqs.rq_attr);
+			rc = pbs_python_populate_python_class_from_svrattrl(py_vn, &rqs.rq_attr, perf_label, perf_action);
 
 			if (rc == -1) {
 				snprintf(log_buffer, sizeof(log_buffer),
@@ -4218,6 +4272,7 @@ create_py_vnodelist_exit:
 		pn = NULL;
 	}
 
+	hook_perf_stat_stop(perf_label, perf_action, 0);
 	return (py_vnlist_ret);
 }
 
@@ -4232,15 +4287,26 @@ create_py_vnodelist_exit:
  * @param[in]	plist->al_name:	<job_name>.<attribute_name>
  * @param[in]	plist->al_resc: <resource_name>,<type>
  * @param[in]	plist->al_value: <value>
+ * @param[in]	perf_label - data passed on to hook_perf_stat* call
+ * @param[in]	perf_action - dat passed on to hook_perf_stat* call
  *
  * @return 	PyObject *
- * @retjal	<object>	- the Python dictionary object holding
+ * @retval	<object>	- the Python dictionary object holding
  *			           the individual job objects, indexed by
  *				   job names.
- * @retjal	NULL		- if an error occured.
+ * @retval	NULL		- if an error occured.
+ *
+ * @note
+ *		This function calls a single hook_perf_stat_start()
+ *		that has some malloc-ed data that are freed in the
+ *		hook_perf_stat_stop() call, which is done at the end of
+ *		this function.
+ *		Ensure that after the hook_perf_stat_start(), all
+ *		program execution path lead to hook_perf_stat_stop()
+ *		call.
  */
 static PyObject *
-create_py_joblist(pbs_list_head *joblist)
+create_py_joblist(pbs_list_head *joblist, char *perf_label, char *perf_action)
 {
 	svrattrl	*plist, *plist_next;
 	PyObject	*py_jn = NULL;  /* class job arg list */
@@ -4265,6 +4331,7 @@ create_py_joblist(pbs_list_head *joblist)
 		return NULL;
 	}
 
+	hook_perf_stat_start(perf_label, perf_action, 0);
 	py_job_class = pbs_python_types_table[PP_JOB_IDX].t_class;
 
 	rqs.rq_id[0] = '\0';
@@ -4365,8 +4432,7 @@ create_py_joblist(pbs_list_head *joblist)
 				goto create_py_joblist_exit;
 			}
 
-			rc = pbs_python_populate_python_class_from_svrattrl(\
-						       py_jn, &rqs.rq_attr);
+			rc = pbs_python_populate_python_class_from_svrattrl(py_jn, &rqs.rq_attr, perf_label, perf_action);
 
 			if (rc == -1) {
 				snprintf(log_buffer, sizeof(log_buffer),
@@ -4444,6 +4510,7 @@ create_py_joblist_exit:
 		pn = NULL;
 	}
 
+	hook_perf_stat_stop(perf_label, perf_action, 0);
 	return (py_joblist_ret);
 }
 
@@ -4459,14 +4526,26 @@ create_py_joblist_exit:
  *	plist->al_resc: <resource_name>.<type>
  *	plist->al_value: <value>
  *
+ * @param[in]	perf_label - data passed on to hook_perf_stat* call
+ * @param[in]	perf_action - dat passed on to hook_perf_stat* call
+ *
  * @return 	PyObject *
  * @retval	<object>	- the Python dictionary object holding
  *			           the individual reservation objects, indexed by
  *				   reservation names.
  * @retval	NULL		- if an error occured.
+ *
+ * @note
+ *		This function calls a single hook_perf_stat_start()
+ *		that has some malloc-ed data that are freed in the
+ *		hook_perf_stat_stop() call, which is done at the end of
+ *		this function.
+ *		Ensure that after the hook_perf_stat_start(), all
+ *		program execution path lead to hook_perf_stat_stop()
+ *		call.
  */
 static PyObject *
-create_py_resvlist(pbs_list_head *resvlist)
+create_py_resvlist(pbs_list_head *resvlist, char *perf_label, char *perf_action)
 {
 	svrattrl	*plist, *plist_next;
 	PyObject	*py_rn = NULL;  /* class reservation arg list */
@@ -4491,6 +4570,7 @@ create_py_resvlist(pbs_list_head *resvlist)
 		return (NULL);
 	}
 
+	hook_perf_stat_start(perf_label, perf_action, 0);
 	py_resv_class = pbs_python_types_table[PP_RESV_IDX].t_class;
 
 	memset(rqs.rq_id, 0, sizeof(rqs.rq_id));
@@ -4585,8 +4665,7 @@ create_py_resvlist(pbs_list_head *resvlist)
 				goto create_py_resvlist_exit;
 			}
 
-			rc = pbs_python_populate_python_class_from_svrattrl(
-						       py_rn, &rqs.rq_attr);
+			rc = pbs_python_populate_python_class_from_svrattrl(py_rn, &rqs.rq_attr, perf_label, perf_action);
 
 			if (rc == -1) {
 				snprintf(log_buffer, sizeof(log_buffer),
@@ -4664,6 +4743,7 @@ create_py_resvlist_exit:
 		pn = NULL;
 	}
 
+	hook_perf_stat_stop(perf_label, perf_action, 0);
 	return (py_resvlist_ret);
 }
 
@@ -4918,6 +4998,8 @@ read_statm(void)
  * @param[in]	event_type - the event type requesting for this
  * @param[in]	param_name - name of the vnode_list parameter
  * @param[in]	vnlist - data for the vnode_list parameter
+ * @param[in]	perf_label - passed on to hook_perf_stat* call.
+ * @param[in]	perf_action - passed on to hook_perf_stat* call.
  *
  * @return PyObject *
  * @retval <python_object>	- the Python object representing the
@@ -4927,7 +5009,8 @@ read_statm(void)
  */
 static PyObject *
 create_hook_vnode_list_param(PyObject *py_event_param,
-	char *event_type, char *param_name, pbs_list_head *vnlist)
+	char *event_type, char *param_name, pbs_list_head *vnlist,
+	char *perf_label, char *perf_action)
 {
 	PyObject	*py_vnlist = NULL;
 	int		rc;
@@ -4939,7 +5022,7 @@ create_hook_vnode_list_param(PyObject *py_event_param,
 
 	(void)PyDict_SetItemString(py_event_param, param_name, Py_None);
 
-	py_vnlist = create_py_vnodelist(vnlist);
+	py_vnlist = create_py_vnodelist(vnlist, perf_label, perf_action);
 	if (py_vnlist == NULL) {
 		return (NULL);
 	}
@@ -4964,6 +5047,7 @@ create_hook_vnode_list_param(PyObject *py_event_param,
  * @param[in]	req_user	- the requesting user
  * @param[in]	req_host	- the requesting host
  * @param[in]	req_params	- a structure containing the input parameters.
+ * @param[in]	perf_label - data passed on to hook_perf_stat* call
  *
  * @return int
  * @retval	0	- success
@@ -4972,11 +5056,10 @@ create_hook_vnode_list_param(PyObject *py_event_param,
  *			   a keyboard interrupt. This maybe caused by the
  *			   calling process getting a SIGINT. In this case,
  *			   just rerun this call.
- *
  */
 int
 _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
-	hook_input_param_t *req_params)
+	hook_input_param_t *req_params, char *perf_label)
 {
 	PyObject *py_event = NULL;
 	PyObject *py_eargs = NULL;
@@ -5008,6 +5091,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 	PyObject *py_pid = NULL;
 	PyObject *py_node_list = (PyObject *) NULL;
 	PyObject *py_failed_node_list = (PyObject *) NULL;
+	char	 perf_action[MAXBUFLEN];
 
 	static long hook_counter = 0; /* for tracking interpreter restart */
 	static long min_restart_interval = 0; /* prevents frequent restarts */
@@ -5258,8 +5342,9 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			goto event_set_exit;
 		}
 
+		snprintf(perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_JOB_OBJECT, rqj->rq_jid);
 		rc = pbs_python_populate_python_class_from_svrattrl(py_job,
-			&rqj->rq_attr);
+			&rqj->rq_attr, perf_label, perf_action);
 
 		if (rc == -1) {
 			LOG_ERROR_ARG2("%s: partially set remaining param['%s'] attributes",
@@ -5301,8 +5386,9 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 				PY_TYPE_EVENT,  PY_EVENT_PARAM_RESV);
 			goto event_set_exit;
 		}
+		snprintf(perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_RESV_OBJECT, rqj->rq_jid);
 		rc = pbs_python_populate_python_class_from_svrattrl(py_resv,
-			&rqj->rq_attr);
+			&rqj->rq_attr, perf_label, perf_action);
 
 		if (rc == -1) {
 			LOG_ERROR_ARG2("%s:partially set remaining param['%s'] attributes",
@@ -5346,8 +5432,9 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			goto event_set_exit;
 		}
 
+		snprintf(perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_JOB_OBJECT, rqj->rq_objname);
 		rc = pbs_python_populate_python_class_from_svrattrl(py_job,
-			&rqj->rq_attr);
+			&rqj->rq_attr, perf_label, perf_action);
 
 		if (rc == -1) {
 			LOG_ERROR_ARG2("%s: partially set remaining param['%s'] attributes",
@@ -5372,7 +5459,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			}
 		} else {
 			/* we own this reference */
-			py_job_o = _pps_helper_get_job(NULL, rqj->rq_objname, NULL);
+			py_job_o = _pps_helper_get_job(NULL, rqj->rq_objname, NULL, perf_label);
 		}
 
 		if (!py_job_o || (py_job_o == Py_None)) {
@@ -5440,7 +5527,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 				hook_set_mode = C_MODE; /* ensure still in C mode */
 			}
 		} else {
-			py_job = _pps_helper_get_job(NULL, rqj->rq_jid, NULL);
+			py_job = _pps_helper_get_job(NULL, rqj->rq_jid, NULL, perf_label);
 			/* NEW - we own ref */
 		}
 
@@ -5537,7 +5624,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 		/* SET VNODE_LIST param */
 		(void)PyDict_SetItemString(py_event_param, PY_EVENT_PARAM_VNODELIST,
 			Py_None);
-		py_vnodelist = create_py_vnodelist(vnlist);
+		py_vnodelist = create_py_vnodelist(vnlist, perf_label, "populate:pbs.event().vnode_list");
 		if (py_vnodelist == NULL) {
 			LOG_ERROR_ARG2("%s: failed to create a Python vnodelist object for param['%s']",
 				PY_TYPE_EVENT, PY_EVENT_PARAM_VNODELIST);
@@ -5559,7 +5646,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 
 		(void)PyDict_SetItemString(py_event_param, PY_EVENT_PARAM_RESVLIST,
 			Py_None);
-		py_resvlist = create_py_resvlist(resvlist);
+		py_resvlist = create_py_resvlist(resvlist, perf_label, "populate:pbs.event().resv_list");
 		if (py_resvlist == NULL) {
 			LOG_ERROR_ARG2("%s: failed to create a Python resvlist object for param['%s']",
 				PY_TYPE_EVENT, PY_EVENT_PARAM_RESVLIST);
@@ -5590,7 +5677,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 				hook_set_mode = C_MODE; /* ensure still in C mode */
 			}
 		} else {
-			py_job = _pps_helper_get_job(NULL, rqj->rq_jid, NULL);
+			py_job = _pps_helper_get_job(NULL, rqj->rq_jid, NULL, perf_label);
 		}
 		/* NEW - we own ref */
 
@@ -5678,7 +5765,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 				hook_set_mode = C_MODE; /* ensure still in C mode */
 			}
 		} else {
-			py_resv = _pps_helper_get_resv(NULL, rqj->rq_objname);
+			py_resv = _pps_helper_get_resv(NULL, rqj->rq_objname, perf_label);
 		}
 
 		if (!py_resv || (py_resv == Py_None)) {
@@ -5733,8 +5820,8 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			goto event_set_exit;
 		}
 
-		rc = pbs_python_populate_python_class_from_svrattrl(py_job,
-			&rqj->rq_attr);
+		snprintf((char *)perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_JOB_OBJECT, rqj->rq_jid);
+		rc = pbs_python_populate_python_class_from_svrattrl(py_job, &rqj->rq_attr, perf_label, perf_action);
 
 		if (rc == -1) {
 			LOG_ERROR_ARG2("%s: partially set remaining param['%s'] attributes",
@@ -5744,7 +5831,8 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 
 		py_vnodelist = create_hook_vnode_list_param(py_event_param,
 					PY_TYPE_EVENT, PY_EVENT_PARAM_VNODELIST,
-					(pbs_list_head *)req_params->vns_list);
+					(pbs_list_head *)req_params->vns_list,
+					perf_label, "populate:pbs.event().vnode_list");
 					
 		if (py_vnodelist == NULL) {
 			rc = -1;
@@ -5755,7 +5843,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 
 			py_vnodelist_fail = create_hook_vnode_list_param(py_event_param,
 						PY_TYPE_EVENT, PY_EVENT_PARAM_VNODELIST_FAIL,
-			    			(pbs_list_head *)req_params->vns_list_fail);
+			    			(pbs_list_head *)req_params->vns_list_fail, perf_label, "populate:pbs.event().vnode_list_fail");
 					
 			if (py_vnodelist_fail == NULL) {
 				rc = -1;
@@ -5827,8 +5915,8 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			goto event_set_exit;
 		}
 
-		rc = pbs_python_populate_python_class_from_svrattrl(py_job,
-			&rqj->rq_attr);
+		snprintf((char *)perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_JOB_OBJECT, rqj->rq_jid);
+		rc = pbs_python_populate_python_class_from_svrattrl(py_job, &rqj->rq_attr, perf_label, perf_action);
 
 		if (rc == -1) {
 			LOG_ERROR_ARG2("%s: partially set remaining param['%s'] attributes",
@@ -5839,7 +5927,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 		py_vnodelist =
 			   create_hook_vnode_list_param(py_event_param,
 					PY_TYPE_EVENT, PY_EVENT_PARAM_VNODELIST,
-					(pbs_list_head *)req_params->vns_list);
+					(pbs_list_head *)req_params->vns_list, perf_label, "populate:pbs.event().vnode_list");
 					
 		if (py_vnodelist == NULL) {
 			rc = -1;
@@ -5849,7 +5937,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 		py_vnodelist_fail =
 			   create_hook_vnode_list_param(py_event_param,
 				PY_TYPE_EVENT, PY_EVENT_PARAM_VNODELIST_FAIL,
-			    	(pbs_list_head *)req_params->vns_list_fail);
+			    	(pbs_list_head *)req_params->vns_list_fail, perf_label, "populate:pbs.event().vnode_list_fail");
 					
 		if (py_vnodelist_fail == NULL) {
 			rc = -1;
@@ -5974,7 +6062,8 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 		py_vnodelist = create_hook_vnode_list_param(py_event_param,
 				PY_TYPE_EVENT,
 				PY_EVENT_PARAM_VNODELIST,
-			    (pbs_list_head *)req_params->vns_list);
+			    (pbs_list_head *)req_params->vns_list,
+			    perf_label, "populate:pbs.event().vnode_list");
 
 		if (py_vnodelist == NULL) {
 			rc = -1;
@@ -5988,7 +6077,7 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 
 			(void)PyDict_SetItemString(py_event_param, PY_EVENT_PARAM_JOBLIST,
 				Py_None);
-			py_joblist = create_py_joblist(joblist);
+			py_joblist = create_py_joblist(joblist, perf_label, "populate:pbs.event().job_list");
 			if (py_joblist == NULL) {
 				LOG_ERROR_ARG2("%s: failed to create a Python joblist object for param['%s']",
 					PY_TYPE_EVENT, PY_EVENT_PARAM_JOBLIST);
@@ -6045,8 +6134,8 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 			goto event_set_exit;
 		}
 
-		rc = pbs_python_populate_python_class_from_svrattrl(py_job,
-			&rqj->rq_attr);
+		snprintf((char *)perf_action, sizeof(perf_action), "populate:%s(%s)", EVENT_JOB_OBJECT, rqj->rq_jid);
+		rc = pbs_python_populate_python_class_from_svrattrl(py_job, &rqj->rq_attr, perf_label, perf_action);
 
 		if (rc == -1) {
 			LOG_ERROR_ARG2("%s: partially set remaining param['%s'] attributes",
@@ -6079,7 +6168,8 @@ _pbs_python_event_set(unsigned int hook_event, char *req_user, char *req_host,
 		py_vnodelist = create_hook_vnode_list_param(py_event_param,
 				PY_TYPE_EVENT,
 				PY_EVENT_PARAM_VNODELIST,
-			    (pbs_list_head *)req_params->vns_list);
+			    (pbs_list_head *)req_params->vns_list,
+			    perf_label, "populate:pbs_event().vnode_list");
 					
 		if (py_vnodelist == NULL) {
 			rc = -1;
@@ -6263,6 +6353,8 @@ populate_svrattrl_from_vnodelist_param(char *vnodelist_name,
  *
  * @param[in]		hook_event 	- event in question
  * @param[in/out]	req_params	- results parameter
+ * @param[in]		perf_label - passed on to hook_perf_stat* call.
+ * @param[in]		perf_action - passed on to hook_perf_stat* call.
  * @note
  * 	Care must be taken to malloc free up allocated entries in 'req_params'
  * 	after use. The 'req_params' entries could be partially allocated upon
@@ -6271,9 +6363,18 @@ populate_svrattrl_from_vnodelist_param(char *vnodelist_name,
  * @return int
  * @retval	0 	for success
  * @retval	-1	otherwise, for failure.
+ *
+ * @note
+ *		This function calls a single hook_perf_stat_start()
+ *		that has some malloc-ed data that are freed in the
+ *		hook_perf_stat_stop() call, which is done at the end of
+ *		this function.
+ *		Ensure that after the hook_perf_stat_start(), all
+ *		program execution path lead to hook_perf_stat_stop()
+ *		call.
  */
 int
-_pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_params)
+_pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_params, char *perf_label, char *perf_action)
 {
 	PyObject 		*py_job = NULL;
 	PyObject 		*py_vnode = NULL;
@@ -6296,7 +6397,9 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 	int			deletejob_flag;
 	int			rerunjob_flag;
 	char			val_str[HOOK_BUF_SIZE];
+	int			rc = -1;
 
+	hook_perf_stat_start(perf_label, perf_action, 0);
 	switch (hook_event) {
 		case HOOK_EVENT_QUEUEJOB:
 
@@ -6304,7 +6407,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 			if (!py_job) {
 				log_err(PBSE_INTERNAL, __func__,
 					"No job parameter found for event!");
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			queue = pbs_python_object_get_attr_string_value(py_job,
@@ -6313,7 +6416,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 				strcpy(((struct rq_queuejob *)(req_params->rq_job))->rq_destin, queue);
 			if (pbs_python_populate_svrattrl_from_python_class(py_job,
 				&((struct rq_queuejob *)(req_params->rq_job))->rq_attr, NULL, 0) == -1) {
-				return -1;
+				goto event_to_request_exit;
 			}
 			print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>",  &((struct rq_queuejob *)(req_params->rq_job))->rq_attr);
 			break;
@@ -6329,21 +6432,21 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 			if (!py_job) {
 				log_err(PBSE_INTERNAL, __func__,
 					"No job parameter found for event!");
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			if (pbs_python_populate_svrattrl_from_python_class(py_job,
 				&((struct rq_queuejob *)(req_params->rq_job))->rq_attr, NULL, 0) == -1) {
 				log_err(PBSE_INTERNAL, __func__,
 					"Failed to populate request structure!");
-				return -1;
+				goto event_to_request_exit;
 			}
 			print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>", &((struct rq_queuejob *)(req_params->rq_job))->rq_attr);
 
 			if (hook_event == HOOK_EVENT_EXECJOB_PROLOGUE) {
 				/* populate vnodelist_fail event param */
 				if (populate_svrattrl_from_vnodelist_param(PY_EVENT_PARAM_VNODELIST_FAIL,(pbs_list_head *)(req_params->vns_list_fail))) {
-					return -1;
+					goto event_to_request_exit;
 				}
 			} else if (hook_event == HOOK_EVENT_EXECJOB_LAUNCH) {
 				int ret;
@@ -6352,13 +6455,13 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 				if (py_progname == NULL) {
 					log_err(PBSE_INTERNAL, __func__,
 						"No progname parameter found for event!");
-					return -1;
+					goto event_to_request_exit;
 				}
 				progname = strdup(pbs_python_object_str(py_progname));
 				if (progname == NULL) {
 					log_err(PBSE_INTERNAL, __func__,
 						"Failed to strdup progname parameter!");
-					return -1;
+					goto event_to_request_exit;
 				}
 				*((char **)(req_params->progname)) = progname;
 
@@ -6366,7 +6469,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 				if (py_arglist == NULL) {
 					log_err(PBSE_INTERNAL, __func__,
 						"No argv parameter found for event!");
-					return -1;
+					goto event_to_request_exit;
 				}
 
 				ret = py_strlist_to_svrattrl(py_arglist,
@@ -6377,27 +6480,27 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 						"%s: Failed to dump Python string list values into a svrattrl list!",
 						PY_EVENT_PARAM_ARGLIST);
 					log_err(PBSE_INTERNAL, __func__, log_buffer);
-					return -1;
+					goto event_to_request_exit;
 				}
 
 				py_env = _pbs_python_event_get_param(PY_EVENT_PARAM_ENV);
 				if (py_env == NULL) {
 					log_err(PBSE_INTERNAL, __func__,
 						"No env parameter found for event!");
-					return -1;
+					goto event_to_request_exit;
 				}
 
 				env_str = strdup(pbs_python_object_str(py_env));
 				if (env_str == NULL) {
 					log_err(PBSE_INTERNAL, __func__,
 						"Failed to strdup progname parameter!");
-					return -1;
+					goto event_to_request_exit;
 				}
 				*((char **)(req_params->env)) = env_str;
 
 				/* populate vnodelist_fail event param */
 				if (populate_svrattrl_from_vnodelist_param(PY_EVENT_PARAM_VNODELIST_FAIL, (pbs_list_head *)(req_params->vns_list_fail))) {
-					return -1;
+					goto event_to_request_exit;
 				}
 			}
 
@@ -6407,7 +6510,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 
 			/* populate vnodelist event param */
 			if (populate_svrattrl_from_vnodelist_param(PY_EVENT_PARAM_VNODELIST, (pbs_list_head *)(req_params->vns_list))) {
-				return -1;
+				goto event_to_request_exit;
 			}
 			print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>", (pbs_list_head *)(req_params->vns_list));
 			Py_CLEAR(py_attr_keys);
@@ -6418,13 +6521,13 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 				if (!py_joblist) {
 					log_err(PBSE_INTERNAL, __func__,
 						"No job list parameter found for event!");
-					return -1;
+					goto event_to_request_exit;
 				}
 
 				if (!PyDict_Check(py_joblist)) {
 					log_err(PBSE_INTERNAL, __func__,
 						"job list parameter not a dictionary!");
-					return -1;
+					goto event_to_request_exit;
 				}
 
 				py_attr_keys = PyDict_Keys(py_joblist); /* NEW ref */
@@ -6434,7 +6537,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 						"Failed to obtain object's '%s' keys",
 						PY_EVENT_PARAM_JOBLIST);
 					log_err(PBSE_INTERNAL, __func__, log_buffer);
-					return -1;
+					goto event_to_request_exit;
 				}
 
 				if (!PyList_Check(py_attr_keys)) {
@@ -6443,7 +6546,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 						PY_EVENT_PARAM_JOBLIST);
 					log_err(PBSE_INTERNAL, __func__, log_buffer);
 					Py_CLEAR(py_attr_keys);
-					return -1;
+					goto event_to_request_exit;
 				}
 
 				num_attrs = PyList_Size(py_attr_keys);
@@ -6469,7 +6572,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 						log_err(PBSE_INTERNAL, __func__, log_buffer);
 						Py_CLEAR(py_attr_keys);
 						free(key_str);
-						return -1;
+						goto event_to_request_exit;
 					}
 
 					if (pbs_python_populate_svrattrl_from_python_class(py_job,
@@ -6479,7 +6582,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 						log_err(PBSE_INTERNAL, __func__, log_buffer);
 						Py_CLEAR(py_attr_keys);
 						free(key_str);
-						return -1;
+						goto event_to_request_exit;
 					}
 
 					deletejob_flag = pbs_python_object_get_attr_integral_value(py_job,
@@ -6500,7 +6603,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 							log_err(errno, __func__, log_buffer);
 							Py_CLEAR(py_attr_keys);
 							free(key_str);
-							return -1;
+							goto event_to_request_exit;
 						}
 					}
 
@@ -6522,7 +6625,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 							log_err(errno, __func__, log_buffer);
 							Py_CLEAR(py_attr_keys);
 							free(key_str);
-							return -1;
+							goto event_to_request_exit;
 						}
 					}
 
@@ -6541,11 +6644,11 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 			if (!py_resv) {
 				log_err(PBSE_INTERNAL, __func__,
 					"No resv parameter found for event!");
-				return -1;
+				goto event_to_request_exit;
 			}
 			if (pbs_python_populate_svrattrl_from_python_class(py_resv,
 				&((struct rq_queuejob *)(req_params->rq_job))->rq_attr, NULL, 0) == -1) {
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>", &((struct rq_queuejob *)(req_params->rq_job))->rq_attr);
@@ -6556,14 +6659,14 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 			if (!py_job) {
 				log_err(PBSE_INTERNAL, __func__,
 					"No job parameter found for event!");
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			py_job_o = _pbs_python_event_get_param(PY_EVENT_PARAM_JOB_O);
 			if (!py_job_o) {
 				log_err(PBSE_INTERNAL, __func__,
 					"No job_o parameter found for event!");
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			/* Need to check if ATTR_v (i.e. Variable_list) changed, and if */
@@ -6587,7 +6690,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 
 			if (pbs_python_populate_svrattrl_from_python_class(py_job,
 				&((struct rq_manage *)(req_params->rq_manage))->rq_attr, NULL, 0) == -1) {
-				return -1;
+				goto event_to_request_exit;
 			}
 			print_svrattrl_list("pbs_populate_svrattrl_from_python_class==>", &((struct rq_manage *)(req_params->rq_manage))->rq_attr);
 			break;
@@ -6597,7 +6700,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 			if (!py_job) {
 				log_err(PBSE_INTERNAL, __func__,
 					"No job parameter found for event!");
-				return -1;
+				goto event_to_request_exit;
 			}
 			queue = pbs_python_object_get_attr_string_value(py_job,
 				ATTR_queue);
@@ -6610,13 +6713,13 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 			if (!py_vnodelist) {
 				log_err(PBSE_INTERNAL, __func__,
 					"No vnode list parameter found for event!");
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			if (!PyDict_Check(py_vnodelist)) {
 				log_err(PBSE_INTERNAL, __func__,
 					"vnode list parameter not a dictionary!");
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			py_attr_keys = PyDict_Keys(py_vnodelist); /* NEW ref */
@@ -6626,7 +6729,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 					"Failed to obtain object's '%s' keys",
 					PY_EVENT_PARAM_VNODE);
 				log_err(PBSE_INTERNAL, __func__, log_buffer);
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			if (!PyList_Check(py_attr_keys)) {
@@ -6635,7 +6738,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 					PY_EVENT_PARAM_VNODE);
 				log_err(PBSE_INTERNAL, __func__, log_buffer);
 				Py_CLEAR(py_attr_keys);
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			num_attrs = PyList_Size(py_attr_keys);
@@ -6661,7 +6764,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 					Py_CLEAR(py_attr_keys);
 					free(key_str);
 					key_str = NULL;
-					return -1;
+					goto event_to_request_exit;
 				}
 
 				if (pbs_python_populate_svrattrl_from_python_class(py_vnode,
@@ -6672,7 +6775,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 					Py_CLEAR(py_attr_keys);
 					free(key_str);
 					key_str = NULL;
-					return -1;
+					goto event_to_request_exit;
 				}
 				free(key_str);
 			}
@@ -6682,13 +6785,13 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 			if (!py_resvlist) {
 				log_err(PBSE_INTERNAL, __func__,
 					"No reservation list parameter found for event!");
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			if (!PyDict_Check(py_resvlist)) {
 				log_err(PBSE_INTERNAL, __func__,
 					"reservation list parameter not a dictionary!");
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			py_attr_keys = PyDict_Keys(py_resvlist); /* NEW ref */
@@ -6698,7 +6801,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 					"Failed to obtain object's '%s' keys",
 					PY_EVENT_PARAM_RESVLIST);
 				log_err(PBSE_INTERNAL, __func__, log_buffer);
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			if (!PyList_Check(py_attr_keys)) {
@@ -6707,7 +6810,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 					PY_EVENT_PARAM_RESVLIST);
 				log_err(PBSE_INTERNAL, __func__, log_buffer);
 				Py_CLEAR(py_attr_keys);
-				return -1;
+				goto event_to_request_exit;
 			}
 
 			num_attrs = PyList_Size(py_attr_keys);
@@ -6733,7 +6836,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 					log_err(PBSE_INTERNAL, __func__, log_buffer);
 					Py_CLEAR(py_attr_keys);
 					free(key_str);
-					return -1;
+					goto event_to_request_exit;
 				}
 
 				if (pbs_python_populate_svrattrl_from_python_class(py_job,
@@ -6743,7 +6846,7 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 					log_err(PBSE_INTERNAL, __func__, log_buffer);
 					Py_CLEAR(py_attr_keys);
 					free(key_str);
-					return -1;
+					goto event_to_request_exit;
 				}
 
 				free(key_str);
@@ -6754,9 +6857,12 @@ _pbs_python_event_to_request(unsigned int hook_event, hook_output_param_t *req_p
 		default:
 			log_err(PBSE_INTERNAL, __func__,
 				"unexpected hook event type");
-			return -1;
+			goto event_to_request_exit;
 	}
-	return 0;
+event_to_request_exit:
+	rc = 0;
+	hook_perf_stat_stop(perf_label, perf_action, 0);
+	return rc;
 }
 
 /**
@@ -6982,7 +7088,7 @@ pbsv1mod_meth_get_queue(PyObject *self, PyObject *args, PyObject *kwds)
 	}
 
 	hook_set_mode = C_MODE;
-	py_que = _pps_helper_get_queue(NULL, name);
+	py_que = _pps_helper_get_queue(NULL, name, "hook_func");
 	hook_set_mode = PY_MODE;
 
 	if (py_que != NULL)
@@ -7041,7 +7147,7 @@ pbsv1mod_meth_get_job(PyObject *self, PyObject *args, PyObject *kwds)
 	}
 
 	hook_set_mode = C_MODE;
-	py_job = _pps_helper_get_job(NULL, jname, qname);
+	py_job = _pps_helper_get_job(NULL, jname, qname, "hook_func");
 	hook_set_mode = PY_MODE;
 
 	if (py_job != NULL)
@@ -7096,7 +7202,7 @@ pbsv1mod_meth_get_resv(PyObject *self, PyObject *args, PyObject *kwds)
 	}
 
 	hook_set_mode = C_MODE;
-	py_resv = _pps_helper_get_resv(NULL, rname);
+	py_resv = _pps_helper_get_resv(NULL, rname, "hook_func");
 	hook_set_mode = PY_MODE;
 
 	if (py_resv != NULL)
@@ -7150,7 +7256,7 @@ pbsv1mod_meth_get_vnode(PyObject *self, PyObject *args, PyObject *kwds)
 	}
 
 	hook_set_mode = C_MODE;
-	py_vnode = _pps_helper_get_vnode(NULL, vname);
+	py_vnode = _pps_helper_get_vnode(NULL, vname, "hook_func");
 	hook_set_mode = PY_MODE;
 
 	if (py_vnode != NULL)
@@ -7201,7 +7307,7 @@ pbsv1mod_meth_server(void)
 {
 	PyObject *py_svr = NULL;
 	hook_set_mode = C_MODE;
-	py_svr = _pps_helper_get_server();
+	py_svr = _pps_helper_get_server("hook_func");
 	hook_set_mode = PY_MODE;
 	return (py_svr);
 }
@@ -8883,18 +8989,15 @@ pbsv1mod_meth_iter_nextfunc(PyObject *self, PyObject *args, PyObject *kwds)
 
 			hook_set_mode = C_MODE;
 			if (strcmp(obj_name, ITER_RESERVATIONS) == 0) {
-				py_object = _pps_helper_get_resv(\
-					(resc_resv *)iter_entry->data, NULL);
+				py_object = _pps_helper_get_resv((resc_resv *)iter_entry->data, NULL, "hook_func");
 				iter_entry->data = (resc_resv *)GET_NEXT(\
 				((resc_resv *)iter_entry->data)->ri_allresvs);
 			} else if (strcmp(obj_name, ITER_QUEUES) == 0) {
-				py_object = _pps_helper_get_queue(\
-					(pbs_queue *)iter_entry->data, NULL);
+				py_object = _pps_helper_get_queue((pbs_queue *)iter_entry->data, NULL, "hook_func");
 				iter_entry->data = (pbs_queue *)GET_NEXT(\
 				((pbs_queue *)iter_entry->data)->qu_link);
 			} else if (strcmp(obj_name, ITER_JOBS) == 0) {
-				py_object = _pps_helper_get_job(\
-					(job *)iter_entry->data, NULL, NULL);
+				py_object = _pps_helper_get_job((job *)iter_entry->data, NULL, NULL, "hook_func");
 
 
 #ifdef NAS /* localmod 014 */
@@ -8930,8 +9033,7 @@ pbsv1mod_meth_iter_nextfunc(PyObject *self, PyObject *args, PyObject *kwds)
 				}
 			} else if (strcmp(obj_name, ITER_VNODES) == 0) {
 
-				py_object = _pps_helper_get_vnode(\
-			     (struct pbsnode *)iter_entry->data, NULL);
+				py_object = _pps_helper_get_vnode((struct pbsnode *)iter_entry->data, NULL, "hook_func");
 
 				iter_entry->data = NULL;
 				vi = iter_entry->data_index + 1;
@@ -10482,6 +10584,7 @@ py_get_server_static(void)
 	PyObject *py_svr = NULL;
 	PyObject *py_sargs = NULL;
 	int tmp_rc = -1;
+	char	perf_label[MAXBUFLEN];
 
 	if (!use_static_data || (server_data == NULL))
 		Py_RETURN_NONE;
@@ -10501,8 +10604,9 @@ py_get_server_static(void)
 	}
 	Py_CLEAR(py_sargs);
 
+	snprintf(perf_label, sizeof(perf_label), "hook_func:%s(%s)", SERVER_OBJECT, server_name);
 	tmp_rc = pbs_python_populate_python_class_from_svrattrl(py_svr,
-		server_data);
+		server_data, perf_label, "populate");
 
 	if (tmp_rc == -1) {
 		log_err(PBSE_INTERNAL, __func__,
@@ -10585,6 +10689,7 @@ py_get_queue_static(char *qname, char *svr_name)
 	char		*attr_name = NULL;
 	pbs_list_head	queuel;
 	int		rc;
+	char		perf_label[MAXBUFLEN];
 
 	if (!use_static_data || (server_queues.data == NULL)) {
 		Py_RETURN_NONE;
@@ -10720,8 +10825,8 @@ py_get_queue_static(char *qname, char *svr_name)
 		goto get_queue_error_exit;
 	}
 
-	rc = pbs_python_populate_python_class_from_svrattrl(\
-				       py_queue, &queuel);
+	snprintf(perf_label, sizeof(perf_label), "hook_func:%s(%s)", SERVER_QUEUE_OBJECT, qname);
+	rc = pbs_python_populate_python_class_from_svrattrl(py_queue, &queuel, perf_label, "populate");
 
 	if (rc == -1) {
 		snprintf(log_buffer, sizeof(log_buffer),
@@ -10822,6 +10927,7 @@ py_get_vnode_static(char *vname, char *svr_name)
 	char		*attr_name = NULL;
 	pbs_list_head	vnodel;
 	int		rc;
+	char		perf_label[MAXBUFLEN];
 
 	if (!use_static_data || (server_vnodes.data == NULL)) {
 		Py_RETURN_NONE;
@@ -10958,8 +11064,8 @@ py_get_vnode_static(char *vname, char *svr_name)
 		goto get_vnode_error_exit;
 	}
 
-	rc = pbs_python_populate_python_class_from_svrattrl(\
-				       py_vnode, &vnodel);
+	snprintf(perf_label, sizeof(perf_label), "hook_func:%s(%s)", SERVER_VNODE_OBJECT, vname);
+	rc = pbs_python_populate_python_class_from_svrattrl(py_vnode, &vnodel, perf_label, "populate");
 	if (rc == -1) {
 		snprintf(log_buffer, sizeof(log_buffer),
 			"failed to fully populate Python"
@@ -11068,6 +11174,7 @@ py_get_job_static(char *jid, char *svr_name, char *queue_name)
 	PyObject *py_server = NULL;
 	PyObject *py_que = NULL;
 	int		rc;
+	char		perf_label[MAXBUFLEN];
 
 	if (!use_static_data || (server_jobs.data == NULL)) {
 		Py_RETURN_NONE;
@@ -11220,8 +11327,8 @@ py_get_job_static(char *jid, char *svr_name, char *queue_name)
 		goto get_job_error_exit;
 	}
 
-	rc = pbs_python_populate_python_class_from_svrattrl(\
-				       py_job, &jobl);
+	snprintf(perf_label, sizeof(perf_label), "hook_func:%s(%s)", SERVER_JOB_OBJECT, jid);
+	rc = pbs_python_populate_python_class_from_svrattrl(py_job, &jobl, perf_label, "populate");
 
 	if (rc == -1) {
 		snprintf(log_buffer, sizeof(log_buffer),
@@ -11347,6 +11454,7 @@ py_get_resv_static(char *resvid, char *svr_name)
 	PyObject *py_server = NULL;
 	PyObject *py_que = NULL;
 	int		rc;
+	char		perf_label[MAXBUFLEN];
 
 	if (!use_static_data || (server_resvs.data == NULL)) {
 		Py_RETURN_NONE;
@@ -11485,8 +11593,8 @@ py_get_resv_static(char *resvid, char *svr_name)
 		goto get_resv_error_exit;
 	}
 
-	rc = pbs_python_populate_python_class_from_svrattrl(\
-				       py_resv, &resvl);
+	snprintf(perf_label, sizeof(perf_label), "hook_func:%s(%s)", SERVER_RESV_OBJECT, resvid);
+	rc = pbs_python_populate_python_class_from_svrattrl(py_resv, &resvl, perf_label, "populate");
 
 	if (rc == -1) {
 		snprintf(log_buffer, sizeof(log_buffer),

--- a/src/lib/Libutil/hook.c
+++ b/src/lib/Libutil/hook.c
@@ -3928,13 +3928,16 @@ hook_perf_stat_stop(char *label, char *action, int print_end_msg)
 	char instance[MAXBUFLEN];
 	char *msg;
 
-	if (!will_log_event(PBSEVENT_DEBUG4))
-		return;
-
 	if ((label == NULL) || (action == NULL))
 		return;
 
 	snprintf(instance, sizeof(instance), "label=%s action=%s", label, action);
+
+	if (!will_log_event(PBSEVENT_DEBUG4)) {
+		perf_stat_remove(instance);
+		return;
+	}
+
 	msg = perf_stat_stop(instance);
 
 	if (msg == NULL)

--- a/src/lib/Libutil/hook.c
+++ b/src/lib/Libutil/hook.c
@@ -3868,3 +3868,82 @@ cleanup_hooks_workdir(struct work_task *ptask)
 		cleanup_hooks_workdir, NULL);
 
 }
+
+/**
+ *
+ * @brief
+ * 	Start profiling the next lines of code, collectively giving it
+ *      a 'label' and an 'action' description.
+ *	The 'label' usually identifies to some object being profiled
+ *	(e.g. hook), while the 'action' describes what
+ *	is being captured for the object (e.g. "initialization").
+ *	Both 'label' and 'action' uniquely identify the
+ *	data collected.
+ *
+ * @param[in]	label - describes a particular object 
+ * @param[in]	action - refers to the object's action
+ *
+ * @param[in]	print_start_msg - if 1, then log a "profile_start" message. 
+ *
+ * @return void
+ *
+ */
+void
+hook_perf_stat_start(char *label, char *action, int print_start_msg)
+{
+	char instance[MAXBUFLEN];
+
+	if (!will_log_event(PBSEVENT_DEBUG4))
+		return;
+
+	if ((label == NULL) || (action == NULL))
+		return;
+
+	snprintf(instance, sizeof(instance), "label=%s action=%s", label, action);
+	perf_stat_start(instance);
+
+	if (print_start_msg) {
+		snprintf(log_buffer, sizeof(log_buffer), "%s profile_start", instance);
+		log_event(PBSEVENT_DEBUG4, PBS_EVENTCLASS_HOOK, LOG_INFO, "hook_perf_stat", log_buffer);
+	}
+}
+
+/**
+ *
+ * @brief
+ * 	Log summary of what has been tracked since hook_perf_stat_start()
+ *	call on the same label, action given.
+ *
+ * @param[in]	label - refers to a particular object 
+ * @param[in]	action - refers to the object's action
+ *
+ * @param[in]	print_end_msg - if 1, then mark a "profile_stop" message. 
+ *
+ * @return void
+ *
+ */
+void
+hook_perf_stat_stop(char *label, char *action, int print_end_msg)
+{
+	char instance[MAXBUFLEN];
+	char *msg;
+
+	if (!will_log_event(PBSEVENT_DEBUG4))
+		return;
+
+	if ((label == NULL) || (action == NULL))
+		return;
+
+	snprintf(instance, sizeof(instance), "label=%s action=%s", label, action);
+	msg = perf_stat_stop(instance);
+
+	if (msg == NULL)
+		return;
+
+	if (print_end_msg)
+		snprintf(log_buffer, sizeof(log_buffer), "%s profile_stop", msg);
+	else
+		snprintf(log_buffer, sizeof(log_buffer), "%s", msg);
+
+	log_event(PBSEVENT_DEBUG4, PBS_EVENTCLASS_HOOK, LOG_INFO, "hook_perf_stat", log_buffer);
+}

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1634,7 +1634,7 @@ perf_stat_alloc(char *instance)
 	if ((instance == NULL) || (instance[0] == '\0'))
 		return NULL;
 
-	p_stat = (perf_stat_t *)malloc(sizeof(perf_stat_t));
+	p_stat = malloc(sizeof(perf_stat_t));
 	if (p_stat == NULL)
 		return NULL;
 
@@ -1670,7 +1670,7 @@ perf_stat_find(char *instance)
 
 	p_stat = (perf_stat_t *)GET_NEXT(perf_stats);
 	while (p_stat) {
-		if ( strcmp(p_stat->instance, instance) == 0) {
+		if (strcmp(p_stat->instance, instance) == 0) {
 			break;
 		}
 		p_stat = (perf_stat_t *)GET_NEXT(p_stat->pi_allstats);
@@ -1697,7 +1697,7 @@ perf_stat_remove(char *instance)
 
 	p_stat = (perf_stat_t *)GET_NEXT(perf_stats);
 	while (p_stat) {
-		if ( strcmp(p_stat->instance, instance) == 0) {
+		if (strcmp(p_stat->instance, instance) == 0) {
 			break;
 		}
 		p_stat = (perf_stat_t *)GET_NEXT(p_stat->pi_allstats);

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -82,6 +82,8 @@
 #ifndef WIN32
 #include <dlfcn.h>
 #include <grp.h>
+#include <time.h>
+#include <sys/time.h>
 #endif
 #include "pbs_error.h"
 
@@ -104,6 +106,16 @@ struct {
 	{ND_Default_Exclhost, VNS_DFLT_EXCLHOST },
 	{ND_Force_Exclhost,   VNS_FORCE_EXCLHOST}
 };
+
+/* Used for collecting performance stats */
+typedef struct perf_stat {
+	char		instance[MAXBUFLEN + 1];
+	double		walltime;
+	double		cputime;
+	pbs_list_link	pi_allstats;
+} perf_stat_t;
+
+static pbs_list_head	perf_stats;
 
 /**
  * @brief
@@ -1519,4 +1531,222 @@ get_preemption_order(struct preempt_ordering *porder, int req, int used)
 	}
 
 	return po;
+}
+
+#ifdef WIN32
+/**
+ * @brief
+ *	Returns the current wall clock time.
+ *
+ * @return double - number of seconds.
+ */
+static double 
+get_walltime(void)
+{
+	LARGE_INTEGER time, freq;
+
+	if (QueryPerformanceFrequency(&freq) == 0)
+        	return (0);
+
+	if (QueryPerformanceCounter(&time) == 0)
+        	return (0);
+
+	return ((double)time.QuadPart / freq.QuadPart);
+}
+
+/**
+ * @brief
+ *	Returns the current processor time.
+ *
+ * @return double - number of seconds.
+ **/
+static double
+get_cputime()
+{
+	FILETIME	create_time;
+	FILETIME	exit_time;
+	FILETIME	kernel_time;
+	FILETIME	user_time;
+
+	/* The times are returned in 100-nanosecond units */
+	if (GetProcessTimes(GetCurrentProcess(), &create_time, &exit_time, &kernel_time, &user_time) == 0)
+		return (0);
+
+	if (user_time.dwLowDateTime != 0)
+		return ((double)user_time.dwLowDateTime * 0.0000001);
+	
+        return ((double)(((unsigned long long)user_time.dwHighDateTime << 32)) * 0.0000001);
+}
+
+#else
+
+/**
+ * @brief
+ *	Returns the current wall clock time.
+ *
+ * @return double - number of seconds.
+ */
+static double
+get_walltime(void)
+{
+
+	struct timeval time;
+
+	if (gettimeofday(&time, NULL) == -1)
+        	return (0);
+
+	return ((double)time.tv_sec + (double)time.tv_usec * .000001);
+}
+
+/**
+ * @brief
+ *	Returns the current processor time.
+ *
+ * @return double - number of seconds.
+ **/
+static double
+get_cputime()
+{
+	clock_t	clock_cycles;
+	clock_cycles = clock();
+	if (clock_cycles == -1)
+		return (0);
+	return (double)clock_cycles / CLOCKS_PER_SEC;
+}
+#endif
+
+/**
+ * @brief
+ *	Allocates memory for a given 'instance' of measurements.
+ *
+ * @param[in] instance - a description of what is being measured.
+ *
+ * @return perf_stat_t - an allocated entry.
+ */
+static perf_stat_t *
+perf_stat_alloc(char *instance)
+{
+	perf_stat_t	*p_stat;
+
+	if ((instance == NULL) || (instance[0] == '\0'))
+		return NULL;
+
+	p_stat = (perf_stat_t *)malloc(sizeof(perf_stat_t));
+	if (p_stat == NULL)
+		return NULL;
+
+	(void)memset((char *)p_stat, (int)0, (size_t)sizeof(perf_stat_t));
+
+	strncpy(p_stat->instance, instance, MAXBUFLEN);
+	p_stat->instance[MAXBUFLEN] = '\0';
+	p_stat->walltime = 0;
+	p_stat->cputime = 0;
+
+	delete_link(&p_stat->pi_allstats);
+	append_link(&perf_stats, &p_stat->pi_allstats, p_stat);
+
+	return (p_stat);
+}
+
+/**
+ * @brief
+ *	Find an 'instance' entry among the list of saved performance
+ *	stats.
+ *
+ * @param[in] instance - entity being measured.
+ *
+ * @return perf_stat_t - found entry.
+ */
+static perf_stat_t *
+perf_stat_find(char *instance)
+{
+	perf_stat_t *p_stat;
+
+	if ((instance == NULL) || (instance[0] == '\0'))
+		return (NULL);
+
+	p_stat = (perf_stat_t *)GET_NEXT(perf_stats);
+	while (p_stat) {
+		if ( strcmp(p_stat->instance, instance) == 0) {
+			break;
+		}
+		p_stat = (perf_stat_t *)GET_NEXT(p_stat->pi_allstats);
+	}
+	return (p_stat);  /* may be a null pointer */
+}
+
+/**
+ * @brief
+ *	Record start counters for the 'instance' entry.
+ *
+ * @param[in] instance - entity being measured
+ *
+ * @return void
+ */
+void
+perf_stat_start(char *instance)
+{
+	static int	init = 0;
+	perf_stat_t	*p_stat;
+
+	if ((instance == NULL) || (instance[0] == '\0'))
+		return;
+
+	if (init == 0) {
+		CLEAR_HEAD(perf_stats);
+		init = 1;
+	}
+
+	p_stat = perf_stat_find(instance);
+	if (p_stat == NULL) {
+		p_stat = perf_stat_alloc(instance);
+		if (p_stat == NULL)
+			return;
+	}
+
+	p_stat->walltime = get_walltime();
+	p_stat->cputime = get_cputime();
+}
+
+/**
+ * @brief
+ *	Returns a summary of statistics gathered (e.g.
+ *	elapsed walltime) since the perf_stat_start() call on the
+ *	same 'instance'.
+ *
+ * @param[in] instance - entity being measured
+ *
+ * @return char *  - a string describing stats gathered.
+ *		   - this is a statically-allocated buffer that
+ *		     will get over-written by the next call to this
+ *		     function.
+ * @note
+ *	This also frees up the memory used by the 'instance' entry
+ *      in the list of saved stats.
+ */
+char *
+perf_stat_stop(char *instance)
+{
+	perf_stat_t	*p_stat;
+	double		now_walltime;
+	double		now_cputime;
+	static		char stat_summary[MAXBUFLEN + 1];
+
+	if ((instance == NULL) || (instance[0] == '\0')) {
+		return (NULL);
+	}
+
+	p_stat = perf_stat_find(instance);
+	if (p_stat == NULL)
+		return (NULL);
+	
+	now_walltime = get_walltime();
+	now_cputime = get_cputime();
+
+	snprintf(stat_summary, sizeof(stat_summary), "%s walltime=%f cputime=%f", instance, (now_walltime - p_stat->walltime),  (now_cputime - p_stat->cputime));
+
+ 	delete_link(&p_stat->pi_allstats);
+	free(p_stat);
+
+	return (stat_summary);
 }

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3617,6 +3617,7 @@ mom_process_hooks(unsigned int hook_event, char *req_user, char *req_host,
 	pbs_list_head *head_ptr;
 	mom_process_hooks_params_t *php = NULL;
 	struct work_task task;
+	char		perf_label[MAXBUFLEN];
 
 	if (hook_input == NULL) {
 		log_err(-1, __func__, "missing input argument to event");
@@ -3792,9 +3793,16 @@ mom_process_hooks(unsigned int hook_event, char *req_user, char *req_host,
 
 		}
 
+		if (pjob != NULL)
+			snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%s", hook_event_as_string(hook_event), phook->hook_name, pjob->ji_qs.ji_jobid);
+		else
+			snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", hook_event_as_string(hook_event), phook->hook_name, getpid());
+
+		hook_perf_stat_start(perf_label, "mom_process_hooks", 1);
 		rc = run_hook(phook, hook_event, hook_input,
 			req_user, req_host, php->parent_wait, (void *)post_run_hook,
 			hook_infile, hook_outfile, hook_datafile, MAXPATHLEN+1, php);
+		hook_perf_stat_stop(perf_label, "mom_process_hooks", 1);
 
 		if (last_phook != NULL) {
 			*last_phook = phook;

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -4656,7 +4656,7 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 			CLEAR_HEAD(event_resv);
 			req_params_out.vns_list = (pbs_list_head *)&event_vnode;
 			req_params_out.resv_list = (pbs_list_head *)&event_resv;
-			rc = pbs_python_event_to_request(hook_event, &req_params_out, perf_label, "hook_output");
+			rc = pbs_python_event_to_request(hook_event, &req_params_out, perf_label, HOOK_PERF_HOOK_OUTPUT);
 			if (rc == -1) {
 				log_err(PBSE_INTERNAL, phook->hook_name, "error occured recreating request!");
 			}
@@ -4732,22 +4732,22 @@ recreate_request(struct batch_request *preq)
 		req_params.rq_job = (struct rq_quejob *)&preq->rq_ind.rq_queuejob;
 		snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", HOOKSTR_QUEUEJOB, preq->rq_ind.rq_queuejob.rq_jid, getpid());
 		rc = pbs_python_event_to_request(HOOK_EVENT_QUEUEJOB,
-			&req_params, perf_label, "hook_output");
+			&req_params, perf_label, HOOK_PERF_HOOK_OUTPUT);
 	} else if (preq->rq_type == PBS_BATCH_SubmitResv) {
 		req_params.rq_job = (struct rq_quejob *)&preq->rq_ind.rq_queuejob;
 		snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", HOOKSTR_RESVSUB, preq->rq_ind.rq_queuejob.rq_jid, getpid());
 		rc =pbs_python_event_to_request(HOOK_EVENT_RESVSUB,
-			&req_params, perf_label, "hook_output");
+			&req_params, perf_label, HOOK_PERF_HOOK_OUTPUT);
 	} else if (preq->rq_type == PBS_BATCH_ModifyJob) {
 		req_params.rq_manage = (struct manage *)&preq->rq_ind.rq_modify;
 		snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", HOOKSTR_MODIFYJOB, preq->rq_ind.rq_modify.rq_objname, getpid());
 		rc =pbs_python_event_to_request(HOOK_EVENT_MODIFYJOB,
-			&req_params, perf_label, "hook_output");
+			&req_params, perf_label, HOOK_PERF_HOOK_OUTPUT);
 	} else if (preq->rq_type == PBS_BATCH_MoveJob) {
 		req_params.rq_move = (struct rq_move *)&preq->rq_ind.rq_move;
 		snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", HOOKSTR_MOVEJOB, preq->rq_ind.rq_move.rq_jid, getpid());
 		rc = pbs_python_event_to_request(HOOK_EVENT_MOVEJOB,
-			&req_params, perf_label, "hook_output");
+			&req_params, perf_label, HOOK_PERF_HOOK_OUTPUT);
 	} else {
 		log_err(PBSE_INTERNAL, __func__, "unexpected request type");
 		rc = -1;

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -3993,6 +3993,7 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 	pid_t 			mypid;
 	pbs_list_head 		event_vnode;
 	pbs_list_head 		event_resv;
+	char			perf_label[MAXBUFLEN];
 
 	if (req_ptr == NULL) {
 		snprintf(log_buffer, sizeof(log_buffer),
@@ -4003,7 +4004,20 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 		return -1;
 	}
 
+	if (phook == NULL) {
+		log_event(PBSEVENT_DEBUG3,
+			PBS_EVENTCLASS_HOOK, LOG_ERR,
+			phook->hook_name, "no associated hook");
+		return -1;
+	}
+
 	mypid = getpid();
+	if (pjob != NULL)
+		snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%s", hook_event_as_string(hook_event), phook->hook_name, pjob->ji_qs.ji_jobid);
+	else
+		snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", hook_event_as_string(hook_event), phook->hook_name, mypid);
+
+	hook_perf_stat_start(perf_label, "server_process_hooks", 1);
 
 	if (suffix_sz == 0)
 		suffix_sz = strlen(HOOK_SCRIPT_SUFFIX);
@@ -4060,7 +4074,7 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 	/* at least one enabled hook */
 	if (!(*event_initialized)) { /* only once for all hooks */
 		rc = pbs_python_event_set(hook_event, rq_user,
-			rq_host, req_ptr);
+			rq_host, req_ptr, perf_label);
 
 		if (rc == -1) { /* internal server code failure */
 			log_event(PBSEVENT_DEBUG2,
@@ -4147,7 +4161,8 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 			pbs_python_set_hook_debug_data_fp(NULL);
 			pbs_python_set_hook_debug_data_file("");
 		}
-		return (-1);
+		rc = -1;
+		goto server_process_hooks_exit;
 	}
 
 	/*
@@ -4180,7 +4195,8 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 			pbs_python_set_hook_debug_output_fp(NULL);
 			pbs_python_set_hook_debug_output_file("");
 		}
-		return (-1);
+		rc = -1;
+		goto server_process_hooks_exit;
 	}
 
 	if (rq_type == PBS_BATCH_HookPeriodic) {
@@ -4210,7 +4226,8 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 				pbs_python_set_hook_debug_output_fp(NULL);
 				pbs_python_set_hook_debug_output_file("");
 			}
-			return (-1);
+			rc = -1;
+			goto server_process_hooks_exit;
 		}
 	}	
 	
@@ -4292,7 +4309,8 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 				pbs_python_set_hook_debug_output_fp(NULL);
 				pbs_python_set_hook_debug_output_file("");
 			}
-			return (-1);
+			rc = -1;
+			goto server_process_hooks_exit;
 		}
 	}
 
@@ -4325,9 +4343,11 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 	}
 
 	/* let rc pass through */
-	if (rc==0)
-		rc=pbs_python_run_code_in_namespace(&svr_interp_data,
-			phook->script, 0);
+	if (rc == 0) {
+		hook_perf_stat_start(perf_label, "run_code", 0);
+		rc = pbs_python_run_code_in_namespace(&svr_interp_data, phook->script, 0);
+		hook_perf_stat_stop(perf_label, "run_code", 0);
+	}
 
 	if (fp_debug != NULL) {
 		fclose(fp_debug);
@@ -4360,9 +4380,11 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 				PBS_EVENTCLASS_HOOK, LOG_ERR,
 				phook->hook_name, msgbuf);
 			free(msgbuf);
-			if (rq_type == PBS_BATCH_HookPeriodic)
+			if (rq_type == PBS_BATCH_HookPeriodic) {
 				/* we will need output file to read data from hook later */
-				return (-1);
+				rc = -1;
+				goto server_process_hooks_exit;
+			}
 		} else {
 			fp_debug_out_save = pbs_python_get_hook_debug_output_fp();
 			if (fp_debug_out_save != NULL) {
@@ -4416,7 +4438,8 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 				pbs_python_set_hook_debug_output_fp(NULL);
 				pbs_python_set_hook_debug_output_file("");
 			}
-			return (-1); /* should not happen */
+			rc = -1;
+			goto server_process_hooks_exit;
 		case -2:	/* unhandled exception */
 			pbs_python_event_reject(NULL);
 			pbs_python_event_param_mod_disallow();
@@ -4431,7 +4454,8 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 				"request rejected as filter hook '%s' encountered an "
 				"exception. Please inform Admin", phook->hook_name);
 			write_hook_reject_debug_output_and_close(hook_msg);
-			return (0);
+			rc = 0;
+			goto server_process_hooks_exit;
 		case -3:	/* alarm timeout */
 			pbs_python_event_reject(NULL);
 			pbs_python_event_param_mod_disallow();
@@ -4446,7 +4470,8 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 				"request rejected as filter hook '%s' got an "
 				"alarm call. Please inform Admin", phook->hook_name);
 			write_hook_reject_debug_output_and_close(hook_msg);
-			return (0);
+			rc = 0;
+			goto server_process_hooks_exit;
 	}
 	*num_run += 1;
 	if (pbs_python_get_scheduler_restart_cycle_flag() == TRUE) {
@@ -4510,7 +4535,8 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 
 		pbs_python_do_vnode_set();
 		write_hook_reject_debug_output_and_close(emsg);
-		return (0);
+		rc = 0;
+		goto server_process_hooks_exit;
 	} else { 	/* hook request has been accepted */
 
 		if (rq_type == PBS_BATCH_RunJob || rq_type == PBS_BATCH_AsyrunJob) {
@@ -4601,7 +4627,8 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 					(vnode_modified?PY_EVENT_PARAM_VNODE:PY_EVENT_PARAM_JOB));
 
 				write_hook_reject_debug_output_and_close(hook_msg);
-				return (0);
+				rc = 0;
+				goto server_process_hooks_exit;
 			}
 
 			hook_msg[0] = '\0';
@@ -4614,7 +4641,8 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 				strncpy(hook_msg, log_buffer, msg_len-1);
 				attribute_jobmap_restore(pjob, runjob_accept_attrlist);
 				write_hook_reject_debug_output_and_close(hook_msg);
-				return (0);
+				rc = 0;
+				goto server_process_hooks_exit;
 			}
 		}
 
@@ -4628,7 +4656,7 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 			CLEAR_HEAD(event_resv);
 			req_params_out.vns_list = (pbs_list_head *)&event_vnode;
 			req_params_out.resv_list = (pbs_list_head *)&event_resv;
-			rc = pbs_python_event_to_request(hook_event, &req_params_out);
+			rc = pbs_python_event_to_request(hook_event, &req_params_out, perf_label, "hook_output");
 			if (rc == -1) {
 				log_err(PBSE_INTERNAL, phook->hook_name, "error occured recreating request!");
 			}
@@ -4639,12 +4667,16 @@ int server_process_hooks(int rq_type, char *rq_user, char *rq_host, hook *phook,
 			if (fp_debug_out != NULL)
 				fclose(fp_debug_out);
 			pbs_python_set_hook_debug_output_fp(NULL);
-			return (1);
+			rc = 1;
+			goto server_process_hooks_exit;
 		}
 	}
 
 	write_hook_accept_debug_output_and_close();
-	return (1);
+	rc = 1;
+server_process_hooks_exit:
+	hook_perf_stat_stop(perf_label, "server_process_hooks", 1);
+	return (rc);
 }
 
 /**
@@ -4668,6 +4700,7 @@ recreate_request(struct batch_request *preq)
 	hook_output_param_t req_params;
 	FILE *fp_debug = NULL;
 	char *hook_outfile = NULL;
+	char perf_label[MAXBUFLEN];		
 
 	if (!svr_interp_data.interp_started) {
 		log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_HOOK,
@@ -4697,20 +4730,24 @@ recreate_request(struct batch_request *preq)
 	hook_output_param_init(&req_params);
 	if (preq->rq_type == PBS_BATCH_QueueJob) {
 		req_params.rq_job = (struct rq_quejob *)&preq->rq_ind.rq_queuejob;
+		snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", HOOKSTR_QUEUEJOB, preq->rq_ind.rq_queuejob.rq_jid, getpid());
 		rc = pbs_python_event_to_request(HOOK_EVENT_QUEUEJOB,
-			&req_params);
+			&req_params, perf_label, "hook_output");
 	} else if (preq->rq_type == PBS_BATCH_SubmitResv) {
 		req_params.rq_job = (struct rq_quejob *)&preq->rq_ind.rq_queuejob;
+		snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", HOOKSTR_RESVSUB, preq->rq_ind.rq_queuejob.rq_jid, getpid());
 		rc =pbs_python_event_to_request(HOOK_EVENT_RESVSUB,
-			&req_params);
+			&req_params, perf_label, "hook_output");
 	} else if (preq->rq_type == PBS_BATCH_ModifyJob) {
 		req_params.rq_manage = (struct manage *)&preq->rq_ind.rq_modify;
+		snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", HOOKSTR_MODIFYJOB, preq->rq_ind.rq_modify.rq_objname, getpid());
 		rc =pbs_python_event_to_request(HOOK_EVENT_MODIFYJOB,
-			&req_params);
+			&req_params, perf_label, "hook_output");
 	} else if (preq->rq_type == PBS_BATCH_MoveJob) {
 		req_params.rq_move = (struct rq_move *)&preq->rq_ind.rq_move;
+		snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", HOOKSTR_MOVEJOB, preq->rq_ind.rq_move.rq_jid, getpid());
 		rc = pbs_python_event_to_request(HOOK_EVENT_MOVEJOB,
-			&req_params);
+			&req_params, perf_label, "hook_output");
 	} else {
 		log_err(PBSE_INTERNAL, __func__, "unexpected request type");
 		rc = -1;

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -6121,6 +6121,7 @@ execute_python_prov_script(hook  *phook,
 	unsigned int		hook_event;
 	char 			*emsg = NULL;
 	hook_input_param_t	req_ptr;
+	char			perf_label[MAXBUFLEN];
 
 	if (!phook || !prov_vnode_info)
 		return rc;
@@ -6130,9 +6131,10 @@ execute_python_prov_script(hook  *phook,
 	if (phook->user != HOOK_PBSADMIN)
 		return rc;
 
+	snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", HOOKSTR_PROVISION, phook->hook_name, getpid());
 	req_ptr.rq_prov = (struct prov_vnode_info *)prov_vnode_info;
 	rc = pbs_python_event_set(hook_event, "root",
-		"server", &req_ptr);
+		"server", &req_ptr, perf_label);
 	if (rc == -1) { /* internal server code failure */
 		log_event(PBSEVENT_DEBUG2,
 			PBS_EVENTCLASS_HOOK, LOG_ERR, __func__,
@@ -6180,9 +6182,11 @@ execute_python_prov_script(hook  *phook,
 	}
 
 	/* let rc pass through */
-	rc=pbs_python_run_code_in_namespace(&svr_interp_data,
+	hook_perf_stat_start(perf_label, "run_code", 0);
+	rc = pbs_python_run_code_in_namespace(&svr_interp_data,
 		phook->script,
 		&exit_code);
+	hook_perf_stat_stop(perf_label, "run_code", 0);
 
 	/* go back to server's private directory */
 	if (chdir(path_priv) != 0) {

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -6182,11 +6182,11 @@ execute_python_prov_script(hook  *phook,
 	}
 
 	/* let rc pass through */
-	hook_perf_stat_start(perf_label, "run_code", 0);
+	hook_perf_stat_start(perf_label, HOOK_PERF_RUN_CODE, 0);
 	rc = pbs_python_run_code_in_namespace(&svr_interp_data,
 		phook->script,
 		&exit_code);
-	hook_perf_stat_stop(perf_label, "run_code", 0);
+	hook_perf_stat_stop(perf_label, HOOK_PERF_RUN_CODE, 0);
 
 	/* go back to server's private directory */
 	if (chdir(path_priv) != 0) {

--- a/src/server/w32_svr_periodic_hook.c
+++ b/src/server/w32_svr_periodic_hook.c
@@ -271,6 +271,7 @@ execute_python_periodic_hook(hook  *phook)
 	hook_input_param_t	req_ptr;
 	FILE    		*fp_out = NULL;
 	FILE			*fp_out_save = NULL;
+	char			perf_label[MAXBUFLEN];
 	
 	if (!phook)
 		return rc;
@@ -291,8 +292,10 @@ execute_python_periodic_hook(hook  *phook)
 	req_ptr.vns_list = (pbs_list_head *)get_vnode_list();
 	req_ptr.resv_list = (pbs_list_head *)get_resv_list();
 
+	snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", hook_event_as_string(hook_event), phook->hook_name, mypid);
+
 	rc = pbs_python_event_set(hook_event, username,
-		"server", &req_ptr);
+		"server", &req_ptr, perf_label);
 
 	if (rc == -1) { /* internal server code failure */
 		log_event(PBSEVENT_DEBUG2,

--- a/src/server/w32_svr_periodic_hook.c
+++ b/src/server/w32_svr_periodic_hook.c
@@ -295,7 +295,7 @@ execute_python_periodic_hook(hook  *phook)
 	snprintf(perf_label, sizeof(perf_label), "hook_%s_%s_%d", hook_event_as_string(hook_event), phook->hook_name, mypid);
 
 	rc = pbs_python_event_set(hook_event, username,
-		"server", &req_ptr, perf_label);
+		PY_TYPE_SERVER, &req_ptr, perf_label);
 
 	if (rc == -1) { /* internal server code failure */
 		log_event(PBSEVENT_DEBUG2,

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -2268,7 +2268,7 @@ main(int argc, char *argv[], char *envp[])
 	extern void pbs_python_svr_destroy_interpreter_data(
 		struct python_interpreter_data *interp_data);
 	
-	if (set_msgdaemonname("pbs_python")) {
+	if (set_msgdaemonname(PBS_PYTHON_PROGRAM)) {
 		fprintf(stderr, "Out of memory\n");
 		return 1;
 	}
@@ -2296,13 +2296,13 @@ main(int argc, char *argv[], char *envp[])
 	/* determine the actual server name */
 	pbs_server_name = pbs_default();
 	if ((!pbs_server_name) || (*pbs_server_name == '\0')) {
-		log_err(-1, "pbs_python", "Unable to get server name");
+		log_err(-1, PBS_PYTHON_PROGRAM, "Unable to get server name");
 		return (-1);
 	}
 
 	/* determine the server host name */
 	if (get_fullhostname(pbs_server_name, server_host, PBS_MAXSERVERNAME) != 0) {
-		log_err(-1, "pbs_python", "Unable to get server host name");
+		log_err(-1, PBS_PYTHON_PROGRAM, "Unable to get server host name");
 		return (-1);
 	}
 
@@ -2707,7 +2707,7 @@ main(int argc, char *argv[], char *envp[])
 				sp = the_input;
 		}
 		snprintf(perf_label, sizeof(perf_label), "%s", sp ? sp : "stdin");
-		hook_perf_stat_start(perf_label, "pbs_python", 1);
+		hook_perf_stat_start(perf_label, PBS_PYTHON_PROGRAM, 1);
 
 		CLEAR_HEAD(default_list);
 		CLEAR_HEAD(event);
@@ -2729,7 +2729,7 @@ main(int argc, char *argv[], char *envp[])
 			&event_vnode, &event_vnode_fail, &job_failed_mom_list,
 			&job_succeeded_mom_list, &event_src_queue,
 			&event_aoe, &event_argv, &event_jobs,
-			perf_label, "load_hook_input_file");
+			perf_label, HOOK_PERF_LOAD_INPUT);
 		if (rc == -1) {
 			fprintf(stderr, "%s: failed to populate svrattrl \n", argv[0]);
 			exit(2);
@@ -2756,7 +2756,7 @@ main(int argc, char *argv[], char *envp[])
 				&server_queues, &server_queues_names,
 				&server_resvs, &server_resvs_resvids,
 				&server_vnodes, &server_vnodes_names,
-				the_data, "load_hook_data");
+				the_data, HOOK_PERF_LOAD_DATA);
 			if (rc == -1) {
 				fprintf(stderr,
 					"%s: failed to populate svrattrl \n",
@@ -2863,7 +2863,7 @@ main(int argc, char *argv[], char *envp[])
 		svr_interp_data.destroy_interpreter_data =
 			pbs_python_svr_destroy_interpreter_data;
 
-		svr_interp_data.daemon_name = strdup("pbs_python");
+		svr_interp_data.daemon_name = strdup(PBS_PYTHON_PROGRAM);
 
 		if (svr_interp_data.daemon_name == NULL) { /* should not happen */
 			fprintf(stderr, "strdup failed");
@@ -2873,9 +2873,9 @@ main(int argc, char *argv[], char *envp[])
 		(void)pbs_python_ext_alloc_python_script(hook_script,
 			(struct python_script **) &py_script);
 
-		hook_perf_stat_start(perf_label, "start_interpreter", 0);
+		hook_perf_stat_start(perf_label, HOOK_PERF_START_PYTHON, 0);
 		pbs_python_ext_start_interpreter(&svr_interp_data);
-		hook_perf_stat_stop(perf_label, "start_interpreter", 0);
+		hook_perf_stat_stop(perf_label, HOOK_PERF_START_PYTHON, 0);
 		hook_input_param_init(&req_params);
 		switch (hook_event) {
 
@@ -2894,8 +2894,7 @@ main(int argc, char *argv[], char *envp[])
 				}
 				if (copy_svrattrl_list(&event_job,
 					&rqj.rq_attr) == -1) {
-					log_err(errno, "pbs_python",
-						"failed to copy event_job");
+					log_err(errno, PBS_PYTHON_PROGRAM, "failed to copy event_job");
 					rc = 1;
 					goto pbs_python_end;
 				}
@@ -2921,8 +2920,7 @@ main(int argc, char *argv[], char *envp[])
 				}
 				if (copy_svrattrl_list(&event_job,
 					&rqm.rq_attr) == -1) {
-					log_err(errno, "pbs_python",
-						"failed to copy event_job");
+					log_err(errno, PBS_PYTHON_PROGRAM, "failed to copy event_job");
 					rc = 1;
 					goto pbs_python_end;
 				}
@@ -2985,8 +2983,7 @@ main(int argc, char *argv[], char *envp[])
 				}
 				if (copy_svrattrl_list(&event_resv,
 					&rqj.rq_attr) == -1) {
-					log_err(errno, "pbs_python",
-						"failed to copy event_job");
+					log_err(errno, PBS_PYTHON_PROGRAM, "failed to copy event_job");
 					rc = 1;
 					goto pbs_python_end;
 				}
@@ -3019,8 +3016,7 @@ main(int argc, char *argv[], char *envp[])
 
 				if (copy_svrattrl_list(&event_job,
 					&rqj.rq_attr) == -1) {
-					log_err(errno, "pbs_python",
-						"failed to copy event_job");
+					log_err(errno, PBS_PYTHON_PROGRAM, "failed to copy event_job");
 					rc = 1;
 					goto pbs_python_end;
 				}
@@ -3055,8 +3051,7 @@ main(int argc, char *argv[], char *envp[])
 
 				if (copy_svrattrl_list(&event_job,
 					&rqj.rq_attr) == -1) {
-					log_err(errno, "pbs_python",
-						"failed to copy event_job");
+					log_err(errno, PBS_PYTHON_PROGRAM, "failed to copy event_job");
 					rc = 1;
 					goto pbs_python_end;
 				}
@@ -3106,8 +3101,7 @@ main(int argc, char *argv[], char *envp[])
 
 				if (copy_svrattrl_list(&event_job,
 					&rqj.rq_attr) == -1) {
-					log_err(errno, "pbs_python",
-						"failed to copy event_job");
+					log_err(errno, PBS_PYTHON_PROGRAM, "failed to copy event_job");
 					rc = 1;
 					goto pbs_python_end;
 				}
@@ -3196,10 +3190,10 @@ main(int argc, char *argv[], char *envp[])
 
 			rc=Py_Main(1, tmp_argv);
 		} else {
-			hook_perf_stat_start(perf_label, "run_code", 0);
+			hook_perf_stat_start(perf_label, HOOK_PERF_RUN_CODE, 0);
 			rc=pbs_python_run_code_in_namespace(&svr_interp_data,
 				py_script, 0);
-			hook_perf_stat_stop(perf_label, "run_code", 0);
+			hook_perf_stat_stop(perf_label, HOOK_PERF_RUN_CODE, 0);
 		}
 		set_alarm(0, pbs_python_set_interrupt);
 
@@ -3260,7 +3254,7 @@ main(int argc, char *argv[], char *envp[])
 			else
 				sp = the_output;
 		}
-		snprintf(perf_action, sizeof(perf_action), "hook_output_to:%s", sp ? sp : "stdout");
+		snprintf(perf_action, sizeof(perf_action), "%s:%s", HOOK_PERF_HOOK_OUTPUT, sp ? sp : "stdout");
 
 		switch (hook_event) {
 
@@ -3623,7 +3617,7 @@ pbs_python_end:
 		if (env_str != NULL)
 			free(env_str);
 
-		hook_perf_stat_stop(perf_label, "pbs_python", 1);
+		hook_perf_stat_stop(perf_label, PBS_PYTHON_PROGRAM, 1);
 	}
 
 	return rc;

--- a/test/tests/functional/pbs_hook_perf_stat.py
+++ b/test/tests/functional/pbs_hook_perf_stat.py
@@ -1,0 +1,482 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class Test_hook_perf_stat(TestFunctional):
+    """
+    This test suite tests that the hook performance stats are in place
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        # ensure LOG_EVENT_DEBUG3 is being recorded to see perf stats
+        a = {'log_events': 4095}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        self.mom.add_config({'$logevent': 4095})
+        self.mom.signal('-HUP')
+
+    def test_queuejob_hook(self):
+        """
+        Test that pbs_server collects performance stats for queuejob hook
+        """
+        hook_content = ("""
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
+s = pbs.server()
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+""")
+        hook_name = 'qhook'
+        hook_event = 'queuejob'
+        hook_attr = {'enabled': 'true', 'event': hook_event}
+        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+
+        j = Job(TEST_USER)
+        self.server.submit(j)
+
+        hd = "hook_perf_stat"
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        tr = "profile_start"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, tr),
+                              regexp=True)
+
+        stat = "walltime=.* cputime=.*"
+        act = "action=populate:pbs\.event\(\)\.job\(.*\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        lbl = "label=hook_func"
+        act = "action=populate:pbs.server\(\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        act = "action=run_code"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+        tr = "profile_stop"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s %s" % (hd, lbl, act, stat, tr),
+                              regexp=True)
+
+        lbl = "label=hook_%s_.*" % (hook_event,)
+        act = "action=hook_output"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+    def test_modifyjob_hook(self):
+        """
+        Test that pbs_server collects performance stats for modifyjob hook
+        """
+        hook_content = ("""
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
+s = pbs.server()
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+""")
+        hook_name = 'mhook'
+        hook_event = 'modifyjob'
+        hook_attr = {'enabled': 'true', 'event': hook_event}
+        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        self.server.alterjob(jid, {'Priority': 7}, runas=TEST_USER)
+
+        hd = "hook_perf_stat"
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        tr = "profile_start"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, tr),
+                              regexp=True)
+
+        stat = "walltime=.* cputime=.*"
+        act = "action=populate:pbs\.event\(\)\.job\(.*\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        act = "action=populate:pbs.server\(\).job\(.*\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        act = "action=populate:pbs.server\(\).queue\(.*\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        act = "action=populate:pbs.server\(\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        act = "action=run_code"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+        tr = "profile_stop"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s %s" % (hd, lbl, act, stat, tr),
+                              regexp=True)
+
+        lbl = "label=hook_%s_.*" % (hook_event,)
+        act = "action=hook_output"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+    def test_movejob_hook(self):
+        """
+        Test that pbs_server collects performance stats for movejob hook
+        """
+        hook_content = ("""
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
+s = pbs.server()
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+""")
+        hook_name = 'mvhook'
+        hook_event = 'movejob'
+        hook_attr = {'enabled': 'true', 'event': hook_event}
+        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+
+        j = Job(TEST_USER, {'Hold_Types': None})
+        jid = self.server.submit(j)
+        self.server.movejob(jobid=jid, destination="workq")
+
+        hd = "hook_perf_stat"
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        tr = "profile_start"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, tr),
+                              regexp=True)
+
+        stat = "walltime=.* cputime=.*"
+        act = "action=populate:pbs.server\(\).job\(.*\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        act = "action=populate:pbs.server\(\).queue\(.*\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        act = "action=populate:pbs.server\(\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        act = "action=run_code"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+        tr = "profile_stop"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s %s" % (hd, lbl, act, stat, tr),
+                              regexp=True)
+
+        lbl = "label=hook_%s_.*" % (hook_event,)
+        act = "action=hook_output"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+    def test_runjob_hook(self):
+        """
+        Test that pbs_server collects performance stats for runjob hook
+        """
+        hook_content = ("""
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
+s = pbs.server()
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+""")
+        hook_name = 'rhook'
+        hook_event = 'runjob'
+        hook_attr = {'enabled': 'true', 'event': hook_event}
+        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+
+        hd = "hook_perf_stat"
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        tr = "profile_start"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, tr),
+                              regexp=True)
+
+        stat = "walltime=.* cputime=.*"
+        act = "action=populate:pbs.server\(\).job\(.*\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        act = "action=populate:pbs.server\(\).queue\(.*\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        act = "action=populate:pbs.server\(\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        act = "action=run_code"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+        tr = "profile_stop"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s %s" % (hd, lbl, act, stat, tr),
+                              regexp=True)
+
+    def test_resvsub_hook(self):
+        """
+        Test that pbs_server collects performance stats for resvsub hook
+        """
+        hook_content = ("""
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
+s = pbs.server()
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+""")
+        hook_name = 'rhook'
+        hook_event = 'resvsub'
+        hook_attr = {'enabled': 'true', 'event': hook_event}
+        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+
+        r = Reservation(TEST_USER)
+        self.server.submit(r)
+
+        hd = "hook_perf_stat"
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        tr = "profile_start"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, tr),
+                              regexp=True)
+
+        stat = "walltime=.* cputime=.*"
+        act = "action=populate:pbs\.event\(\)\.resv\(.*\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        lbl = "label=hook_func"
+        act = "action=populate:pbs.server\(\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        act = "action=run_code"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+        tr = "profile_stop"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s %s" % (hd, lbl, act, stat, tr),
+                              regexp=True)
+
+        lbl = "label=hook_%s_.*" % (hook_event,)
+        act = "action=hook_output"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+    def test_periodic_hook(self):
+        """
+        Test that pbs_server collects performance stats for periodic hook
+        """
+        hook_content = ("""
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
+s = pbs.server()
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+""")
+        hook_name = 'phook'
+        hook_event = 'periodic'
+        hook_attr = {'event': hook_event, 'freq': 5}
+        self.server.create_import_hook(hook_name, hook_attr,
+                                       hook_content, overwrite=True)
+
+        hd = "hook_perf_stat"
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        tr = "profile_start"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, tr),
+                              regexp=True)
+
+        stat = "walltime=.* cputime=.*"
+        act = "action=populate:pbs\.event\(\)\.vnode_list"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        act = "action=populate:pbs\.event\(\)\.resv_list"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        lbl = "label=hook_func"
+        act = "action=populate:pbs.server\(\)"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        act = "action=run_code"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+        tr = "profile_stop"
+        act = "action=server_process_hooks"
+        self.server.log_match("%s;%s %s %s %s" % (hd, lbl, act, stat, tr),
+                              regexp=True)
+
+        lbl = "label=hook_%s_.*" % (hook_event,)
+        act = "action=hook_output"
+        self.server.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                              regexp=True)
+
+    def test_mom_hooks(self):
+        """
+        Test that pbs_mom collects performance stats for mom hooks
+        """
+        hook_content = ("""
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "mom hook called")
+s = pbs.server()
+pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % (s.name,))
+""")
+        for hook_event in ['execjob_begin',
+                           'execjob_launch',
+                           'execjob_prologue',
+                           'execjob_epilogue',
+                           'execjob_end']:
+            hook_name = hook_event.replace('execjob_', '')
+            hook_attr = {'enabled': 'true', 'event': hook_event}
+            self.server.create_import_hook(hook_name, hook_attr, hook_content)
+        j = Job(TEST_USER)
+        j.set_sleep_time(5)
+        self.server.submit(j)
+
+        for hook_event in ['execjob_begin',
+                           'execjob_launch',
+                           'execjob_prologue',
+                           'execjob_epilogue',
+                           'execjob_end']:
+            hook_name = hook_event.replace('execjob_', '')
+
+            hd = "hook_perf_stat"
+            lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+            tr = "profile_start"
+            act = "action=mom_process_hooks"
+            self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, tr),
+                               regexp=True)
+
+            act = "action=pbs_python"
+            self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, tr),
+                               regexp=True)
+
+            stat = "walltime=.* cputime=.*"
+            act = "action=load_hook_input_file"
+            self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                               regexp=True)
+
+            act = "action=start_interpreter"
+            self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                               regexp=True)
+
+            act = "action=populate:pbs\.event\(\)\.job\(.*\)"
+            self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                               regexp=True)
+
+            act = "action=run_code"
+            self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                               regexp=True)
+
+            act = "action=hook_output_to:.*"
+            self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                               regexp=True)
+
+            tr = "profile_stop"
+            act = "action=pbs_python"
+            self.mom.log_match("%s;%s %s %s %s" % (hd, lbl, act, stat, tr),
+                               regexp=True)
+
+            act = "action=mom_process_hooks"
+            self.mom.log_match("%s;%s %s %s %s" % (hd, lbl, act, stat, tr),
+                               regexp=True)
+
+    def test_mom_period_hook(self):
+        """
+        Test that pbs_mom collects performance stats for mom period hooks
+        """
+        hook_content = ("""
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "mom hook called")
+s = pbs.server()
+pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % (s.name,))
+""")
+        hook_name = "mom_period"
+        hook_event = "exechost_periodic"
+        hook_attr = {'enabled': 'true', 'event': hook_event}
+        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+
+        hd = "hook_perf_stat"
+        lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
+        tr = "profile_start"
+        act = "action=pbs_python"
+        self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, tr),
+                           regexp=True)
+
+        stat = "walltime=.* cputime=.*"
+        act = "action=load_hook_input_file"
+        self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                           regexp=True)
+
+        act = "action=start_interpreter"
+        self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                           regexp=True)
+
+        act = "action=populate:pbs\.event\(\)\.vnode_list"
+        self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                           regexp=True)
+
+        act = "action=populate:pbs\.event\(\)\.job_list"
+        self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                           regexp=True)
+
+        act = "action=run_code"
+        self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                           regexp=True)
+
+        act = "action=hook_output_to:.*"
+        self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
+                           regexp=True)
+
+        tr = "profile_stop"
+        act = "action=pbs_python"
+        self.mom.log_match("%s;%s %s %s %s" % (hd, lbl, act, stat, tr),
+                           regexp=True)

--- a/test/tests/functional/pbs_hook_perf_stat.py
+++ b/test/tests/functional/pbs_hook_perf_stat.py
@@ -57,12 +57,12 @@ class Test_hook_perf_stat(TestFunctional):
         """
         Test that pbs_server collects performance stats for queuejob hook
         """
-        hook_content = ("""
+        hook_content = """
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
 pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-""")
+"""
         hook_name = 'qhook'
         hook_event = 'queuejob'
         hook_attr = {'enabled': 'true', 'event': hook_event}
@@ -106,12 +106,12 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_server collects performance stats for modifyjob hook
         """
-        hook_content = ("""
+        hook_content = """
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
 pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-""")
+"""
         hook_name = 'mhook'
         hook_event = 'modifyjob'
         hook_attr = {'enabled': 'true', 'event': hook_event}
@@ -163,12 +163,12 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_server collects performance stats for movejob hook
         """
-        hook_content = ("""
+        hook_content = """
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
 pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-""")
+"""
         hook_name = 'mvhook'
         hook_event = 'movejob'
         hook_attr = {'enabled': 'true', 'event': hook_event}
@@ -216,12 +216,12 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_server collects performance stats for runjob hook
         """
-        hook_content = ("""
+        hook_content = """
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
 pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-""")
+"""
         hook_name = 'rhook'
         hook_event = 'runjob'
         hook_attr = {'enabled': 'true', 'event': hook_event}
@@ -263,12 +263,12 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_server collects performance stats for resvsub hook
         """
-        hook_content = ("""
+        hook_content = """
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
 pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-""")
+"""
         hook_name = 'rhook'
         hook_event = 'resvsub'
         hook_attr = {'enabled': 'true', 'event': hook_event}
@@ -312,12 +312,12 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_server collects performance stats for periodic hook
         """
-        hook_content = ("""
+        hook_content = """
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
 pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-""")
+"""
         hook_name = 'phook'
         hook_event = 'periodic'
         hook_attr = {'event': hook_event, 'freq': 5}
@@ -363,12 +363,12 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_mom collects performance stats for mom hooks
         """
-        hook_content = ("""
+        hook_content = """
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "mom hook called")
 s = pbs.server()
 pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
-""")
+"""
         for hook_event in ['execjob_begin',
                            'execjob_launch',
                            'execjob_prologue',
@@ -433,12 +433,12 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
         """
         Test that pbs_mom collects performance stats for mom period hooks
         """
-        hook_content = ("""
+        hook_content = """
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "mom hook called")
 s = pbs.server()
 pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
-""")
+"""
         hook_name = "mom_period"
         hook_event = "exechost_periodic"
         hook_attr = {'enabled': 'true', 'event': hook_event}

--- a/test/tests/functional/pbs_hook_perf_stat.py
+++ b/test/tests/functional/pbs_hook_perf_stat.py
@@ -61,7 +61,7 @@ class Test_hook_perf_stat(TestFunctional):
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
 """)
         hook_name = 'qhook'
         hook_event = 'queuejob'
@@ -110,7 +110,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
 """)
         hook_name = 'mhook'
         hook_event = 'modifyjob'
@@ -167,7 +167,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
 """)
         hook_name = 'mvhook'
         hook_event = 'movejob'
@@ -220,7 +220,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
 """)
         hook_name = 'rhook'
         hook_event = 'runjob'
@@ -228,7 +228,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
         self.server.create_import_hook(hook_name, hook_attr, hook_content)
 
         j = Job(TEST_USER)
-        jid = self.server.submit(j)
+        self.server.submit(j)
 
         hd = "hook_perf_stat"
         lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
@@ -267,7 +267,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
 """)
         hook_name = 'rhook'
         hook_event = 'resvsub'
@@ -316,7 +316,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
+pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
 """)
         hook_name = 'phook'
         hook_event = 'periodic'
@@ -367,7 +367,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % (s.name,))
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "mom hook called")
 s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % (s.name,))
+pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
 """)
         for hook_event in ['execjob_begin',
                            'execjob_launch',
@@ -416,7 +416,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % (s.name,))
             self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                                regexp=True)
 
-            act = "action=hook_output_to:.*"
+            act = "action=hook_output:.*"
             self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                                regexp=True)
 
@@ -437,7 +437,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % (s.name,))
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "mom hook called")
 s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % (s.name,))
+pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
 """)
         hook_name = "mom_period"
         hook_event = "exechost_periodic"
@@ -472,7 +472,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % (s.name,))
         self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                            regexp=True)
 
-        act = "action=hook_output_to:.*"
+        act = "action=hook_output:.*"
         self.mom.log_match("%s;%s %s %s" % (hd, lbl, act, stat),
                            regexp=True)
 

--- a/test/tests/functional/pbs_hook_perf_stat.py
+++ b/test/tests/functional/pbs_hook_perf_stat.py
@@ -53,20 +53,27 @@ class Test_hook_perf_stat(TestFunctional):
         self.mom.add_config({'$logevent': 4095})
         self.mom.signal('-HUP')
 
-    def test_queuejob_hook(self):
-        """
-        Test that pbs_server collects performance stats for queuejob hook
-        """
-        hook_content = """
+        self.hook_content = """
 import pbs
 pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
 s = pbs.server()
 pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
 """
+        self.mhook_content = """
+import pbs
+pbs.logmsg(pbs.LOG_DEBUG, "mom hook called")
+s = pbs.server()
+pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
+"""
+
+    def test_queuejob_hook(self):
+        """
+        Test that pbs_server collects performance stats for queuejob hook
+        """
         hook_name = 'qhook'
         hook_event = 'queuejob'
         hook_attr = {'enabled': 'true', 'event': hook_event}
-        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+        self.server.create_import_hook(hook_name, hook_attr, self.hook_content)
 
         j = Job(TEST_USER)
         self.server.submit(j)
@@ -106,16 +113,10 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_server collects performance stats for modifyjob hook
         """
-        hook_content = """
-import pbs
-pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
-s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-"""
         hook_name = 'mhook'
         hook_event = 'modifyjob'
         hook_attr = {'enabled': 'true', 'event': hook_event}
-        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+        self.server.create_import_hook(hook_name, hook_attr, self.hook_content)
 
         j = Job(TEST_USER)
         jid = self.server.submit(j)
@@ -163,16 +164,10 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_server collects performance stats for movejob hook
         """
-        hook_content = """
-import pbs
-pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
-s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-"""
         hook_name = 'mvhook'
         hook_event = 'movejob'
         hook_attr = {'enabled': 'true', 'event': hook_event}
-        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+        self.server.create_import_hook(hook_name, hook_attr, self.hook_content)
 
         j = Job(TEST_USER, {'Hold_Types': None})
         jid = self.server.submit(j)
@@ -216,16 +211,10 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_server collects performance stats for runjob hook
         """
-        hook_content = """
-import pbs
-pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
-s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-"""
         hook_name = 'rhook'
         hook_event = 'runjob'
         hook_attr = {'enabled': 'true', 'event': hook_event}
-        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+        self.server.create_import_hook(hook_name, hook_attr, self.hook_content)
 
         j = Job(TEST_USER)
         self.server.submit(j)
@@ -263,16 +252,10 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_server collects performance stats for resvsub hook
         """
-        hook_content = """
-import pbs
-pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
-s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-"""
         hook_name = 'rhook'
         hook_event = 'resvsub'
         hook_attr = {'enabled': 'true', 'event': hook_event}
-        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+        self.server.create_import_hook(hook_name, hook_attr, self.hook_content)
 
         r = Reservation(TEST_USER)
         self.server.submit(r)
@@ -312,17 +295,11 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_server collects performance stats for periodic hook
         """
-        hook_content = """
-import pbs
-pbs.logmsg(pbs.LOG_DEBUG, "server hook called")
-s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
-"""
         hook_name = 'phook'
         hook_event = 'periodic'
         hook_attr = {'event': hook_event, 'freq': 5}
         self.server.create_import_hook(hook_name, hook_attr,
-                                       hook_content, overwrite=True)
+                                       self.hook_content, overwrite=True)
 
         hd = "hook_perf_stat"
         lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)
@@ -363,12 +340,6 @@ pbs.logmsg(pbs.LOG_DEBUG, "server data collected for %s" % s.name)
         """
         Test that pbs_mom collects performance stats for mom hooks
         """
-        hook_content = """
-import pbs
-pbs.logmsg(pbs.LOG_DEBUG, "mom hook called")
-s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
-"""
         for hook_event in ['execjob_begin',
                            'execjob_launch',
                            'execjob_prologue',
@@ -376,7 +347,8 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
                            'execjob_end']:
             hook_name = hook_event.replace('execjob_', '')
             hook_attr = {'enabled': 'true', 'event': hook_event}
-            self.server.create_import_hook(hook_name, hook_attr, hook_content)
+            self.server.create_import_hook(hook_name, hook_attr,
+                                           self.mhook_content)
         j = Job(TEST_USER)
         j.set_sleep_time(5)
         self.server.submit(j)
@@ -433,16 +405,11 @@ pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
         """
         Test that pbs_mom collects performance stats for mom period hooks
         """
-        hook_content = """
-import pbs
-pbs.logmsg(pbs.LOG_DEBUG, "mom hook called")
-s = pbs.server()
-pbs.logmsg(pbs.LOG_DEBUG, "mom data collected for %s" % s.name)
-"""
         hook_name = "mom_period"
         hook_event = "exechost_periodic"
         hook_attr = {'enabled': 'true', 'event': hook_event}
-        self.server.create_import_hook(hook_name, hook_attr, hook_content)
+        self.server.create_import_hook(hook_name, hook_attr,
+                                       self.mhook_content)
 
         hd = "hook_perf_stat"
         lbl = "label=hook_%s_%s_.*" % (hook_event, hook_name)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Put infrastructure in place so that we can accurately measure the time it takes a hook to execute.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* The amount of walltime and cputime that sections of PBS code in support of hooks are reported, via  server_logs messages for server hooks, and mom_logs messages for mom hooks, under the high log level of DEBUG4.
* In order to see these messages, set server log_event value to:
`# qmgr -c "set server log_events = 4095"` 
and set mom_priv/config value of $logevent to 4095:
```
 # cat /var/spool/pbs/mom_priv/config
 $logevent 4095
```
* The log messages are in the form of space space-separated token headed by the substring "hook_perf_stat;":
   * **basic log message:**
`"hook_perf_stat;label=<description_of_section_of_code> action=<action_of_section_of_code> walltime=<num_of_seconds> cputime=<num_of_seconds>"`
    * **header message**: marks the start of profiling of a particular hook:
`"hook_perf_stat;label=<description_of_section_of_code> action=<action_of_section_of_code> profile_start"`
    * **trailer log message:** shows the amount taken from when the hook first got loaded (marked by the header message) to when it actually executed and completed:
`"hook_perf_stat;label=<description_of_section_of_code> action=<action_of_section_of_code> walltime=<num_of_seconds> cputime=<num_of_seconds> profile_stop"`
    * **label value format**: <hook_event>_<hook_name>_<unique_identifier_like_object_id_or_pid>
    * **special label value: "hook_func"** means a function inside the hook script, like pbs.server(), has been profiled and this was the result.
    * **special action value: "run_code"** shows elapsed time that the hook python script actually took.
    * **special action value: "start_interpreter"** shows up in mom hooks when the pbs_python command actually makes a call to start the interpreter.
   * s**pecial action value: "populate*"** for showing how long it takes for a particularly named Python object to be populated.
   * **special action value: "load_hook_input_file"** for showing the time it takes to load values from hook input file, which is done in mom hooks via pbs_python.
   * s**special action value: "hook_output"** for showing the time it takes for PBS to consume the values that were set by the target hook.

#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
* [hook_perf_stat.ptl.050719.txt](https://github.com/PBSPro/pbspro/files/3153923/hook_perf_stat.ptl.050719.txt)
* [valgrind_server_output.050319.txt](https://github.com/PBSPro/pbspro/files/3143141/valgrind_server_output.050319.txt)
* [valgrind_mom_output.050319.txt]* (https://github.com/PBSPro/pbspro/files/3143143/valgrind_mom_output.050319.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
