### PR TITLE
Fixed memory leak when a job is preempted multiple times

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2774,10 +2774,6 @@ struct preempt_ordering *schd_get_preempt_order(resource_resv *resresv)
 	if (get_job_req_used_time(resresv, &req, &used) != 0)
 		return NULL;
 
-	if (req == -1 || used == -1)
-		schdlog(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO, resresv->name,
-				"No walltime/cput to determine percent of time left - will use first preempt order");
-
 	po = get_preemption_order(conf.preempt_order, req, used);
 
 	return po;
@@ -3247,7 +3243,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 
 		po = schd_get_preempt_order(pjob);
 		if (po != NULL) {
-			if (po->order[0] == PREEMPT_METHOD_SUSPEND && pjob->job->can_suspend) {
+			if (policy->rel_on_susp != NULL && po->order[0] == PREEMPT_METHOD_SUSPEND && pjob->job->can_suspend) {
 				pjob->job->resreleased = create_res_released_array(npolicy, pjob);
 				pjob->job->resreq_rel = create_resreq_rel_list(npolicy, pjob);
 			}
@@ -3255,7 +3251,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 
 		update_universe_on_end(npolicy, pjob,  "S", NO_ALLPART);
 		rjobs_count--;
-		if ( nsinfo->calendar != NULL ) {
+		if (nsinfo->calendar != NULL) {
 			te = find_timed_event(nsinfo->calendar->events, 0, pjob->name, TIMED_END_EVENT, 0);
 			if (te != NULL) {
 				if (delete_event(nsinfo, te, DE_NO_FLAGS) == 0)

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2884,8 +2884,10 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 				int update_accrue_type = 1;
 				preempted_list[preempted_count++] = job->rank;
 				if (preempt_jobs_reply[i].order[0] == 'S') {
-					/* Set resources_released and execselect on the job */
-					create_res_released(policy, job);
+					if (policy->rel_on_susp != NULL) {
+						/* Set resources_released and execselect on the job */
+						create_res_released(policy, job);
+					}
 
 					update_universe_on_end(policy, job, "S", NO_FLAGS);
 					job->job->is_susp_sched = 1;

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2888,7 +2888,6 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 						/* Set resources_released and execselect on the job */
 						create_res_released(policy, job);
 					}
-
 					update_universe_on_end(policy, job, "S", NO_FLAGS);
 					job->job->is_susp_sched = 1;
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -1202,6 +1202,14 @@ update_resresv_on_run(resource_resv *resresv, nspec **nspec_arr)
 		if (resresv->job->is_suspended) {
 			for (ns_size = 0; nspec_arr[ns_size] != NULL; ns_size++)
 				nspec_arr[ns_size]->ninfo->num_susp_jobs--;
+			if (resresv->job->resreleased != NULL) {
+				free_nspecs(resresv->job->resreleased);
+				resresv->job->resreleased = NULL;
+			}
+			if (resresv->job->resreq_rel != NULL) {
+				free_resource_req_list(resresv->job->resreq_rel);
+				resresv->job->resreq_rel = NULL;
+			}
 		}
 
 		set_job_state("R", resresv->job);

--- a/src/server/req_preemptjob.c
+++ b/src/server/req_preemptjob.c
@@ -500,12 +500,6 @@ struct preempt_ordering *svr_get_preempt_order(job *pjob, pbs_sched *psched)
 	if (get_job_req_used_time(pjob, &req, &used) != 0)
 		return NULL;
 
-	if (used == -1 || req == -1) {
-		snprintf(log_buffer, sizeof(log_buffer),
-				"No walltime/cput to determine percent of time left - will use first preempt_order");
-		log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO, pjob->ji_qs.ji_jobid, log_buffer);
-	}
-
 	po = get_preemption_order(psched->preempt_order, req, used);
 
 	return po;


### PR DESCRIPTION
#### Describe Bug or Feature
There is a memory leak in the scheduler during preemption.  The following has to happen to trigger this memory leak:
1) Job A is preempted for high priority job H1
2) H1 fails to run
3) SInce H1 fails to run, A  is run again
4) In the same cycle, we preempt A again for H2.

In the process of preempting A the first time, we set a couple of job members.  These are not cleared when we run the job again.  When we preempt the job the second time, we write the same members again leaking the memory from the first.

#### Describe Your Change
The members mentioned above were for RRTROS (not releasing all resources on suspend).
I did the following fixes:
1) When a job is run and the RRTROS members are set, free them and NULL them.
2) If RRTROS is not set, don't set the RRTROS members on the preempted job.

Random fix: I removed a prolific log message that provided little benefit.

#### Attach Test and Valgrind Logs/Output
[valgrind-before.log](https://github.com/PBSPro/pbspro/files/3327563/valgrind-before.log)
[valgrind-after.log](https://github.com/PBSPro/pbspro/files/3327562/valgrind-after.log)
Look for the memory leaked from dup_job_info() in the before log and for it not being there in the after.
[preemption.log](https://github.com/PBSPro/pbspro/files/3327567/preemption.log)

