### PR TITLE
Fix for schema upgrade with dbuser 'pbs'

### DIFF
--- a/src/cmds/scripts/pbs_schema_upgrade
+++ b/src/cmds/scripts/pbs_schema_upgrade
@@ -161,9 +161,9 @@ upgrade_pbs_schema_from_v1_3_0() {
 
 	${PGSQL_DIR}/bin/psql -p ${PBS_DATA_SERVICE_PORT} -d pbs_datastore -U ${PBS_DATA_SERVICE_USER} <<-EOF > /dev/null
 		
-		CREATE EXTENSION hstore;
+		CREATE EXTENSION hstore SCHEMA pbs;
 		
-		ALTER TABLE pbs.job ADD attributes public.hstore DEFAULT ''::public.hstore;
+		ALTER TABLE pbs.job ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
 		UPDATE pbs.job SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
@@ -172,7 +172,7 @@ upgrade_pbs_schema_from_v1_3_0() {
 		UPDATE pbs.job SET attributes='' WHERE attributes IS NULL;
 		ALTER TABLE pbs.job ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.node ADD attributes public.hstore DEFAULT ''::public.hstore;
+		ALTER TABLE pbs.node ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
 		UPDATE pbs.node SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
@@ -181,7 +181,7 @@ upgrade_pbs_schema_from_v1_3_0() {
 		UPDATE pbs.node SET attributes='' WHERE attributes IS NULL;
 		ALTER TABLE pbs.node ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.queue ADD attributes public.hstore DEFAULT ''::public.hstore;
+		ALTER TABLE pbs.queue ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
 		UPDATE pbs.queue SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
@@ -190,7 +190,7 @@ upgrade_pbs_schema_from_v1_3_0() {
 		UPDATE pbs.queue SET attributes='' WHERE attributes IS NULL;
 		ALTER TABLE pbs.queue ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.resv ADD attributes public.hstore DEFAULT ''::public.hstore;
+		ALTER TABLE pbs.resv ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
 		UPDATE pbs.resv SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
@@ -199,7 +199,7 @@ upgrade_pbs_schema_from_v1_3_0() {
 		UPDATE pbs.resv SET attributes='' WHERE attributes IS NULL;
 		ALTER TABLE pbs.resv ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.scheduler ADD attributes public.hstore DEFAULT ''::public.hstore;
+		ALTER TABLE pbs.scheduler ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
 		UPDATE pbs.scheduler SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
@@ -208,7 +208,7 @@ upgrade_pbs_schema_from_v1_3_0() {
 		UPDATE pbs.scheduler SET attributes='' WHERE attributes IS NULL;
 		ALTER TABLE pbs.scheduler ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.server ADD attributes public.hstore DEFAULT ''::public.hstore;
+		ALTER TABLE pbs.server ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
 		UPDATE pbs.server SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Overlay upgrade fails due to a mismatch in "hstore" extension's schema name. "hstore" extension was being created without any specified schema value. By default, it was chosen "public"/"pbs". 

#### Describe Your Change
 Modified the extension creation and its usage under "pbs" schema.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
NA

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[After_fix.txt](https://github.com/PBSPro/pbspro/files/3302596/After_fix.txt)
[Before_fix.txt](https://github.com/PBSPro/pbspro/files/3302597/Before_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
