### PR TITLE
Sched crash while creating node partition with indirect resource

### DIFF
--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -423,6 +423,9 @@ create_node_partitions(status *policy, node_info **nodes, char **resnames, unsig
 				res = &unset_res;
 			}
 			if (res != NULL) {
+				/* Incase of indirect resource, point it to the right place */
+			        if (res->indirect_res != NULL)
+					res = res->indirect_res;
 				for (val_i = 0; res->str_avail[val_i] != NULL; val_i++) {
 					/* 2: 1 for '=' 1 for '\0' */
 					if (reslen + strlen(res->str_avail[val_i]) + 2 < 1024) {

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -535,6 +535,9 @@ create_node_partitions(status *policy, node_info **nodes, char **resnames, unsig
 				res = &unset_res;
 			}
 			if (res != NULL) {
+				/* Incase of indirect resource, point it to the right place */
+			        if (res->indirect_res != NULL)
+					res = res->indirect_res;
 				if (compare_res_to_str(res, np_arr[np_i]->res_val, CMP_CASE)) {
 					if (np_arr[np_i]->ok_break) {
 						tmpres = find_resource(nodes[node_i]->res, getallres(RES_HOST));

--- a/test/tests/functional/pbs_schedule_indirect_resources.py
+++ b/test/tests/functional/pbs_schedule_indirect_resources.py
@@ -114,7 +114,7 @@ class TestSchedulingIndirectResources(TestFunctional):
             self.submit_job(attr)]
 
         # since there are 6 vnodes and the test grouped them on foostr
-        # resource, we now have groups in pair of vnode 0-3, 1-4, 2-5
+        # resource, we now have groups in pair of vnode 0+3, 1+4, 2+5
         # check that the jobs are running on correct vnode groups.
         for i in range(3):
             self.server.expect(JOB, {'job_state': 'R'}, id=j[i][0])

--- a/test/tests/functional/pbs_schedule_indirect_resources.py
+++ b/test/tests/functional/pbs_schedule_indirect_resources.py
@@ -113,7 +113,9 @@ class TestSchedulingIndirectResources(TestFunctional):
             self.submit_job(attr),
             self.submit_job(attr)]
 
-        # Verify that the jobs are running on correct vnodes
+        # since there are 6 vnodes and the test grouped them on foostr
+        # resource, we now have groups in pair of vnode 0-3, 1-4, 2-5
+        # check that the jobs are running on correct vnode groups.
         for i in range(3):
             self.server.expect(JOB, {'job_state': 'R'}, id=j[i][0])
             self.server.status(JOB, 'exec_vnode', j[i][0])

--- a/test/tests/functional/pbs_schedule_indirect_resources.py
+++ b/test/tests/functional/pbs_schedule_indirect_resources.py
@@ -1,0 +1,128 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestSchedulingIndirectResources(TestFunctional):
+    """
+    Test Scheduler resolve indirect resources correctly
+    """
+
+    def config_complex_for_grouping(self, res, res_type='string', flag='h'):
+        """
+        Configure the PBS complex for node grouping test
+        """
+        # Create a non-consumable custom resource foostr'
+        self.server.add_resource(res, res_type, flag)
+
+        # Add resource to the resources line in sched_config
+        self.scheduler.add_resource(res)
+
+        # Set resource as the node_group_key
+        attr = {'node_group_enable': 'True', 'node_group_key': res}
+        self.server.manager(MGR_CMD_SET, SERVER, attr)
+
+    def submit_job(self, attr):
+        """
+        Helper function to submit a sleep job with provided attributes
+        """
+        job = Job(TEST_USER1, attr)
+        job.set_sleep_time(3600)
+        jobid = self.server.submit(job)
+
+        return (jobid, job)
+
+    def test_node_grouping_with_indirect_res(self):
+        """
+        Test node grouping with indirect resources set on some nodes
+        Steps:
+        -> Configure the system to have 6 vnodes with custom resource 'foostr'
+        set as the node_group_key
+        -> Set 'foostr' to 'A', 'B', and 'C' on the first three vnodes
+        -> Set 'foostr' for the next three vnodes to point to the first three
+        vnodes correspondingly
+        -> Verify that the last three vnodes are part of their respective
+        placement sets
+        """
+
+        # Delete any existing vnodes on the system
+        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
+
+        # Create 6 vnodes
+        attr = {'resources_available.ncpus': 1}
+        self.server.create_vnodes('vnode', attr, 6, mom=self.mom)
+
+        # Configure a system with 6 vnodes and 'foostr' as node_group_key
+        self.config_complex_for_grouping('foostr')
+
+        # Set 'foostr' to 'A', 'B' and 'C' respectively for the first
+        # three vnodes
+        attr = {'resources_available.foostr': 'A'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[0]')
+        attr = {'resources_available.foostr': 'B'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[1]')
+        attr = {'resources_available.foostr': 'C'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[2]')
+
+        # Set 'foostr' for last three vnodes as indirect resource to
+        # the first three vnodes correcpondingly
+        attr = {'resources_available.foostr': '@vnode[0]'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[3]')
+        attr = {'resources_available.foostr': '@vnode[1]'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[4]')
+        attr = {'resources_available.foostr': '@vnode[2]'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, 'vnode[5]')
+
+        # Verify that the last three vnodes are part of their respective
+        # placement sets
+        # Submit 3 jobs requesting placement sets 'A', 'B' and 'C', and vnodes
+        # vnode[3], vnode[4] and vnode[5] respectively
+        attr1 = {'Resource_List.select': '1:foostr=A:vnode=vnode[3]'}
+        attr2 = {'Resource_List.select': '1:foostr=B:vnode=vnode[4]'}
+        attr3 = {'Resource_List.select': '1:foostr=C:vnode=vnode[5]'}
+        j = [
+            self.submit_job(attr1),
+            self.submit_job(attr2),
+            self.submit_job(attr3)]
+
+        # Verify that the jobs are running on correct vnodes
+        for i in range(3):
+            self.server.expect(JOB, {'job_state': 'R'}, id=j[i][0])
+            self.server.status(JOB, 'exec_vnode', j[i][0])
+            self.assertEqual(
+                j[i][1].get_vnodes()[0], 'vnode[' + str(i + 3) + ']')

--- a/test/tests/functional/pbs_schedule_indirect_resources.py
+++ b/test/tests/functional/pbs_schedule_indirect_resources.py
@@ -38,7 +38,7 @@
 from tests.functional import *
 
 
-class TestSchedulingIndirectResources(TestFunctional):
+class TestIndirectResources(TestFunctional):
     """
     Test Scheduler resolve indirect resources correctly
     """
@@ -108,16 +108,13 @@ class TestSchedulingIndirectResources(TestFunctional):
         # Submit 3 jobs requesting 2 vnodes and check they ran on the nodes
         # within same group
         attr = {'Resource_List.select': '2:ncpus=1'}
-        j = [
-            self.submit_job(attr),
-            self.submit_job(attr),
-            self.submit_job(attr)]
 
         # since there are 6 vnodes and the test grouped them on foostr
         # resource, we now have groups in pair of vnode 0+3, 1+4, 2+5
         # check that the jobs are running on correct vnode groups.
         for i in range(3):
-            self.server.expect(JOB, {'job_state': 'R'}, id=j[i][0])
-            self.server.status(JOB, 'exec_vnode', j[i][0])
-            vn = j[i][1].get_vnodes()
+            jid, j = self.submit_job(attr)
+            self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+            self.server.status(JOB, 'exec_vnode', jid)
+            vn = j.get_vnodes()
             self.assertEqual(int(vn[0][6])+3, int(vn[1][6]))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
scheduler crashes while creating node partition when the node resource it is looking at is an indirect resource.

#### Describe Your Change
Since in case of indirect resources, we do not set value of the resource on the resource structure. Scheduler should instead be using the resource structure of the node on which this indirect resource is dependent on.

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
[test_out.txt](https://github.com/PBSPro/pbspro/files/3283641/test_out.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
