### PR TITLE
pbs_snapshot --obfuscate doesn't obfuscate filenames

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -544,10 +544,13 @@ class ObfuscateSnapshot(object):
         for root, _, fnames in os.walk(snap_dir):
             for fname in fnames:
                 fpath = os.path.join(root, fname)
+                new_fname = None
 
                 # Obfuscate values from val_obf_map
                 for key, val in self.val_obf_map.iteritems():
                     self._replace_str_in_file(key, val, fpath)
+                    if key in fname:
+                        new_fname = fname.replace(key, val)
 
                 # Remove the attr values from vals_to_del list
                 fout = self.du.create_temp_file()
@@ -556,6 +559,9 @@ class ObfuscateSnapshot(object):
                     for val in self.vals_to_del:
                         data = data.replace(val, "")
                     fdout.write(data)
+                if new_fname is not None:
+                    os.remove(fpath)
+                    fpath = os.path.join(root, new_fname)
                 shutil.move(fout, fpath)
 
         with open(map_file, "w") as fd:

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -892,8 +892,7 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
             for val in val_list:
                 # Just do a grep for the value in the snapshot
                 cmd = ["grep", "-wR", "\'" + str(val) + "\'", snap_dir]
-                ret = self.du.run_cmd(cmd=cmd, as_script=True,
-                                      level=logging.DEBUG)
+                ret = self.du.run_cmd(cmd=cmd, level=logging.DEBUG)
                 # grep returns 2 if an error occurred
                 self.assertNotEqual(ret["rc"], 2, "grep failed!")
                 self.assertIn(ret["out"], ["", None, []], str(val) +
@@ -901,8 +900,7 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
                               str(real_values))
                 # Also make sure that no filenames contain the sensitive val
                 cmd = ["find", snap_dir, "-name",  "\'*" + str(val) + "*\'"]
-                ret = self.du.run_cmd(cmd=cmd, as_script=True,
-                                      level=logging.DEBUG)
+                ret = self.du.run_cmd(cmd=cmd, level=logging.DEBUG)
                 self.assertEquals(ret["rc"], 0, "find command failed!")
                 self.assertIn(ret["out"], ["", None, []], str(val) +
                               " was not obfuscated. Real values:\n" +

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -899,6 +899,14 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
                 self.assertIn(ret["out"], ["", None, []], str(val) +
                               " was not obfuscated. Real values:\n" +
                               str(real_values))
+                # Also make sure that no filenames contain the sensitive val
+                cmd = ["find", snap_dir, "-name",  "\'*" + str(val) + "*\'"]
+                ret = self.du.run_cmd(cmd=cmd, as_script=True,
+                                      level=logging.DEBUG)
+                self.assertEquals(ret["rc"], 0, "find command failed!")
+                self.assertIn(ret["out"], ["", None, []], str(val) +
+                              " was not obfuscated. Real values:\n" +
+                              str(real_values))
 
     @classmethod
     def tearDownClass(self):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Post https://github.com/PBSPro/pbspro/pull/1096 we are still putting the un-obfuscated job ID in the printjob files (e.g., ./mom_priv/jobs/19.osuse15.JB_printjob):

pbs_snapshot --obfuscate -o /tmp

osuse15:/tmp/snapshot_20190515_14_19_30 # ls mom_priv/jobs/
19.osuse15.JB_printjob 20.osuse15.JB_printjob


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added check for the presence of sensitive values in filenames, if present they'll get replaced with obfuscated values.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[before_fix.log](https://github.com/PBSPro/pbspro/files/3188196/before_fix.log)
[after_fix.log](https://github.com/PBSPro/pbspro/files/3188197/after_fix.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
