### PR TITLE
Fixed issue where custom resources requesting -1/-2 didn't work

### DIFF
--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1224,7 +1224,7 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 				else
 					avail = dynamic_avail(res);
 
-				if (avail == SCHD_INFINITY && (flags & UNSET_RES_ZERO))
+				if (avail == SCHD_INFINITY_RES && (flags & UNSET_RES_ZERO))
 					avail = 0;
 
 				/*
@@ -1232,7 +1232,7 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 				 * 0 amount of the resource, we do not need to check if any is
 				 * available
 				 */
-				if (avail != SCHD_INFINITY && resreq->amount != 0) {
+				if (avail != SCHD_INFINITY_RES && resreq->amount != 0) {
 					if (avail < resreq->amount) {
 						fail = 1;
 						if (err != NULL) {
@@ -1241,7 +1241,7 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 
 							res_to_str_r(resreq, RF_REQUEST, resbuf1, sizeof(resbuf1));
 							res_to_str_c(avail, res->def, RF_AVAIL, resbuf2, sizeof(resbuf2));
-							if ((flags & UNSET_RES_ZERO) && res->avail == SCHD_INFINITY)
+							if ((flags & UNSET_RES_ZERO) && res->avail == SCHD_INFINITY_RES)
 								res_to_str_c(0, res->def, RF_AVAIL, resbuf3, sizeof(resbuf3));
 							else
 								res_to_str_r(res, RF_AVAIL, resbuf3, sizeof(resbuf3));
@@ -1302,8 +1302,8 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 sch_resource_t
 dynamic_avail(schd_resource *res)
 {
-	if (res->avail == SCHD_INFINITY)
-		return SCHD_INFINITY;
+	if (res->avail == SCHD_INFINITY_RES)
+		return SCHD_INFINITY_RES;
 	else if ((res->avail - res->assigned) <=0)
 		return 0;
 	else

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -41,6 +41,8 @@
 extern "C" {
 #endif
 
+#include <math.h>
+
 /* macro to turn a value from enum preempt into it's bit for the bitfield */
 #define PREEMPT_TO_BIT(X) (1 << (X) )
 
@@ -92,12 +94,21 @@ enum select_job_status
 
 #define INIT_ARR_SIZE 2048
 
+/* We need two sets of UNSPECIFIED/SCHD_INFINITY constants.  One for resources
+ * which can be negative, and one for positive integer values.  While we could
+ * use some numbers near -LONG_MAX, that would mean every integer used in the
+ * scheduler would need to be a long, when an int or smaller type is fine.
+ */ 
+
 /* Unspecified resource value */
-#define UNSPECIFIED -1
+#define UNSPECIFIED_RES -HUGE_VAL
 #define UNSPECIFIED_STR "UNSPECIFIED"
 /* infinity value for resources */
-#define SCHD_INFINITY -2
+#define SCHD_INFINITY_RES HUGE_VAL
 #define SCHD_INFINITY_STR "SCHD_INFINITY"
+
+#define UNSPECIFIED -1
+#define SCHD_INFINITY -2
 
 /* infinity walltime value for forever job. This is 5 years(=60 * 60 * 24 * 365 * 5 seconds) */
 #define JOB_INFINITY (60 * 60 * 24 * 365 * 5)
@@ -129,7 +140,7 @@ enum update_accruetype_mode
 };
 
 /* Default values for datatype resource */
-#define RES_DEFAULT_AVAIL SCHD_INFINITY
+#define RES_DEFAULT_AVAIL SCHD_INFINITY_RES
 #define RES_DEFAULT_ASSN 0
 
 #define PREEMPT_QUEUE_SERVER_SOFTLIMIT (1 << (PREEMPT_OVER_QUEUE_LIMIT) | 1 << (PREEMPT_OVER_SERVER_LIMIT) )

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1036,7 +1036,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 					LOG_INFO, njob->name, log_msg);
 
 			/* If this job couldn't run, the mark the equiv class so the rest of the jobs are discarded quickly.*/
-			if(sinfo->equiv_classes != NULL && njob->ec_index != UNSPECIFIED ) {
+			if(sinfo->equiv_classes != NULL && njob->ec_index != UNSPECIFIED) {
 				resresv_set *ec = sinfo->equiv_classes[njob->ec_index];
 				if (rc != RUN_FAILURE &&  !ec->can_not_run) {
 					ec->can_not_run = 1;

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -4762,7 +4762,7 @@ preemption_similarity(resource_resv *hjob, resource_resv *pjob, schd_error *full
 			case INSUFFICIENT_QUEUE_RESOURCE:
 				if (hjob->job->queue == pjob->job->queue) {
 					for (res = hjob->job->queue->qres; res != NULL; res = res->next) {
-						if (res->avail != SCHD_INFINITY)
+						if (res->avail != SCHD_INFINITY_RES)
 							if (find_resource_req(pjob->resreq, res->def) != NULL)
 								match = 1;
 					}
@@ -4770,7 +4770,7 @@ preemption_similarity(resource_resv *hjob, resource_resv *pjob, schd_error *full
 				break;
 			case INSUFFICIENT_SERVER_RESOURCE:
 				for (res = hjob->server->res; res != NULL; res = res->next) {
-					if (res->avail != SCHD_INFINITY)
+					if (res->avail != SCHD_INFINITY_RES)
 						if (find_resource_req(pjob->resreq, res->def) != NULL)
 							match = 1;
 				}

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -252,14 +252,14 @@ add_str_to_array(char ***str_arr, char *str)
  * @retval	a number in kilobytes or seconds
  * @retval	0 for False, if type is boolean
  * @retval	1 for True, if type is boolean
- * @retval	SCHD_INFINITY	: if not a number
+ * @retval	SCHD_INFINITY_RES	: if not a number
  *
  */
 sch_resource_t
 res_to_num(char *res_str, struct resource_type *type)
 {
-	sch_resource_t count = SCHD_INFINITY;	/* convert string resource to numeric */
-	sch_resource_t count2 = SCHD_INFINITY;	/* convert string resource to numeric */
+	sch_resource_t count = SCHD_INFINITY_RES;	/* convert string resource to numeric */
+	sch_resource_t count2 = SCHD_INFINITY_RES;	/* convert string resource to numeric */
 	char *endp;				/* used for strtol() */
 	char *endp2;				/* used for strtol() */
 	long multiplier = 1;			/* multiplier to count */
@@ -267,7 +267,7 @@ res_to_num(char *res_str, struct resource_type *type)
 	int is_time = 0;			/* resource value is a time spec */
 
 	if (res_str == NULL)
-		return SCHD_INFINITY;
+		return SCHD_INFINITY_RES;
 
 	if (!strcasecmp(ATR_TRUE, res_str)) {
 		if (type != NULL) {
@@ -288,7 +288,7 @@ res_to_num(char *res_str, struct resource_type *type)
 			type->is_string = 1;
 			type->is_non_consumable = 1;
 		}
-		count = SCHD_INFINITY;
+		count = SCHD_INFINITY_RES;
 	}
 	else {
 		count = (sch_resource_t) strtod(res_str, &endp);
@@ -300,7 +300,7 @@ res_to_num(char *res_str, struct resource_type *type)
 				count += count2 * 60;
 				count += strtol(endp2 + 1, &endp, 10);
 				if (*endp != '\0')
-					count = SCHD_INFINITY;
+					count = SCHD_INFINITY_RES;
 			}
 			else			 { /* form of MM:SS */
 				count *= 60;
@@ -1613,7 +1613,7 @@ res_to_str_re(void *p, enum resource_fields fld, char **buf,
 	}
 	else if (rt->is_num) {
 		int const_print = 0;
-		if (amount == UNSPECIFIED) {
+		if (amount == UNSPECIFIED_RES) {
 			if (flags & PRINT_INT_CONST) {
 				if (flags & NOEXPAND)
 					snprintf(*buf, *bufsize, UNSPECIFIED_STR);
@@ -1622,7 +1622,7 @@ res_to_str_re(void *p, enum resource_fields fld, char **buf,
 
 				const_print = 1;
 			}
-		} else if (amount == SCHD_INFINITY) {
+		} else if (amount == SCHD_INFINITY_RES) {
 			if (flags & PRINT_INT_CONST) {
 				if (flags & NOEXPAND)
 					snprintf(*buf, *bufsize, SCHD_INFINITY_STR);

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -964,7 +964,7 @@ talk_with_mom(node_info *ninfo)
 						break;
 					}
 				}
-				else if (res->avail == SCHD_INFINITY)
+				else if (res->avail == SCHD_INFINITY_RES)
 					res->avail = 0;
 
 				snprintf(errbuf, sizeof(errbuf), "%s = %s (\"%s\")",

--- a/src/scheduler/resource.c
+++ b/src/scheduler/resource.c
@@ -608,7 +608,7 @@ is_res_avail_set(schd_resource *res)
 		if (res->str_avail != NULL && res->str_avail[0] != NULL)
 			return 1;
 	}
-	else if (res->avail != SCHD_INFINITY)
+	else if (res->avail != SCHD_INFINITY_RES)
 		return 1;
 
 	return 0;

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -1037,7 +1037,7 @@ set_resource_req(resource_req *req, char *val)
 {
 	resdef *rdef;
 
-	/* if val is a string, req -> amount will be set to SCHD_INFINITY */
+	/* if val is a string, req -> amount will be set to SCHD_INFINITY_RES */
 	req->amount = res_to_num(val, &(req->type));
 	req->res_str = string_dup(val);
 
@@ -1050,7 +1050,7 @@ set_resource_req(resource_req *req, char *val)
 	if (rdef != NULL)
 		req->type = rdef->type;
 
-	if (req->amount == SCHD_INFINITY) {
+	if (req->amount == SCHD_INFINITY_RES) {
 		/* Verify that this is actually a non-numeric resource */
 		if (!req->def->type.is_string)
 			return 0;

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -3145,9 +3145,9 @@ set_resource(schd_resource *res, char *val, enum resource_fields field)
 			if (res->type.is_consumable != 0 || res->type.is_non_consumable !=0)
 				memset(&(res->type), 0, sizeof(struct resource_type));
 
-			/* if val is a string, avail will be set to SCHD_INFINITY */
+			/* if val is a string, avail will be set to SCHD_INFINITY_RES */
 			res->avail = res_to_num(val, &(res->type));
-			if (res->avail == SCHD_INFINITY) {
+			if (res->avail == SCHD_INFINITY_RES) {
 				/* Verify that this is a string type resource */
 				if (!res->def->type.is_string)
 					return 0;
@@ -3162,9 +3162,8 @@ set_resource(schd_resource *res, char *val, enum resource_fields field)
 			free(res->str_assigned);
 			res->str_assigned = NULL;
 		}
-		/* only set the type there is not type set */
-		if (res->type.is_non_consumable == 0 && res->type.is_consumable == 0)
-			res->assigned = res_to_num(val, &(res->type));
+		if (val[0] == '@') /* Indirect resources will be found elsewhere, assign 0 */
+			res->assigned = 0;
 		else
 			res->assigned = res_to_num(val, NULL);
 		res->str_assigned = string_dup(val);

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -310,7 +310,7 @@ next_event(server_info *sinfo, int advance)
 	 * status.
 	 */
 	if (!calendar->eol) {
-		if (sinfo->policy->prime_status_end !=SCHD_INFINITY) {
+		if (sinfo->policy->prime_status_end != SCHD_INFINITY) {
 			if (te == NULL ||
 				(*calendar->current_time <= sinfo->policy->prime_status_end &&
 				sinfo->policy->prime_status_end < te->event_time)) {

--- a/src/scheduler/sort.c
+++ b/src/scheduler/sort.c
@@ -116,11 +116,11 @@
 int
 cmpres(sch_resource_t r1, sch_resource_t r2)
 {
-	if (r1 == SCHD_INFINITY && r2 == SCHD_INFINITY)
+	if (r1 == SCHD_INFINITY_RES && r2 == SCHD_INFINITY_RES)
 		return 0;
-	if (r1 == SCHD_INFINITY)
+	if (r1 == SCHD_INFINITY_RES)
 		return -1;
-	if (r2 == SCHD_INFINITY)
+	if (r2 == SCHD_INFINITY_RES)
 		return 1;
 	if (r1 < r2)
 		return -1;

--- a/test/tests/functional/pbs_job_sort_formula.py
+++ b/test/tests/functional/pbs_job_sort_formula.py
@@ -45,8 +45,8 @@ class TestJobSortFormula(TestFunctional):
 
     def test_job_sort_formula_negative_value(self):
         """
-        Test to see that negative values in the job_sort_formula
-        correctly sort properly
+        Test to see that negative values in the
+        job_sort_formula sort properly
         """
         a = {'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, self.server.shortname)
@@ -57,7 +57,7 @@ class TestJobSortFormula(TestFunctional):
 
         j1 = Job(TEST_USER, attrs={'Resource_List.foo': -2})
         jid1 = self.server.submit(j1)
-        j2 = Job(TEST_USER, attrs={'Resource_List.foo': 1})
+        j2 = Job(TEST_USER, attrs={'Resource_List.foo': -1})
         jid2 = self.server.submit(j2)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})

--- a/test/tests/functional/pbs_job_sort_formula.py
+++ b/test/tests/functional/pbs_job_sort_formula.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestJobSortFormula(TestFunctional):
+    """
+    Tests for the job_sort_formula
+    """
+
+    def test_job_sort_formula_negative_value(self):
+        """
+        Test to see that negative values in the job_sort_formula
+        correctly sort properly
+        """
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.server.shortname)
+        self.server.manager(MGR_CMD_CREATE, RSC, {'type': 'float'}, id='foo')
+
+        a = {'job_sort_formula': 'foo', 'scheduling': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, a, runas=ROOT_USER)
+
+        j1 = Job(TEST_USER, attrs={'Resource_List.foo': -2})
+        jid1 = self.server.submit(j1)
+        j2 = Job(TEST_USER, attrs={'Resource_List.foo': 1})
+        jid2 = self.server.submit(j2)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+
+        c = self.scheduler.cycles(lastN=1)[0]
+        job_order = [jid2, jid1]
+        for i, job in enumerate(job_order):
+            self.assertEqual(job.split('.')[0], c.political_order[i])
+
+        self.server.expect(JOB, {'job_state=R': 2})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The scheduler uses special values for unspecified and infinity values (-1/-2).  The values they used are actually valid values that can be requested by a job for a custom resource.   The default value for a resource is infinity (-2).  If a job requested -2, the scheduler would set the value to the resource. It would then think it failed to set it since it was still set to the default value.  The job would be considered invalid for the cycle and be ignored.

#### Describe Your Change
The values for UNSPECIFIED and SCHD_INFINITY are too widely used on too many data types to change them to some sort of hugely negative or positive value.  It would require changing everything from a 5 bit field to many ints to longs.  The resource data type is a double.  There is a special floating point value called HUGE_VAL.  This is usually used for errors from floating point math functions.  I used HUGE_VAL for SCHD_INFINITY_RES and -HUGE_VAL for UNSPECIFIED_RES.

The customer who reported this bug used the custom resources in the job_sort_formula, so I wrote a generic job_sort_formula having a job request -2.  The test would fail if the job was ignored since the order of the two jobs would not be correct.

#### Attach Test and Valgrind Logs/Output
[job_sort_formula.log](https://github.com/PBSPro/pbspro/files/3219014/job_sort_formula.log)
