### PR TITLE
Sched's run_update_resresv is perf bottleneck for large no. of jobs

### DIFF
--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -674,9 +674,8 @@ update_queue_on_run(queue_info *qinfo, resource_resv *resresv, char *job_state)
 
 		req = req->next;
 	}
-	free(qinfo->running_jobs);
-	qinfo->running_jobs = resource_resv_filter(qinfo->jobs, qinfo->sc.total,
-		check_run_job, NULL, 0);
+
+	qinfo->running_jobs = add_resresv_to_array(qinfo->running_jobs, resresv, NO_FLAGS);
 
 	if (qinfo->has_soft_limit || qinfo->has_hard_limit) {
 

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1765,10 +1765,8 @@ update_server_on_run(status *policy, server_info *sinfo,
 		}
 
 
-		/* a new job has been run, recreate running jobs array */
-		free(sinfo->running_jobs);
-		sinfo->running_jobs = resource_resv_filter(
-			sinfo->jobs, sinfo->sc.total, check_run_job, NULL, 0);
+		/* a new job has been run, update running jobs array */
+		sinfo->running_jobs = add_resresv_to_array(sinfo->running_jobs, resresv, NO_FLAGS);
 	}
 
 	if (sinfo->has_soft_limit || sinfo->has_hard_limit) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When there are a large number of jobs in the system (test used 1 million), scheduler's run_update_resresv() becomes a performance bottleneck and takes around 75+% of the total sched cycle time. This happens because the code calls check_run_job() to recreate the array of running jobs after every job is run.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Instead of calling check_run_job(), just call add_resresv_to_array() to add a job run to the array.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before:
<img width="944" alt="Screen Shot 2019-06-11 at 2 54 11 PM" src="https://user-images.githubusercontent.com/4574875/59777519-7679ec00-92d2-11e9-9b1a-3fa77c12bf35.png">

After:
<img width="980" alt="Screen Shot 2019-06-12 at 10 43 09 PM" src="https://user-images.githubusercontent.com/4574875/59777546-81cd1780-92d2-11e9-8755-3eed07108ea5.png">



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
