### PR TITLE
Fix manager() adding extra quotes

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -844,9 +844,9 @@ if %s e.job.in_ms_mom():
                 script = fd.read()
         except IOError:
             self.assertTrue(False, 'Failed to open hook file %s' % filename)
-        events = 'execjob_begin,execjob_launch,execjob_attach,'
-        events += 'execjob_epilogue,execjob_end,exechost_startup,'
-        events += 'exechost_periodic,execjob_resize,execjob_abort'
+        events = ['execjob_begin', 'execjob_launch', 'execjob_attach',
+                  'execjob_epilogue', 'execjob_end', 'exechost_startup',
+                  'exechost_periodic', 'execjob_resize', 'execjob_abort']
         a = {'enabled': 'True',
              'freq': '10',
              'alarm': 30,
@@ -1898,8 +1898,8 @@ if %s e.job.in_ms_mom():
         self.load_config(self.cfg4 % (self.swapctl))
         # remove epilogue and periodic from the list of events
         attr = {'enabled': 'True',
-                'event': 'execjob_begin,execjob_launch,'
-                         'execjob_attach,execjob_end,exechost_startup'}
+                'event': ['execjob_begin', 'execjob_launch',
+                          'execjob_attach', 'execjob_end', 'exechost_startup']}
         self.server.manager(MGR_CMD_SET, HOOK, attr, self.hook_name)
         self.server.expect(NODE, {'state': 'free'}, id=self.nodes_list[0])
         j = Job(TEST_USER)
@@ -2337,7 +2337,7 @@ except Exception as exc:
     event.reject()
 event.accept()
 """ % jid1
-        events = 'execjob_begin,exechost_periodic'
+        events = ['execjob_begin', 'exechost_periodic']
         hookconf = {'enabled': 'True', 'freq': 2, 'alarm': 30, 'event': events}
         self.server.create_import_hook(hookname, hookconf, hookbody,
                                        overwrite=True)
@@ -2745,9 +2745,9 @@ event.accept()
             self.remove_vntype()
         for mom in self.moms_list:
             mom.delete_vnode_defs()
-        events = 'execjob_begin,execjob_launch,execjob_attach,'
-        events += 'execjob_epilogue,execjob_end,exechost_startup,'
-        events += 'exechost_periodic,execjob_resize,execjob_abort'
+        events = ['execjob_begin', 'execjob_launch', 'execjob_attach',
+                  'execjob_epilogue', 'execjob_end', 'exechost_startup',
+                  'exechost_periodic', 'execjob_resize', 'execjob_abort']
         # Disable the cgroups hook
         conf = {'enabled': 'False', 'freq': 30, 'event': events}
         self.server.manager(MGR_CMD_SET, HOOK, conf, self.hook_name)

--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -73,7 +73,7 @@ class TestFairshare(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'job_sort_formula': 'fairshare_perc'})
 
-        formula = '"pow(2,-(fairshare_tree_usage/fairshare_perc))"'
+        formula = 'pow(2,-(fairshare_tree_usage/fairshare_perc))'
         self.server.manager(MGR_CMD_SET, SERVER, {'job_sort_formula': formula})
 
         formula = 'fairshare_factor'
@@ -151,7 +151,7 @@ class TestFairshare(TestFunctional):
         self.set_up_resource_group()
         self.scheduler.set_sched_config({'log_filter': 2048})
 
-        formula = '"pow(2,-(fairshare_tree_usage/fairshare_perc))"'
+        formula = 'pow(2,-(fairshare_tree_usage/fairshare_perc))'
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         self.server.manager(MGR_CMD_SET, SERVER, {'job_sort_formula': formula})
@@ -263,7 +263,7 @@ class TestFairshare(TestFunctional):
         self.set_up_resource_group()
         self.scheduler.set_sched_config({'log_filter': 2048})
 
-        formula = '\"fairshare_factor + (walltime/ncpus)\"'
+        formula = 'fairshare_factor + (walltime/ncpus)'
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         self.server.manager(MGR_CMD_SET, SERVER, {'job_sort_formula': formula})

--- a/test/tests/functional/pbs_python_restart_settings.py
+++ b/test/tests/functional/pbs_python_restart_settings.py
@@ -256,7 +256,8 @@ localnode = pbs.get_local_nodename()
 vn = pbs.server().vnode(localnode)
 pbs.event().accept()
 """
-        a = {'event': "queuejob,movejob,modifyjob,runjob", 'enabled': "True"}
+        a = {'event': ["queuejob", "movejob", "modifyjob", "runjob"],
+             'enabled': "True"}
         self.server.create_import_hook("test", a, hook_body, overwrite=True)
         # Create workq2
         a = {'queue_type': 'e', 'started': 't', 'enabled': 't'}
@@ -337,7 +338,7 @@ pbs.event().accept()
 import pbs
 pbs.event().accept()
 """
-        a = {'event': "queuejob,modifyjob", 'enabled': 'True'}
+        a = {'event': ["queuejob", "modifyjob"], 'enabled': 'True'}
         self.server.create_import_hook("test", a, hook_body, overwrite=True)
         # Set max_objects and min_interval so that further changes
         # will generate a log message.

--- a/test/tests/functional/pbs_qmgr.py
+++ b/test/tests/functional/pbs_qmgr.py
@@ -165,11 +165,11 @@ class TestQmgr(TestFunctional):
         Set the node's comment, then print it and re-import it
         """
         a = {'comment': comment}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.hostname)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         qmgr_path = \
             os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin', 'qmgr')
         qmgr_cmd_print = qmgr_path + \
-            (' -c "p n %s comment"' % self.mom.hostname)
+            (' -c "p n %s comment"' % self.mom.shortname)
         ret = self.du.run_cmd(self.server.hostname,
                               cmd=qmgr_cmd_print, as_script=True)
         self.assertEqual(ret['rc'], 0)

--- a/test/tests/functional/pbs_sched_preempt_enforce_resumption.py
+++ b/test/tests/functional/pbs_sched_preempt_enforce_resumption.py
@@ -42,6 +42,7 @@ class TestSchedPreemptEnforceResumption(TestFunctional):
     """
     Test sched_preempt_enforce_resumption working
     """
+
     def setUp(self):
         TestFunctional.setUp(self)
 

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -259,7 +259,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         This test case checks that periodic and queuejob
         event can be set for the same hook
         """
-        events = "periodic,queuejob"
+        events = ["periodic", "queuejob"]
         hook_name = "TestHook"
         hook_attrib = {'event': events, 'freq': 100}
         scr = self.create_hook(True, 10)
@@ -335,7 +335,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         self.server.manager(MGR_CMD_SET, HOOK, attrs, hook_name)
         expected_msg = "periodic hook started at "
         self.server.log_match(expected_msg, starttime=start_time,
-                              interval=(freq+1))
+                              interval=(freq + 1))
         self.check_next_occurances(count=1, freq=freq, hook_run_time=25,
                                    check_for_hook_end=False)
         hook_name = "exechost_periodic_hook3"
@@ -347,10 +347,10 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         self.server.create_import_hook(hook_name, attrs, scr)
         start_time = int(time.time())
         expected_msg = "periodic hook started at "
-        self.mom.log_match(expected_msg, interval=(freq+1),
+        self.mom.log_match(expected_msg, interval=(freq + 1),
                            starttime=start_time)
         expected_msg = "periodic hook ended at "
-        self.mom.log_match(expected_msg, interval=(hook_run_time+1),
+        self.mom.log_match(expected_msg, interval=(hook_run_time + 1),
                            starttime=start_time)
 
     def test_other_pbs_operations_work(self):

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -680,7 +680,7 @@ e.accept()
         to calculate percent done and also if the soft_walltime is exceeded,
         the percent done should remain at 100%
         """
-        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': '"R 10 S"'},
+        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'R 10 S'},
                             runas=ROOT_USER)
         a = {'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)

--- a/test/tests/selftest/pbs_manager.py
+++ b/test/tests/selftest/pbs_manager.py
@@ -35,46 +35,27 @@
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
 
-from tests.functional import *
+from tests.selftest import *
 
 
-class TestHookSwig(TestFunctional):
-
+class TestManager(TestSelf):
     """
-    This test suite contains hook test to verify that the internal,
-    swig-generated 'pbs_ifl.py' does not cause an exception.
+    Test ptl.server.manager()
     """
 
-    def test_hook(self):
+    def test_pbs_conf(self):
         """
-        Create a hook, import a hook content that test pbs.server() call.
+        Test setting an string array with quote characters
         """
-        hook_name = "testhook"
-        hook_body = """
-import pbs
-e = pbs.event()
-s = pbs.server()
-if e.job.id:
-    jid = e.job.id
-else:
-    jid = "newjob"
-pbs.logjobmsg(jid, "server is %s" % (s.name,))
-"""
-        a = {'event': ['queuejob', 'execjob_begin'], 'enabled': 'True'}
-        self.server.create_import_hook(hook_name, a, hook_body)
-
-        j = Job(TEST_USER)
-        a = {'Resource_List.select': '1:ncpus=1', 'Resource_List.walltime': 30}
-
-        j.set_attributes(a)
-        j.set_sleep_time(10)
-
-        try:
-            jid = self.server.submit(j)
-        except PbsSubmitError:
-            pass
-        self.server.log_match("Job;%s;server is %s" % (
-            "newjob", self.server.shortname))
-
-        self.mom.log_match("Job;%s;server is %s" % (
-            jid, self.server.shortname))
+        attr = {'type': 'string_array', 'flag': 'h'}
+        rc = self.server.manager(MGR_CMD_CREATE, RSC, attr, id='f')
+        self.assertEqual(rc, 0)
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {"resources_available.f":
+                             ["A'A", 'B"B', 'C C']
+                             })
+        servers = self.server.filter(SERVER,
+                                     {'resources_available.f':
+                                      """A'A,B"B,C C"""})
+        self.logger.info(servers)
+        self.assertTrue(servers)


### PR DESCRIPTION
#### Describe Bug or Feature
 A previous check-in #1089 introduced a bug where PTL would quote string values if it contained certain characters. This would fail with string arrays. It would also fail with tests that added quotes to the strings so qmgr could import it; it would double-quote some strings. This will cause tests that set Fairshare order to fail. 


#### Describe Your Change
manager() will now also take lists of strings.
Design: https://pbspro.atlassian.net/wiki/spaces/PD/pages/1281458177/manager+should+use+python+lists+for+string+arrays

**String Arrays**
If any of the strings in the list have quotes or special characters, it will separately set each one, so qmgr does not get confused as to what is a string boundary and what is actually in the string.
Otherwise, it will join the string with commas and fall through to the strings case.

**Strings**
If the first and last character are both single or double quotes, don't add quotes.


#### Attach Test Logs or Output
~~[after-fix-self.txt](https://github.com/PBSPro/pbspro/files/3180075/after-fix-self.txt)~~
[after-fix8.txt](https://github.com/PBSPro/pbspro/files/3184749/after-fix8.txt)
[after-fix9.txt](https://github.com/PBSPro/pbspro/files/3184750/after-fix9.txt)
[after-fix10.txt](https://github.com/PBSPro/pbspro/files/3188475/after-fix10.txt)


