### PR TITLE
remove extra double quotes in events in order to load hook

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -844,9 +844,9 @@ if %s e.job.in_ms_mom():
                 script = fd.read()
         except IOError:
             self.assertTrue(False, 'Failed to open hook file %s' % filename)
-        events = '"execjob_begin,execjob_launch,execjob_attach,'
+        events = 'execjob_begin,execjob_launch,execjob_attach,'
         events += 'execjob_epilogue,execjob_end,exechost_startup,'
-        events += 'exechost_periodic,execjob_resize,execjob_abort"'
+        events += 'exechost_periodic,execjob_resize,execjob_abort'
         a = {'enabled': 'True',
              'freq': '10',
              'alarm': 30,
@@ -2745,9 +2745,9 @@ event.accept()
             self.remove_vntype()
         for mom in self.moms_list:
             mom.delete_vnode_defs()
-        events = '"execjob_begin,execjob_launch,execjob_attach,'
+        events = 'execjob_begin,execjob_launch,execjob_attach,'
         events += 'execjob_epilogue,execjob_end,exechost_startup,'
-        events += 'exechost_periodic,execjob_resize,execjob_abort"'
+        events += 'exechost_periodic,execjob_resize,execjob_abort'
         # Disable the cgroups hook
         conf = {'enabled': 'False', 'freq': 30, 'event': events}
         self.server.manager(MGR_CMD_SET, HOOK, conf, self.hook_name)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Extra '"' in events string causes the pbs_cgroups hook to not get loaded.


#### Describe Your Change
Remove the extra '"' in the events string in load_hook() and tearDown() in pbs_cgroups_hook.py.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test Logs or Output

[pbs-22861_after.txt](https://github.com/PBSPro/pbspro/files/3175034/pbs-22861_after.txt)
[pbs-22861_before.txt](https://github.com/PBSPro/pbspro/files/3175035/pbs-22861_before.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
