### PR TITLE
Use manager() to set preempt_order in PTL tests

### DIFF
--- a/test/tests/functional/pbs_resource_usage_log.py
+++ b/test/tests/functional/pbs_resource_usage_log.py
@@ -342,7 +342,7 @@ class TestResourceUsageLog(TestFunctional):
         a = {'queue_type': 'e', 'started': 't',
              'enabled': 't', 'priority': '180'}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id="highp")
-        self.scheduler.set_sched_config({'preempt_order': 'R'})
+        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'R'})
 
         a = {'Resource_List.select': '1:ncpus=1:mem=200gb'}
         j1 = Job(TEST_USER, a)


### PR DESCRIPTION
**Problem**
Missed out on using manager() instead of set_sched_config for preempt_order

**Analysis**
As part of #903, some of the preemption parameters were moved from sched_config to qmgr, preempt_order being one of them.
In one of the PTL tests, I missed out in using manager() instead of set_sched_config for setting preempt_order

**Solution**
User manager() instead of set_sched_config()

**Testing Logs**
[ptl_22591.txt](https://github.com/PBSPro/pbspro/files/3148471/ptl_22591.txt)
