### PR TITLE
pbs_snapshot: Add /etc/os-release to snapshot

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -1741,7 +1741,13 @@ quit()
         snap_ospath = os.path.join(self.snapdir, OS_PATH)
         with open(snap_ospath, "w") as osfd:
             osinfo = self.du.get_os_info()
-            osfd.write(osinfo)
+            osfd.write(osinfo + "\n")
+            # If /etc/os-release is available then save that as well
+            fpath = os.path.join(os.sep, "etc", "os-release")
+            if os.path.isfile(fpath):
+                with open(fpath, "r") as fd:
+                    fcontent = fd.read()
+                osfd.write("\n/etc/os-release:\n" + fcontent)
         if self.create_tar:
             self.__add_to_archive(snap_ospath)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
On some platforms (like SLES 15), os_info was not capturing information about the Linux Distro. So, we should also try to capture /etc/os-release is it's available as that has information about Distro.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
PBSSnapUtils.capture_system_info now checks for /etc/os-release and captures it as well to the system/os_info file


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
os_info now captures /etc/os-release as well:
[root@pbspro system]# cat os_info 
Linux-4.9.125-linuxkit-x86_64-with-centos-7.6.1810-Core

/etc/os-release:
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
