### PR TITLE
Fairshare usage can become << 1, leading to unexpected errors

### DIFF
--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -314,6 +314,8 @@ enum fairshare_flags
 	FS_TRIM = 1
 };
 
+#define FAIRSHARE_MIN_USAGE 1
+
 /* flags used for copy constructors - bit field */
 enum dup_flags
 {

--- a/src/scheduler/fairshare.c
+++ b/src/scheduler/fairshare.c
@@ -521,8 +521,8 @@ decay_fairshare_tree(group_info *root)
 	decay_fairshare_tree(root->child);
 
 	root->usage *= conf.fairshare_decay_factor;
-	if (root->usage == 0)
-		root->usage = 1;
+	if (root->usage < FAIRSHARE_MIN_USAGE)
+		root->usage = FAIRSHARE_MIN_USAGE;
 }
 
 /**

--- a/src/scheduler/fairshare.c
+++ b/src/scheduler/fairshare.c
@@ -226,8 +226,8 @@ new_group_info()
 	new->shares = UNSPECIFIED;
 	new->tree_percentage = 0.0;
 	new->group_percentage = 0.0;
-	new->usage = 1;
-	new->temp_usage = 1;
+	new->usage = FAIRSHARE_MIN_USAGE;
+	new->temp_usage = FAIRSHARE_MIN_USAGE;
 	new->usage_factor = 0.0;
 	new->gpath = NULL;
 	new->parent = NULL;

--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -366,13 +366,12 @@ class TestFairshare(TestFunctional):
 
         t = int(time.time())
         time.sleep(2)
-
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
-        self.scheduler.log_match("Decaying Fairshare Tree", starttime=t,
-                                 max_attempts=5)
+        self.scheduler.log_match("Decaying Fairshare Tree", starttime=t)
 
         # Check that TEST_USER's usage is 1
         fs = self.scheduler.query_fairshare(name=str(TEST_USER))
-        self.assertEquals(fs.usage, 1)
+        fs_usage = int(fs.usage)
+        self.assertEquals(
+            fs_usage, 1, "Fairshare usage %d not equal to 1" % int(fs_usage))

--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -373,5 +373,5 @@ class TestFairshare(TestFunctional):
         # Check that TEST_USER's usage is 1
         fs = self.scheduler.query_fairshare(name=str(TEST_USER))
         fs_usage = int(fs.usage)
-        self.assertEquals(
-            fs_usage, 1, "Fairshare usage %d not equal to 1" % int(fs_usage))
+        self.assertEquals(fs_usage, 1,
+                          "Fairshare usage %d not equal to 1" % fs_usage)

--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -365,7 +365,6 @@ class TestFairshare(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
         t = int(time.time())
-        # Sleep for 2 seconds
         time.sleep(2)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Inside decay_fairshare_tree(), scheduler has a check to prevent the usage from going below 0, but it's not very effective as usage is a float value:

	root->usage *= conf.fairshare_decay_factor;
    
    	if (root->usage == 0)
    		root->usage = 1;

So, the usage can end up becoming really small (like 1e-40 small), which can end up causing various errors:
- If the job_sort_formula is set to something unrelated to fairshare, like 'queue_priority',  it starts failing once fairshare usage factor reaches such small values because the value of a resource_resv's ginfo->usage_factor gets set to 'nan' after a call to calc_usage_factor(), and 'fairshare_tree_usage' is  part of the data that's passed to Python 'formula_evaluate'. It fails as:
  File "<string>", line 1, in <module>NameError: name 'nan' is not defined

- Then, if job_sort_formula is set to "pow(2,(fairshare_tree_usage/fairshare_perc))", I noticed the scheduler logging errors w.r.t formula evaluation after some decay cycles:

[ravi@pbspro sched_logs]$ grep "Formula evaluation for job had an error" *
20190515:05/15/2019 09:25:54;0100;pbs_sched;Job;2.pbspro;Formula evaluation for job had an error. Zero value will be used: float division by zero
20190515:05/15/2019 09:25:54;0100;pbs_sched;Job;3.pbspro;Formula evaluation for job had an error. Zero value will be used: float division by zero
20190515:05/15/2019 09:25:54;0100;pbs_sched;Job;0.pbspro;Formula evaluation for job had an error. Zero value will be used: float division by zero
20190515:05/15/2019 09:25:54;0100;pbs_sched;Job;1.pbspro;Formula evaluation for job had an error. Zero value will be used: float division by zero
20190515:05/15/2019 09:28:38;0100;pbs_sched;Job;2.pbspro;Formula evaluation for job had an error. Zero value will be used: float division by zero
20190515:05/15/2019 09:28:38;0100;pbs_sched;Job;3.pbspro;Formula evaluation for job had an error. Zero value will be used: float division by zero
20190515:05/15/2019 09:28:38;0100;pbs_sched;Job;2.pbspro;Formula evaluation for job had an error. Zero value will be used: float division by zero
20190515:05/15/2019 09:28:38;0100;pbs_sched;Job;3.pbspro;Formula evaluation for job had an error. Zero value will be used: float division by zero

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The fix is pretty simple, we just change the condition "if (root->usage == 0)" to "if (root->usage < 1)"

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
[before_fix.log](https://github.com/PBSPro/pbspro/files/3181973/before_fix.log)
[after_fix.log](https://github.com/PBSPro/pbspro/files/3181974/after_fix.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
