### PR TITLE
Fixed server crash with expired subjobs in reservation

### DIFF
--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -1138,9 +1138,6 @@ req_deleteReservation(struct batch_request *preq)
 				continue;
 			}
 
-			if (pjob == NULL)
-				break;
-
 			newreq = alloc_br(PBS_BATCH_DeleteJob);
 			if (newreq != NULL) {
 

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -1120,6 +1120,12 @@ req_deleteReservation(struct batch_request *preq)
 
 			pnxj = (job *) GET_NEXT(pjob->ji_jobque);
 
+			/* skip all expired subjobs, expired subjobs are deleted when array parent is
+			 * issued delete request
+			 */
+			for (; pnxj != NULL && (pnxj->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) &&
+			     pnxj->ji_qs.ji_state == JOB_STATE_EXPIRED; pnxj = (job *) GET_NEXT(pnxj->ji_jobque))
+				;
 			/*
 			 * If a history job (job state is JOB_STATE_MOVED
 			 * or JOB_STATE_FINISHED, then no need to delete
@@ -1131,6 +1137,10 @@ req_deleteReservation(struct batch_request *preq)
 				pjob = pnxj;
 				continue;
 			}
+
+			if (pjob == NULL)
+				break;
+
 			newreq = alloc_br(PBS_BATCH_DeleteJob);
 			if (newreq != NULL) {
 

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -1098,8 +1098,8 @@ class TestReservations(TestFunctional):
         # Submit a advance reservation and an array job to the reservation
         # once reservation confirmed
         now = int(time.time())
-        a = {'reserve_start': now + 20,
-             'reserve_end': now + 80}
+        a = {'reserve_start': now + 10,
+             'reserve_end': now + 40}
         r = Reservation(TEST_USER, attrs=a)
         rid = self.server.submit(r)
         rid_q = rid.split('.')[0]
@@ -1111,11 +1111,11 @@ class TestReservations(TestFunctional):
         # ends
         a = {ATTR_q: rid_q, ATTR_J: '1-20'}
         j = Job(TEST_USER, attrs=a)
-        j.set_sleep_time(10)
+        j.set_sleep_time(2)
         jid = self.server.submit(j)
 
         a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
-        self.server.expect(RESV, a, id=rid, offset=20)
+        self.server.expect(RESV, a, id=rid, offset=10)
         self.server.expect(JOB, {'job_state': 'B'}, jid)
         # Wait for reservation to delete from server
         msg = "Que;" + rid_q + ";deleted at request of pbs_server@"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When there are expired subjobs in a reservation and reservation ends PBS server tries to clean up all the jobs inside the reservation and it crashes while doing so.
This works fine when job_history is disabled, but when job_history is enabled then reservation's job list also consists of expired subjobs. 
What happens is that in req_deleteReservation() function we iterate through the list of all jobs and issue a local request to delete the jobs. While doing so we maintain a pointer to next job in the list because the job in hand will get deleted and then we can not iterate to next job.
Now, when we encounter an array parent, we issue a delete job request and then in req_deletejob we delete all the expired subjobs of this parent. This results in req_deleteReservations holding onto a dangling next job pointer (because the next job to delete was the expired subjob), hence the crash.

#### Describe Your Change
While trying to find the next job to delete in the list, we just skip all the expired subjobs. This makes server work only on array parents and other jobs.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[server_leak.txt](https://github.com/PBSPro/pbspro/files/3279120/server_leak.txt)
[test_fix.txt](https://github.com/PBSPro/pbspro/files/3279121/test_fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
