### PR TITLE
Use UUID in CUDA_VISIBLE_DEVICES

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -779,7 +779,7 @@ class HookUtils(object):
                     if key.startswith('mic'):
                         mics.append(key[3:])
                     elif key.startswith('nvidia'):
-                        gpus.append(key[6:])
+                        gpus.append(node.devices['gpu'][key]['uuid'])
                 if mics:
                     env_list.append('OFFLOAD_DEVICES=%s' %
                                     string.join(mics, ','))
@@ -788,6 +788,7 @@ class HookUtils(object):
                     # This will cause it to fail.
                     env_list.append('CUDA_VISIBLE_DEVICES=%s' %
                                     string.join(gpus, ','))
+                    env_list.append('CUDA_DEVICE_ORDER=PCI_BUS_ID')
             pbs.logmsg(pbs.EVENT_DEBUG4, 'ENV_LIST: %s' % env_list)
             cgroup.write_job_env_file(event.job.id, env_list)
         # Add jobid to cgroup_jobs file to tell periodic handler that this
@@ -844,6 +845,7 @@ class HookUtils(object):
         Handler for execjob_launch events.
         """
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Method called' % caller_name())
+        node = NodeUtils(cgroup.cfg)
         # delete this jobid from cgroup_jobs in case hook events before me
         # failed to do that
         cgroup.remove_jobid_from_cgroup_jobs(event.job.id)
@@ -856,7 +858,7 @@ class HookUtils(object):
             pbs.logmsg(pbs.EVENT_DEBUG4,
                        'assigned_resources: %s' %
                        (cgroup.assigned_resources))
-            cgroup.setup_job_devices_env()
+            cgroup.setup_job_devices_env(node.devices['gpu'])
         return True
 
     def _exechost_periodic_handler(self, event, cgroup, jobutil):
@@ -997,7 +999,7 @@ class HookUtils(object):
                     if key.startswith('mic'):
                         mics.append(key[3:])
                     elif key.startswith('nvidia'):
-                        gpus.append(key[6:])
+                        gpus.append(node.devices['gpu'][key]['uuid'])
                 if mics:
                     env_list.append('OFFLOAD_DEVICES=%s' %
                                     string.join(mics, ','))
@@ -1006,6 +1008,7 @@ class HookUtils(object):
                     # This will cause it to fail.
                     env_list.append('CUDA_VISIBLE_DEVICES=%s' %
                                     string.join(gpus, ','))
+                    env_list.append('CUDA_DEVICE_ORDER=PCI_BUS_ID')
             pbs.logmsg(pbs.EVENT_DEBUG4, 'ENV_LIST: %s' % env_list)
             cgroup.write_job_env_file(event.job.id, env_list)
         return True
@@ -1396,7 +1399,7 @@ class NodeUtils(object):
                 for inst in devices[dclass]:
                     for gpuid in gpus:
                         bus_id = devices[dclass][inst]['bus_id'].lower()
-                        if bus_id == gpus[gpuid]:
+                        if bus_id == gpus[gpuid]['pci_bus_id']:
                             devices['gpu'][gpuid] = devices[dclass][inst]
                             # For NVIDIA devices, sysfs doesn't contain a dev
                             # file, so we must get the major, minor and device
@@ -1414,6 +1417,8 @@ class NodeUtils(object):
                                 devices[dclass][inst]['type'] = \
                                     devinfo['type']
                                 devices[dclass][inst]['device'] = path
+                                devices[dclass][inst]['uuid'] = \
+                                    gpus[gpuid]['uuid']
         if gpus and not devices['gpu']:
             pbs.logmsg(pbs.EVENT_SYSTEM, '%s: GPUs discovered but could not '
                        'be successfully mapped to devices.' % (caller_name()))
@@ -1463,7 +1468,10 @@ class NodeUtils(object):
                     if len(domain) != 4:
                         raise ValueError('GPU ID not recognized: ' + bus_id)
                     name = 'nvidia%s' % child.find('minor_number').text
-                    gpus[name] = (domain + ':' + instance).lower()
+                    gpus[name] = {
+                        'pci_bus_id': (domain + ':' + instance).lower(),
+                        'uuid': child.find('uuid').text
+                    }
         except Exception as exc:
             pbs.logmsg(pbs.EVENT_DEBUG, 'Unexpected error: %s' % exc)
         pbs.logmsg(pbs.EVENT_DEBUG4, 'GPUs: %s' % gpus)
@@ -2945,7 +2953,7 @@ class CgroupUtils(object):
             except Exception:
                 raise
 
-    def setup_job_devices_env(self):
+    def setup_job_devices_env(self, gpus):
         """
         Setup the job environment for the devices assigned to the job for an
         execjob_launch hook
@@ -2964,7 +2972,7 @@ class CgroupUtils(object):
                 if name.startswith('mic'):
                     offload_devices.append(name[3:])
                 elif name.startswith('nvidia'):
-                    cuda_visible_devices.append(name[6:])
+                    cuda_visible_devices.append(gpus[name]['uuid'])
             if offload_devices:
                 value = string.join(offload_devices, '\\,')
                 pbs.event().env['OFFLOAD_DEVICES'] = '%s' % value
@@ -2973,6 +2981,7 @@ class CgroupUtils(object):
             if cuda_visible_devices:
                 value = string.join(cuda_visible_devices, '\\,')
                 pbs.event().env['CUDA_VISIBLE_DEVICES'] = '%s' % value
+                pbs.event().env['CUDA_DEVICE_ORDER'] = 'PCI_BUS_ID'
                 pbs.logmsg(pbs.EVENT_DEBUG4,
                            'cuda_visible_devices: %s' % cuda_visible_devices)
             pbs.logmsg(pbs.EVENT_DEBUG4,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The numbers used in `CUDA_VISIBLE_DEVICES` (`0, 1, 2 ...`) are not stable, 

#### Describe Your Change
1. Use GPU UUID instead
2. Set `CUDA_DEVICE_ORDER` to `PCI_BUS_ID`

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[cuda_visible_devices_uuid.txt](https://github.com/PBSPro/pbspro/files/3288314/cuda_visible_devices_uuid.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
