### PR TITLE
Update PTL FW to execute test apart from tests dir

### DIFF
--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -437,7 +437,7 @@ if __name__ == '__main__':
         loader = PTLTestLoader()
         testinfo = PTLTestInfo()
         loader.set_data(testgroup, testsuites, excludes, True,
-                        need_info=True)
+                        testfiles)
         testinfo.set_data(testsuites, list_test,
                           showinfo, verbose, gen_ts_tree)
         plugins = (loader, testinfo)
@@ -453,7 +453,7 @@ if __name__ == '__main__':
         runner = PTLTestRunner()
         db = PTLTestDb()
         data = PTLTestData()
-        loader.set_data(testgroup, testsuites, excludes, follow)
+        loader.set_data(testgroup, testsuites, excludes, follow, testfiles)
         testtags.set_data(tags, eval_tags)
         runner.set_data(paramfile, testparam, lcov_bin, lcov_data, lcov_out,
                         genhtml_bin, lcov_nosrc, lcov_baseurl,

--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -434,10 +434,13 @@ if __name__ == '__main__':
         follow = True
 
     if only_info:
+        loader = PTLTestLoader()
         testinfo = PTLTestInfo()
+        loader.set_data(testgroup, testsuites, excludes, True,
+                        need_info=True)
         testinfo.set_data(testsuites, list_test,
                           showinfo, verbose, gen_ts_tree)
-        plugins = (testinfo,)
+        plugins = (loader, testinfo)
     elif (tags_info or list_tags):
         loader = PTLTestLoader()
         testtags = PTLTestTags()

--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -433,8 +433,9 @@ if __name__ == '__main__':
         testsuites = 'PBSTestSuite'
         follow = True
 
+    loader = PTLTestLoader()
+
     if only_info:
-        loader = PTLTestLoader()
         testinfo = PTLTestInfo()
         loader.set_data(testgroup, testsuites, excludes, True,
                         testfiles)
@@ -442,13 +443,11 @@ if __name__ == '__main__':
                           showinfo, verbose, gen_ts_tree)
         plugins = (loader, testinfo)
     elif (tags_info or list_tags):
-        loader = PTLTestLoader()
         testtags = PTLTestTags()
         loader.set_data(testgroup, testsuites, excludes, True)
         testtags.set_data(tags, eval_tags, tags_info, list_tags, verbose)
         plugins = (loader, testtags)
     else:
-        loader = PTLTestLoader()
         testtags = PTLTestTags()
         runner = PTLTestRunner()
         db = PTLTestDb()

--- a/test/fw/ptl/utils/plugins/ptl_test_info.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_info.py
@@ -77,7 +77,7 @@ class PTLTestInfo(Plugin):
     Load test cases from given parameter
     """
     name = 'PTLTestInfo'
-    score = sys.maxint - 1
+    score = sys.maxint - 2
     logger = logging.getLogger(__name__)
 
     def __init__(self):
@@ -128,26 +128,9 @@ class PTLTestInfo(Plugin):
         """
         Is the class wanted?
         """
-        if not issubclass(cls, PBSTestSuite):
-            return False
-        if cls.__name__ == 'PBSTestSuite':
-            return False
         self._tree.setdefault(cls.__name__, cls)
         if len(cls.__bases__) > 0:
             self.wantClass(cls.__bases__[0])
-        return False
-
-    def wantFunction(self, function):
-        """
-        Is the function wanted?
-        """
-        return False
-
-    def wantMethod(self, method):
-        """
-        Is the method wanted?
-        """
-        return False
 
     def _get_hierarchy(self, cls, level=0):
         delim = '    ' * level

--- a/test/fw/ptl/utils/plugins/ptl_test_loader.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_loader.py
@@ -208,7 +208,7 @@ class PTLTestLoader(Plugin):
                     tests_dir += [ptl_test_dir]
                 rv = old_loadTestsFromNames(tests_dir, module)
             else:
-                rv = old_loadTestsFromNames(names, module)
+                rv = old_loadTestsFromNames(tests_dir, module)
             self.check_unknown()
             return rv
         loader.loadTestsFromNames = check_loadTestsFromNames

--- a/test/fw/ptl/utils/plugins/ptl_test_loader.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_loader.py
@@ -202,9 +202,8 @@ class PTLTestLoader(Plugin):
                 ptl_test_dir = os.path.join(ptl_test_dir.split('ptl')[0],
                                             "ptl", "tests")
                 user_test_dir = os.environ.get("PTL_TESTS_DIR", None)
-                if user_test_dir is not None:
-                    if os.path.isdir(user_test_dir):
-                        tests_dir += [user_test_dir]
+                if user_test_dir and os.path.isdir(user_test_dir):
+                    tests_dir += [user_test_dir]
                 if os.path.isdir(ptl_test_dir):
                     tests_dir += [ptl_test_dir]
                 rv = old_loadTestsFromNames(tests_dir, module)

--- a/test/fw/ptl/utils/plugins/ptl_test_loader.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_loader.py
@@ -197,9 +197,9 @@ class PTLTestLoader(Plugin):
         def check_loadTestsFromNames(names, module=None):
             tests_dir = names
             if not self.testfiles:
-                ptl_test_dir = sys.argv[0]
-                ptl_test_dir = ptl_test_dir.replace('bin/pbs_benchpress',
-                                                    'tests')
+                ptl_test_dir = __file__
+                ptl_test_dir = os.path.join(ptl_test_dir.split('ptl')[0],
+                                            "ptl", "tests")
                 user_test_dir = os.environ.get("PTL_TESTS_DIR", None)
                 if user_test_dir is not None:
                     tests_dir += [user_test_dir]

--- a/test/fw/ptl/utils/plugins/ptl_test_loader.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_loader.py
@@ -206,9 +206,7 @@ class PTLTestLoader(Plugin):
                     tests_dir += [user_test_dir]
                 if os.path.isdir(ptl_test_dir):
                     tests_dir += [ptl_test_dir]
-                rv = old_loadTestsFromNames(tests_dir, module)
-            else:
-                rv = old_loadTestsFromNames(tests_dir, module)
+            rv = old_loadTestsFromNames(tests_dir, module)
             self.check_unknown()
             return rv
         loader.loadTestsFromNames = check_loadTestsFromNames

--- a/test/fw/ptl/utils/plugins/ptl_test_loader.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_loader.py
@@ -197,8 +197,7 @@ class PTLTestLoader(Plugin):
         def check_loadTestsFromNames(names, module=None):
             tests_dir = names
             if not self.testfiles:
-                self._du = DshUtils()
-                ptl_test_dir = self._du.which(exe='pbs_benchpress')
+                ptl_test_dir = sys.argv[0]
                 ptl_test_dir = ptl_test_dir.replace('bin/pbs_benchpress',
                                                     'tests')
                 user_test_dir = os.environ.get("PTL_TESTS_DIR", None)

--- a/test/fw/ptl/utils/plugins/ptl_test_loader.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_loader.py
@@ -83,6 +83,7 @@ class PTLTestLoader(Plugin):
         :param testgroup: Test group
         :param suites: Test suites to load
         :param excludes: Tests to exclude while running
+        :param testfiles: Flag to check if test is run by filename
         """
         if os.access(str(testgroup), os.R_OK):
             f = open(testgroup, 'r')
@@ -202,7 +203,8 @@ class PTLTestLoader(Plugin):
                                             "ptl", "tests")
                 user_test_dir = os.environ.get("PTL_TESTS_DIR", None)
                 if user_test_dir is not None:
-                    tests_dir += [user_test_dir]
+                    if os.path.isdir(user_test_dir):
+                        tests_dir += [user_test_dir]
                 if os.path.isdir(ptl_test_dir):
                     tests_dir += [ptl_test_dir]
                 rv = old_loadTestsFromNames(tests_dir, module)

--- a/test/fw/ptl/utils/plugins/ptl_test_loader.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_loader.py
@@ -211,7 +211,6 @@ class PTLTestLoader(Plugin):
                 rv = old_loadTestsFromNames(names, module)
             self.check_unknown()
             return rv
-        
         loader.loadTestsFromNames = check_loadTestsFromNames
         return loader
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Currently in PTL, to run a test case using "pbs_benchpress -t" option, user has to go default test directory and then run the test case. If user is in non test directory then PTL used to throw an error saying " Unknown testsuite/Unknown testcase"


#### Describe Your Change
PTL will now search tests in current directory first, if it doesn't find test in current directory then it will search in PTL installed tests directory. If it doesn't find in both of the paths then it will search in environment variable "PTLTESTS" where user can explictly mention the path to tests directory.

#### Logs of test execution
[smoktest_results.txt](https://github.com/PBSPro/pbspro/files/3290142/smoktest_results.txt)
