### PR TITLE
Suppress rpmlint warning: only-non-binary-in-usr-lib

### DIFF
--- a/pbspro-rpmlintrc
+++ b/pbspro-rpmlintrc
@@ -5,6 +5,7 @@ addFilter("non-standard-executable-perm .*pbs_iff")
 addFilter("setuid-binary .*pbs_iff")
 addFilter("non-standard-executable-perm .*pbs_rcp")
 addFilter("setuid-binary .*pbs_rcp")
+addFilter("only-non-binary-in-usr-lib")
 # FIXME: The following errors need to be addressed rather than ignored
 addFilter('permissions-file-setuid-bit')
 setBadness('permissions-file-setuid-bit', 0)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
rpmlint complains about binary (executable) files under `/usr/lib`, but PBS Pro is not installing any new executable files under that directory. 


#### Describe Your Change
Suppress this warning in `rpmlintrc`

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[rpmlint_after.txt](https://github.com/PBSPro/pbspro/files/3229728/rpmlint_after.txt)
[rpmlint_before.txt](https://github.com/PBSPro/pbspro/files/3229729/rpmlint_before.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->