### PR TITLE
pbs_cgroups_hook.py tests that skip after fix to load_hook() and tear…

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1898,8 +1898,8 @@ if %s e.job.in_ms_mom():
         self.load_config(self.cfg4 % (self.swapctl))
         # remove epilogue and periodic from the list of events
         attr = {'enabled': 'True',
-                'event': '"execjob_begin,execjob_launch,'
-                         'execjob_attach,execjob_end,exechost_startup"'}
+                'event': 'execjob_begin,execjob_launch,'
+                         'execjob_attach,execjob_end,exechost_startup'}
         self.server.manager(MGR_CMD_SET, HOOK, attr, self.hook_name)
         self.server.expect(NODE, {'state': 'free'}, id=self.nodes_list[0])
         j = Job(TEST_USER)
@@ -2337,7 +2337,7 @@ except Exception as exc:
     event.reject()
 event.accept()
 """ % jid1
-        events = '"execjob_begin,exechost_periodic"'
+        events = 'execjob_begin,exechost_periodic'
         hookconf = {'enabled': 'True', 'freq': 2, 'alarm': 30, 'event': events}
         self.server.create_import_hook(hookname, hookconf, hookbody,
                                        overwrite=True)


### PR DESCRIPTION
…Down()

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Two tests are still skipping despite fix in #1125:
test_cgroup_execjob_end_should_delete_cgroup
test_cgroup_periodic_update_known_jobs

#### Describe Your Change
Removed extra '"' in the events string in the tests.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->

#### Attach Test Logs or Output
[pbs-22878_after.txt](https://github.com/PBSPro/pbspro/files/3180302/pbs-22878_after.txt)
[pbs-22878_before.txt](https://github.com/PBSPro/pbspro/files/3180303/pbs-22878_before.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
