### PR TITLE
pbs_rsub coredumps in case that all hosts are invalid

### DIFF
--- a/src/cmds/pbs_rsub.c
+++ b/src/cmds/pbs_rsub.c
@@ -297,8 +297,7 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 		}
 
 		if (maintenance_hosts == NULL) {
-			fprintf(stderr, "pbs_rsub: missing host(s)");
-			fprintf(stderr, "\n");
+			fprintf(stderr, "pbs_rsub: missing host(s)\n");
 			return (++errflg);
 		}
 	}
@@ -865,6 +864,14 @@ main(int argc, char *argv[], char *envp[])
 		}
 
 		pbs_statfree(bstat_head);	/* free info returned by pbs_statvnodes() */
+
+		if (select_str == NULL) {
+			fprintf(stderr, "pbs_rsub: missing host(s)\n");
+			print_usage();
+
+			CS_close_app();
+			exit(2);
+		}
 
 		/* add crafted select */
 		if ((i = set_resources(&attrib, select_str, 0, &erp)) != 0) {

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -107,6 +107,44 @@ class TestMaintenanceReservations(TestFunctional):
 
         self.assertEquals("pbs_rsub: can't use -l place with --hosts", msg)
 
+    def test_maintenance_missing_hosts(self):
+        """
+        Test if the pbs_rsub with all unknown hosts return error.
+        Test if the --hosts without host parameter return error.
+        """
+        now = int(time.time())
+
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'managers': '%s@*' % TEST_USER})
+
+        a = {'reserve_start': now + 3600,
+             'reserve_end': now + 7200}
+        h = ["foo"]
+        r = Reservation(TEST_USER, attrs=a, hosts=h)
+
+        msg = ""
+
+        try:
+            self.server.submit(r)
+        except PbsSubmitError as err:
+            msg = err.msg[0].strip()
+
+        self.assertEquals("pbs_rsub: missing host(s)", msg)
+
+        a = {'reserve_start': now + 3600,
+             'reserve_end': now + 7200}
+        h = [""]
+        r = Reservation(TEST_USER, attrs=a, hosts=h)
+
+        msg = ""
+
+        try:
+            self.server.submit(r)
+        except PbsSubmitError as err:
+            msg = err.msg[0].strip()
+
+        self.assertEquals("pbs_rsub: missing host(s)", msg)
+
     def test_maintenance_confirm(self):
         """
         Test if the maintenance (prefixed with 'M') is immediately


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
I forgot to test the pbs_rsub command with only invalid hosts as parameters in #1070.

The command pbs_rsub coredumps if all hosts are not found in the hosts' pool:

```
$ pbs_rsub -R 1200 -E 1300 --hosts foo
Segmentation fault (core dumped)
```

If at least one host is found the problem will not appear. The problem is that an empty select is used because select is not crafted at all.

#### Describe Your Change
Check the emptiness of select before setting.

New PTL test for this bug is added and this test also checks using '--hosts' without additional parameters.

#### Link to Design Doc
None


#### Attach Test and Valgrind Logs/Output
[ptl_maintenance_output.txt](https://github.com/PBSPro/pbspro/files/3231501/ptl_maintenance_output.txt)

<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
