### PR TITLE
single-node non-interactive job cannot start a task using pbsdsh or…

### DIFF
--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -906,7 +906,8 @@ impersonate_user(uid_t uid, gid_t gid)
 	if (pwd == NULL)
 		return -1;
 
-	if (initgroups(pwd->pw_name, gid) == -1) {
+	if ((geteuid() != uid) &&
+		(initgroups(pwd->pw_name, gid) == -1)) {
 		return -1;
 	}
 

--- a/test/tests/functional/pbs_job_task.py
+++ b/test/tests/functional/pbs_job_task.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestJobTask(TestFunctional):
+    """
+    This test suite validates the job task using pbsdsh or pbs_tmrsh
+    """
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'job_history_enable': 'true'})
+
+    def test_singlenode_pbsdsh(self):
+        """
+        This test case validates that task started by pbsdsh runs
+        properly within a single-noded job.
+        """
+
+        job = Job(TEST_USER)
+        script = ['pbsdsh echo "OK"']
+        job.create_script(body=script)
+        jid = self.server.submit(job)
+
+        self.server.expect(JOB, {'job_state': 'F'}, id=jid, extend='x')
+
+        job_status = self.server.status(JOB, id=jid, extend='x')
+        if job_status:
+            job_output_file = job_status[0]['Output_Path'].split(':')[1]
+
+        with open(job_output_file, 'r') as fd:
+            job_out = fd.read().strip()
+            self.logger.info("job_out=%s" % (job_out,))
+
+        self.assertEquals(job_out, "OK")
+
+    def test_singlenode_pbs_tmrsh(self):
+        """
+        This test case validates that task started by pbs_tmrsh runs
+        properly within a single-noded job.
+        """
+
+        job = Job(TEST_USER)
+        script = ['pbs_tmrsh $(hostname -f) echo "OK"']
+        job.create_script(body=script)
+        jid = self.server.submit(job)
+
+        self.server.expect(JOB, {'job_state': 'F'}, id=jid, extend='x')
+
+        job_status = self.server.status(JOB, id=jid, extend='x')
+        if job_status:
+            job_output_file = job_status[0]['Output_Path'].split(':')[1]
+
+        with open(job_output_file, 'r') as fd:
+            job_out = fd.read().strip()
+            self.logger.info("job_out=%s" % (job_out,))
+
+        self.assertEquals(job_out, "OK")


### PR DESCRIPTION
… pbs_tmrsh

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This bug was introduced in #1127 and it is caused by calling initgroups() as the user (not superuser). It fails. The function becomeuser() is called within set_credentils() and set_credentils() is called before open_std_out_err().  open_std_out_err() leads to calling impersonate_user() and the initgroups() subsequently.

It can lead to troubles with MPI too.

Steps to reproduce:
`$ echo 'pbs_tmrsh $(hostname -f) hostname' | qsub -l select=vnode=torque4
28739.torque4.ics.muni.cz`
It causes following error in mom log:
`06/19/2019 13:28:28;0001;pbs_mom;Job;28739.torque4.ics.muni.cz;Unable to open standard output/error`
`06/19/2019 13:28:28;0001;pbs_mom;Job;28739.torque4.ics.muni.cz;task not started, Retry hostname -3`
and the output is empty:
`-rw-------  1 vchlum meta            0 čen 19 13:28 STDIN.o28739`

#### Describe Your Change
Call initgroups() only if it is not called as the user.

#### Link to Design Doc
None

#### Attach Test and Valgrind Logs/Output
[ptl_initgroups_as_user.txt](https://github.com/PBSPro/pbspro/files/3305780/ptl_initgroups_as_user.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
