### PR TITLE
MGR_USR and OPR_USR added in PTL setup

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5063,6 +5063,7 @@ class Server(PBSService):
         ignore_attrs += [ATTR_status, ATTR_total, ATTR_count]
         ignore_attrs += [ATTR_rescassn, ATTR_FLicenses, ATTR_SvrHost]
         ignore_attrs += [ATTR_license_count, ATTR_version, ATTR_managers]
+        ignore_attrs += [ATTR_operators]
         ignore_attrs += [ATTR_pbs_license_info, ATTR_power_provisioning]
         unsetlist = []
         setdict = {}

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -107,6 +107,7 @@ OPER_USER = PbsUser('pbsoper', uid=4356, groups=[TSTGRP0, TSTGRP2, GRP_PBS,
 ADMIN_USER = PbsUser('pbsadmin', uid=4357, groups=[TSTGRP0, TSTGRP2, GRP_PBS,
                                                    GRP_AGT])
 PBSROOT_USER = PbsUser('pbsroot', uid=4371, groups=[TSTGRP0, TSTGRP2])
+
 ROOT_USER = PbsUser('root', uid=0, groups=[ROOT_GRP])
 
 PBS_USERS = (TEST_USER, TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
@@ -1286,10 +1287,10 @@ class PBSTestSuite(unittest.TestCase):
         except PbsManagerError as e:
             self.logger.error(e.msg)
         a = {ATTR_managers: (INCR, current_user + '@*,' +
-             MGR_USER.name + '@*')}
+             str(MGR_USER) + '@*')}
         server.manager(MGR_CMD_SET, SERVER, a, sudo=True)
 
-        a1 = {ATTR_operators: (INCR, OPER_USER.name + '@*')}
+        a1 = {ATTR_operators: (INCR, str(OPER_USER) + '@*')}
         server.manager(MGR_CMD_SET, SERVER, a1, sudo=True)
         if ((self.revert_to_defaults and self.server_revert_to_defaults) or
                 force):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1281,10 +1281,16 @@ class PBSTestSuite(unittest.TestCase):
         try:
             # Unset managers list
             server.manager(MGR_CMD_UNSET, SERVER, 'managers', sudo=True)
+            # Unset operators list
+            server.manager(MGR_CMD_UNSET, SERVER, 'operators', sudo=True)
         except PbsManagerError as e:
             self.logger.error(e.msg)
-        a = {ATTR_managers: (INCR, current_user + '@*')}
+        a = {ATTR_managers: (INCR, current_user + '@*,' +
+             MGR_USER.name + '@*')}
         server.manager(MGR_CMD_SET, SERVER, a, sudo=True)
+
+        a1 = {ATTR_operators: (INCR, OPER_USER.name + '@*')}
+        server.manager(MGR_CMD_SET, SERVER, a1, sudo=True)
         if ((self.revert_to_defaults and self.server_revert_to_defaults) or
                 force):
             server.revert_to_defaults(reverthooks=self.revert_hooks,

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -177,7 +177,7 @@ class TestQstatFormats(TestFunctional):
             #        "PBS_O_QUEUE":"workq",
             #    },
 
-            if ',' in val and key != 'managers':
+            if key == ATTR_v:
                 for v in val.split(','):
                     qstat_attrs.append(str(v).split('=')[0])
         return qstat_attrs

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -177,7 +177,7 @@ class TestQstatFormats(TestFunctional):
             #        "PBS_O_QUEUE":"workq",
             #    },
 
-            if ',' in val:
+            if ',' in val and key != 'managers':
                 for v in val.split(','):
                     qstat_attrs.append(str(v).split('=')[0])
         return qstat_attrs

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -807,9 +807,6 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
 
         # We will try to set all attributes which --obfuscate anonymizes
         manager1 = str(MGR_USER) + '@*'
-        self.server.manager(MGR_CMD_SET, SERVER,
-                            {ATTR_managers: (INCR, manager1)},
-                            sudo=True)
         manager2 = str(TEST_USER) + "@*"
         self.server.manager(MGR_CMD_SET, SERVER,
                             {ATTR_managers: (INCR, manager2)},
@@ -817,8 +814,6 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
         real_values[ATTR_managers] = [manager1, manager2]
 
         operator = str(OPER_USER) + '@*'
-        self.server.manager(MGR_CMD_SET, SERVER,
-                            {ATTR_operators: (INCR, operator)})
         real_values[ATTR_operators] = [operator]
 
         real_values[ATTR_SvrHost] = [self.server.hostname]

--- a/test/tests/selftest/pbs_managers_operators.py
+++ b/test/tests/selftest/pbs_managers_operators.py
@@ -73,7 +73,6 @@ class TestManagersOperators(TestSelf):
         """
         Check that default operator user is set on PTL setup
         """
-        svr_opr = self.server.status(SERVER, 'operators')[0]['operators'] \
-            .split(",")
-        opr_usr = {str(OPER_USER) + '@*'}
-        self.assertEqual(opr_usr, set(svr_opr))
+        svr_opr = str(self.server.status(SERVER, 'operators'))
+        opr_usr = str(OPER_USER) + '@*'
+        self.assertEqual(opr_usr, svr_opr)

--- a/test/tests/selftest/pbs_managers_operators.py
+++ b/test/tests/selftest/pbs_managers_operators.py
@@ -73,6 +73,6 @@ class TestManagersOperators(TestSelf):
         """
         Check that default operator user is set on PTL setup
         """
-        svr_opr = str(self.server.status(SERVER, 'operators'))
+        svr_opr = self.server.status(SERVER, 'operators')[0].get('operators')
         opr_usr = str(OPER_USER) + '@*'
         self.assertEqual(opr_usr, svr_opr)

--- a/test/tests/selftest/pbs_managers_operators.py
+++ b/test/tests/selftest/pbs_managers_operators.py
@@ -53,10 +53,10 @@ class TestManagersOperators(TestSelf):
         manager_usr_str = str(MGR_USER) + '@*'
         current_usr = pwd.getpwuid(os.getuid())[0]
         current_usr_str = str(current_usr) + '@*'
-        mgr_users = [manager_usr_str, current_usr_str]
+        mgr_users = {manager_usr_str, current_usr_str}
         svr_mgr = self.server.status(SERVER, 'managers')[0]['managers']\
             .split(",")
-        self.assertEqual(mgr_users, svr_mgr)
+        self.assertEqual(mgr_users, set(svr_mgr))
 
         mgr_user1 = str(TEST_USER)
         mgr_user2 = str(TEST_USER1)
@@ -67,7 +67,7 @@ class TestManagersOperators(TestSelf):
 
         svr_mgr = self.server.status(SERVER, 'managers')[0]['managers'] \
             .split(",")
-        self.assertEqual(mgr_users, svr_mgr)
+        self.assertEqual(mgr_users, set(svr_mgr))
 
     def test_default_oper(self):
         """
@@ -75,5 +75,5 @@ class TestManagersOperators(TestSelf):
         """
         svr_opr = self.server.status(SERVER, 'operators')[0]['operators'] \
             .split(",")
-        opr_usr = [str(OPER_USER) + '@*']
-        self.assertEqual(opr_usr, svr_opr)
+        opr_usr = {str(OPER_USER) + '@*'}
+        self.assertEqual(opr_usr, set(svr_opr))

--- a/test/tests/selftest/pbs_managers_operators_ext.py
+++ b/test/tests/selftest/pbs_managers_operators_ext.py
@@ -53,12 +53,12 @@ class TestManagersOperators(TestSelf):
         manager_usr_str = str(MGR_USER) + '@*'
         current_usr = pwd.getpwuid(os.getuid())[0]
         current_usr_str = str(current_usr) + '@*'
-        svr_mgr = self.server.status(SERVER, 'managers')
-        if str(manager_usr_str) not in str(svr_mgr):
-            raise ValueError
-        if str(current_usr_str) not in str(svr_mgr):
-            raise ValueError
+        svr_mgr = str(self.server.status(SERVER, 'managers'))
+        self.assertIn(str(manager_usr_str), svr_mgr)
+        self.assertIn(str(current_usr_str), svr_mgr)
 
+        print("server is ++++++++++++++")
+        print(str(self.server.status()))
         mgr_user1 = str(TEST_USER)
         mgr_user2 = str(TEST_USER1)
         a = {ATTR_managers: (INCR, mgr_user1 + '@*,' + mgr_user2 + '@*')}
@@ -66,16 +66,13 @@ class TestManagersOperators(TestSelf):
         self.logger.info("Calling test setUp:")
         TestSelf.setUp(self)
 
-        svr_mgr = self.server.status(SERVER, 'managers')
-        if str(manager_usr_str) not in str(svr_mgr):
-            raise ValueError
-        if str(current_usr_str) not in str(svr_mgr):
-            raise ValueError
+        svr_mgr = str(self.server.status(SERVER, 'managers'))
+        self.assertIn(str(manager_usr_str), svr_mgr)
+        self.assertIn(str(current_usr_str), svr_mgr)
 
     def test_default_oper(self):
         """
         Check that default operator user is set on PTL setup
         """
-        svr_opr = self.server.status(SERVER, 'operators')
-        if str(OPER_USER) not in str(svr_opr):
-            raise ValueError
+        svr_opr = str(self.server.status(SERVER, 'operators'))
+        self.assertIn(str(OPER_USER) + '@*', svr_opr)

--- a/test/tests/selftest/pbs_managers_operators_ext.py
+++ b/test/tests/selftest/pbs_managers_operators_ext.py
@@ -41,21 +41,22 @@ from tests.selftest import *
 class TestManagersOperators(TestSelf):
 
     """
-    This test suite contains tests related to managers and operators
-
+        Additional managers users, except current user and MGR_USER
+        should get unset after test setUp run
     """
     def test_managers_unset_setup(self):
         """
-        Additional managers users, except current user should get unset
-        after test setUp run
+        Additional managers users, except current user and MGR_USER should
+        get unset after test setUp run
         """
         runas = ROOT_USER
         manager_usr_str = str(MGR_USER) + '@*'
         current_usr = pwd.getpwuid(os.getuid())[0]
         current_usr_str = str(current_usr) + '@*'
-        svr_mgr = str(self.server.status(SERVER, 'managers'))
-        self.assertIn(str(manager_usr_str), svr_mgr)
-        self.assertIn(str(current_usr_str), svr_mgr)
+        mgr_users = [manager_usr_str, current_usr_str]
+        svr_mgr = self.server.status(SERVER, 'managers')[0]['managers']\
+            .split(",")
+        self.assertEqual(mgr_users, svr_mgr)
 
         mgr_user1 = str(TEST_USER)
         mgr_user2 = str(TEST_USER1)
@@ -64,13 +65,15 @@ class TestManagersOperators(TestSelf):
         self.logger.info("Calling test setUp:")
         TestSelf.setUp(self)
 
-        svr_mgr = str(self.server.status(SERVER, 'managers'))
-        self.assertIn(str(manager_usr_str), svr_mgr)
-        self.assertIn(str(current_usr_str), svr_mgr)
+        svr_mgr = self.server.status(SERVER, 'managers')[0]['managers'] \
+            .split(",")
+        self.assertEqual(mgr_users, svr_mgr)
 
     def test_default_oper(self):
         """
         Check that default operator user is set on PTL setup
         """
-        svr_opr = str(self.server.status(SERVER, 'operators'))
-        self.assertIn(str(OPER_USER) + '@*', svr_opr)
+        svr_opr = self.server.status(SERVER, 'operators')[0]['operators'] \
+            .split(",")
+        opr_usr = [str(OPER_USER) + '@*']
+        self.assertEqual(opr_usr, svr_opr)

--- a/test/tests/selftest/pbs_managers_operators_ext.py
+++ b/test/tests/selftest/pbs_managers_operators_ext.py
@@ -57,8 +57,6 @@ class TestManagersOperators(TestSelf):
         self.assertIn(str(manager_usr_str), svr_mgr)
         self.assertIn(str(current_usr_str), svr_mgr)
 
-        print("server is ++++++++++++++")
-        print(str(self.server.status()))
         mgr_user1 = str(TEST_USER)
         mgr_user2 = str(TEST_USER1)
         a = {ATTR_managers: (INCR, mgr_user1 + '@*,' + mgr_user2 + '@*')}

--- a/test/tests/selftest/pbs_managers_operators_ext.py
+++ b/test/tests/selftest/pbs_managers_operators_ext.py
@@ -38,7 +38,7 @@
 from tests.selftest import *
 
 
-class ManagersOperators(TestSelf):
+class TestManagersOperators(TestSelf):
 
     """
     This test suite contains tests related to managers and operators
@@ -50,13 +50,32 @@ class ManagersOperators(TestSelf):
         after test setUp run
         """
         runas = ROOT_USER
+        manager_usr_str = str(MGR_USER) + '@*'
         current_usr = pwd.getpwuid(os.getuid())[0]
-        attr = {ATTR_managers: current_usr + '@*'}
-        self.server.expect(SERVER, attrib=attr)
+        current_usr_str = str(current_usr) + '@*'
+        svr_mgr = self.server.status(SERVER, 'managers')
+        if str(manager_usr_str) not in str(svr_mgr):
+            raise ValueError
+        if str(current_usr_str) not in str(svr_mgr):
+            raise ValueError
+
         mgr_user1 = str(TEST_USER)
         mgr_user2 = str(TEST_USER1)
         a = {ATTR_managers: (INCR, mgr_user1 + '@*,' + mgr_user2 + '@*')}
         self.server.manager(MGR_CMD_SET, SERVER, a, runas=runas)
         self.logger.info("Calling test setUp:")
         TestSelf.setUp(self)
-        self.server.expect(SERVER, attrib=attr)
+
+        svr_mgr = self.server.status(SERVER, 'managers')
+        if str(manager_usr_str) not in str(svr_mgr):
+            raise ValueError
+        if str(current_usr_str) not in str(svr_mgr):
+            raise ValueError
+
+    def test_default_oper(self):
+        """
+        Check that default operator user is set on PTL setup
+        """
+        svr_opr = self.server.status(SERVER, 'operators')
+        if str(OPER_USER) not in str(svr_opr):
+            raise ValueError


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The current PTL framework adds the user by which the PTL is run to the list of managers in the setup.
This change will add  MGR_USER and OPER_USER to the list of managers and operators in the PTL setup irrespective of the user by which PTL is run


#### Attach Test and Valgrind Logs/Output
[test_mgr_opr_log.txt](https://github.com/PBSPro/pbspro/files/3284332/test_mgr_opr_log.txt)
[snapshot_unit_test.txt](https://github.com/PBSPro/pbspro/files/3287145/snapshot_unit_test.txt)
[qstat_format_logs.txt](https://github.com/PBSPro/pbspro/files/3287194/qstat_format_logs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
