### PR TITLE
Sched refactor to only query necessary attribs

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -521,7 +521,7 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 	struct attropl opl = { NULL, ATTR_q, NULL, NULL, EQ };
 	static struct attropl opl2[2] = { { &opl2[1], ATTR_state, NULL, "Q", EQ},
 		{ NULL, ATTR_array, NULL, "True", NE} };
-	struct attrl *attrib = NULL;
+	static struct attrl *attrib = NULL;
 	int i;
 
 	/* linked list of jobs returned from pbs_selstat() */
@@ -609,14 +609,16 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 
 	server_time = qinfo->server->server_time;
 
-	for (i = 0; jobattrs[i] != NULL; i++) {
-		struct attrl *temp_attrl = NULL;
+	if (attrib == NULL) {
+		for (i = 0; jobattrs[i] != NULL; i++) {
+			struct attrl *temp_attrl = NULL;
 
-		temp_attrl = new_attrl();
-		temp_attrl->name = strdup(jobattrs[i]);
-		temp_attrl->next = attrib;
-		temp_attrl->value = "";
-		attrib = temp_attrl;
+			temp_attrl = new_attrl();
+			temp_attrl->name = strdup(jobattrs[i]);
+			temp_attrl->next = attrib;
+			temp_attrl->value = "";
+			attrib = temp_attrl;
+		}
 	}
 
 	/* get jobs from PBS server */

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -133,6 +133,7 @@
 #include <grunt.h>
 #include <libutil.h>
 #include <pbs_internal.h>
+#include "attribute.h"
 #include "node_info.h"
 #include "server_info.h"
 #include "job_info.h"
@@ -181,9 +182,51 @@ query_nodes(int pbs_sd, server_info *sinfo)
 	int num_nodes = 0;			/* the number of nodes */
 	int i;
 	int nidx;
+	static struct attrl *attrib = NULL;
+	char *nodeattrs[] = {
+			ATTR_NODE_state,
+			ATTR_NODE_Mom,
+			ATTR_NODE_Port,
+			ATTR_partition,
+			ATTR_NODE_jobs,
+			ATTR_NODE_ntype,
+			ATTR_maxrun,
+			ATTR_maxuserrun,
+			ATTR_maxgrprun,
+			ATTR_queue,
+			ATTR_NODE_pcpus,
+			ATTR_p,
+			ATTR_NODE_Sharing,
+			ATTR_NODE_License,
+			ATTR_rescavail,
+			ATTR_rescassn,
+			ATTR_NODE_NoMultiNode,
+			ATTR_ResvEnable,
+			ATTR_NODE_ProvisionEnable,
+			ATTR_NODE_current_aoe,
+			ATTR_NODE_power_provisioning,
+			ATTR_NODE_current_eoe,
+			ATTR_NODE_in_multivnode_host,
+			ATTR_NODE_last_state_change_time,
+			ATTR_NODE_last_used_time,
+			ATTR_NODE_resvs,
+			NULL
+	};
+
+	if (attrib == NULL) {
+		for (i = 0; nodeattrs[i] != NULL; i++) {
+			struct attrl *temp_attrl = NULL;
+
+			temp_attrl = new_attrl();
+			temp_attrl->name = strdup(nodeattrs[i]);
+			temp_attrl->next = attrib;
+			temp_attrl->value = "";
+			attrib = temp_attrl;
+		}
+	}
 
 	/* get nodes from PBS server */
-	if ((nodes = pbs_statvnode(pbs_sd, NULL, NULL, NULL)) == NULL) {
+	if ((nodes = pbs_statvnode(pbs_sd, NULL, attrib, NULL)) == NULL) {
 		err = pbs_geterrmsg(pbs_sd);
 		sprintf(errbuf, "Error getting nodes: %s", err);
 		schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_NODE, LOG_INFO, "", errbuf);

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -217,7 +217,7 @@ class TestSchedPerf(TestPerformance):
         self.assertLess(cycle2_time, cycle1_time,
                         'Optimization was not faster')
 
-    @timeout(3600)
+    @timeout(5000)
     def test_sched_query(self):
         """
         Test scheduler's turnaround time with focus on querying the universe
@@ -238,14 +238,14 @@ class TestSchedPerf(TestPerformance):
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         self.server.expect(JOB, {"job_state=R": 10010})
 
-        # Now kick a 100 sched cycles to exercise the querying of universe
-        for _ in range(100):
+        # Now kick 300 sched cycles to exercise the querying of universe
+        for _ in range(300):
             self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
             self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
-        cycles = self.scheduler.cycles(lastN=100)
+        cycles = self.scheduler.cycles(lastN=300)
         sum_all_len = 0
         for cycle in cycles:
             sum_all_len += cycle.end - cycle.start
-        self.logger.info("Average sched cycle length for last 100 cycles: "
-                         + str(sum_all_len / len(cycles)))
+        self.logger.info("Sum of sched cycle lengths for last 100 cycles: "
+                         + str(sum_all_len))

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -216,3 +216,33 @@ class TestSchedPerf(TestPerformance):
             cycle1_time, cycle2_time, (cycle1_time / cycle2_time) * 100))
         self.assertLess(cycle2_time, cycle1_time,
                         'Optimization was not faster')
+
+    @timeout(3600)
+    def test_sched_query(self):
+        """
+        Test scheduler's turnaround time with focus on querying the universe
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+
+        # We have 10010 vnodes, submit 10050 jobs so that it can run almost
+        # all of them
+        a = {'Resource_List.select': '1:ncpus=1'}
+        jids = self.submit_jobs(attribs=a, num=10050, step=0, wt_start=900)
+
+        # Kick a sched cycle which will run 1010 jobs
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+        jid1010 = jids[1009]
+        self.server.expect(JOB, {"job_state": "R"}, jid1010)
+
+        # Now kick a 100 sched cycles to exercise the querying of universe
+        for _ in range(100):
+            self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+            self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+
+        cycles = self.scheduler.cycles(lastN=100)
+        sum_all_len = 0
+        for cycle in cycles:
+            sum_all_len += cycle.end - cycle.start
+        self.logger.info("Average sched cycle length for last 100 cycles: "
+                         + str(sum_all_len / len(cycles)))

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -224,16 +224,19 @@ class TestSchedPerf(TestPerformance):
         """
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
+        # We want to submit jobs with -V option
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'default_qsub_arguments': '-V'})
+
         # We have 10010 vnodes, submit 10050 jobs so that it can run almost
         # all of them
         a = {'Resource_List.select': '1:ncpus=1'}
-        jids = self.submit_jobs(attribs=a, num=10050, step=0, wt_start=900)
+        self.submit_jobs(attribs=a, num=10050, step=0, wt_start=900)
 
-        # Kick a sched cycle which will run 1010 jobs
+        # Kick a sched cycle which will run 10010 jobs
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
-        jid1010 = jids[1009]
-        self.server.expect(JOB, {"job_state": "R"}, jid1010)
+        self.server.expect(JOB, {"job_state=R": 10010})
 
         # Now kick a 100 sched cycles to exercise the querying of universe
         for _ in range(100):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Right now, scheduler queries all attributes of jobs when querying the universe every cycle, but only uses a limited set from them. So, there's time and memory wasted in packaging & sending unnecessary data over the wire, so we should refactor the code to only query the attributes that it needs.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Just added a list of attributes to query in the selstat request.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Since this is just refactoring, smoke testing should be enough. We start seeing performance benefits of this when there are more than 300k jobs in the queue, so it's not suitable to write a performance test for this.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
