### PR TITLE
Fix for intermittent failure of test_cgroup_prefix_and_devices

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -211,7 +211,7 @@ if sleeptime > 0:
 #PBS -joe
 echo $PBS_JOBID
 cpuset_base=`grep cgroup /proc/mounts | grep cpuset | cut -d' ' -f2 | \
-             grep cgroup`
+             sort | tail -1`
 if [ -z "$cpuset_base" ]; then
     echo "Cpuset subsystem not mounted."
     exit 1
@@ -284,7 +284,7 @@ check_file_diff() {
 
 jobnum=${PBS_JOBID%%.*}
 cpuset_base=`grep cgroup /proc/mounts | grep cpuset | cut -d' ' -f2 | \
-             grep cgroup`
+             sort | tail -1`
 if [ -d "$cpuset_base/propbs" ]; then
     cpuset_job="$cpuset_base/propbs/$PBS_JOBID"
 else

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -211,7 +211,7 @@ if sleeptime > 0:
 #PBS -joe
 echo $PBS_JOBID
 cpuset_base=`grep cgroup /proc/mounts | grep cpuset | cut -d' ' -f2 | \
-             tr " " "\n" | sed -n '1p'`
+             grep cgroup`
 if [ -z "$cpuset_base" ]; then
     echo "Cpuset subsystem not mounted."
     exit 1
@@ -284,7 +284,7 @@ check_file_diff() {
 
 jobnum=${PBS_JOBID%%.*}
 cpuset_base=`grep cgroup /proc/mounts | grep cpuset | cut -d' ' -f2 | \
-             tr " " "\n" | sed -n '1p'`
+             grep cgroup`
 if [ -d "$cpuset_base/propbs" ]; then
     cpuset_job="$cpuset_base/propbs/$PBS_JOBID"
 else


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestCgroupsHook.test_cgroup_prefix_and_devices would intermittently fail on some machines.


#### Describe Your Change
The test checks that only the devices subsystem is enabled with the correct allowable devices from within a job script.  The change was to move this check outside the job script, after a job is submitted and goes into R state.


#### Attach Test and Valgrind Logs/Output
test showing intermittent failures:
[TestCgroupsHook.test_cgroup_prefix_and_devices_x48_19.4_before.txt](https://github.com/PBSPro/pbspro/files/3242448/TestCgroupsHook.test_cgroup_prefix_and_devices_x48_19.4_before.txt)

test passes consistently:
[TestCgroupsHook.test_cgroup_prefix_and_devices_x48_19.4_after.txt](https://github.com/PBSPro/pbspro/files/3242294/TestCgroupsHook.test_cgroup_prefix_and_devices_x48_19.4_after.txt)
[TestCgroupsHook.test_cgroup_prefix_and_devices_x69_19.4_after.txt](https://github.com/PBSPro/pbspro/files/3242299/TestCgroupsHook.test_cgroup_prefix_and_devices_x69_19.4_after.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
