### PR TITLE
updates to test_passing_shell_function.Test_passing_environment_variable_via_qsub

### DIFF
--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -104,13 +104,13 @@ exit 0
         ret = self.du.run_cmd(self.server.hostname, cmd=fn)
         self.assertEqual(ret['rc'], 0, foo_msg)
         msg = 'BASH_FUNC_'
-        self.n = 'foo'
+        n = 'foo'
         for m in ret['out']:
             if m.find(msg) != -1:
-                self.n = m.split('=')[0]
-                continue
+                n = m.split('=')[0]
+                break
         # Adjustments in bash due to ShellShock malware fix in various OS
-        os.environ[self.n] = '() { if [ /bin/true ]; then\necho hello;\nfi\n}'
+        os.environ[n] = '() { if [ /bin/true ]; then\necho hello;\nfi\n}'
         script = ['#PBS -V']
         script += ['env | grep -A 3 foo\n']
         script += ['foo\n']
@@ -122,7 +122,7 @@ exit 0
         job_output = ""
         with open(job_outfile, 'r') as f:
             job_output = f.read().strip()
-        match = self.n + \
+        match = n + \
             '=() {  if [ /bin/true ]; then\n echo hello;\n fi\n}\nhello'
         self.assertEqual(job_output, match,
                          msg="Environment variable foo content does "

--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -89,7 +89,28 @@ class Test_passing_environment_variable_via_qsub(TestFunctional):
         Define a shell function with new line characters and check that
         the function is passed correctly
         """
-        os.environ['foo'] = '() { if [ /bin/true ]; then\necho hello;\nfi\n}'
+        # Check if ShellShock fix for exporting shell function in bash exists
+        # on this system and what "BASH_FUNC_" format to use
+        foo_scr = """#!/bin/bash
+foo() { a=B; echo $a; }
+export -f foo
+env | grep foo
+unset -f foo
+exit 0
+"""
+        fn = self.du.create_temp_file(body=foo_scr)
+        self.du.chmod(path=fn, mode=0755)
+        foo_msg = 'Failed to run foo_scr'
+        ret = self.du.run_cmd(self.server.hostname, cmd=fn)
+        self.assertEqual(ret['rc'], 0, foo_msg)
+        msg = 'BASH_FUNC_'
+        self.n = 'foo'
+        for m in ret['out']:
+            if m.find(msg) != -1:
+                self.n = m.split('=')[0]
+                continue
+        # Adjustments in bash due to ShellShock malware fix in various OS
+        os.environ[self.n] = '() { if [ /bin/true ]; then\necho hello;\nfi\n}'
         script = ['#PBS -V']
         script += ['env | grep -A 3 foo\n']
         script += ['foo\n']
@@ -101,7 +122,8 @@ class Test_passing_environment_variable_via_qsub(TestFunctional):
         job_output = ""
         with open(job_outfile, 'r') as f:
             job_output = f.read().strip()
-        match = 'foo=() {  if [ /bin/true ]; then\n echo hello;\n fi\n}\nhello'
+        match = self.n + \
+            '=() {  if [ /bin/true ]; then\n echo hello;\n fi\n}\nhello'
         self.assertEqual(job_output, match,
                          msg="Environment variable foo content does "
                          "not match original")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test_passing_shell_function.Test_passing_environment_variable_via_qsub is failing because of changes in bash when passing a shell function in the environment.


#### Describe Your Change
Changed the way the shell function is exported based on the ShellShock malware fix in various OS.
The expected job output was also changed accordingly.


#### Attach Test and Valgrind Logs/Output
[Test_passing_environment_variable_via_qsub_19.4_a01_after.txt](https://github.com/PBSPro/pbspro/files/3311106/Test_passing_environment_variable_via_qsub_19.4_a01_after.txt)
[Test_passing_environment_variable_via_qsub_19.4_a01_before.txt](https://github.com/PBSPro/pbspro/files/3311107/Test_passing_environment_variable_via_qsub_19.4_a01_before.txt)
[Test_passing_environment_variable_via_qsub_19.4_x37_after.txt](https://github.com/PBSPro/pbspro/files/3311108/Test_passing_environment_variable_via_qsub_19.4_x37_after.txt)
[Test_passing_environment_variable_via_qsub_19.4_x37_before.txt](https://github.com/PBSPro/pbspro/files/3311109/Test_passing_environment_variable_via_qsub_19.4_x37_before.txt)
[Test_passing_environment_variable_via_qsub_19.4_x90_after.txt](https://github.com/PBSPro/pbspro/files/3311110/Test_passing_environment_variable_via_qsub_19.4_x90_after.txt)
[Test_passing_environment_variable_via_qsub_19.4_x90_before.txt](https://github.com/PBSPro/pbspro/files/3311111/Test_passing_environment_variable_via_qsub_19.4_x90_before.txt)
[Test_passing_environment_variable_via_qsub_19.4_xarm-02_after.txt](https://github.com/PBSPro/pbspro/files/3311112/Test_passing_environment_variable_via_qsub_19.4_xarm-02_after.txt)
[Test_passing_environment_variable_via_qsub_19.4_xarm-02_before.txt](https://github.com/PBSPro/pbspro/files/3311113/Test_passing_environment_variable_via_qsub_19.4_xarm-02_before.txt)

[Test_passing_environment_variable_via_qsub_19.4_td-10_after.txt](https://github.com/PBSPro/pbspro/files/3340666/Test_passing_environment_variable_via_qsub_19.4_td-10_after.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
