### PR TITLE
Fixed preemption with multiple scheduler (and misc server crashes)

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -1162,7 +1162,7 @@ extern int   job_or_resv_save_db(void *, int, int);
 
 
 #ifdef	_BATCH_REQUEST_H
-extern job  *chk_job_request(char *, struct batch_request *, int *);
+extern job  *chk_job_request(char *, struct batch_request *, int *, int *);
 extern int   net_move(job *, struct batch_request *);
 extern int   svr_chk_owner(struct batch_request *, job *);
 extern int   svr_movejob(job *, char *, struct batch_request *);

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2874,7 +2874,8 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 		for (i = 0; i < no_of_jobs; i++) {
 			job = find_resource_resv(sinfo->running_jobs, preempt_jobs_reply[i].job_id);
 			if (job == NULL) {
-				snprintf(log_buffer, sizeof(log_buffer), "Server replied to preemption request with job %s which does not exist.", preempt_jobs_reply[i].job_id);
+				snprintf(log_buffer, sizeof(log_buffer), "Server replied to preemption request with job which does not exist.");
+				schdlog(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_DEBUG, preempt_jobs_reply[i].job_id, log_buffer);
 				continue;
 			}
 

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2873,6 +2873,11 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 
 		for (i = 0; i < no_of_jobs; i++) {
 			job = find_resource_resv(sinfo->running_jobs, preempt_jobs_reply[i].job_id);
+			if (job == NULL) {
+				snprintf(log_buffer, sizeof(log_buffer), "Server replied to preemption request with job %s which does not exist.", preempt_jobs_reply[i].job_id);
+				continue;
+			}
+
 			if (preempt_jobs_reply[i].order[0] == '0') {
 				done = 0;
 				fail_list[fail_count++] = job->rank;

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -709,6 +709,13 @@ job_purge(job *pjob)
 		reply_text(pjob->ji_rerun_preq, PBSE_INTERNAL, "job rerun");
 		pjob->ji_rerun_preq = NULL;
 	}
+#ifndef PBS_MOM
+	if (pjob->ji_pmt_preq != NULL) {
+		log_joberr(PBSE_INTERNAL, __func__, "preempt request outstanding",
+			   pjob->ji_qs.ji_jobid);
+		reply_preempt_jobs_request(PBSE_INTERNAL, PREEMPT_METHOD_DELETE, pjob);
+	}
+#endif
 #ifdef	PBS_MOM
 	delete_link(&pjob->ji_jobque);
 	delete_link(&pjob->ji_alljobs);

--- a/src/server/req_message.c
+++ b/src/server/req_message.c
@@ -77,7 +77,7 @@ static void post_message_req(struct work_task *);
 
 extern char *msg_messagejob;
 
-extern job  *chk_job_request(char *, struct batch_request *, int *);
+extern job  *chk_job_request(char *, struct batch_request *, int *, int *);
 
 
 
@@ -97,7 +97,7 @@ req_messagejob(struct batch_request *preq)
 	job		 *pjob;
 	int		  rc;
 
-	if ((pjob = chk_job_request(preq->rq_ind.rq_message.rq_jid, preq, &jt)) == 0)
+	if ((pjob = chk_job_request(preq->rq_ind.rq_message.rq_jid, preq, &jt, NULL)) == 0)
 		return;
 
 	if (jt != IS_ARRAY_NO) {
@@ -194,7 +194,7 @@ req_py_spawn(struct batch_request *preq)
 	 ** Returns job pointer for singleton job or "parent" of
 	 ** an array job.
 	 */
-	pjob = chk_job_request(jid, preq, &jt);
+	pjob = chk_job_request(jid, preq, &jt, NULL);
 	if (pjob == NULL)
 		return;
 
@@ -289,7 +289,7 @@ req_relnodesjob(struct batch_request *preq)
 	 ** Returns job pointer for singleton job or "parent" of
 	 ** an array job.
 	 */
-	pjob = chk_job_request(jid, preq, &jt);
+	pjob = chk_job_request(jid, preq, &jt, NULL);
 	if (pjob == NULL) {
 		return;
 	}

--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -96,7 +96,7 @@ extern char *msg_nostf_resv;
 int modify_resv_attr(resc_resv *presv, svrattrl *plist, int perm, int *bad);
 extern void resv_revert_alter_times(resc_resv *presv);
 extern int gen_future_reply(resc_resv *presv, long fromNow);
-extern job  *chk_job_request(char *, struct batch_request *, int *);
+extern job  *chk_job_request(char *, struct batch_request *, int *, int *);
 extern resc_resv  *chk_rescResv_request(char *, struct batch_request *);
 
 
@@ -191,7 +191,7 @@ req_modifyjob(struct batch_request *preq)
 	if (pseldef == NULL)  /* do one time to keep handy */
 		pseldef = find_resc_def(svr_resc_def, "select", svr_resc_size);
 
-	pjob = chk_job_request(preq->rq_ind.rq_modify.rq_objname, preq, &jt);
+	pjob = chk_job_request(preq->rq_ind.rq_modify.rq_objname, preq, &jt, NULL);
 	if (pjob == NULL)
 		return;
 

--- a/src/server/req_movejob.c
+++ b/src/server/req_movejob.c
@@ -116,7 +116,7 @@ req_movejob(struct batch_request *req)
 				LOG_INFO, "", "movejob event: accept req by default");
 	}
 
-	jobp = chk_job_request(req->rq_ind.rq_move.rq_jid, req, &jt);
+	jobp = chk_job_request(req->rq_ind.rq_move.rq_jid, req, &jt, NULL);
 
 	if (jobp == NULL)
 		return;
@@ -193,11 +193,11 @@ req_orderjob(struct batch_request *req)
 	job	*pjob2;
 	long	 rank;
 	int	 rc;
-	char	 tmpqn[PBS_MAXQUEUENAME+1];
+	char	 tmpqn[PBS_MAXQUEUENAME + 1];
 
-	if ((pjob1=chk_job_request(req->rq_ind.rq_move.rq_jid, req, &jt1)) == NULL)
+	if ((pjob1 = chk_job_request(req->rq_ind.rq_move.rq_jid, req, &jt1, NULL)) == NULL)
 		return;
-	if ((pjob2=chk_job_request(req->rq_ind.rq_move.rq_destin, req, &jt2)) == NULL)
+	if ((pjob2 = chk_job_request(req->rq_ind.rq_move.rq_destin, req, &jt2, NULL)) == NULL)
 		return;
 	if ((jt1 == IS_ARRAY_Single) || (jt2 == IS_ARRAY_Single) ||
 		(jt1 == IS_ARRAY_Range)  || (jt2 == IS_ARRAY_Range)) {

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -145,7 +145,7 @@ extern char *msg_job_abort;
 extern pbs_list_head svr_deferred_req;
 extern time_t time_now;
 extern int   svr_totnodes;	/* non-zero if using nodes */
-extern job  *chk_job_request(char *, struct batch_request *, int *);
+extern job  *chk_job_request(char *, struct batch_request *, int *, int *);
 
 
 /* private data */
@@ -323,7 +323,7 @@ req_runjob(struct batch_request *preq)
 	}
 
 	jid = preq->rq_ind.rq_run.rq_jid;
-	parent = chk_job_request(jid, preq, &jt);
+	parent = chk_job_request(jid, preq, &jt, NULL);
 	if (parent == NULL)
 		return;		/* note, req_reject already called */
 

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -470,9 +470,11 @@ post_signal_req(struct work_task *pwt)
 			rel_resc(pjob);
 		}
 
+		if (pjob == NULL)
+			pjob = find_job(preq->rq_ind.rq_signal.rq_jid);
 		if (pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(rc, PREEMPT_METHOD_SUSPEND, pjob);
-		
+
 		req_reject(rc, 0, preq);
 	} else {
 

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -84,7 +84,7 @@ int create_resreleased (job *pjob);
 
 extern char *msg_momreject;
 extern char *msg_signal_job;
-extern job  *chk_job_request(char *, struct batch_request *, int *);
+extern job  *chk_job_request(char *, struct batch_request *, int *, int *);
 
 
 /**
@@ -113,12 +113,17 @@ req_signaljob(struct batch_request *preq)
 	int		  resume = 0;
 	char		 *vrange;
 	int		  x, y, z;
+	int 		 err = PBSE_NONE;
 
 	jid = preq->rq_ind.rq_signal.rq_jid;
 
-	parent = chk_job_request(jid, preq, &jt);
-	if (parent == NULL)
-		return;		/* note, req_reject already called */
+	parent = chk_job_request(jid, preq, &jt, &err);
+	if (parent == NULL) {
+		pjob = find_job(jid);
+		if (pjob != NULL && pjob->ji_pmt_preq != NULL)
+			reply_preempt_jobs_request(err, PREEMPT_METHOD_SUSPEND, pjob);
+		return; /* note, req_reject already called */
+	}
 
 	if (strcmp(preq->rq_ind.rq_signal.rq_signame, SIG_RESUME) == 0 || strcmp(preq->rq_ind.rq_signal.rq_signame, SIG_ADMIN_RESUME) == 0)
 		resume = 1;
@@ -516,7 +521,9 @@ post_signal_req(struct work_task *pwt)
 				form_attr_comment("Job run at %s", pjob->ji_wattr[(int) JOB_ATR_exec_vnode].at_val.at_str));
 		}
 
-		if (pjob->ji_pmt_preq != NULL)
+		if (pjob == NULL)
+			pjob = find_job(preq->rq_ind.rq_signal.rq_jid);
+		if (pjob != NULL && pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(PBSE_NONE, PREEMPT_METHOD_SUSPEND, pjob);
 		
 		reply_ack(preq);

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -472,7 +472,7 @@ post_signal_req(struct work_task *pwt)
 
 		if (pjob == NULL)
 			pjob = find_job(preq->rq_ind.rq_signal.rq_jid);
-		if (pjob->ji_pmt_preq != NULL)
+		if (pjob != NULL && pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(rc, PREEMPT_METHOD_SUSPEND, pjob);
 
 		req_reject(rc, 0, preq);

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -412,7 +412,7 @@ authenticate_user(struct batch_request *preq, struct connection *pcred)
 
 
 job *
-chk_job_request(char *jobid, struct batch_request *preq, int *rc)
+chk_job_request(char *jobid, struct batch_request *preq, int *rc, int *err)
 {
 	int	 t;
 	int	 histerr = 0;
@@ -434,6 +434,8 @@ chk_job_request(char *jobid, struct batch_request *preq, int *rc)
 	if (pjob == NULL) {
 		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_INFO,
 			jobid, msg_unkjobid);
+		if (err != NULL)
+			*err = PBSE_UNKJOBID;
 		req_reject(PBSE_UNKJOBID, 0, preq);
 		return NULL;
 	} else {
@@ -441,13 +443,13 @@ chk_job_request(char *jobid, struct batch_request *preq, int *rc)
 		if (histerr && deletehist == 0) {
 			if (pjob->ji_pmt_preq != NULL)
 				reply_preempt_jobs_request(histerr, PREEMPT_METHOD_DELETE, pjob);
+			if (err != NULL)
+				*err = histerr;
 			req_reject(histerr, 0, preq);
 			return NULL;
 		}
 		if (deletehist ==1&& pjob->ji_qs.ji_state == JOB_STATE_MOVED &&
 			pjob->ji_qs.ji_substate != JOB_SUBSTATE_FINISHED) {
-			if (pjob->ji_pmt_preq != NULL)
-				reply_preempt_jobs_request(PBSE_UNKJOBID, PREEMPT_METHOD_DELETE, pjob);
 			job_purge(pjob);
 			req_reject(PBSE_UNKJOBID, 0, preq);
 			return NULL;
@@ -477,8 +479,8 @@ chk_job_request(char *jobid, struct batch_request *preq, int *rc)
 			preq->rq_user, preq->rq_host);
 		log_event(PBSEVENT_SECURITY, PBS_EVENTCLASS_JOB, LOG_INFO,
 			pjob->ji_qs.ji_jobid, log_buffer);
-		if (pjob->ji_pmt_preq != NULL)
-			reply_preempt_jobs_request(PBSE_PERM, PREEMPT_METHOD_DELETE, pjob);
+		if (err != NULL)
+			*err = PBSE_PERM;
 		req_reject(PBSE_PERM, 0, preq);
 		return NULL;
 	}
@@ -496,8 +498,8 @@ chk_job_request(char *jobid, struct batch_request *preq, int *rc)
 			pjob->ji_qs.ji_state);
 		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, LOG_INFO,
 			pjob->ji_qs.ji_jobid, log_buffer);
-		if (pjob->ji_pmt_preq != NULL)
-			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_DELETE, pjob);
+		if (err != NULL)
+			*err = PBSE_BADSTATE;
 		req_reject(PBSE_BADSTATE, 0, preq);
 		return NULL;
 	}

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -404,6 +404,7 @@ authenticate_user(struct batch_request *preq, struct connection *pcred)
  *						(1) - for an Array Job
  *						(2)   - for a single subjob
  *						(3)    - for a range of  subjobs
+ * @param[out]	err		PBSE reason why request was rejected
  *
  * @return	job *
  * @retval	a pointer to the job	: if found and the tests pass.


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When two or more schedulers preempt jobs at the same time, the server would crash.  This is due to the use of global variables.  They would be used intermixed between the schedulers, and then when one scheduler was replied to, set to NULL.  The next use of that variable would dereference it and crash.

#### Describe Your Change
The three global variables used by preemption are already on the preq.  One is the total number of jobs to preempt.  Next is the jobs that were preempted.  Last is how many jobs were preempted.  The global variables were used to keep track of preemption progress, and then stores on the preq for replying.  Now I just store the progress on the preq directly.

#### Attach Test and Valgrind Logs/Output
[multi_preemption.log](https://github.com/PBSPro/pbspro/files/3259574/multi_preemption.log)
[preemption.log](https://github.com/PBSPro/pbspro/files/3259575/preemption.log)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
