### PR TITLE
Address rpmlint warning: dangerous-command

### DIFF
--- a/pbspro-rpmlintrc
+++ b/pbspro-rpmlintrc
@@ -12,4 +12,3 @@ addFilter('non-position-independent-executable')
 setBadness('non-position-independent-executable', 0)
 addFilter('devel-file-in-non-devel-package')
 setBadness('devel-file-in-non-devel-package', 0)
-

--- a/src/cmds/scripts/Makefile.am
+++ b/src/cmds/scripts/Makefile.am
@@ -86,6 +86,7 @@ dist_libexec_SCRIPTS = \
 	pbs_pgsql_env.sh \
 	pbs_postinstall \
 	pbs_preuninstall \
+	pbs_posttrans \
 	pbs_schema_upgrade
 
 dist_bin_SCRIPTS = \

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -796,7 +796,7 @@ is_boottime()
 		fi
 	fi
 	
-	BOOTPYFILE="/var/tmp/pbs_bootcheck.py"
+	BOOTPYFILE="${pbslibdir}/python/pbs_bootcheck.py"
 	BOOTCHECKFILE="/var/tmp/pbs_boot_check"
 
 	if [ ! -r "${BOOTPYFILE}" ] ; then

--- a/src/cmds/scripts/pbs_postinstall.in
+++ b/src/cmds/scripts/pbs_postinstall.in
@@ -397,10 +397,6 @@ install_pbsinitd() {
 		esac
 		pbslibdir="${PBS_EXEC}/lib64"
 		[ -d "${pbslibdir}" ] || pbslibdir="${PBS_EXEC}/lib"
-		if [ -f ${pbslibdir}/python/pbs_bootcheck.py ] ; then
-			cp ${pbslibdir}/python/pbs_bootcheck.py /var/tmp/pbs_bootcheck.py
-			chmod 0644 /var/tmp/pbs_bootcheck.py
-		fi
 		if [ -f /var/tmp/pbs_boot_check ] ; then
 			rm -f /var/tmp/pbs_boot_check
 		fi

--- a/src/cmds/scripts/pbs_posttrans
+++ b/src/cmds/scripts/pbs_posttrans
@@ -1,4 +1,4 @@
-
+#!/bin/bash
 #
 # Copyright (C) 1994-2019 Altair Engineering, Inc.
 # For more information, contact Altair at www.altair.com.
@@ -36,79 +36,9 @@
 # trademark licensing policies.
 #
 
-libinitdir = $(libdir)/init.d
-
-dist_libinit_DATA = \
-	limits.pbs_mom \
-	limits.pbs_mom.compat \
-	limits.post_services \
-	limits.post_services.compat \
-	sgigenvnodelist.awk \
-	sgiICEvnode.sh \
-	sgiICEplacement.sh
-
-libmpidir = $(libdir)/MPI
-
-dist_libmpi_DATA = \
-	pbsrun.bgl.init.in \
-	pbsrun.ch_gm.init.in \
-	pbsrun.ch_mx.init.in \
-	pbsrun.gm_mpd.init.in \
-	pbsrun.intelmpi.init.in \
-	pbsrun.mpich2.init.in \
-	pbsrun.mvapich1.init.in \
-	pbsrun.mvapich2.init.in \
-	pbsrun.mx_mpd.init.in \
-	sgiMPI.awk
-
-pythonlibdir = $(libdir)/python
-
-dist_pythonlib_PYTHON = \
-	pbs_bootcheck.py \
-	pbs_topologyinfo.py
-
-sysprofiledir = /etc/profile.d
-
-dist_sysprofile_DATA = \
-	pbs.csh \
-	pbs.sh
-
-unitfiledir = @_unitdir@
-
-dist_unitfile_DATA = \
-	pbs.service
-
-dist_libexec_SCRIPTS = \
-	au-nodeupdate \
-	install_db \
-	pbs_habitat \
-	pbs_init.d \
-	pbs_pgsql_env.sh \
-	pbs_postinstall \
-	pbs_preuninstall \
-	pbs_schema_upgrade
-
-dist_bin_SCRIPTS = \
-	pbs_topologyinfo \
-	printjob
-
-dist_sbin_SCRIPTS = \
-	pbs_dataservice \
-	pbs_ds_password \
-	pbs_server \
-	pbs_snapshot
-
-dist_sysconf_DATA = \
-	modulefile \
-	pbs_db_schema.sql
-
-CLEANFILES = \
-	pbs_init.d \
-	limits.pbs_mom \
-	limits.post_services
-
-limits.pbs_mom: $(srcdir)/limits.pbs_mom.compat
-	cp $? $@
-
-limits.post_services: $(srcdir)/limits.post_services.compat
-	cp $? $@
+# The %preun section of 14.x unconditially removes /etc/init.d/pbs
+# because it does not check whether the package is being removed
+# or upgraded. Make sure it exists here.
+if [ -r $1/libexec/pbs_init.d ]; then
+	install -D $1/libexec/pbs_init.d /etc/init.d/pbs
+fi

--- a/src/cmds/scripts/pbs_preuninstall
+++ b/src/cmds/scripts/pbs_preuninstall
@@ -46,7 +46,7 @@ if [ `basename $pbs_exec` = $pbs_version ]; then
         [ `basename "$link_target"` = $pbs_version ] && rm -f $top_level/default
     fi
 fi
-rm -f /opt/modulefiles/pbs/%{version}
+rm -f /opt/modulefiles/pbs/$pbs_version
 
 case "$1" in
 server|execution)

--- a/src/cmds/scripts/pbs_preuninstall
+++ b/src/cmds/scripts/pbs_preuninstall
@@ -1,4 +1,4 @@
-
+#!/bin/bash
 #
 # Copyright (C) 1994-2019 Altair Engineering, Inc.
 # For more information, contact Altair at www.altair.com.
@@ -35,80 +35,29 @@
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
 #
+pbs_version="$2"
+pbs_exec="$3"
+have_systemd="${4:-0}"
 
-libinitdir = $(libdir)/init.d
+if [ `basename $pbs_exec` = $pbs_version ]; then
+    top_level=`dirname $pbs_exec`
+    if [ -h $top_level/default ]; then
+        link_target=`readlink $top_level/default`
+        [ `basename "$link_target"` = $pbs_version ] && rm -f $top_level/default
+    fi
+fi
+rm -f /opt/modulefiles/pbs/%{version}
 
-dist_libinit_DATA = \
-	limits.pbs_mom \
-	limits.pbs_mom.compat \
-	limits.post_services \
-	limits.post_services.compat \
-	sgigenvnodelist.awk \
-	sgiICEvnode.sh \
-	sgiICEplacement.sh
-
-libmpidir = $(libdir)/MPI
-
-dist_libmpi_DATA = \
-	pbsrun.bgl.init.in \
-	pbsrun.ch_gm.init.in \
-	pbsrun.ch_mx.init.in \
-	pbsrun.gm_mpd.init.in \
-	pbsrun.intelmpi.init.in \
-	pbsrun.mpich2.init.in \
-	pbsrun.mvapich1.init.in \
-	pbsrun.mvapich2.init.in \
-	pbsrun.mx_mpd.init.in \
-	sgiMPI.awk
-
-pythonlibdir = $(libdir)/python
-
-dist_pythonlib_PYTHON = \
-	pbs_bootcheck.py \
-	pbs_topologyinfo.py
-
-sysprofiledir = /etc/profile.d
-
-dist_sysprofile_DATA = \
-	pbs.csh \
-	pbs.sh
-
-unitfiledir = @_unitdir@
-
-dist_unitfile_DATA = \
-	pbs.service
-
-dist_libexec_SCRIPTS = \
-	au-nodeupdate \
-	install_db \
-	pbs_habitat \
-	pbs_init.d \
-	pbs_pgsql_env.sh \
-	pbs_postinstall \
-	pbs_preuninstall \
-	pbs_schema_upgrade
-
-dist_bin_SCRIPTS = \
-	pbs_topologyinfo \
-	printjob
-
-dist_sbin_SCRIPTS = \
-	pbs_dataservice \
-	pbs_ds_password \
-	pbs_server \
-	pbs_snapshot
-
-dist_sysconf_DATA = \
-	modulefile \
-	pbs_db_schema.sql
-
-CLEANFILES = \
-	pbs_init.d \
-	limits.pbs_mom \
-	limits.post_services
-
-limits.pbs_mom: $(srcdir)/limits.pbs_mom.compat
-	cp $? $@
-
-limits.post_services: $(srcdir)/limits.post_services.compat
-	cp $? $@
+case "$1" in
+server|execution)
+    [ -x /etc/init.d/pbs ] && /etc/init.d/pbs stop
+    [ -x /sbin/chkconfig ] && /sbin/chkconfig --del pbs >/dev/null 2>&1
+    rm -f /etc/rc.d/rc?.d/[KS]??pbs
+    rm -f /var/tmp/pbs_boot_check
+    if [ $have_systemd = 1 ]; then
+        echo "have systemd"
+        systemctl disable pbs
+        rm -f /usr/lib/systemd/system-preset/95-pbs.preset
+    fi
+    ;;
+esac


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
rpmlint complains about dangerous commands in `%post`, `%preun` and `%posttrans` sections in the RPM spec file

#### Describe Your Change
* Copy `pbs_init.d` script to `/etc/init.d/pbs` during the `%install` phase rather than `%post`
* Move commands in `%preun` and `%posttrans` to separate scripts
* Removed the copying of `python/pbs_bootcheck.py` to `var/tmp`
 
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
[build_and_test.txt](https://github.com/PBSPro/pbspro/files/3189017/dangerous_cmd_build_and_test.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
