### PR TITLE
Fix test_cgroup_cpuset failure due to not seeing hook config file upd…

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -904,6 +904,10 @@ if %s e.job.in_ms_mom():
                 break
             time.sleep(1)
             count -= 1
+        # A HUP of each mom ensures update to hook config file is
+        # seen by the exechost_startup hook.
+        for mom in self.moms_list:
+            mom.signal('-HUP')
 
     def load_default_config(self):
         """


### PR DESCRIPTION
…ate.

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* On hyper-threaded hosts with only 1 core of say 2 cpus, the test_cgroup_cpuset from pbs_cgroups_hook.ptl testsuite is failing as it could only run 1 job (when it needed 2).
* Reason being is that although the test specifically use a hook config file  with 'use_hyperthreads=true' which would allow cgroups exechost_startup to make all the virtual cpus available (i.e. resources_available.ncpus=2), this setting is not seen as mom is not restarted, so exechost_startup does not run.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* The fix is to add a HUP mom step inside the load_config() function.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* 2 hosts used here (x100 and x91) that are hyper-threaded with only 1 core of 2 cpuset,  and another host that is not hyper-threaded (a02) with multiple cpus. The following shows single runs of test_cgroup_cpuset (*PASS, *FAIL)  as well as the full testsuite run (*FULL) with 1 host and 3 hosts (*FULL3):
[a02_ptl.FULL.txt](https://github.com/PBSPro/pbspro/files/3192371/a02_ptl.FULL.txt)
[a02_ptl.PASS_AFT.txt](https://github.com/PBSPro/pbspro/files/3192372/a02_ptl.PASS_AFT.txt)
[a02_ptl.PASS_BEF.txt](https://github.com/PBSPro/pbspro/files/3192373/a02_ptl.PASS_BEF.txt)
[x91_ptl.FAIL.txt](https://github.com/PBSPro/pbspro/files/3192374/x91_ptl.FAIL.txt)
[x91_ptl.FULL.txt](https://github.com/PBSPro/pbspro/files/3192375/x91_ptl.FULL.txt)
[x91_ptl.PASS.txt](https://github.com/PBSPro/pbspro/files/3192376/x91_ptl.PASS.txt)
[x100_ptl.FAIL.txt](https://github.com/PBSPro/pbspro/files/3192377/x100_ptl.FAIL.txt)
[x100_ptl.FULL.txt](https://github.com/PBSPro/pbspro/files/3192378/x100_ptl.FULL.txt)
[x100_ptl.FULL3.txt](https://github.com/PBSPro/pbspro/files/3192379/x100_ptl.FULL3.txt)
[x100_ptl.PASS.txt](https://github.com/PBSPro/pbspro/files/3192380/x100_ptl.PASS.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
