### PR TITLE
Fix for upgrade issue on Cray

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -485,7 +485,6 @@ backupdir() {
 	if [ -d "$1" -a -d "$2" ]; then
 		backupdir="$(basename $1).pre.${PBS_VERSION}"
 		echo "*** Backing up $1 to ${2}/${backupdir}"
-		echo "*** ${2}/${backupdir} may need to be manually removed if you do not wish to downgrade PBSPro."
 		mv "$1" "${2}/${backupdir}"
 	fi
 }
@@ -676,7 +675,10 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			if [ -d "${old_inst_dir}" ]; then
 				backupdir "$old_inst_dir" "$PBS_HOME"
 				if [ $? -ne 0 ]; then
-					echo "*** ${old_inst_dir} need to be manually backup and copy ${PBS_EXEC}/pgsql as ${PBS_HOME}/pgsql.forupgrade."
+					echo "*** ${old_inst_dir} needs to be manually backed up and run the below command"
+					echo "*** cp -pr ${PBS_EXEC}/pgsql ${PBS_HOME}/pgsql.forupgrade"
+				else
+					echo "*** ${PBS_HOME}/$(basename ${old_inst_dir}).pre.${PBS_VERSION} may need to be manually removed if you do not wish to downgrade PBSPro."
 				fi
 			fi
 		fi

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -671,11 +671,12 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			fi
 			exit $ret
 		else
-			#Remove old dataservice directory
 			if [ -d "${old_inst_dir}" ]; then
 				backupdir "$old_inst_dir" "$PBS_HOME"
 				if [ $? -ne 0 ]; then
-					echo "*** ${old_inst_dir} needs to be manually backed up and run the below command"
+					echo "Failed to backup $old_inst_dir, please follow the below instructions:"
+					echo "*** Backup "$old_inst_dir" if you need to downgrade pgsql later on."
+					echo "*** For future upgrades to be successful run the below command."
 					echo "*** cp -pr ${PBS_EXEC}/pgsql ${PBS_HOME}/pgsql.forupgrade"
 				else
 					echo "*** ${PBS_HOME}/$(basename ${old_inst_dir}).pre.${PBS_VERSION} may need to be manually removed if you do not wish to downgrade PBSPro."

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -155,8 +155,13 @@ utf8_to_sql_ascii() {
 	# are working with old database.
 	#
 
-	PGSQL_INST_DIR="${PBS_HOME}/pgsql.old"
-	export PGSQL_INST_DIR
+	if [ -d "${PBS_HOME}/pgsql.old" ]; then
+		PGSQL_INST_DIR="${PBS_HOME}/pgsql.old"
+		export PGSQL_INST_DIR
+	elif [ -d "${PBS_HOME}/pgsql.forupgrade" ]; then
+		PGSQL_INST_DIR="${PBS_HOME}/pgsql.forupgrade"
+		export PGSQL_INST_DIR
+	fi
 
 	${PBS_EXEC}/sbin/pbs_dataservice start > /dev/null
 	if [ $? -ne 0 ]; then
@@ -218,8 +223,19 @@ upgrade_pbs_database() {
 	user="${PBS_DATA_SERVICE_USER}"
 	inst_dir="${PGSQL_DIR}"
 	data_dir="${PBS_HOME}/datastore"
-	old_inst_dir="${PBS_HOME}/pgsql.old"
-	old_data_dir="${PBS_HOME}/datastore.old"
+
+	# Check for existence of old data service directory.
+	if [ -d "${PBS_HOME}/pgsql.old" ]; then
+		old_inst_dir="${PBS_HOME}/pgsql.old"
+		old_data_dir="${PBS_HOME}/datastore.old"
+	elif [ -d "${PBS_HOME}/pgsql.forupgrade" ]; then
+		old_inst_dir="${PBS_HOME}/pgsql.forupgrade"
+		old_data_dir="${PBS_HOME}/datastore.forupgrade"
+	else
+		echo "Data service directory from previous PBS installation not found,"
+		echo "Datastore upgrade cannot continue"
+		return 1
+	fi
 
 	if [ ! -f "${data_dir}/PG_VERSION" ]; then
 		echo "Database version file: ${data_dir}/PG_VERSION not found, cannot continue"
@@ -270,13 +286,6 @@ upgrade_db() {
 
 	if [ ! -x "${inst_dir}/bin/pg_upgrade" ]; then
 		echo "${inst_dir}/bin/pg_upgrade not found"
-		return 1
-	fi
-
-	# Check for existence of old data service directory.
-	if [ ! -d "${old_inst_dir}" ]; then
-		echo "Data service directory from previous PBS installation not found,"
-		echo "Datastore upgrade cannot continue"
 		return 1
 	fi
 
@@ -477,7 +486,7 @@ backupdir() {
 		backupdir="$(basename $1).pre.${PBS_VERSION}"
 		echo "*** Backing up $1 to ${2}/${backupdir}"
 		echo "*** ${2}/${backupdir} may need to be manually removed if you do not wish to downgrade PBSPro."
-		cp -pr --no-preserve=timestamps "$1" "${2}/${backupdir}" 2>&1
+		mv "$1" "${2}/${backupdir}"
 	fi
 }
 
@@ -664,11 +673,10 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 			exit $ret
 		else
 			#Remove old dataservice directory
-			if [ `echo "${old_inst_dir}"| grep "pgsql.old"` ]; then
+			if [ -d "${old_inst_dir}" ]; then
 				backupdir "$old_inst_dir" "$PBS_HOME"
-				err=`rm -rf "${old_inst_dir}"`
 				if [ $? -ne 0 ]; then
-					echo "$err"
+					echo "*** ${old_inst_dir} need to be manually backup and copy ${PBS_EXEC}/pgsql as ${PBS_HOME}/pgsql.forupgrade."
 				fi
 			fi
 		fi
@@ -836,8 +844,8 @@ fi
 #
 echo "${pbs_version}" >"$PBS_HOME/pbs_version"
 
-# Copy pgsql directory to PBS_HOME (as pgsql.old) for it's future upgrade
-[ ! -d "${PBS_HOME}/pgsql.old" -a -d "${PBS_EXEC}/pgsql" -a -d "${PBS_HOME}" ] && cp -pr --no-preserve=timestamps "${PBS_EXEC}/pgsql" "${PBS_HOME}/pgsql.old" 2>&1
+# Copy pgsql directory to PBS_HOME (as pgsql.forupgrade) for it's future upgrade
+[ ! -d "${PBS_HOME}/pgsql.forupgrade" -a -d "${PBS_EXEC}/pgsql" -a -d "${PBS_HOME}" ] && cp -pr --no-preserve=timestamps "${PBS_EXEC}/pgsql" "${PBS_HOME}/pgsql.forupgrade" 2>&1
 
 echo "*** End of ${0}"
 exit 0

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -472,6 +472,15 @@ check_hostname() {
 	return 1
 }
 
+backupdir() {
+	if [ -d "$1" -a -d "$2" ]; then
+		backupdir="$(basename $1).pre.${PBS_VERSION}"
+		echo "*** Backing up $1 to ${2}/${backupdir}"
+		echo "*** ${2}/${backupdir} may need to be manually removed if you do not wish to downgrade PBSPro."
+		cp -pr --no-preserve=timestamps "$1" "${2}/${backupdir}" 2>&1
+	fi
+}
+
 #
 # Start of the pbs_habitat script
 #
@@ -656,6 +665,7 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 		else
 			#Remove old dataservice directory
 			if [ `echo "${old_inst_dir}"| grep "pgsql.old"` ]; then
+				backupdir "$old_inst_dir" "$PBS_HOME"
 				err=`rm -rf "${old_inst_dir}"`
 				if [ $? -ne 0 ]; then
 					echo "$err"
@@ -825,6 +835,9 @@ fi
 # This will prevent updating PBS_HOME if this same version is re-installed
 #
 echo "${pbs_version}" >"$PBS_HOME/pbs_version"
+
+# Copy pgsql directory to PBS_HOME (as pgsql.old) for it's future upgrade
+[ ! -d "${PBS_HOME}/pgsql.old" -a -d "${PBS_EXEC}/pgsql" -a -d "${PBS_HOME}" ] && cp -pr --no-preserve=timestamps "${PBS_EXEC}/pgsql" "${PBS_HOME}/pgsql.old" 2>&1
 
 echo "*** End of ${0}"
 exit 0


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Upgrades require access to previous versions of pgsql which is problematic on Cray, causes upgrades w/ database changes to fail
In Cray while doing RPM upgrade PBS_HOME is not accessible


#### Describe Your Change
Copying pgsql. old to PBS_HOME from pbs_habitat instead of the spec file (on a fresh install and upgrade).

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
