### PR TITLE
Fixed when high priority requesting vnode fails to preempt

### DIFF
--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -671,6 +671,10 @@ int add_event_to_nodes(timed_event *te, nspec **nspecs);
 
 int add_node_events(timed_event *te, void *arg1, void *arg2);
 
+/*
+ * Find a node by its hostname
+ */
+node_info *find_node_by_host(node_info **ninfo_arr, char *host);
 #ifdef	__cplusplus
 }
 #endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If a high priority job requests a vnode/host it fails to find a low priority job for preemption.


#### Describe Your Change
The problem was that when we pass through all the low priority jobs in scheduler to find out which job can help in running the high priority job, we check for chunk level resources only. While it works in most cases but there is a special case for vnode/host resource. These resources are node level resources but they don't usually end up as a chunk level resource because of which scheduler fails to find the preemptible candidates and that results in high priority job not running.

FIX: To fix this problem, Scheduler now checks in execvnode of the running job to match the vnode name when the resource in contention is vnode. In case of host, it looks through all the nodes the job is running on matches the host.


#### Link to Design Doc

NA


#### Attach Test Logs or Output
[test_after_fix.txt](https://github.com/PBSPro/pbspro/files/3150794/test_after_fix.txt)
[test_before_fix.txt](https://github.com/PBSPro/pbspro/files/3150795/test_before_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
