### PR TITLE
Test test_soft_job_array of TestSoftWalltime is failing while verifying the job's attribute

### DIFF
--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -1036,6 +1036,8 @@ e.accept()
         regular jobs
         """
 
+        a = {'resources_available.ncpus': 1}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
         J = Job(TEST_USER, attrs={ATTR_J: '1-5',


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test test_soft_job_array of TestSoftWalltime is failing while verifying the job's attribute


#### Describe Your Change
Problem:
Test test_soft_job_array failling while checking job_state of first subjob in Array. 
In the Test array_job is submitted of 5 subjobs. then 5 sec. soft_walltime is set on array_job and check that sub_job is not deleted after completetion of soft_walltime.
The race condition occured such that if machine having more than 5 resources_available.ncpus value then all subjobs running parrallely and completed. PTL try to get job_state 'X' of first sub_job, but cannot get expected job_state in 60 attempts and test got failed. machines having resources_available.ncpus value less than 5 after completetion of first job PTL easily get 'X'. 

Solution:
Set resorces_available.ncpus value to 1 in test. After completion of first job, second job is in R state and PTL easily get job_state 'X' for first job.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
- Before fix
[before_fix.txt](https://github.com/PBSPro/pbspro/files/3260206/before_fix.txt)
- After fix
[after_fix.txt](https://github.com/PBSPro/pbspro/files/3260207/after_fix.txt)
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
