### PR TITLE
Fixed invalid read and double free in preemption code

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2882,7 +2882,7 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 			if (preempt_jobs_reply[i].order[0] == '0') {
 				done = 0;
 				fail_list[fail_count++] = job->rank;
-				schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO, job->name, "Job failed to be deleted");
+				schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO, job->name, "Job failed to be preempted");
 			}
 			else {
 				int update_accrue_type = 1;

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -2714,7 +2714,7 @@ discard_job(job *pjob, char *txt, int noack)
 	int	 rc;
 	int	 rver;
 
-	/* We're about to discard the job, reply to a preemption. 
+	/* We're about to discard the job, reply to a preemption.
 	 * This serves as a catch all just incase the code doesn't reply on its own.
 	 */
 

--- a/src/server/req_preemptjob.c
+++ b/src/server/req_preemptjob.c
@@ -389,11 +389,12 @@ reply_preempt_jobs_request(int code, int aux, struct job *pjob)
 				job_preempt_fail(preq, pjob->ji_qs.ji_jobid);
 				clear_preempt_vars = 1;
 			} else {
-				/* reply_preempt_jobs_request() is somewhat recursive.  It is possible for one call to issue the next
-				 * preempt request.  The next preempt request immediately fails and calls reply_preempt_jobs_request()
-				 * again before the first call ends.  There is a case when the last job in the preemption reply fails
-				 * in the recursive call.  This will reply to the scheduler's preq.  We don't want to pop back up here
-				 * and reply again, so we return.
+				/* reply_preempt_jobs_request() is somewhat recursive.  If a preemption method fails, one call will issue the next
+				 * preemptiom method request.  The next preemption method request immediately is rejected, it will call
+				 * reply_preempt_jobs_request() again before the first call ends.  A reject like this is considered a successful 
+				 * call to issue_Drequest().  If pjob->ji_pmt_preq has been NULLed, it means the last preemption method has failed.  
+				 * If this is the last job in the preemption list, the call to reply_preempt_job_request() will have replied to 
+				 * the scheduler.  In this case, we do not want to reply a second time.
 				 */
 				if (pjob->ji_pmt_preq == NULL)
 					return;

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -233,7 +233,7 @@ req_rerunjob(struct batch_request *preq)
 
 	if ((preq->rq_perm & (ATR_DFLAG_MGWR | ATR_DFLAG_OPWR)) == 0) {
 		if (parent->ji_pmt_preq != NULL)
-			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_DELETE, parent);
+			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_REQUEUE, parent);
 		req_reject(PBSE_PERM, 0, preq);
 		return;
 	}
@@ -277,7 +277,7 @@ req_rerunjob(struct batch_request *preq)
 
 		if (parent->ji_qs.ji_state != JOB_STATE_BEGUN) {
 			if (parent->ji_pmt_preq != NULL)
-				reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_DELETE, parent);
+				reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_REQUEUE, parent);
 			req_reject(PBSE_BADSTATE, 0, preq);
 			return;
 		}
@@ -434,7 +434,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 	if ((pjob->ji_wattr[(int)JOB_ATR_rerunable].at_val.at_long == 0) &&
 		(force == 0)) {
 		if (pjob->ji_pmt_preq != NULL)
-			reply_preempt_jobs_request(PBSE_NORERUN, PREEMPT_METHOD_DELETE, pjob);
+			reply_preempt_jobs_request(PBSE_NORERUN, PREEMPT_METHOD_REQUEUE, pjob);
 		req_reject(PBSE_NORERUN, 0, preq);
 		return;
 	}
@@ -443,24 +443,25 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 
 	if (pjob->ji_qs.ji_state != JOB_STATE_RUNNING) {
 		if (pjob->ji_pmt_preq != NULL)
-			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_DELETE, pjob);
+			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_REQUEUE, pjob);
 
 		req_reject(PBSE_BADSTATE, 0, preq);
 		return;
 	}
 	/* a node failure tolerant job could be waiting for healthy nodes
-         * and it would have a JOB_SUBSTATE_PRERUN substate.
-         */
+	 * and it would have a JOB_SUBSTATE_PRERUN substate.
+	 */
 	if ((pjob->ji_qs.ji_substate != JOB_SUBSTATE_RUNNING) &&
             (pjob->ji_qs.ji_substate != JOB_SUBSTATE_PRERUN) && (force == 0)) {
 		if (pjob->ji_pmt_preq != NULL)
-			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_DELETE, pjob);
+			reply_preempt_jobs_request(PBSE_BADSTATE, PREEMPT_METHOD_REQUEUE, pjob);
 		req_reject(PBSE_BADSTATE, 0, preq);
 		return;
 	}
 
 	/* Set the flag for post_rerun only when
-	 * force is set and request is from manager */
+	 * force is set and request is from manager 
+	 */
 	if (force == 1 && is_mgr == 1)
 		force_rerun = (void *)1;
 
@@ -492,7 +493,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 
 	if (rc != 0) {
 		if (pjob->ji_pmt_preq != NULL)
-			reply_preempt_jobs_request(rc, PREEMPT_METHOD_DELETE, pjob);
+			reply_preempt_jobs_request(rc, PREEMPT_METHOD_REQUEUE, pjob);
 		req_reject(rc, 0, preq);
 		return;
 	}

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -442,14 +442,12 @@ chk_job_request(char *jobid, struct batch_request *preq, int *rc, int *err)
 	} else {
 		histerr = svr_chk_histjob(pjob);
 		if (histerr && deletehist == 0) {
-			if (pjob->ji_pmt_preq != NULL)
-				reply_preempt_jobs_request(histerr, PREEMPT_METHOD_DELETE, pjob);
 			if (err != NULL)
 				*err = histerr;
 			req_reject(histerr, 0, preq);
 			return NULL;
 		}
-		if (deletehist ==1&& pjob->ji_qs.ji_state == JOB_STATE_MOVED &&
+		if (deletehist == 1&& pjob->ji_qs.ji_state == JOB_STATE_MOVED &&
 			pjob->ji_qs.ji_substate != JOB_SUBSTATE_FINISHED) {
 			job_purge(pjob);
 			req_reject(PBSE_UNKJOBID, 0, preq);

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -347,7 +347,8 @@ exit 1
 
     def test_preempt_retry(self):
         """
-        Test to make sure that preemption is retried if it fails.
+        Test that jobs can be successfully preempted after a previously failed
+        attempt at preemption. 
         """
         # in CLI mode Rerunnable requires a 'n' value.  It's different with API
         m = self.server.get_op_mode()
@@ -385,15 +386,10 @@ exit 3
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid3)
 
-        self.mom.log_match(jid2 + ";checkpoint failed:")
-        self.mom.log_match(jid1 + ";checkpoint failed:")
+        self.server.log_match(jid1 + ';Job failed to be preempted')
+        self.server.log_match(jid2 + ';Job failed to be preempted')
 
-        abort_script = """#!/bin/bash
-kill -9 $1
-exit 0
-"""
-        self.insert_checkpoint_script(abort_script)
-
+        # Allow jobs to be requeued.
         attrs = {'Rerunable': 'y'}
         self.server.alterjob(jid1, attrs)
         self.server.alterjob(jid2, attrs)

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -348,7 +348,7 @@ exit 1
     def test_preempt_retry(self):
         """
         Test that jobs can be successfully preempted after a previously failed
-        attempt at preemption. 
+        attempt at preemption.
         """
         # in CLI mode Rerunnable requires a 'n' value.  It's different with API
         m = self.server.get_op_mode()

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -77,10 +77,10 @@ exit 1
         """
         j1 = Job(TEST_USER)
         jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
         time.sleep(1)
         j2 = Job(TEST_USER)
         jid2 = self.server.submit(j2)
-        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
 
         j3 = Job(TEST_USER)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When there are multiple preemption methods (e.g. preempt_order: SCR), it is possible to reply to the scheduler's preemption preq twice.  The first reply frees it, and the second will touch freed memory and free it a second time.

How it happens:
The function reply_preempt_jobs_request() is minorly recursive.  If the function is called with a preemption failure, it will call issue_Drequest() with the next preemption method.  Since the request is local, we directly call the req_* function (e.g. req_signaljob()).  If the req_* function rejects our new request, we will call reply_preempt_jobs_request() a second time.

The problem happens when we are handling the last job in the preemption request.  reply_preempt_jobs_request() is called with the second to last preemption method, and will issue the last preemption method.  The last preemption method is rejected so reply_preempt_jobs_request() is called again.  Since we're out of preemption methods, the preemption fails.  We see we're done with all of the jobs so we reply to the scheduler's preq and return.  This pops us back up the original call to reply_preempt_jobs_request().  It gets no indication that the preemption has failed.  It also sees that the preemption has finished and replies to the scheduler's preq a second time.

Let me try and visualize this a little.  Let's say preempt_order is SCR.
1. post_hold() calls reply_preempt_jobs_request() when the checkpoint fails.
2. reply_preempt_jobs_request() will call issue_Drequest() 
3. issue_Drequest() calls req_rerunjob().
4. req_rerunjob() rejects the request.  It will call reply_preempt_jobs_request() again
5. reply_preempt_jobs_request() sees we're out of preemption methods so fails the preemption for this job
6. reply_preempt_jobs_request() sees we have just serviced the final job in the preemption, so it replies to the scheduler's preq and returns.
7. we return back up to reply_preempt_jobs_request() that was called in 1 above.
8. reply_preempt_jobs_request() notices the preemption is finished and replies a second time.

#### Describe Your Change
The fix is simple: when we we get to 7 above, we return from reply_preempt_jobs_request() instead of going down and replying to the scheduler a second time.

#### Attach Test and Valgrind Logs/Output
[valgrind-before.log](https://github.com/PBSPro/pbspro/files/3308310/valgrind-before.log)
[valgrind-after.log](https://github.com/PBSPro/pbspro/files/3308309/valgrind-after.log)
[preemption.log](https://github.com/PBSPro/pbspro/files/3312280/preemption.log)


Note that there is an invalid read in reply_preempt_jobs_request() in the before, and it is gone in the after report.