### PR TITLE
Use initgroups to get user's supplementary groups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -273,6 +273,8 @@ AC_CHECK_FUNCS([ \
 	select \
 	setresuid \
 	setresgid \
+	getpwuid \
+	initgroups \
 	seteuid \
 	setegid \
 	strerror_r \

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -903,6 +903,8 @@ impersonate_user(uid_t uid, gid_t gid)
 {
 #if defined(HAVE_GETPWUID) && defined(HAVE_INITGROUPS)
 	struct passwd *pwd = getpwuid(uid);
+	if (pwd == NULL)
+		return -1;
 
 	if (initgroups(pwd->pw_name, gid) == -1) {
 		return -1;

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -73,6 +73,34 @@ class TestQsub_direct_write(TestFunctional):
         self.assertEqual(2, file_count)
         self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
 
+    def test_direct_write_when_job_succeeds_controlled(self):
+        """
+        submit a sleep job and make sure that the std_files
+        are getting directly written to the mapped directory
+        when direct_files option is used.
+
+	directory should be
+	1) owned by a different user
+	2) owned by a group that is not the job user's primary gid
+		(but is a gid that the user is a member of)
+	3) not accessible via group permissions
+        """
+        j = Job(TEST_USER4, attrs={ATTR_k: 'doe'})
+        j.set_sleep_time(10)
+        sub_dir = self.du.mkdtemp(uid=TEST_USER4.uid)
+        mapping_dir = self.du.mkdtemp(uid=TEST_USER5.uid, gid=TSTGRP4.gid, mode=770)
+        self.mom.add_config(
+            {'$usecp': self.server.hostname + ':' + sub_dir
+             + ' ' + mapping_dir})
+        self.mom.restart()
+        jid = self.server.submit(j, submit_dir=sub_dir)
+        self.logger.info(self.msg)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        file_count = len([name for name in os.listdir(
+            mapping_dir) if os.path.isfile(os.path.join(mapping_dir, name))])
+        self.assertEqual(2, file_count)
+        self.server.expect(JOB, {ATTR_k: 'doe'}, id=jid)
+
     def test_direct_write_output_file(self):
         """
         submit a sleep job and make sure that the output file

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -79,17 +79,17 @@ class TestQsub_direct_write(TestFunctional):
         are getting directly written to the mapped directory
         when direct_files option is used.
 
-	directory should be
-	1) owned by a different user
-	2) owned by a group that is not the job user's primary gid
-		(but is a gid that the user is a member of)
-	3) not accessible via group permissions
+        directory should be
+        1) owned by a different user
+        2) owned by a group that is not the job user's primary gid
+                (but is a gid that the user is a member of)
+        3) not accessible via group permissions
         """
         j = Job(TEST_USER4, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
         sub_dir = self.du.mkdtemp(uid=TEST_USER4.uid)
         mapping_dir = self.du.mkdtemp(uid=TEST_USER5.uid, gid=TSTGRP4.gid, \
-			mode=770)
+                        mode=770)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -88,7 +88,8 @@ class TestQsub_direct_write(TestFunctional):
         j = Job(TEST_USER4, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
         sub_dir = self.du.mkdtemp(uid=TEST_USER4.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER5.uid, gid=TSTGRP4.gid, mode=770)
+        mapping_dir = self.du.mkdtemp(uid=TEST_USER5.uid, gid=TSTGRP4.gid, \
+			mode=770)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -88,7 +88,7 @@ class TestQsub_direct_write(TestFunctional):
         j = Job(TEST_USER4, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
         sub_dir = self.du.mkdtemp(uid=TEST_USER4.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER5.uid, gid=TSTGRP4.gid, \
+        mapping_dir = self.du.mkdtemp(uid=TEST_USER5.uid, gid=TSTGRP4.gid,
                         mode=770)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -89,7 +89,7 @@ class TestQsub_direct_write(TestFunctional):
         j.set_sleep_time(10)
         sub_dir = self.du.mkdtemp(uid=TEST_USER4.uid)
         mapping_dir = self.du.mkdtemp(
-            uid=TEST_USER5.uid, gid=TSTGRP4.gid, mode=770)
+            uid=TEST_USER5.uid, gid=TSTGRP4.gid, mode=0770)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -83,7 +83,7 @@ class TestQsub_direct_write(TestFunctional):
         1) owned by a different user
         2) owned by a group that is not the job user's primary gid
                 (but is a gid that the user is a member of)
-        3) not accessible via group permissions
+        3) not accessible via other permissions
         """
         j = Job(TEST_USER4, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)

--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -88,8 +88,8 @@ class TestQsub_direct_write(TestFunctional):
         j = Job(TEST_USER4, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
         sub_dir = self.du.mkdtemp(uid=TEST_USER4.uid)
-        mapping_dir = self.du.mkdtemp(uid=TEST_USER5.uid, gid=TSTGRP4.gid,
-                        mode=770)
+        mapping_dir = self.du.mkdtemp(
+            uid=TEST_USER5.uid, gid=TSTGRP4.gid, mode=770)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir
              + ' ' + mapping_dir})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Direct Write of Output and Error files fails to work if the target pathname resides under a directory that is restricted to a group that's not the user's primary gid.  The solution is to access the user's supplementary groups in addition to their primary gid.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Inserted call(s) to initgroups().  Unfortuantely, initgroups needs the username (string) and not just the uid.  I considered modifying impersonate_user to require a char *eusrname, but it turns out to implement this you modify the api of several other functions.  Using getpwuid to look up the username means the api of imerpersonate_user() and revert_from_user() can be retained.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->

Sorry... don't have one.  I'm customer trying to request this commercially and decided to take a stab at the code myself.

#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->

Test logs are attached in the comments.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
