### PR TITLE
load_conf() changes to make sure server and mom pbs_cgroups.PY are th…

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -890,7 +890,7 @@ if %s e.job.in_ms_mom():
             os.sep, pbs_home, 'mom_priv', 'hooks', 'pbs_cgroups.CF')
         # reload config if server and mom cfg differ up to count times
         count = 5
-        while ( count > 0 ):
+        while (count > 0):
             r1 = self.du.run_cmd(cmd=['cat', svr_conf], sudo=True)
             r2 = self.du.run_cmd(cmd=['cat', mom_conf], sudo=True)
             if r1['out'] != r2['out']:

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -882,6 +882,28 @@ if %s e.job.in_ms_mom():
         self.moms_list[0].log_match('pbs_cgroups.CF;copy hook-related '
                                     'file request received',
                                     starttime=self.server.ctime)
+        pbs_home = self.server.pbs_conf['PBS_HOME']
+        svr_conf = os.path.join(
+            os.sep, pbs_home, 'server_priv', 'hooks', 'pbs_cgroups.CF')
+        pbs_home = self.mom.pbs_conf['PBS_HOME']
+        mom_conf = os.path.join(
+            os.sep, pbs_home, 'mom_priv', 'hooks', 'pbs_cgroups.CF')
+        # reload config if server and mom cfg differ up to count times
+        count = 5
+        while ( count > 0 ):
+            r1 = self.du.run_cmd(cmd=['cat', svr_conf], sudo=True)
+            r2 = self.du.run_cmd(cmd=['cat', mom_conf], sudo=True)
+            if r1['out'] != r2['out']:
+                self.logger.info('server & mom pbs_cgroups.CF differ')
+                self.server.manager(MGR_CMD_IMPORT, HOOK, a, self.hook_name)
+                self.moms_list[0].log_match('pbs_cgroups.CF;copy hook-related '
+                                            'file request received',
+                                            starttime=self.server.ctime)
+            else:
+                self.logger.info('server & mom pbs_cgroups.CF match')
+                break
+            time.sleep(1)
+            count -= 1
 
     def load_default_config(self):
         """


### PR DESCRIPTION
…e same

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Because the server and mom pbs_cgroups.CF differ the test TestCgroupsHook.test_cgroup_reserve_mem intermittently failed with:

    self.assertEqual(mem_resv.value, 51200)
    AssertionError: 0 != 51200

and with:

    vmem1 = PbsTypeSize(vmem[0]['resources_available.vmem'])
    IndexError: list index out of range


#### Describe Your Change
Added a loop in load_conf() that checks if server and mom pbs_cgroups.CF are the same and reloads the configuration if they differ.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test Logs or Output

Ran the test 50 times in a loop:
[PBS-22791_x48_19.4.0_050919.txt](https://github.com/PBSPro/pbspro/files/3163426/PBS-22791_x48_19.4.0_050919.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
