### PR TITLE
Sched leaks resv batch status when querying universe fails

### DIFF
--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -171,8 +171,10 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 		return NULL;
 
 	err = new_schd_error();
-	if(err == NULL)
+	if(err == NULL) {
+		pbs_statfree(resvs);
 		return NULL;
+	}
 
 	cur_resv = resvs;
 
@@ -543,6 +545,7 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 						free(execvnodes_seq);
 						free(execvnode_ptr);
 						free_schd_error(err);
+						pbs_statfree(resvs);
 						return NULL;
 					}
 					sprintf(logmsg, "Occurrence %d/%d,%s", occr_idx, count, start_time);

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -171,10 +171,8 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 		return NULL;
 
 	err = new_schd_error();
-	if(err == NULL) {
-		pbs_statfree(resvs);
+	if (err == NULL)
 		return NULL;
-	}
 
 	cur_resv = resvs;
 
@@ -186,7 +184,6 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 	if ((resresv_arr = (resource_resv **) malloc(sizeof(resource_resv *)
 		* (num_resv + 1))) == NULL) {
 		log_err(errno, "query_reservations", MEM_ERR_MSG);
-		pbs_statfree(resvs);
 		free_schd_error(err);
 		return NULL;
 	}
@@ -197,7 +194,6 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 		int ignore_resv = 0;
 		/* convert resv info from server batch_status into resv_info */
 		if ((resresv = query_resv(cur_resv, sinfo)) == NULL) {
-			pbs_statfree(resvs);
 			free_resource_resv_array(resresv_arr);
 			free_schd_error(err);
 			return NULL;
@@ -444,7 +440,6 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 				if ((tmp = (resource_resv **) realloc(resresv_arr,
 					sizeof(resource_resv *) * (sinfo->num_resvs + 1))) == NULL) {
 					log_err(errno, "query_reservations", MEM_ERR_MSG);
-					pbs_statfree(resvs);
 					free_resource_resv_array(resresv_arr);
 					free_execvnode_seq(tofree);
 					free(execvnodes_seq);
@@ -488,7 +483,6 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 							log_err(errno,
 								"query_reservations",
 								"Error duplicating resource reservation");
-							pbs_statfree(resvs);
 							free_resource_resv_array(resresv_arr);
 							free_execvnode_seq(tofree);
 							free(execvnodes_seq);
@@ -545,7 +539,6 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 						free(execvnodes_seq);
 						free(execvnode_ptr);
 						free_schd_error(err);
-						pbs_statfree(resvs);
 						return NULL;
 					}
 					sprintf(logmsg, "Occurrence %d/%d,%s", occr_idx, count, start_time);
@@ -568,7 +561,6 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 		}
 	}
 
-	pbs_statfree(resvs);
 	free_schd_error(err);
 
 	return resresv_arr;

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -176,7 +176,7 @@ query_server(status *pol, int pbs_sd)
 	struct batch_status *server;	/* info about the server */
 	struct batch_status *all_sched;	/* info about all server's scheduler objects */
 	struct batch_status *sched;	/* info about the this scheduler object */
-	struct batch_status *bs_resvs = NULL;	/* batch status of the reservations */
+	struct batch_status *bs_resvs;	/* batch status of the reservations */
 	server_info *sinfo;		/* scheduler internal form of server info */
 	queue_info **qinfo;		/* array of queues on the server */
 	counts *cts;			/* used to count running per user/grp */
@@ -262,12 +262,15 @@ query_server(status *pol, int pbs_sd)
 	 */
 	if (dflt_sched)
 		bs_resvs = stat_resvs(pbs_sd);
+	else
+		bs_resvs = NULL;
 
 	/* get the nodes, if any - NOTE: will set sinfo -> num_nodes */
 	if ((sinfo->nodes = query_nodes(pbs_sd, sinfo)) == NULL) {
 		pbs_statfree(server);
 		sinfo->fairshare = NULL;
 		free_server(sinfo);
+		pbs_statfree(bs_resvs);
 		return NULL;
 	}
 
@@ -281,6 +284,7 @@ query_server(status *pol, int pbs_sd)
 		pbs_statfree(server);
 		sinfo->fairshare = NULL;
 		free_server(sinfo);
+		pbs_statfree(bs_resvs);
 		return NULL;
 	}
 
@@ -322,6 +326,7 @@ query_server(status *pol, int pbs_sd)
 			if (ret_val == 0) {
 				sinfo->fairshare = NULL;
 				free_server(sinfo);
+				pbs_statfree(bs_resvs);
 				return NULL;
 			}
 		}

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -331,9 +331,10 @@ query_server(status *pol, int pbs_sd)
 			}
 		}
 	}
-	
+
 	/* get reservations, if any - NOTE: will set sinfo -> num_resvs */
 	sinfo->resvs = query_reservations(sinfo, bs_resvs);
+	pbs_statfree(bs_resvs);
 
 	if (create_server_arrays(sinfo) == 0) { /* bad stuff happened */
 		sinfo->fairshare = NULL;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
While querying universe when scheduler fails to query nodes/queues it errors out, but while doing so it forgets freeing up memory allocated for reservation batch_status structure.


#### Describe Your Change
Freeing up reservation batch_status appropriately in error path.


#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
There is no automated test for this change as it involves artificially failing query_nodes/queues in scheduler.
Attached are gdb results
[resv_leak.txt](https://github.com/PBSPro/pbspro/files/3189276/resv_leak.txt)
[resv_leak_with_fix.txt](https://github.com/PBSPro/pbspro/files/3189277/resv_leak_with_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
