### PR TITLE
Fixed PTL issue trigger_sched_cycle set to False by default

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8305,7 +8305,7 @@ class Server(PBSService):
                 return self.expect(obj_type, attrib, id, op, attrop,
                                    attempt + 1, max_attempts, interval, count,
                                    extend, level=level, msg=" ".join(msg),
-                                   trigger_sched_cycle=False)
+                                   trigger_sched_cycle=trigger_sched_cycle)
 
         self.logger.log(level, prefix + " ".join(msg) + ' ...  OK')
         return True


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
trigger_sched_cycle value was set to False by default rather than setting the value passed


#### Describe Your Change
Assigned the appropriate value


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
