### PR TITLE
Sched crash when array job and reservation is submitted

### DIFF
--- a/.travis/opensuse_leap_15.sh
+++ b/.travis/opensuse_leap_15.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -xe
-OS_NAME=$(${DOCKER_EXEC} cat /etc/os-release | awk -F[=\"] '/^NAME=/ {print $3}')
-OS_VERSION=$(${DOCKER_EXEC} cat /etc/os-release | awk -F[=\"] '/^VERSION=/ {print $3}')
-OS_NAME_VERSION=${OS_NAME// /_}_${OS_VERSION// /_}
-${DOCKER_EXEC} zypper -n ar -f -G http://download.opensuse.org/repositories/devel:/tools/${OS_NAME_VERSION}/devel:tools.repo
-${DOCKER_EXEC} zypper -n ar -f -G http://download.opensuse.org/repositories/devel:/libraries:/c_c++/${OS_NAME_VERSION}/devel:libraries:c_c++.repo
+PRETTY_NAME=$(${DOCKER_EXEC} cat /etc/os-release | awk -F[=\"] '/^PRETTY_NAME=/ {print $3}')
+PRETTY_NAME=${PRETTY_NAME# }
+PRETTY_NAME=${PRETTY_NAME% }
+${DOCKER_EXEC} zypper -n ar -f -G http://download.opensuse.org/repositories/devel:/tools/${PRETTY_NAME// /_}/devel:tools.repo
+${DOCKER_EXEC} zypper -n ar -f -G http://download.opensuse.org/repositories/devel:/libraries:/c_c++/${PRETTY_NAME// /_}/devel:libraries:c_c++.repo
 ${DOCKER_EXEC} zypper -n ref
 ${DOCKER_EXEC} zypper -n update
 ${DOCKER_EXEC} zypper -n install rpmdevtools


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Scheduler crashes when it encounters an array job and a reservation in the same scheduling cycle.

#### Describe Your Change
As part of speeding up scheduler, we added a way to find a job/reservation based on their indexes in the all_resresv array.
But after these indexes are created, all_resresv array gets sorted to bring timed events in front in order to create a calendar. This sort messes up the indexes and causes the crash. While the sort is needed there is no reason to have all_resresv sorted.
As part of the fix, create_events code which creates the calendar will create a local copy of the array and sort that local copy instead of sorting all_resresv array.

#### Link to Design Doc
None


#### Attach Test and Valgrind Logs/Output
[smoketest_out.txt](https://github.com/PBSPro/pbspro/files/3267010/smoketest_out.txt)


#### NOTE
It is a chery-pick of #1109 

