### PR TITLE
Fixed invalid read in qrerun, qhold, qdel, and qsig

### DIFF
--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -355,7 +355,7 @@ req_deletejob(struct batch_request *preq)
 	int forcedel = 0;
 	int i;
 	int j;
-	char *jid;
+	char jid[PBS_MAXSVRJOBID + 1];
 	int jt; /* job type */
 	int offset;
 	char *pc;
@@ -370,7 +370,7 @@ req_deletejob(struct batch_request *preq)
 	int count = 0;
 	int err = PBSE_NONE;
 
-	jid = preq->rq_ind.rq_delete.rq_objname;
+	snprintf(jid, sizeof(jid), "%s", preq->rq_ind.rq_delete.rq_objname);
 
 	if (preq->rq_extend && strstr(preq->rq_extend, DELETEHISTORY))
 		delhist = 1;

--- a/src/server/req_holdjob.c
+++ b/src/server/req_holdjob.c
@@ -129,21 +129,24 @@ chk_hold_priv(long val, int perm)
 void
 req_holdjob(struct batch_request *preq)
 {
-	long		*hold_val;
-	int		 jt;		/* job type */
-	int		 newstate;
-	int		 newsub;
-	long		 old_hold;
-	job		*pjob;
-	char		*pset;
-	int		 rc;
-	char 		 date[32];
-	time_t 		 now;
+	long *hold_val;
+	int jt;		/* job type */
+	int newstate;
+	int newsub;
+	long old_hold;
+	job *pjob;
+	char *pset;
+	char jid[PBS_MAXSVRJOBID + 1];
+	int rc;
+	char date[32];
+	time_t now;
 	int err = PBSE_NONE;
 
-	pjob = chk_job_request(preq->rq_ind.rq_hold.rq_orig.rq_objname, preq, &jt, &err);
+	snprintf(jid, sizeof(jid), "%s", preq->rq_ind.rq_hold.rq_orig.rq_objname);
+
+	pjob = chk_job_request(jid, preq, &jt, &err);
 	if (pjob == NULL) {
-		pjob = find_job(preq->rq_ind.rq_hold.rq_orig.rq_objname);
+		pjob = find_job(jid);
 		if (pjob != NULL && pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(err, PREEMPT_METHOD_CHECKPOINT, pjob);
 		return;
@@ -153,7 +156,7 @@ req_holdjob(struct batch_request *preq)
 		 * We need to find the job again because chk_job_request() will return
 		 * the parent array if the job is a subjob.
 		 */
-		pjob = find_job(preq->rq_ind.rq_hold.rq_orig.rq_objname);
+		pjob = find_job(jid);
 		if (pjob != NULL && pjob->ji_pmt_preq != NULL)
 			reply_preempt_jobs_request(PBSE_IVALREQ, PREEMPT_METHOD_CHECKPOINT, pjob);
 		req_reject(PBSE_IVALREQ, 0, preq);

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -208,21 +208,21 @@ force_reque(job *pjob)
 void
 req_rerunjob(struct batch_request *preq)
 {
-	int		  anygood = 0;
-	int		  i;
-	int		  j;
-	char		 *jid;
-	int		  jt;		/* job type */
-	int		  offset;
-	char		 *pc;
-	job		 *pjob;
-	job		 *parent;
-	char		 *range;
-	char		 *vrange;
-	int		  x, y, z;
-	int 		  err = PBSE_NONE;
+	int anygood = 0;
+	int i;
+	int j;
+	char jid[PBS_MAXSVRJOBID + 1];
+	int jt;				/* job type */
+	int offset;
+	char *pc;
+	job *pjob;
+	job *parent;
+	char *range;
+	char *vrange;
+	int x, y, z;
+	int err = PBSE_NONE;
 
-	jid = preq->rq_ind.rq_signal.rq_jid;
+	snprintf(jid, sizeof(jid), "%s", preq->rq_ind.rq_signal.rq_jid);
 	parent = chk_job_request(jid, preq, &jt, &err);
 	if (parent == NULL) {
 		pjob = find_job(jid);

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -99,23 +99,23 @@ extern job  *chk_job_request(char *, struct batch_request *, int *, int *);
 void
 req_signaljob(struct batch_request *preq)
 {
-	int		  anygood = 0;
-	int		  i;
-	int		  j;
-	char		 *jid;
-	int		  jt;		/* job type */
-	int		  offset;
-	char		 *pc;
-	job		 *pjob;
-	job		 *parent;
-	char		 *range;
-	int		  suspend = 0;
-	int		  resume = 0;
-	char		 *vrange;
-	int		  x, y, z;
-	int 		 err = PBSE_NONE;
+	int anygood = 0;
+	int i;
+	int j;
+	char jid[PBS_MAXSVRJOBID + 1];
+	int jt; /* job type */
+	int offset;
+	char *pc;
+	job *pjob;
+	job *parent;
+	char *range;
+	int suspend = 0;
+	int resume = 0;
+	char *vrange;
+	int x, y, z;
+	int err = PBSE_NONE;
 
-	jid = preq->rq_ind.rq_signal.rq_jid;
+	snprintf(jid, sizeof(jid), "%s", preq->rq_ind.rq_signal.rq_jid);
 
 	parent = chk_job_request(jid, preq, &jt, &err);
 	if (parent == NULL) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The functions req_deletejob(), req_signaljob(), req_holdjob(), and req_rerunjob() call chk_job_request() to do some checking and return the pjob.  If the checks fail, chk_job_request() returns NULL.  The calling functions need the pjob in order to check and reply to the preemption request for the job.  If chk_job_request() returned NULL, the functions would call find_job() on the job id.  The job id is passed into these functions as part of the preq.  Since chk_job_request() replied to the preq, it was freed.  When find_job() was called, we were accessing freed memory.

#### Describe Your Change
Copy the job id into a local variable before calling chk_job_request()

#### Attach Test and Valgrind Logs/Output
[valgrind-before.log](https://github.com/PBSPro/pbspro/files/3316197/valgrind-before.log)
[valgrind-after.log](https://github.com/PBSPro/pbspro/files/3316196/valgrind-after.log)

Look for the four calling functions in the before log and for them not being there in the after log.  There is an invalid read from python, but that's because I use a python compiled for valgrind.
