### PR TITLE
Primetime related tests from TestMultipleSchedulers fail

### DIFF
--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -1655,6 +1655,11 @@ class TestMultipleSchedulers(TestFunctional):
         This function will set the prime time
         in holidays file
         """
+        self.scheds[scid].holidays_delete_entry('a')
+
+        cur_year = datetime.datetime.today().year
+        self.scheds[scid].holidays_set_year(cur_year)
+
         p_day = 'weekday'
         p_hhmm = time.strftime('%H%M', time.localtime(ptime_start))
         np_hhmm = time.strftime('%H%M', time.localtime(ptime_end))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
After https://github.com/PBSPro/pbspro/pull/979 was checked in, the holidays file feature was enhanced to assume 24x7 prime-time if there was no year entry. 2 tests in TestMultipleSchedulers (test_prime_time_backfill and test_prime_time_multisched) modify holidays file but don't add a year entry to it, so PBS just assumes 24x7 primetime now and that's why they fail.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Just added the missing year entry to holidays file.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
[before_fix.log](https://github.com/PBSPro/pbspro/files/3165416/before_fix.log)
[after_fix.log](https://github.com/PBSPro/pbspro/files/3165417/after_fix.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
