### PR TITLE
Enhanced save & load configuration methods for server object in PTL

### DIFF
--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -171,6 +171,7 @@ def usage():
     msg += ['--list-tags: List all currenlty used tags\n']
     msg += [
         '--verbose: show verbose output (used with -i, -L or --tag-info)\n']
+    msg += ['--use-current-setup: Runs test on current PBS setup\n']
     msg += ['--version: show version number and exit\n']
 
     print(''.join(msg))
@@ -187,6 +188,7 @@ if __name__ == '__main__':
     outfile = None
     dbtype = None
     dbname = None
+    use_cur_setup = False
     dbaccess = None
     testfiles = None
     testsuites = None
@@ -232,7 +234,7 @@ if __name__ == '__main__':
     largs += ['stop-on-failure', 'enable-nose-debug']
     largs += ['post-analysis-data=', 'gen-ts-tree']
     largs += ['tc-failure-threshold=', 'cumulative-tc-failure-threshold=']
-    largs += ['max-postdata-threshold=', 'user-plugins=']
+    largs += ['max-postdata-threshold=', 'user-plugins=', 'use-current-setup']
 
     try:
         opts, args = getopt.getopt(
@@ -336,6 +338,8 @@ if __name__ == '__main__':
         elif o == '-h':
             usage()
             sys.exit(0)
+        elif o == '--use-current-setup':
+            use_cur_setup = True
         elif o == '--version':
             print(ptl.__version__)
             sys.exit(0)
@@ -454,9 +458,11 @@ if __name__ == '__main__':
         data = PTLTestData()
         loader.set_data(testgroup, testsuites, excludes, follow, testfiles)
         testtags.set_data(tags, eval_tags)
-        runner.set_data(paramfile, testparam, lcov_bin, lcov_data, lcov_out,
+        runner.set_data(paramfile, testparam, lcov_bin,
+                        lcov_data, lcov_out,
                         genhtml_bin, lcov_nosrc, lcov_baseurl,
-                        tc_failure_threshold, cumulative_tc_failure_threshold)
+                        tc_failure_threshold, cumulative_tc_failure_threshold,
+                        use_cur_setup)
         db.set_data(dbtype, dbname, dbaccess)
         data.set_data(post_data_dir, max_postdata_threshold)
         plugins = (loader, testtags, runner, db, data)

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -500,6 +500,7 @@ class PTLTestRunner(Plugin):
     def __init__(self):
         Plugin.__init__(self)
         self.param = None
+        self.use_cur_setup = False
         self.lcov_bin = None
         self.lcov_data = None
         self.lcov_out = None
@@ -525,7 +526,7 @@ class PTLTestRunner(Plugin):
     def set_data(self, paramfile, testparam,
                  lcov_bin, lcov_data, lcov_out, genhtml_bin, lcov_nosrc,
                  lcov_baseurl, tc_failure_threshold,
-                 cumulative_tc_failure_threshold):
+                 cumulative_tc_failure_threshold, use_cur_setup):
         if paramfile is not None:
             _pf = open(paramfile, 'r')
             _params_from_file = _pf.readlines()
@@ -542,6 +543,7 @@ class PTLTestRunner(Plugin):
             else:
                 testparam = _f
         self.param = testparam
+        self.use_cur_setup = use_cur_setup
         self.lcov_bin = lcov_bin
         self.lcov_data = lcov_data
         self.lcov_out = lcov_out
@@ -573,6 +575,7 @@ class PTLTestRunner(Plugin):
 
     def startContext(self, context):
         context.param = self.param
+        context.use_cur_setup = self.use_cur_setup
         context.start_time = datetime.datetime.now()
         if isclass(context) and issubclass(context, unittest.TestCase):
             self.result.logger.info(self.result.separator1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Currently cPickle is used to dump configuration using save_configuration() & load_configuration() is used to load it, which does not work as intended. Pickle is slow, unsafe and is not human readable. Storing configurations in json format would be a better option.


#### Describe Your Change
PBSTestSuite's Server.save_configuration() method should save all the configurations of PBS server listed below:
Commands output:
qmgr print server
qmgr print sched
qmgr print resource
qmgr list pbshook
save hooks .CF, .PY & .HK files.
pbsnodes -av
PBS Configuration file:
pbs.conf

* Load_configuration is used to load saved above configurations

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/spaces/PD/pages/1156284419/Update+file+format+and+file+name+for+data+saved+using+save+configuration+method+in+PTL)** --> 
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1156284419/Update+file+format+and+file+name+for+data+saved+using+save+configuration+method+in+PTL


#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->

[custom_setup_logs.txt](https://github.com/PBSPro/pbspro/files/3593469/custom_setup_logs.txt)
[use_cur_setup OOB logs.txt](https://github.com/PBSPro/pbspro/files/3593470/use_cur_setup.OOB.logs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
