### PR TITLE
database shutdown / server abort relating to duplicate queue creation

### DIFF
--- a/.travis/opensuse_leap_15.sh
+++ b/.travis/opensuse_leap_15.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -xe
-OS_NAME=$(${DOCKER_EXEC} cat /etc/os-release | awk -F[=\"] '/^NAME=/ {print $3}')
-OS_VERSION=$(${DOCKER_EXEC} cat /etc/os-release | awk -F[=\"] '/^VERSION=/ {print $3}')
-OS_NAME_VERSION=${OS_NAME// /_}_${OS_VERSION// /_}
-${DOCKER_EXEC} zypper -n ar -f -G http://download.opensuse.org/repositories/devel:/tools/${OS_NAME_VERSION}/devel:tools.repo
-${DOCKER_EXEC} zypper -n ar -f -G http://download.opensuse.org/repositories/devel:/libraries:/c_c++/${OS_NAME_VERSION}/devel:libraries:c_c++.repo
+PRETTY_NAME=$(${DOCKER_EXEC} cat /etc/os-release | awk -F[=\"] '/^PRETTY_NAME=/ {print $3}')
+PRETTY_NAME=${PRETTY_NAME# }
+PRETTY_NAME=${PRETTY_NAME% }
+${DOCKER_EXEC} zypper -n ar -f -G http://download.opensuse.org/repositories/devel:/tools/${PRETTY_NAME// /_}/devel:tools.repo
+${DOCKER_EXEC} zypper -n ar -f -G http://download.opensuse.org/repositories/devel:/libraries:/c_c++/${PRETTY_NAME// /_}/devel:libraries:c_c++.repo
 ${DOCKER_EXEC} zypper -n ref
 ${DOCKER_EXEC} zypper -n update
 ${DOCKER_EXEC} zypper -n install rpmdevtools

--- a/src/cmds/scripts/pbs_schema_upgrade
+++ b/src/cmds/scripts/pbs_schema_upgrade
@@ -163,47 +163,59 @@ upgrade_pbs_schema_from_v1_3_0() {
 		
 		CREATE EXTENSION hstore;
 		
-		ALTER TABLE pbs.job ADD attributes public.hstore DEFAULT ''::public.hstore NOT NULL;
+		ALTER TABLE pbs.job ADD attributes public.hstore DEFAULT ''::public.hstore;
 		UPDATE pbs.job SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
 					      concat(attr_flags, '.' , attr_value) AS value
 						FROM pbs.job_attr WHERE pbs.job_attr.ji_jobid=pbs.job.ji_jobid) AS attr);
+		UPDATE pbs.job SET attributes='' WHERE attributes IS NULL;
+		ALTER TABLE pbs.job ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.node ADD attributes public.hstore DEFAULT ''::public.hstore NOT NULL;
+		ALTER TABLE pbs.node ADD attributes public.hstore DEFAULT ''::public.hstore;
 		UPDATE pbs.node SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
 					      concat(attr_flags, '.' , attr_value) AS value
 						FROM pbs.node_attr WHERE pbs.node_attr.nd_name=pbs.node.nd_name) AS attr);
+		UPDATE pbs.node SET attributes='' WHERE attributes IS NULL;
+		ALTER TABLE pbs.node ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.queue ADD attributes public.hstore DEFAULT ''::public.hstore NOT NULL;
+		ALTER TABLE pbs.queue ADD attributes public.hstore DEFAULT ''::public.hstore;
 		UPDATE pbs.queue SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
 					      concat(attr_flags, '.' , attr_value) AS value
 						FROM pbs.queue_attr WHERE pbs.queue_attr.qu_name=pbs.queue.qu_name) AS attr);
+		UPDATE pbs.queue SET attributes='' WHERE attributes IS NULL;
+		ALTER TABLE pbs.queue ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.resv ADD attributes public.hstore DEFAULT ''::public.hstore NOT NULL;
+		ALTER TABLE pbs.resv ADD attributes public.hstore DEFAULT ''::public.hstore;
 		UPDATE pbs.resv SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
 					      concat(attr_flags, '.' , attr_value) AS value
 						FROM pbs.resv_attr WHERE pbs.resv_attr.ri_resvid=pbs.resv.ri_resvid) AS attr);
+		UPDATE pbs.resv SET attributes='' WHERE attributes IS NULL;
+		ALTER TABLE pbs.resv ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.scheduler ADD attributes public.hstore DEFAULT ''::public.hstore NOT NULL;
+		ALTER TABLE pbs.scheduler ADD attributes public.hstore DEFAULT ''::public.hstore;
 		UPDATE pbs.scheduler SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
 					      concat(attr_flags, '.' , attr_value) AS value
 						FROM pbs.scheduler_attr WHERE pbs.scheduler_attr.sched_name=pbs.scheduler.sched_name) AS attr);
+		UPDATE pbs.scheduler SET attributes='' WHERE attributes IS NULL;
+		ALTER TABLE pbs.scheduler ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.server ADD attributes public.hstore DEFAULT ''::public.hstore NOT NULL;
+		ALTER TABLE pbs.server ADD attributes public.hstore DEFAULT ''::public.hstore;
 		UPDATE pbs.server SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
 					      concat(attr_flags, '.' , attr_value) AS value
 						FROM pbs.server_attr WHERE pbs.server_attr.sv_name=pbs.server.sv_name) AS attr);
+		UPDATE pbs.server SET attributes='' WHERE attributes IS NULL;
+		ALTER TABLE pbs.server ALTER COLUMN attributes SET NOT NULL;
 
 		DROP TABLE pbs.server_attr;
 		DROP TABLE pbs.scheduler_attr;

--- a/src/include/queue.h
+++ b/src/include/queue.h
@@ -153,7 +153,7 @@ struct pbs_queue {
 		int	qu_type;		/* queue type: exec, route */
 		time_t	qu_ctime;		/* time queue created */
 		time_t	qu_mtime;		/* time queue last modified */
-		char	qu_name[PBS_MAXQUEUENAME]; /* queue name */
+		char	qu_name[PBS_MAXQUEUENAME + 1]; /* queue name */
 	} qu_qs;
 
 	int	qu_numjobs;			/* current numb jobs in queue */

--- a/src/lib/Libdb/db_postgres_attr.c
+++ b/src/lib/Libdb/db_postgres_attr.c
@@ -101,7 +101,13 @@ convert_array_to_db_attr_list(char *raw_array, pbs_db_attr_list_t *attr_list)
 	struct pg_array *array = (struct pg_array *) raw_array;
 	struct str_data *val = (struct str_data *)(raw_array + sizeof(struct pg_array));
 
-	if (ntohl(array->ndim) != 1 || ntohl(array->elemtype) != TEXTOID) {
+	if (ntohl(array->ndim) == 0) {
+		attr_list->attributes = attrs;
+		attr_list->attr_count = 0;
+		return 0;
+	}
+
+	if (ntohl(array->ndim) > 1 || ntohl(array->elemtype) != TEXTOID) {
 		return -1;
 	}
 

--- a/src/server/attr_recov_db.c
+++ b/src/server/attr_recov_db.c
@@ -195,6 +195,13 @@ encode_attr_db(struct attribute_def *padef, struct attribute *pattr, int numattr
 		pal = (svrattrl *)GET_NEXT(pal->al_link);
 		count++;
 	}
+
+	if (count == 0) {
+		attr_list->attributes = NULL;
+		attr_list->attr_count = 0;
+		return 0;
+	}
+
 	attr_list->attributes = calloc(count, sizeof(pbs_db_attr_info_t));
 	if (!attr_list->attributes)
 		return -1;

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -121,7 +121,7 @@ que_alloc(char *name)
 	CLEAR_HEAD(pq->qu_jobs);
 	CLEAR_LINK(pq->qu_link);
 
-	snprintf(pq->qu_qs.qu_name, PBS_MAXQUEUENAME, "%s", name);
+	snprintf(pq->qu_qs.qu_name, sizeof(pq->qu_qs.qu_name), "%s", name);
 	append_link(&svr_queues, &pq->qu_link, pq);
 	server.sv_qs.sv_numque++;
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->
Cherry-pick from master: https://github.com/PBSPro/pbspro/pull/1076
#### Describe Bug or Feature
Three issues are being addressed here related to queues
1) database shutdown / server abort when trying to create the same queue second time which is having max queue name length .
que_alloc() will copy queue name to a string which can hold only 14 characters. During the next attempt, 15 char long queue name is compared with this string in find_queuebyname() and proceeds to insert in database as it couldn't find a match. Database will see this as a duplicate entry and will throw a primary key violation resulting in a panic_stop_db

2) If you create a queue, by default it wont be having any attributes with it. So it inserts empty string to the attribute field of pbs.queue table. However our database API's are not able to handle this empty string value and hence will not be able to load these values back to the memory after a restart. Hence `qstat -Qf` will not display this queue and re-creating this queue will cause server abort as it is unable to handle primary key violation exception in the db.

3) After an overlay upgrade all the queues are found missing if one of the queue does not have any attribute associated with it:
Overlay upgrade sql commands are trying to insert a NULL (as no attribute is present) and hence resulting in an error due to the NOT NULL constraint in the table defenition. Due to this error attribute fields of other entries are also filled with empty string rather than the actual value. After upgrade a fresh incarnation of the server wont be able to read these values due to bug mentioned above. 

#### Describe Your Change
1) Add one more byte to hold null character.
2) Update the database API's to read empty string
3) Following changes are made to the sql command to fix overlay upgrade issue:
Create attribute field without NOT NULL constraint -> Insert values including NULL -> convert all the NULL to empty string -> Introduce NOT NULL constraint for attribute field.


#### Attach Test Logs or Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
[logs_19_1_2.txt](https://github.com/PBSPro/pbspro/files/3252158/logs_19_1_2.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->

CC: @subhasisb , @suresh-thelkar , @agrawalravi90 
