### PR TITLE
Scheduler marks job equiv class not run on preemption

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2895,11 +2895,13 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 					job->job->is_susp_sched = 1;
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,
 						job->name, "Job preempted by suspension");
+					job->can_not_run = 1;
 				} else if (preempt_jobs_reply[i].order[0] == 'C') {
 					job->job->is_checkpointed = 1;
 					update_universe_on_end(policy, job, "Q", NO_FLAGS);
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,
 						job->name, "Job preempted by checkpointing");
+					job->can_not_run = 1;
 				} else if (preempt_jobs_reply[i].order[0] == 'Q') {
 					update_universe_on_end(policy, job, "Q", NO_FLAGS);
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -2032,7 +2032,7 @@ else:
         # make sure that the second job ran in the same cycle as the high
         # priority job
         c = self.scheduler.cycles(lastN=3)
-        for _, sched_cycle in enumerate(c):
+        for sched_cycle in c:
             if jidh.split('.')[0] in sched_cycle.sched_job_run:
                 break
         self.assertIn(jid2.split('.')[0], sched_cycle.sched_job_run)

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -1974,7 +1974,16 @@ else:
 
     def change_res(self, name, total, node_num, attribs):
         """
-        Change the value of memory on one of the node
+        Callback to change the value of memory on one of the node
+
+        :param name: Name of the vnode which is being created
+        :type name: str
+        :param total: Total number of vnodes being created
+        :type total: int
+        :param node_num: Index of the node for which callback is being called
+        :type node_num: int
+        :param attribs: attributes of the node being created
+        :type attribs: dict
         """
         if node_num % 2 != 0:
             attribs['resource_available.mem'] = '16gb'
@@ -1984,7 +1993,7 @@ else:
 
     def test_equiv_class_not_marked_on_suspend(self):
         """
-        Test that is a job is suspended then scheduler does not mark its
+        Test that if a job is suspended then scheduler does not mark its
         equivalence class as can_not_run within the same cycle when it gets
         suspended.
         """

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -1971,3 +1971,59 @@ else:
         # one for no foores
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
+
+    def change_res(self, name, total, node_num, attribs):
+        """
+        Change the value of memory on one of the node
+        """
+        if node_num % 2 != 0:
+            attribs['resource_available.mem'] = '16gb'
+        else:
+            attribs['resource_available.mem'] = '4gb'
+        return attribs
+
+    def test_equiv_class_not_marked_on_suspend(self):
+        """
+        Test that is a job is suspended then scheduler does not mark its
+        equivalence class as can_not_run within the same cycle when it gets
+        suspended.
+        """
+        a = {'resources_available.ncpus': 2}
+        self.server.create_vnodes('vnode', a, 2, self.mom,
+                                  attrfunc=self.change_res)
+
+        # Create an express queue
+        a = {'queue_type': 'e', 'started': 't',
+             'enabled': 't', 'Priority': 200}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq2')
+        # Set node sort key so that higher memory node comes up first
+        a = {'node_sort_key': '"mem HIGH " ALL'}
+        self.scheduler.set_sched_config(a)
+
+        a = {'Resource_List.select': '1:ncpus=1:mem=4gb'}
+        (jid1, ) = self.submit_jobs(1, a)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+
+        # Turn off scheduling
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+
+        # submit another normal job
+        (jid2, ) = self.submit_jobs(1, a)
+
+        # submit a high priority job
+        a = {'queue': 'wq2', 'Resource_List.select': '1:ncpus=2:mem=14gb',
+             'Resource_List.place': 'excl'}
+        (jidh, ) = self.submit_jobs(1, a)
+
+        # Turn on scheduling
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jidh)
+
+        # make sure that the second job ran in the same cycle as the high
+        # priority job
+        c = self.scheduler.cycles(lastN=3)
+        for i in range(len(c)):
+            if jidh.split('.')[0] in c[i].sched_job_run.keys():
+                break
+        self.assertIn(jid2.split('.')[0], c[i].sched_job_run.keys())

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -2023,7 +2023,7 @@ else:
         # make sure that the second job ran in the same cycle as the high
         # priority job
         c = self.scheduler.cycles(lastN=3)
-        for i, sched_cycle in enumerate(c):
+        for _, sched_cycle in enumerate(c):
             if jidh.split('.')[0] in sched_cycle.sched_job_run:
                 break
         self.assertIn(jid2.split('.')[0], sched_cycle.sched_job_run)

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -1993,11 +1993,11 @@ else:
                                   attrfunc=self.change_res)
 
         # Create an express queue
-        a = {'queue_type': 'e', 'started': 't',
-             'enabled': 't', 'Priority': 200}
+        a = {'queue_type': 'execution', 'started': 'true',
+             'enabled': 'true', 'Priority': 200}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq2')
         # Set node sort key so that higher memory node comes up first
-        a = {'node_sort_key': '"mem HIGH " ALL'}
+        a = {'node_sort_key': '"mem HIGH" ALL'}
         self.scheduler.set_sched_config(a)
 
         a = {'Resource_List.select': '1:ncpus=1:mem=4gb'}
@@ -2023,7 +2023,7 @@ else:
         # make sure that the second job ran in the same cycle as the high
         # priority job
         c = self.scheduler.cycles(lastN=3)
-        for i in range(len(c)):
-            if jidh.split('.')[0] in c[i].sched_job_run.keys():
+        for i, sched_cycle in enumerate(c):
+            if jidh.split('.')[0] in sched_cycle.sched_job_run:
                 break
-        self.assertIn(jid2.split('.')[0], c[i].sched_job_run.keys())
+        self.assertIn(jid2.split('.')[0], sched_cycle.sched_job_run)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When scheduler preempts a job by suspension or checkpoint, it tries to run the preempted job in the same cycle and then it finds that the job can not run because of high priority job run on its resources.
This makes scheduler mark the preempted job's equivalence class as "not run". Doing this affects other jobs in the same class from running in the same cycle.

#### Describe Your Change
Mark the preempted job (suspended or checkpointed) as "can not run" because these jobs cannot run within the same cycle. Doing this will avoid scheduler from trying to run them in the cycle they were preempted and also not mark their equivalence class is "not run"

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_bug.txt](https://github.com/PBSPro/pbspro/files/3292420/test_bug.txt)
[test_fix.txt](https://github.com/PBSPro/pbspro/files/3292421/test_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
