### PR TITLE
Fix clang static analyzer warnings

### DIFF
--- a/src/cmds/pbs_demux.c
+++ b/src/cmds/pbs_demux.c
@@ -166,18 +166,18 @@ main(int argc, char *argv[])
 #endif
 
 	maxfd = sysconf(_SC_OPEN_MAX);
-	routem = (struct routem *)malloc(maxfd*sizeof(struct routem));
+	routem = (struct routem *)malloc(maxfd * sizeof(struct routem));
 	if (routem == NULL) {
 		fprintf(stderr, "%s: out of memory\n", argv[0]);
 		exit(2);
 	}
-	for (i=0; i<maxfd; ++i) {
-		(routem+i)->r_where = invalid;
-		(routem+i)->r_nl    = 1;
-		(routem+i)->r_first = 0;
+	for (i = 0; i < maxfd; ++i) {
+		(routem + i)->r_where = invalid;
+		(routem + i)->r_nl    = 1;
+		(routem + i)->r_first = 0;
 	}
-	(routem+main_sock_out)->r_where = new_out;
-	(routem+main_sock_err)->r_where = new_err;
+	(routem + main_sock_out)->r_where = new_out;
+	(routem + main_sock_err)->r_where = new_err;
 
 
 	FD_ZERO(&readset);
@@ -218,20 +218,20 @@ main(int argc, char *argv[])
 			}
 		}
 
-		for (i=0; n && i<maxfd; ++i) {
+		for (i = 0; n && i < maxfd; ++i) {
 			if (FD_ISSET(i, &selset)) {     /* this socket has data */
 				n--;
-				switch ((routem+i)->r_where) {
+				switch ((routem + i)->r_where) {
 					case new_out:
 					case new_err:
 						newsock = accept(i, 0, 0);
-						(routem+newsock)->r_where =  (routem+i)->r_where== new_out ? old_out : old_err;
+						(routem + newsock)->r_where =  (routem + i)->r_where == new_out ? old_out : old_err;
 						FD_SET(newsock, &readset);
-						(routem+newsock)->r_first = 1;
+						(routem + newsock)->r_first = 1;
 						break;
 					case old_out:
 					case old_err:
-						readit(i, routem+i);
+						readit(i, routem + i);
 						break;
 					default:
 						fprintf(stderr, "%s: internal error\n", argv[0]);
@@ -240,5 +240,6 @@ main(int argc, char *argv[])
 			}
 		}
 	}
+	free(routem);
 	return 0;
 }

--- a/src/cmds/pbs_rsub.c
+++ b/src/cmds/pbs_rsub.c
@@ -803,8 +803,10 @@ main(int argc, char *argv[], char *envp[])
 						ncpus_str = pattr->value;
 				}
 
-				ncpus = strtol(ncpus_str, &endp, 0);
-				if (*endp != '\0') {
+				if (ncpus_str != NULL)
+					ncpus = strtol(ncpus_str, &endp, 0);
+				
+				if (*endp != '\0' || ncpus_str == NULL) {
 					fprintf(stderr, "pbs_rsub: Attribute value error\n");
 					CS_close_app();
 					exit(2);

--- a/src/cmds/pbs_rsub.c
+++ b/src/cmds/pbs_rsub.c
@@ -794,7 +794,7 @@ main(int argc, char *argv[], char *envp[])
 
 			for (bstat = bstat_head; bstat; bstat = bstat->next) {
 				char *ncpus_str = NULL;
-				int ncpus;
+				int ncpus = 0;
 
 				for (pattr = bstat->attribs; pattr; pattr = pattr->next) {
 					if (pattr->resource && strcmp(pattr->name, ATTR_rescavail) == 0 && strcmp(pattr->resource, "host") == 0)

--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -1235,7 +1235,7 @@ main(int argc, char *argv[])
 					return 1;
 				}
 				generate_json(stdout);
-				free_json_node();
+				free_json_node_list();
 			}
 			pbs_statfree(bstat_head);
 
@@ -1288,7 +1288,7 @@ main(int argc, char *argv[])
 					exit(1);
 				}
 				generate_json(stdout);
-				free_json_node();
+				free_json_node_list();
 			}
 
 			break;
@@ -1359,7 +1359,7 @@ main(int argc, char *argv[])
 					exit(1);
 				}
 				generate_json(stdout);
-				free_json_node();
+				free_json_node_list();
 			}
 			pbs_statfree(bstat_head);
 			break;

--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -4225,6 +4225,9 @@ parse_request(char *request, char ***req)
 		fprintf(stderr, "malloc failure (errno %d)\n", errno);
 		exit(1);
 	}
+	for (i = IND_FIRST; i <= IND_LAST; i++)
+		(*req)[i] = NULL;
+		
 	for (i = 0; !EOL(*foreptr) && i < MAX_REQ_WORDS && error == 0;) {
 		while (White(*foreptr))
 			foreptr++;

--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -656,7 +656,7 @@ attrlist_add(struct attropl  **attrlist, char *attname,
 	*attrlist = paol;
 
 	ltxt = attname_len;
-	Mstring(paol->name, ltxt+1);
+	Mstring(paol->name, ltxt + 1);
 	strncpy(paol->name, attname, ltxt);
 	paol->name[ltxt] = '\0';
 
@@ -2641,7 +2641,7 @@ execute(int aopt, int oper, int type, char *names, struct attropl *attribs)
 			}
 
 			sp = sname->svr;
-			if ((oper == MGR_CMD_LIST)) {
+			if (oper == MGR_CMD_LIST) {
 				sa = attropl2attrl(attribs);
 				switch (type) {
 					case MGR_OBJ_SERVER:
@@ -2685,7 +2685,7 @@ execute(int aopt, int oper, int type, char *names, struct attropl *attribs)
 
 				pbs_statfree(ss);
 			}
-			else if ((oper == MGR_CMD_PRINT)) {
+			else if (oper == MGR_CMD_PRINT) {
 
 				sa = attropl2attrl(attribs);
 				switch (type) {
@@ -4225,10 +4225,6 @@ parse_request(char *request, char ***req)
 		fprintf(stderr, "malloc failure (errno %d)\n", errno);
 		exit(1);
 	}
-	for (i=IND_FIRST;i<=IND_LAST;i++) {
-		(*req)[i] = '\0';
-	}
-
 	for (i = 0; !EOL(*foreptr) && i < MAX_REQ_WORDS && error == 0;) {
 		while (White(*foreptr))
 			foreptr++;
@@ -4245,15 +4241,14 @@ parse_request(char *request, char ***req)
 			pstderr("qmgr: max word length exceeded\n");
 			CaretErr(request, chars_parsed);
 		}
-		if (len != 0) {
-			(*req)[i] = (char *) malloc(len + 1);
-			if ((*req)[i] == NULL) {
-				fprintf(stderr, "malloc failure (errno %d)\n", errno);
-				exit(1);
-			}
-			((*req)[i])[len] = '\0';
-			strncpy((*req)[i], backptr, len);
+		(*req)[i] = (char *)malloc(len + 1);
+		if ((*req)[i] == NULL) {
+			fprintf(stderr, "malloc failure (errno %d)\n", errno);
+			exit(1);
 		}
+		((*req)[i])[len] = '\0';
+		if (len > 0)
+			strncpy((*req)[i], backptr, len);
 		i++;
 
 	}

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -3150,7 +3150,7 @@ svr_no_args:
 		if (add_json_node(JSON_OBJECT_END, JSON_NULL, JSON_NOVALUE, NULL, NULL) == NULL)
 			exit_qstat("out of memory");
 		generate_json(stdout);
-		free_json_node();
+		free_json_node_list();
 	}
 #ifdef NAS /* localmod 071 */
 	tcl_run(tcl_opt);

--- a/src/include/pbs_json.h
+++ b/src/include/pbs_json.h
@@ -39,4 +39,4 @@ struct JsonNode{
 JsonNode* add_json_node(JsonNodeType ntype, JsonValueType vtype, JsonEscapeType esc_type, char *key, void *value);
 char *strdup_escape(JsonEscapeType esc_type, const char *str);
 int  generate_json(FILE *stream);
-void free_json_node();
+void free_json_node_list();

--- a/src/lib/Libattr/attr_func.c
+++ b/src/lib/Libattr/attr_func.c
@@ -1439,7 +1439,7 @@ attropl2attrl(struct attropl *from)
 		if (from->name != NULL) {
 			if ((ap->name = (char*) malloc(strlen(from->name) + 1)) == NULL) {
 				perror("Out of memory");
-				free_attrl(ap);
+				free_attrl_list(rattrl);
 				return NULL;
 			}
 			strcpy(ap->name, from->name);
@@ -1447,7 +1447,7 @@ attropl2attrl(struct attropl *from)
 		if (from->resource != NULL) {
 			if ((ap->resource = (char*) malloc(strlen(from->resource) + 1)) == NULL) {
 				perror("Out of memory");
-				free_attrl(ap);
+				free_attrl_list(rattrl);
 				return NULL;
 			}
 			strcpy(ap->resource, from->resource);
@@ -1455,7 +1455,7 @@ attropl2attrl(struct attropl *from)
 		if (from->value != NULL) {
 			if ((ap->value = (char*) malloc(strlen(from->value) + 1)) == NULL) {
 				perror("Out of memory");
-				free_attrl(ap);
+				free_attrl_list(rattrl);
 				return NULL;
 			}
 			strcpy(ap->value, from->value);

--- a/src/lib/Libcmds/parse_destid.c
+++ b/src/lib/Libcmds/parse_destid.c
@@ -122,8 +122,15 @@ parse_destination_id(char *destination_in, char **queue_name_out, char **server_
 	if (*c != '\0') goto err;
 
 	/* set char * pointers to static data, to arguments */
-	if (queue_name_out != NULL) *queue_name_out = queue_name;
-	if (server_name_out != NULL) *server_name_out = server_name;
+	if (queue_name_out != NULL) 
+		*queue_name_out = queue_name;
+	else
+		free(queue_name);
+	
+	if (server_name_out != NULL)
+		*server_name_out = server_name;
+	else
+		free(server_name);
 
 	return 0;
 

--- a/src/lib/Libcmds/parse_jobid.c
+++ b/src/lib/Libcmds/parse_jobid.c
@@ -71,7 +71,7 @@
  *
  */
 int
-parse_jobid(char *job_id, char **arg_seq_number, char **arg_parent_server, char ** arg_current_server)
+parse_jobid(char *job_id, char **arg_seq_number, char **arg_parent_server, char **arg_current_server)
 {
 	int is_resv = 0;
 	char *c;
@@ -223,9 +223,20 @@ parse_jobid(char *job_id, char **arg_seq_number, char **arg_parent_server, char 
 	}
 
 	/* set char * pointers to static data, to arguments */
-	if (arg_seq_number != NULL) *arg_seq_number = seq_number;
-	if (arg_parent_server != NULL) *arg_parent_server = parent_server;
-	if (arg_current_server != NULL) *arg_current_server = current_server;
+	if (arg_seq_number != NULL) 
+		*arg_seq_number = seq_number;
+	else
+		free(seq_number);
+
+	if (arg_parent_server != NULL) 
+		*arg_parent_server = parent_server;
+	else
+		free(parent_server);
+	
+	if (arg_current_server != NULL)
+		*arg_current_server = current_server;
+	else
+		free(current_server);
 
 	return 0;
 

--- a/src/lib/Libcmds/pbs_json.c
+++ b/src/lib/Libcmds/pbs_json.c
@@ -203,7 +203,7 @@ free_json_node(JsonNode *node)
 
 /**
  * @brief
- *	frees a json node
+ *	frees the json node list
  *
  * @return	Void
  *

--- a/src/lib/Libcmds/pbs_json.c
+++ b/src/lib/Libcmds/pbs_json.c
@@ -35,6 +35,7 @@
 * trademark licensing policies.
 */
 
+#include <stdlib.h>
 #include <ctype.h>
 #include "pbs_json.h"
 #include "libutil.h"
@@ -244,8 +245,10 @@ add_json_node(JsonNodeType ntype, JsonValueType vtype, JsonEscapeType esc_type, 
 	if (node->value_type == JSON_STRING) {
 		if (value != NULL) {
 			ptr = strdup_escape(esc_type, value);
-			if (ptr == NULL)
+			if (ptr == NULL) {
+				free(node);
 				return NULL;
+			}
 		}
 		node->value.string = ptr;
 	}

--- a/src/lib/Libcmds/pbs_json.c
+++ b/src/lib/Libcmds/pbs_json.c
@@ -184,6 +184,45 @@ strdup_escape(JsonEscapeType esc_type, const char *str)
 }
 
 /**
+ * @brief free an individual json node
+ * @param[in] node - node to free
+ * 
+ * @return void
+ */
+void
+free_json_node(JsonNode *node)
+{
+	if ((node->value_type == JSON_STRING) || (node->value_type == JSON_NUMERIC)) {
+		if (node->value.string != NULL)
+			free(node->value.string);
+	}
+	if (node->key != NULL)
+		free(node->key);
+	free(node);
+}
+
+/**
+ * @brief
+ *	frees a json node
+ *
+ * @return	Void
+ *
+ */
+void
+free_json_node_list()
+{
+	JsonLink *link = head;
+	while (link != NULL) {
+		free_json_node(link->node);
+		head = link->next;
+		free(link);
+		link = head;
+	}
+	head = NULL;
+	prev_link = NULL;
+}
+
+/**
  * @brief
  *	add node to json list
  *
@@ -213,6 +252,7 @@ add_json_node(JsonNodeType ntype, JsonValueType vtype, JsonEscapeType esc_type, 
 	if (key != NULL) {
 		ptr = strdup((char *)key);
 		if (ptr == NULL) {
+			free_json_node(node);
 			fprintf(stderr, "Json Node: out of memory\n");
 			return NULL;
 		}
@@ -229,24 +269,26 @@ add_json_node(JsonNodeType ntype, JsonValueType vtype, JsonEscapeType esc_type, 
 		if (strcmp(pc, "") == 0) {
 			node->value_type = JSON_NUMERIC;
 			ptr = strdup(value);
-			if (ptr == NULL)
+			if (ptr == NULL) {
+				free_json_node(node);
 				return NULL;
+			}
 			node->value.string = ptr;
 		} else
 			node->value_type = JSON_STRING;
-   	} else {
+	} else {
 		node->value_type = vtype;
 		if (node->value_type == JSON_INT)
 			node->value.inumber = *((long int *)value);
 		else if (node->value_type == JSON_FLOAT)
 			node->value.fnumber = *((double *)value);
-    	}
-            
+	}
+
 	if (node->value_type == JSON_STRING) {
 		if (value != NULL) {
 			ptr = strdup_escape(esc_type, value);
 			if (ptr == NULL) {
-				free(node);
+				free_json_node(node);
 				return NULL;
 			}
 		}
@@ -254,38 +296,11 @@ add_json_node(JsonNodeType ntype, JsonValueType vtype, JsonEscapeType esc_type, 
 	}
 	rc = link_node(node);
 	if (rc) {
-		free(node);
+		free_json_node(node);
 		fprintf(stderr, "Json link: out of memory\n");
 		return NULL;
 	}
 	return node;
-}
-
-/**
- * @brief
- *	frees a json node
- *
- * @return	Void
- *
- */
-void
-free_json_node() {
-
-	JsonLink *link = head;
-	while (link != NULL) {
-		if ((link->node->value_type == JSON_STRING) || (link->node->value_type == JSON_NUMERIC )) {
-			if (link->node->value.string != NULL)
-				free(link->node->value.string);
-		}
-		if (link->node->key != NULL)
-			free(link->node->key);
-		free(link->node);
-		head = link->next;
-		free(link);
-		link = head;
-	}
-	head = NULL;
-	prev_link = NULL;
 }
 
 /**

--- a/src/lib/Libcmds/set_resource.c
+++ b/src/lib/Libcmds/set_resource.c
@@ -159,7 +159,6 @@ set_resources(struct attrl **attrib, char *resources, int add, char **erptr)
 		if (str == NULL) {
 			free(v);
 			free_attrl(attr);
-			free(str);
 			fprintf(stderr, "Out of memory\n");
 			return 2;
 		}

--- a/src/lib/Libcmds/set_resource.c
+++ b/src/lib/Libcmds/set_resource.c
@@ -138,6 +138,7 @@ set_resources(struct attrl **attrib, char *resources, int add, char **erptr)
 		/* Allocate memory for the attrl structure */
 		attr = new_attrl();
 		if (attr == NULL) {
+			free(v);
 			fprintf(stderr, "Out of memory\n");
 			return 2;
 		}
@@ -145,6 +146,8 @@ set_resources(struct attrl **attrib, char *resources, int add, char **erptr)
 		/* Allocate memory for the attribute name and copy */
 		str = (char *) malloc(strlen(ATTR_l)+1);
 		if (str == NULL) {
+			free(v);
+			free_attrl(attr);
 			fprintf(stderr, "Out of memory\n");
 			return 2;
 		}
@@ -154,6 +157,9 @@ set_resources(struct attrl **attrib, char *resources, int add, char **erptr)
 		/* Allocate memory for the resource name and copy */
 		str = (char *) malloc(len + 1);
 		if (str == NULL) {
+			free(v);
+			free_attrl(attr);
+			free(str);
 			fprintf(stderr, "Out of memory\n");
 			return 2;
 		}
@@ -167,6 +173,7 @@ set_resources(struct attrl **attrib, char *resources, int add, char **erptr)
 		} else {
 			str = (char *) malloc(1);
 			if (str == NULL) {
+				free_attrl(attr);
 				fprintf(stderr, "Out of memory\n");
 				return 2;
 			}

--- a/src/lib/Libdb/db_postgres_common.c
+++ b/src/lib/Libdb/db_postgres_common.c
@@ -449,6 +449,7 @@ pbs_get_connect_string(char *host, int timeout, int *err_code, char *errmsg, int
 	} else {
 		if ((hostaddr = get_hostaddr(host)) == (pbs_net_t)0) {
 			free(pquoted);
+			free(svr_conn_info);
 			free(p);
 			free(usr);
 			snprintf(errmsg, len, "Could not resolve dataservice host %s", host);
@@ -459,6 +460,7 @@ pbs_get_connect_string(char *host, int timeout, int *err_code, char *errmsg, int
 		q = inet_ntoa(in);
 		if (!q) {
 			free(pquoted);
+			free(svr_conn_info);
 			free(p);
 			free(usr);
 			snprintf(errmsg, len, "inet_ntoa failed, errno=%d", errno);

--- a/src/lib/Libecl/ecl_verify.c
+++ b/src/lib/Libecl/ecl_verify.c
@@ -355,15 +355,13 @@ verify_an_attribute(int batch_request, int parent_object, int cmd,
 	return PBSE_NONE;
 
 err:
-	if ((err_code !=0) && (*err_msg == NULL)) {
+	if ((err_code != 0) && (*err_msg == NULL)) {
 		/* find err_msg and update it */
 		p = pbse_to_txt(err_code);
 		if (p) {
 			*err_msg = strdup(p);
-			if (*err_msg == NULL) {
-				err_code = PBSE_SYSTEM;
+			if (*err_msg == NULL)
 				return -1;
-			}
 		}
 	}
 	return err_code;

--- a/src/lib/Libecl/ecl_verify_values.c
+++ b/src/lib/Libecl/ecl_verify_values.c
@@ -339,7 +339,7 @@ verify_value_path(int batch_request, int parent_object, int cmd,
 {
 	char *path_out;
 
-	if ((pattr->value == NULL) || (pattr->value[0] == '\0'))
+	if ((pattr == NULL) || (pattr->value == NULL) || (pattr->value[0] == '\0'))
 		return PBSE_BADATVAL;
 
 	path_out = malloc(MAXPATHLEN + 1);

--- a/src/lib/Libecl/ecl_verify_values.c
+++ b/src/lib/Libecl/ecl_verify_values.c
@@ -338,14 +338,15 @@ verify_value_path(int batch_request, int parent_object, int cmd,
 	struct attropl *pattr, char **err_msg)
 {
 	char *path_out;
+
+	if ((pattr->value == NULL) || (pattr->value[0] == '\0'))
+		return PBSE_BADATVAL;
+
 	path_out = malloc(MAXPATHLEN + 1);
 	if (path_out == NULL)
 		return PBSE_SYSTEM;
 	else
-		memset(path_out, 0, MAXPATHLEN+1);
-
-	if ((pattr->value == NULL) || (pattr->value[0] == '\0'))
-		return PBSE_BADATVAL;
+		memset(path_out, 0, MAXPATHLEN + 1);
 
 	if (prepare_path(pattr->value, path_out) != 0) {
 		free(path_out);

--- a/src/lib/Libifl/pbsD_alterjo.c
+++ b/src/lib/Libifl/pbsD_alterjo.c
@@ -83,6 +83,11 @@ __pbs_alterjob(int c, char *jobid, struct attrl *attrib, char *extend)
 			ap = ap->next;
 		}
 		if (ap == NULL) {
+			while (ap1 != NULL) {
+				ap = ap1->next;
+				free(ap1);
+				ap1 = ap;
+			}
 			pbs_errno = PBSE_SYSTEM;
 			return -1;
 		}

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -326,7 +326,7 @@ engage_authentication(int sd,
 			if ((ret = CS_client_auth(sd)) == CS_SUCCESS)
 				return (0);
 
-			if ((ret == CS_AUTH_USE_IFF)) {
+			if (ret == CS_AUTH_USE_IFF) {
 				/* CS_client_auth that got called was the one for STD security */
 				/*sock_port needs to be passed only for Windows.*/
 				if (PBSD_authenticate(sd, server_name, server_port, clnt_paddr) == 0)

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -97,8 +97,10 @@ __pbs_selectjob(int c, struct attropl *attrib, char *extend)
 		ret = PBSD_select_get(c);
 
 	/* unlock the thread lock and update the thread context data */
-	if (pbs_client_thread_unlock_connection(c) != 0)
+	if (pbs_client_thread_unlock_connection(c) != 0) {
+		free(ret);
 		return NULL;
+	}
 
 	return ret;
 }
@@ -252,7 +254,7 @@ PBSD_select_get(int c)
 		 structures", freeing all strings we just allocated...
 		 */
 
-		totsize = stringtot + (njobs+1) * (sizeof(char *));
+		totsize = stringtot + (njobs + 1) * (sizeof(char *));
 		retval = (char **)malloc(totsize);
 		if (retval == NULL) {
 			pbs_errno = PBSE_SYSTEM;
@@ -261,7 +263,7 @@ PBSD_select_get(int c)
 		}
 		sr = reply->brp_un.brp_select;
 		sp = (char *)retval + (njobs + 1) * sizeof(char *);
-		for (i=0; i<njobs; i++) {
+		for (i = 0; i < njobs; i++) {
 			retval[i] = sp;
 			strcpy(sp, sr->brp_jobid);
 			sp += strlen(sp) + 1;

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -98,6 +98,7 @@ __pbs_selectjob(int c, struct attropl *attrib, char *extend)
 
 	/* unlock the thread lock and update the thread context data */
 	if (pbs_client_thread_unlock_connection(c) != 0) {
+		/* Even though ret is a char **, PBSD_select_get() allocated all its memory in one malloc() */
 		free(ret);
 		return NULL;
 	}

--- a/src/lib/Libifl/pbsD_stathost.c
+++ b/src/lib/Libifl/pbsD_stathost.c
@@ -672,7 +672,7 @@ build_collective(struct batch_status *pbs,
 				else
 					cupatl->next = nwpatl;
 				if ((nwpatl->name = strdup(attr_names[i].an_name)) == NULL) {
-					free(nwpatl);
+					free_attrl_list(hdpatl);
 					pbs_errno = PBSE_SYSTEM;
 					return;
 				}
@@ -693,40 +693,37 @@ build_collective(struct batch_status *pbs,
 	/* then for resources_assigned				    */
 
 	for (i = 0; i < consumable_size; ++i) {
-		if ((consum+i)->cons_set == 0)
+		if ((consum + i)->cons_set == 0)
 			continue;
-		if ((consum+i)->cons_consum) {
+		if ((consum + i)->cons_consum) {
 			sprintf(convtbuf, "%lld", (consum+i)->cons_avail_sum);
 			if ((consum+i)->cons_k)
 				strcat(convtbuf, "kb");
 			dup = convtbuf;
 		} else {
-			dup = (consum+i)->cons_avail_str;
+			dup = (consum + i)->cons_avail_str;
 		}
 		if (dup != NULL) {
-			nwpatl = malloc(sizeof(struct attrl));
+			nwpatl = new_attrl();
 
 			if (nwpatl) {
 				if (hdpatl == NULL)
 					hdpatl = nwpatl;
 				else
 					cupatl->next = nwpatl;
-				nwpatl->next     = NULL;
+				nwpatl->next = NULL;
 				if ((nwpatl->name = strdup(ATTR_rescavail)) == NULL) {
-					free(nwpatl);
+					free_attrl_list(hdpatl);
 					pbs_errno = PBSE_SYSTEM;
 					return;
 				}
 				if ((nwpatl->resource = strdup((consum+i)->cons_resource)) == NULL) {
-					free(nwpatl->name);
-					free(nwpatl);
+					free_attrl_list(hdpatl);
 					pbs_errno = PBSE_SYSTEM;
 					return;
 				}
 				if ((nwpatl->value = strdup(dup)) == NULL) {
-					free(nwpatl->name);
-					free(nwpatl->resource);
-					free(nwpatl);
+					free_attrl_list(hdpatl);
 					pbs_errno = PBSE_SYSTEM;
 					return;
 				}
@@ -754,20 +751,17 @@ build_collective(struct batch_status *pbs,
 				else
 					cupatl->next = nwpatl;
 				if ((nwpatl->name = strdup(ATTR_rescassn)) == NULL) {
-					free(nwpatl);
+					free_attrl_list(hdpatl);
 					pbs_errno = PBSE_SYSTEM;
 					return;
 				}
 				if ((nwpatl->resource = strdup((consum+i)->cons_resource)) == NULL) {
-					free(nwpatl->name);
-					free(nwpatl);
+					free_attrl_list(hdpatl);
 					pbs_errno = PBSE_SYSTEM;
 					return;
 				}
 				if ((nwpatl->value = strdup(convtbuf)) == NULL) {
-					free(nwpatl->resource);
-					free(nwpatl->name);
-					free(nwpatl);
+					free_attrl_list(hdpatl);
 					pbs_errno = PBSE_SYSTEM;
 					return;
 				}

--- a/src/lib/Libifl/pbsD_stathost.c
+++ b/src/lib/Libifl/pbsD_stathost.c
@@ -663,7 +663,7 @@ build_collective(struct batch_status *pbs,
 
 	hdpatl = NULL;
 
-	for (i=0; attr_names[i].an_name; ++i) {
+	for (i = 0; attr_names[i].an_name; ++i) {
 		if (attr_names[i].an_value) {
 			nwpatl = new_attrl();
 			if (nwpatl) {
@@ -676,11 +676,12 @@ build_collective(struct batch_status *pbs,
 					pbs_errno = PBSE_SYSTEM;
 					return;
 				}
-				nwpatl->value    = attr_names[i].an_value;
+				nwpatl->value = attr_names[i].an_value;
 				/* note, the above is not dupped */
 				attr_names[i].an_value = NULL;
 				cupatl = nwpatl;
 			} else {
+				free_attrl_list(hdpatl);
 				pbs_errno = PBSE_SYSTEM;
 				return;
 			}
@@ -691,7 +692,7 @@ build_collective(struct batch_status *pbs,
 	/* takes two passes, first for resources_available and      */
 	/* then for resources_assigned				    */
 
-	for (i=0; i<consumable_size; ++i) {
+	for (i = 0; i < consumable_size; ++i) {
 		if ((consum+i)->cons_set == 0)
 			continue;
 		if ((consum+i)->cons_consum) {
@@ -731,6 +732,7 @@ build_collective(struct batch_status *pbs,
 				}
 				cupatl = nwpatl;
 			} else {
+				free_attrl_list(hdpatl);
 				pbs_errno = PBSE_SYSTEM;
 				return;
 			}
@@ -738,12 +740,12 @@ build_collective(struct batch_status *pbs,
 	}
 
 	/* now do the resources_assigned */
-	for (i=0; i<consumable_size; ++i) {
-		if ((consum+i)->cons_set == 0)
+	for (i = 0; i < consumable_size; ++i) {
+		if ((consum + i)->cons_set == 0)
 			continue;
-		if ((consum+i)->cons_consum) {
+		if ((consum + i)->cons_consum) {
 			sprintf(convtbuf, "%lld", (consum+i)->cons_assn_sum);
-			if ((consum+i)->cons_k)
+			if ((consum + i)->cons_k)
 				strcat(convtbuf, "kb");
 			nwpatl = new_attrl();
 			if (nwpatl) {
@@ -771,6 +773,7 @@ build_collective(struct batch_status *pbs,
 				}
 				cupatl = nwpatl;
 			} else {
+				free_attrl_list(hdpatl);
 				pbs_errno = PBSE_SYSTEM;
 				return;
 			}
@@ -813,19 +816,19 @@ struct batch_status *build_return_status(struct batch_status *bstatus,
 
 	/* is the host in question a single or multi-vnode host */
 
-	for (i=0; i<host_list_size; ++i) {
-		if (strcasecmp(hname, (phost_list+i)->hl_name) == 0) {
-			if ((phost_list+i)->hl_node != NULL) {
+	for (i = 0; i < host_list_size; ++i) {
+		if (strcasecmp(hname, (phost_list + i)->hl_name) == 0) {
+			if ((phost_list + i)->hl_node != NULL) {
 
 				/* single vnode host - use the real one */
 
 				/* prevent double free: copy name, move attribs */
-				if ((npbs->name = strdup((phost_list+i)->hl_node->name)) == NULL) {
+				if ((npbs->name = strdup((phost_list + i)->hl_node->name)) == NULL) {
 					free(npbs);
 					pbs_errno = PBSE_SYSTEM;
 					return NULL;
 				}
-				npbs->attribs = (phost_list+i)->hl_node->attribs;
+				npbs->attribs = (phost_list + i)->hl_node->attribs;
 				(phost_list+i)->hl_node->attribs = NULL;
 				if ((phost_list+i)->hl_node->text)
 					if ((npbs->text = strdup((phost_list+i)->hl_node->text)) == NULL) {

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -213,8 +213,8 @@ parse_config_line(FILE *fp, char **key, char **val)
 	char *split;
 	char *ret;
 
-	*key = '\0';
-	*val = '\0';
+	*key = "";
+	*val = "";
 
 	/* Use a do-while rather than a goto. */
 	do {

--- a/src/lib/Libnet/hnls.c
+++ b/src/lib/Libnet/hnls.c
@@ -471,8 +471,10 @@ free_if_info(struct log_net_info *ni)
 		struct log_net_info *temp;
 		temp = curr;
 		curr = curr -> next;
-		for (i = 0; temp->ifhostnames[i]; i++)
-			free(temp->ifhostnames[i]);
+		if (temp->ifhostnames != NULL) {
+			for (i = 0; temp->ifhostnames[i]; i++)
+				free(temp->ifhostnames[i]);
+		}
 		free(temp->ifhostnames);
 		free(temp);
 	}

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -2032,10 +2032,10 @@ pbs_python_populate_attributes_to_python_class(PyObject *py_instance,
 		if ((encode_rv == 0) && (svrattr_val != NULL)) {
 			encode_rv = 1;
 		}
-		if ((encode_rv == 0)) {
+		if (encode_rv == 0) {
 			/* not set or no value */
 			continue;
-		} else if ((encode_rv >= 1)) {    /* good, single value */
+		} else if (encode_rv >= 1) {    /* good, single value */
 			/* we could be a resource list */
 			if (ATTR_IS_RESC(attr_def_p)) {
 				if (!PyObject_HasAttrString(py_instance, attr_def_p->at_name)) {
@@ -11312,7 +11312,7 @@ py_get_job_static(char *jid, char *svr_name, char *queue_name)
 	if (py_jargs == NULL) {
 		snprintf(log_buffer, sizeof(log_buffer),
 			"could not build args list for job %s",
-			plist->al_name);
+			plist ? plist->al_name: "");
 		log_err(PBSE_INTERNAL, __func__, log_buffer);
 		goto get_job_error_exit;
 	}
@@ -11322,7 +11322,7 @@ py_get_job_static(char *jid, char *svr_name, char *queue_name)
 	if (py_job == NULL) {
 		snprintf(log_buffer, sizeof(log_buffer),
 			"failed to create a python job %s object",
-			plist->al_name);
+			plist ? plist->al_name: "");
 		log_err(PBSE_INTERNAL, __func__, log_buffer);
 		goto get_job_error_exit;
 	}
@@ -11333,7 +11333,7 @@ py_get_job_static(char *jid, char *svr_name, char *queue_name)
 	if (rc == -1) {
 		snprintf(log_buffer, sizeof(log_buffer),
 			"failed to fully populate Python"
-			" job %s object", plist->al_name);
+			" job %s object", plist ? plist->al_name: "");
 		log_err(PBSE_INTERNAL, __func__, log_buffer);
 		goto get_job_error_exit;
 	}
@@ -11617,8 +11617,8 @@ py_get_resv_static(char *resvid, char *svr_name)
 			if (py_que != NULL) {
 				/* py_server queue ref ct incremented as part of py_resv */
 				(void)PyObject_SetAttrString(py_resv, ATTR_queue, py_que);
+				Py_DECREF(py_que); /* we no longer need to reference */
 			}
-			Py_DECREF(py_que);	/* we no longer need to reference */
 		}
 	}
 

--- a/src/lib/Libpython/pbs_python_svr_size_type.c
+++ b/src/lib/Libpython/pbs_python_svr_size_type.c
@@ -587,20 +587,13 @@ pps_size_number_methods_subtract(PyObject *left, PyObject *right)
 
 		if (rc != 0)
 			goto QUIT;
-#ifdef NAS /* localmod 005 */
 		if (tmp_right.atsv_num > tmp_left.atsv_num) {
-#else
-		l_result = tmp_left.atsv_num - tmp_right.atsv_num;
-		if ((l_result < 0) || (l_result > tmp_left.atsv_num)) {
-#endif /* localmod 005 */
 			PyErr_SetString(PyExc_ArithmeticError,
 				"expression evaluates to negative _size value");
 			result = NULL;
 			goto QUIT;
 		}
-#ifdef NAS /* localmod 005 */
 		l_result = tmp_left.atsv_num - tmp_right.atsv_num;
-#endif /* localmod 005 */
 		sz_result.atsv_num = l_result;
 		sz_result.atsv_shift = tmp_left.atsv_shift;
 		sz_result.atsv_units = tmp_left.atsv_units;

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -89,6 +89,7 @@
 #include <sys/time.h>
 #ifndef WIN32
 #include <stdint.h>
+#include <stdlib.h>
 #endif
 
 #include "avltree.h"
@@ -1270,7 +1271,7 @@ tpp_recv(int sd, void *data, int len)
 		cur_pkt = TPP_QUE_DATA(n);
 
 	/* read from head */
-	if ((cur_pkt == NULL)) {
+	if (cur_pkt == NULL) {
 		errno = EWOULDBLOCK;
 		return -1; /* no data currently - would block */
 	}

--- a/src/lib/Libtpp/tpp_dis.c
+++ b/src/lib/Libtpp/tpp_dis.c
@@ -843,6 +843,7 @@ set_tpp_config(struct pbs_config *pbs_conf,
 
 		hlen = strlen(nm);
 		if ((tmp = realloc(formatted_names, len + hlen + 2)) == NULL) { /* 2 for command and null char */
+			free(formatted_names);
 			snprintf(log_buffer, TPP_LOGBUF_SZ, "Failed to make formatted node name");
 			fprintf(stderr, "%s\n", log_buffer);
 			tpp_log_func(LOG_CRIT, NULL, log_buffer);

--- a/src/lib/Libtpp/tpp_dis.c
+++ b/src/lib/Libtpp/tpp_dis.c
@@ -844,6 +844,7 @@ set_tpp_config(struct pbs_config *pbs_conf,
 		hlen = strlen(nm);
 		if ((tmp = realloc(formatted_names, len + hlen + 2)) == NULL) { /* 2 for command and null char */
 			free(formatted_names);
+			free(nm);
 			snprintf(log_buffer, TPP_LOGBUF_SZ, "Failed to make formatted node name");
 			fprintf(stderr, "%s\n", log_buffer);
 			tpp_log_func(LOG_CRIT, NULL, log_buffer);

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -271,8 +271,6 @@ send_leaves_to_router(tpp_router_t *parent, tpp_router_t *target)
 	}
 	tpp_unlock(&router_lock);
 
-	free(pkey);
-
 	chunks[0].len = sizeof(tpp_join_pkt_hdr_t);
 	while ((lf_data = (struct leaf_data *) tpp_deque(&ctl_hdr_queue))) {
 
@@ -288,6 +286,7 @@ send_leaves_to_router(tpp_router_t *parent, tpp_router_t *target)
 		free(lf_data->addrs);
 		free(lf_data);
 	}
+	free(pkey);
 	return 0;
 
 err:

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -1240,7 +1240,7 @@ assign_to_worker(int tfd, int delay, thrd_data_t *td)
 		return 1;
 
 	if (conn->td != NULL) {
-		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "ERROR! tfd=%d conn_td=%p, conn_td_index=%d, thrd_td=%p, thrd_td_index=%d", tfd, conn->td, conn->td->thrd_index, td, td->thrd_index);
+		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "ERROR! tfd=%d conn_td=%p, conn_td_index=%d, thrd_td=%p, thrd_td_index=%d", tfd, conn->td, conn->td->thrd_index, td, td ? td->thrd_index: -1);
 		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 	}
 
@@ -2145,7 +2145,7 @@ send_data(phy_conn_t *conn)
 				if (the_pkt_presend_handler(conn->sock_fd, p) != 0) {
 					/* handler asked not to send data, skip packet */
 					conn->send_queue_size -= tosend;
-					n = tpp_que_del_elem(&conn->send_queue, n);
+					(void) tpp_que_del_elem(&conn->send_queue, n);
 					n = TPP_QUE_HEAD(&conn->send_queue);
 					p = TPP_QUE_DATA(n);
 					continue;
@@ -2338,7 +2338,7 @@ send_data(phy_conn_t *conn)
 			 * all data in this packet has been sent or done with.
 			 * delete this node and get next node in queue
 			 */
-			n = tpp_que_del_elem(&conn->send_queue, n);
+			(void)tpp_que_del_elem(&conn->send_queue, n);
 			n = TPP_QUE_HEAD(&conn->send_queue);
 			p = TPP_QUE_DATA(n);
 		}

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -1136,11 +1136,11 @@ tpp_multi_deflate_do(void *c, int fini, void *inbuf, unsigned int inlen)
 			ctx->len = ctx->len * 2;
 			p = realloc(ctx->cmpr_buf, ctx->len);
 			if (!p) {
+				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating deflate buffer %d bytes", ctx->len);
+				tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 				deflateEnd(&ctx->cmpr_strm);
 				free(ctx->cmpr_buf);
 				free(ctx);
-				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating deflate buffer %d bytes", ctx->len);
-				tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
 				return -1;
 			}
 			ctx->cmpr_buf = p;
@@ -1470,12 +1470,14 @@ tpp_get_addresses(char *names, int *count)
 		
 		addrs_tmp = tpp_sock_resolve_host(token, &tmp_count); /* get all ipv4 addresses */
 		if (addrs_tmp) {
-			if ((addrs = realloc(addrs, (tot_count + tmp_count) * sizeof(tpp_addr_t))) == NULL) {
+			tpp_addr_t *tmp;
+			if ((tmp = realloc(addrs, (tot_count + tmp_count) * sizeof(tpp_addr_t))) == NULL) {
 				free(addrs);
 				free(node_names);
 				tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating address block");
 				return NULL;
 			}
+			addrs = tmp;
 
 			for (i = 0; i < tmp_count; i++) {
 				for (j = 0; j < tot_count; j++) {

--- a/src/lib/Libutil/avltree.c
+++ b/src/lib/Libutil/avltree.c
@@ -995,8 +995,10 @@ create_tree(int dups, int keylen)
 	if (AVL_p == NULL)
 		return NULL;
 
-	if (avl_create_index(AVL_p, dups, keylen))
+	if (avl_create_index(AVL_p, dups, keylen)) {
+		free(AVL_p);
 		return NULL;
+	}
 
 	return AVL_p;
 }

--- a/src/lib/Libutil/execvnode_seq_util.c
+++ b/src/lib/Libutil/execvnode_seq_util.c
@@ -460,7 +460,7 @@ unroll_execvnode_seq(char *str, char ***tofree)
 	/* Allocate memory for the returning variable rev_dict which
 	 * will be an array of pointers of length, the number of occurrences,
 	 * for which each index corresponds to the execvnode associated to that occurrence */
-	if ((rev_dict = (char **) malloc((max_idx+1)*sizeof(char *))) == NULL) {
+	if ((rev_dict = (char **) malloc((max_idx + 1) * sizeof(char *))) == NULL) {
 		DBPRT(("unroll_execvnode_seq: %s\n", MALLOC_ERR_MSG));
 		return NULL;
 	}
@@ -469,7 +469,7 @@ unroll_execvnode_seq(char *str, char ***tofree)
 	 * This block of memory is made as large as rev_dict in the worst case where
 	 * all execvnodes are distinct but is resized later for the average case
 	 * where most execvnodes after a certain date will be identical */
-	if ((*tofree = (char **) malloc((max_idx+1)*sizeof(char *))) == NULL) {
+	if ((*tofree = (char **) malloc((max_idx + 1) * sizeof(char *))) == NULL) {
 		free(rev_dict);
 		return NULL;
 	}
@@ -498,11 +498,11 @@ unroll_execvnode_seq(char *str, char ***tofree)
 				last = first;
 				/* Each index in range is parsed */
 				range = string_token(NULL, RANGE_TOK, &nm3);
-				if (range!=NULL)
+				if (range != NULL)
 					last = atoi(range);
 				/* Append the <vnode> token to the pointer array
 				 * for each index indicated by range */
-				for (i=first; i<=last; i++)
+				for (i = first; i <= last; i++)
 					rev_dict[i] = (char *) tmp;
 			}
 			else {
@@ -671,6 +671,7 @@ dict_to_str(dictionary *dict)
 	 * resize to what's actually been used */
 	tmp = realloc(condensed, (strlen(condensed)+1)*sizeof(char));
 	if (tmp == NULL) {
+		free(condensed);
 		DBPRT(("dict_to_str: %s\n", MALLOC_ERR_MSG));
 		return NULL;
 	}

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1464,7 +1464,7 @@ show_nonprint_chars(char *str)
 		return str;
 
 	nsize = (strlen(str) * 2) + 1;
-	if (nsize > locbuf_size) {
+	if (nsize > locbuf_size || locbuf == NULL) {
 		char *tmpbuf;
 		if ((tmpbuf = realloc(locbuf, nsize)) == NULL)
 			return str;

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -6159,10 +6159,8 @@ cput_proc(pid_t pid)
 	double		cputime;
 	proc_stat_t	*ps = NULL;
 
-	cputime = 0.0;
-
 	mom_get_sample();
-	for (i=0; i<nproc; i++) {
+	for (i = 0; i < nproc; i++) {
 		ps = &proc_info[i];
 		if (ps->pid == pid)
 			break;
@@ -6278,7 +6276,7 @@ mem_proc(pid_t pid)
 	proc_stat_t	*ps = NULL;
 
 	mom_get_sample();
-	for (i=0; i<nproc; i++) {
+	for (i = 0; i < nproc; i++) {
 		ps = &proc_info[i];
 		if (ps->pid == pid)
 			break;
@@ -6396,7 +6394,7 @@ resi_proc(pid_t pid)
 
 
 	mom_get_sample();
-	for (i=0; i<nproc; i++) {
+	for (i = 0; i < nproc; i++) {
 		ps = &proc_info[i];
 		if (ps->pid == pid)
 			break;

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -2776,7 +2776,6 @@ send_resc_used_to_ms(int stream, char *jobid)
 	CLEAR_HEAD(send_head);
 
 	pal = (svrattrl *)GET_NEXT(lhead);
-	psatl = pal;
 
 	while (pal != NULL) {
 		nxpal = (struct svrattrl *)GET_NEXT(pal->al_link);
@@ -2870,7 +2869,6 @@ recv_resc_used_from_sister(int stream, char *jobid, int nodeidx)
 		pdef->at_free(&pjob->ji_resources[nodeidx].nr_used);
 	}
 	/* decode attributes from request into job structure */
-	errcode = 0;
 	clear_attr(&pjob->ji_resources[nodeidx].nr_used,
 		&job_attr_def[JOB_ATR_resc_used]);
 
@@ -6075,13 +6073,17 @@ aterr:
 			info = disrcs(fd, &len, &ret);
 			if (ret != DIS_SUCCESS) {
 				free(name);
+				free(info);
 				sprintf(log_buffer, bail_format, "POSTINFO info");
 				goto err;
 			}
 			DBPRT(("%s: POSTINFO %s task %8.8X sent info %s:%s(%d)\n", __func__,
 				jobid, fromtask, name, info, (int)len))
-			if (prev_error)
+			if (prev_error) {
+				free(name);
+				free(info);
 				goto done;
+			}
 
 			task_saveinfo(ptask, name, info, (int)len);
 			ret = tm_reply(fd, version, TM_OKAY, event);
@@ -6111,7 +6113,7 @@ aterr:
 	BAIL("tvnodeid")
 
 	pnode = pjob->ji_vnods;
-	for (i=0; i<pjob->ji_numvnod; i++, pnode++) {
+	for (i = 0; i < pjob->ji_numvnod; i++, pnode++) {
 		if (pnode->vn_node == tvnodeid)
 			break;
 	}
@@ -6193,9 +6195,9 @@ aterr:
 			argc = disrui(fd, &ret);
 			if (ret != DIS_SUCCESS)
 				goto done;
-			argv = (char **)calloc(argc+1, sizeof(char *));
+			argv = (char **)calloc(argc + 1, sizeof(char *));
 			assert(argv);
-			for (i=0; i<argc; i++) {
+			for (i = 0; i < argc; i++) {
 				argv[i] = disrst(fd, &ret);
 				if (ret != DIS_SUCCESS) {
 					argv[i] = NULL;
@@ -6210,7 +6212,7 @@ aterr:
 			numele = 3;
 			envp = (char **)calloc(numele, sizeof(char *));
 			assert(envp);
-			for (i=0;; i++) {
+			for (i = 0; ; i++) {
 				char	*env;
 
 				env = disrst(fd, &ret);
@@ -6287,45 +6289,75 @@ aterr:
 			ret = im_compose(phost->hn_stream, jobid, cookie,
 					 IM_SPAWN_TASK, ep->ee_event, fromtask,
 					 found_empty_string ? IM_PROTOCOL_VER : IM_OLD_PROTOCOL_VER);
-			if (ret != DIS_SUCCESS)
+			if (ret != DIS_SUCCESS) {
+				arrayfree(argv);
+				arrayfree(envp);
 				goto done;
+			}
 			ret = diswui(phost->hn_stream, myvnodeid);
-			if (ret != DIS_SUCCESS)
+			if (ret != DIS_SUCCESS) {
+				arrayfree(argv);
+				arrayfree(envp);
 				goto done;
+			}
 			ret = diswui(phost->hn_stream, tvnodeid);
-			if (ret != DIS_SUCCESS)
+			if (ret != DIS_SUCCESS) {
+				arrayfree(argv);
+				arrayfree(envp);
 				goto done;
+			}
 			ret = diswui(phost->hn_stream, TM_NULL_TASK);
-			if (ret != DIS_SUCCESS)
+			if (ret != DIS_SUCCESS) {
+				arrayfree(argv);
+				arrayfree(envp);
 				goto done;
+			}
 			if (found_empty_string) {
 				ret = diswui(phost->hn_stream, argc);
-				if (ret != DIS_SUCCESS)
-			  		goto done;
-				for (i=0; i<argc; i++) {
+				if (ret != DIS_SUCCESS) {
+					arrayfree(argv);
+					arrayfree(envp);
+					goto done;
+				}
+				for (i = 0; i < argc; i++) {
 					ret = diswst(phost->hn_stream, argv[i]);
-					if (ret != DIS_SUCCESS)
+					if (ret != DIS_SUCCESS) {
+						arrayfree(argv);
+						arrayfree(envp);
 						goto done;
+					}
 				}
 			} else {
-			  	for (i=0; argv[i]; i++) {
+			  	for (i = 0; argv[i]; i++) {
 					ret = diswst(phost->hn_stream, argv[i]);
-					if (ret != DIS_SUCCESS)
+					if (ret != DIS_SUCCESS) {
+						arrayfree(argv);
+						arrayfree(envp);
 						goto done;
+					}
 				}
 				ret = diswst(phost->hn_stream, "");
-				if (ret != DIS_SUCCESS)
+				if (ret != DIS_SUCCESS) {
+					arrayfree(argv);
+					arrayfree(envp);
 					goto done;
+				}
 			}
-			for (i=0; envp[i]; i++) {
+			for (i = 0; envp[i]; i++) {
 				ret = diswst(phost->hn_stream, envp[i]);
-				if (ret != DIS_SUCCESS)
+				if (ret != DIS_SUCCESS) {
+					arrayfree(argv);
+					arrayfree(envp);
 					goto done;
+				}
 			}
 			ret = (rpp_flush(phost->hn_stream) == -1) ?
 				DIS_NOCOMMIT : DIS_SUCCESS;
-			if (ret != DIS_SUCCESS)
+			if (ret != DIS_SUCCESS) {
+				arrayfree(argv);
+				arrayfree(envp);
 				goto done;
+			}
 			reply = FALSE;
 			arrayfree(argv);
 			arrayfree(envp);

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -6073,7 +6073,6 @@ aterr:
 			info = disrcs(fd, &len, &ret);
 			if (ret != DIS_SUCCESS) {
 				free(name);
-				free(info);
 				sprintf(log_buffer, bail_format, "POSTINFO info");
 				goto err;
 			}

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3524,7 +3524,7 @@ void reply_hook_bg(job *pjob)
 
 	pjob = php->hook_input->pjob;
 
-	if ( php->hook_output && *(php->hook_output->reject_errcode)){
+	if (php->hook_output && *(php->hook_output->reject_errcode)){
 		reply_hook_bg(pjob);
 		goto fini;
 	}

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -1874,7 +1874,7 @@ add_mom_action(char *str)
 	str = skipwhite(str);
 	if (*str == '\0')
 		return HANDLER_FAIL;
-	for (na=0; na<(int)LastAction; na++) {
+	for (na = 0; na < (int)LastAction; na++) {
 		if (strcmp(arg, mom_action[na].ma_name) == 0) {
 			/* have a valid event name */
 			break;
@@ -1964,23 +1964,25 @@ add_mom_action(char *str)
 		}
 		pargs = (char **)malloc((count+1) * sizeof(char *));
 		if (pargs == NULL) {
+			free(scp);
 			return HANDLER_FAIL;
 		}
 
-		/* now we  know how many and have space, copy each arg */
+		/* now we know how many and have space, copy each arg */
 
-		for (i=0; i<count; i++) {
+		for (i = 0; i < count; i++) {
 			str = wtokcpy(str, arg, _POSIX_PATH_MAX);
 			str = skipwhite(str);
-			if ((*(pargs+i) = strdup(arg)) == NULL) {
-				for (;i>=0;i--) {
-					free(*(pargs+i));
+			if ((*(pargs + i) = strdup(arg)) == NULL) {
+				for ( ; i >= 0; i--) {
+					free(*(pargs + i));
 				}
+				free(scp);
 				free(pargs);
 				return HANDLER_FAIL;
 			}
 		}
-		*(pargs+i) = NULL;
+		*(pargs + i) = NULL;
 
 		/* now we can set the action array member */
 
@@ -1991,10 +1993,8 @@ add_mom_action(char *str)
 		goto done;
 	}
 
-	/* not a script,  must be a recognized verb */
+	/* not a script, must be a recognized verb */
 
-	str = TOKCPY(str, arg);
-	str = skipwhite(str);
 	if (strcmp(arg, "requeue") == 0) {
 
 		/* Requeue Verb */
@@ -2771,8 +2771,10 @@ do_mom_action_script(int	ae,	/* index into action table */
 
 	/* set args[0] to script */
 	args[0] = strdup(ma->ma_script);
-	if (args[0] == NULL)
+	if (args[0] == NULL) {
+		free(args);
 		return -1;
+	}
 
 	pargs = ma->ma_args;
 	for (i = 1; i < nargs; i++, pargs++) {
@@ -3120,6 +3122,7 @@ do_mom_action_script(int	ae,	/* index into action table */
 		vtable.v_envp = (char **)calloc(vtable.v_ensize,
 			sizeof(char *));
 		if (vtable.v_envp == NULL) {
+			free(args);
 			log_err(errno, "setup environment", "out of memory");
 			return -1;
 		}
@@ -3187,6 +3190,7 @@ do_mom_action_script(int	ae,	/* index into action table */
 				PBS_EVENTCLASS_JOB,
 				LOG_ERR, pjob->ji_qs.ji_jobid,
 				"failed to setup dependent environment!");
+			free(args);
 			return -1;
 		}
 
@@ -4769,6 +4773,7 @@ do_readdir(char *dirname, time_t *mod)
 		}
 	}
 	if (errno != 0 && errno != ENOENT) {
+		free_dirlist(list);
 		perror(dirname);
 		(void) closedir(dirp);
 		return NULL;

--- a/src/resmom/stage_func.c
+++ b/src/resmom/stage_func.c
@@ -450,9 +450,9 @@ is_direct_write(job *pjob, enum job_file which, char *path, int *direct_write_po
 				snprintf(working_path, MAXPATHLEN + 1, "%s", pjob->ji_wattr[JOB_ATR_outpath].at_val.at_str);
 			if (
 #ifdef WIN32
-					(working_path[strlen(working_path) -1] == '\\')
+					working_path[strlen(working_path) -1] == '\\'
 #else
-					(working_path[strlen(working_path) -1] == '/')
+					working_path[strlen(working_path) -1] == '/'
 #endif
 					) {
 				strcat(working_path, pjob->ji_qs.ji_jobid);
@@ -467,9 +467,9 @@ is_direct_write(job *pjob, enum job_file which, char *path, int *direct_write_po
 				snprintf(working_path, MAXPATHLEN + 1, "%s", pjob->ji_wattr[JOB_ATR_errpath].at_val.at_str);
 		if (
 #ifdef WIN32
-				(working_path[strlen(working_path) -1] == '\\')
+				working_path[strlen(working_path) -1] == '\\'
 #else
-				(working_path[strlen(working_path) -1] == '/')
+				working_path[strlen(working_path) -1] == '/'
 #endif
 				) {
 				strcat(working_path, pjob->ji_qs.ji_jobid);

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -505,15 +505,15 @@ shrink_to_run_event(status *policy, server_info *sinfo,
 			/* If there are no events left to check or if we have reached the front of event list or
 			 * if the event is falling before min end time, break.
 			 */
-			if ((te == NULL && last_skipped_event == NULL) || te == initial_event || te->event_time < min_end_time)
-				break;
-			/* If no events in this segment, then try last skipped event of the previous segment */
-			else if (te == NULL) {
+			if (te == NULL)
+			{
 				te = last_skipped_event;
 				last_skipped_event = NULL;
 				/* No need to try next segments after this event as there are no events left */
 				retry_count = 0;
-			}
+			} else if ((te == NULL && last_skipped_event == NULL) || te == initial_event || te->event_time < min_end_time)
+				break;
+			/* If no events in this segment, then try last skipped event of the previous segment */
 			/* Skip events that fall in the previous segment or if the event time is already tried */
 			else if (te->event_time > end_time || te->event_time == last_tried_event_time) {
 				last_skipped_event = te;
@@ -728,6 +728,9 @@ is_ok_to_run(status *policy, server_info *sinfo,
 	resource_req	*resreq = NULL;
 
 	if (sinfo == NULL || resresv == NULL || perr == NULL)
+		return NULL;
+	
+	if (resresv->is_job && qinfo == NULL)
 		return NULL;
 
 	err = perr;
@@ -1036,7 +1039,7 @@ is_ok_to_run(status *policy, server_info *sinfo,
 	 */
 	if (sinfo->res != NULL) {
 		if (resresv->is_resv ||
-				(resresv->is_job && resresv->job->resv == NULL)) {
+				(resresv->is_job && resresv->job != NULL && resresv->job->resv == NULL)) {
 			res = simulate_resmin(sinfo->res, endtime, sinfo->calendar, NULL, resresv);
 			if ((resresv->job != NULL) && (resresv->job->resreq_rel != NULL))
 				resreq = resresv->job->resreq_rel;
@@ -1257,14 +1260,16 @@ check_avail_resources(schd_resource *reslist, resource_req *reqlist,
 					}
 				}
 			}
-			if(fail && (flags&RETURN_ALL_ERR)) {
+			if(fail && (flags & RETURN_ALL_ERR)) {
 				fail = 0;
 				any_fail = 1;
-				err->next = new_schd_error();
-				if(err->next == NULL)
-					return 0;
-				prev_err = err;
-				err = err->next;
+				if (err != NULL) {
+					err->next = new_schd_error();
+					if (err->next == NULL)
+						return 0;
+					prev_err = err;
+					err = err->next;
+				}
 			}
 		}
 	}
@@ -1695,12 +1700,16 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
  * @retval	0	: if it is dedtime and qinfo is a dedtime queue or
  *	     			if it is not dedtime and qinfo is not a dedtime queue
  * @retval	DED_TIME	: if jobs can not run in queue because of dedtime restrictions
+ * @retval	SCHD_ERROR	: An error has occurred.
  *
  */
 int
 check_ded_time_queue(queue_info *qinfo)
 {
 	int rc = 0;		/* return code */
+
+	if (qinfo == NULL || qinfo->server == NULL)
+		return SCHD_ERROR;
 
 	if (is_ded_time(qinfo->server->server_time)) {
 		if (qinfo->is_ded_queue)

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -502,19 +502,21 @@ shrink_to_run_event(status *policy, server_info *sinfo,
 		/* Now, go backwards in the events list */
 		for (te = farthest_event; retry_count != 0;
 			te = find_prev_timed_event(te, IGNORE_DISABLED_EVENTS, event_mask)) {
-			/* If there are no events left to check or if we have reached the front of event list or
-			 * if the event is falling before min end time, break.
-			 */
 			if (te == NULL)
 			{
+				/* If we've reached the end of the list, we're done */
+				if (last_skipped_event == NULL)
+					break;
 				te = last_skipped_event;
 				last_skipped_event = NULL;
 				/* No need to try next segments after this event as there are no events left */
 				retry_count = 0;
-			} else if ((te == NULL && last_skipped_event == NULL) || te == initial_event || te->event_time < min_end_time)
+			/* If we have reached the front of event list or if the event is falling before min end time, break. */
+			} else if (te == initial_event || te->event_time < min_end_time)
 				break;
-			/* If no events in this segment, then try last skipped event of the previous segment */
-			/* Skip events that fall in the previous segment or if the event time is already tried */
+			/* If no events in this segment, then try last skipped event of the previous segment
+			 * Skip events that fall in the previous segment or if the event time is already tried 
+			 */
 			else if (te->event_time > end_time || te->event_time == last_tried_event_time) {
 				last_skipped_event = te;
 				continue;

--- a/src/scheduler/fairshare.c
+++ b/src/scheduler/fairshare.c
@@ -367,8 +367,10 @@ preload_tree()
 	if ((head = new_fairshare_head()) == NULL)
 		return 0;
 
-	if ((root = new_group_info()) == NULL)
+	if ((root = new_group_info()) == NULL) {
+		free_fairshare_head(head);
 		return 0;
+	}
 
 	head->root = root;
 

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1589,11 +1589,9 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 				else
 					ret = 1;
 			}
-			else {
+			else
 				/* if we're simulating, resresvs can't fail to run */
 				ret = 1;
-				execvnode = "";
-			}
 		}
 		else  { /* should never happen */
 			schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, rr->name,
@@ -2435,6 +2433,14 @@ sched_settings_frm_svr(struct batch_status *status)
 		}
 		attr = attr->next;
 	}
+
+	if (tmp_priv_dir == NULL || tmp_log_dir == NULL) {
+		free(tmp_priv_dir);
+		free(tmp_log_dir);
+		free(tmp_comment);
+		return 0;
+	}
+
 	if (!dflt_sched) {
 		int err;
 		int priv_dir_update_fail = 0;

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2434,12 +2434,8 @@ sched_settings_frm_svr(struct batch_status *status)
 		attr = attr->next;
 	}
 
-	if (tmp_priv_dir == NULL || tmp_log_dir == NULL) {
-		free(tmp_priv_dir);
-		free(tmp_log_dir);
-		free(tmp_comment);
-		return 0;
-	}
+	if (tmp_priv_dir == NULL || tmp_log_dir == NULL)
+		goto cleanup;
 
 	if (!dflt_sched) {
 		int err;

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3870,9 +3870,9 @@ is_job_array(char *jobname)
 	bracket = strchr(jobname, (int) '[');
 
 	if (bracket != NULL) {
-		if (*(bracket+1) == ']')
+		if (*(bracket + 1) == ']')
 			ret = 1;
-		if (strchr(bracket, (int) '-') != NULL)
+		else if (strchr(bracket, (int) '-') != NULL)
 			ret = 3;
 		else
 			ret = 2;
@@ -4413,7 +4413,7 @@ geteoename(selspec *select)
 {
 	resource_req *req;
 
-	if (select == NULL)
+	if (select == NULL || select->chunks == NULL || select->chunks[0] == NULL)
 		return NULL;
 
 	/* we only need to look at 1st chunk since either all request eoe

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -645,8 +645,8 @@ string_array_to_str(char **strarr)
 
 	len += i; /* added space for the commas */
 
-	if (arrlen <= len) {
-		tmp = realloc(arrbuf, arrlen+len+1);
+	if (arrlen <= len || arrbuf == NULL) {
+		tmp = realloc(arrbuf, arrlen + len + 1);
 		if (tmp != NULL) {
 			arrlen += len + 1;
 			arrbuf = tmp;

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -640,6 +640,9 @@ string_array_to_str(char **strarr)
 	if (strarr == NULL)
 		return NULL;
 
+	if (strarr[0] == NULL)
+		return "";
+
 	for (i = 0; strarr[i] != NULL; i++)
 		len += strlen(strarr[i]);
 
@@ -663,7 +666,7 @@ string_array_to_str(char **strarr)
 		strcat(arrbuf, strarr[i]);
 		strcat(arrbuf, ",");
 	}
-	arrbuf[strlen(arrbuf)-1] = '\0';
+	arrbuf[strlen(arrbuf) - 1] = '\0';
 
 	return arrbuf;
 }

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -4173,7 +4173,7 @@ parse_selspec(char *select_spec)
 	}
 
 	s = strlen(select_spec);
-	if (s > specbuf_size) {
+	if (s > specbuf_size || specbuf == NULL) {
 		tmpptr = realloc(specbuf, s * 2 + 1);
 		if (tmpptr == NULL) {
 			log_err(errno, "parse_selspec", MEM_ERR_MSG);
@@ -4766,7 +4766,7 @@ reorder_nodes(node_info **nodes, resource_resv *resresv)
 
 	nsize = count_array((void **) nodes);
 
-	if (node_array_size < nsize + 1) {
+	if ((node_array_size < nsize + 1) || node_array == NULL) {
 		tmparr = realloc(node_array, sizeof(node_info *) * (nsize + 1));
 		if (tmparr == NULL) {
 			log_err(errno, __func__, MEM_ERR_MSG);

--- a/src/scheduler/range.c
+++ b/src/scheduler/range.c
@@ -166,6 +166,10 @@ dup_range_list(range *old_r)
 
 	while (cur_old_r != NULL) {
 		new_r = dup_range(cur_old_r);
+		if (new_r == NULL) {
+			free_range(new_r_head);
+			return NULL;
+		}
 
 		if (prev_new_r != NULL)
 			prev_new_r->next = new_r;

--- a/src/scheduler/range.c
+++ b/src/scheduler/range.c
@@ -167,7 +167,7 @@ dup_range_list(range *old_r)
 	while (cur_old_r != NULL) {
 		new_r = dup_range(cur_old_r);
 		if (new_r == NULL) {
-			free_range(new_r_head);
+			free_range_list(new_r_head);
 			return NULL;
 		}
 

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -1025,8 +1025,8 @@ find_resource_req(resource_req *reqlist, resdef *def)
  * @brief
  *		set_resource_req - set the value and type of a resource req
  *
- * @param[out]	req	-	the resource_req to set
- * @param[in]	val -	the string value
+ * @param[out]	req		the resource_req to set
+ * @param[in]	val -		the string value (can be NULL)
  *
  * @return	int
  * @retval	1 for Success
@@ -1036,6 +1036,9 @@ int
 set_resource_req(resource_req *req, char *val)
 {
 	resdef *rdef;
+
+	if (req == NULL)
+		return 0;
 
 	/* if val is a string, req -> amount will be set to SCHD_INFINITY_RES */
 	req->amount = res_to_num(val, &(req->type));
@@ -1052,7 +1055,7 @@ set_resource_req(resource_req *req, char *val)
 
 	if (req->amount == SCHD_INFINITY_RES) {
 		/* Verify that this is actually a non-numeric resource */
-		if (!req->def->type.is_string)
+		if (!req->type.is_string)
 			return 0;
 	}
 
@@ -2083,8 +2086,10 @@ create_select_from_nspec(nspec **nspec_array)
 			}
 		}
 	}
-	/* get rid of trailing '+' */
-	select_spec[strlen(select_spec)-1] = '\0';
+	if (select_spec != NULL) {
+		/* get rid of trailing '+' */
+		select_spec[strlen(select_spec) - 1] = '\0';
+	}
 
 	return select_spec;
 }

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1050,12 +1050,9 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						 * the required fields.
 						 */
 						release_nodes(nresv_copy);
-						nresv_copy->nspec_arr = parse_execvnode(occr_execvnodes_arr[j],
-							sinfo);
-						nresv_copy->ninfo_arr = create_node_array_from_nspec(
-							nresv_copy->nspec_arr);
-						nresv_copy->resv->resv_nodes = create_resv_nodes(
-							nresv_copy->nspec_arr, sinfo);
+						nresv_copy->nspec_arr = parse_execvnode(occr_execvnodes_arr[j], sinfo);
+						nresv_copy->ninfo_arr = create_node_array_from_nspec(nresv_copy->nspec_arr);
+						nresv_copy->resv->resv_nodes = create_resv_nodes(nresv_copy->nspec_arr, sinfo);
 					}
 
 					/* Note that the sequence of occurrence dates and time are determined
@@ -1232,7 +1229,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 	int confirmd_occr = 0;   /* the number of confirmed occurrence(s) */
 	int j, cur_count;
 
-	int tot_vnodes;   /* total number of vnodes associated to the reservation */
+	int tot_vnodes = 0;   /* total number of vnodes associated to the reservation */
 	int vnodes_down = 0;   /* the number of vnodes that are down */
 	char names_of_down_vnodes[MAXVNODELIST] = "";  /* the list of down vnodes */
 

--- a/src/server/attr_recov_db.c
+++ b/src/server/attr_recov_db.c
@@ -209,8 +209,7 @@ encode_attr_db(struct attribute_def *padef, struct attribute *pattr, int numattr
 	attrs = attr_list->attributes;
 
 	/* now that attribute has been encoded, update to db */
-	while ((pal = (svrattrl *)GET_NEXT(lhead)) !=
-		(svrattrl *)0) {
+	while ((pal = (svrattrl *)GET_NEXT(lhead)) != NULL) {
 		attrs[j].attr_name[sizeof(attrs[j].attr_name) - 1] = '\0';
 		strncpy(attrs[j].attr_name, pal->al_atopl.name, sizeof(attrs[j].attr_name));
 		if (pal->al_atopl.resource) {
@@ -313,6 +312,8 @@ decode_attr_db(
 
 		amt = pal->al_tsize - sizeof(svrattrl);
 		if (amt < 1) {
+			free(pal);
+			free(palarray);
 			snprintf(log_buffer,LOG_BUF_SIZE, "Invalid attr list size in DB");
 			log_err(-1, __func__, log_buffer);
 			goto out;

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -2013,7 +2013,7 @@ mgr_hook_set(struct batch_request *preq)
 			default:
 				snprintf(hook_msg, sizeof(hook_msg),
 					"%s - %s:%d", msg_internal,
-					plx->al_name, plx->al_op);
+					plx ? plx->al_name: "", plx ? plx->al_op: -1);
 				goto mgr_hook_set_error;
 		}
 		free(hook_fail_action_val);
@@ -6027,8 +6027,10 @@ check_add_hook_mcast_info(int conn, mominfo_t *minfo, char *hookname, int action
 						g_sync_hook_tid)) == NULL)
 			return NULL;
 
-		if ((dup_msgid = strdup(g_hook_mcast_array[i].msgid)) == NULL)
+		if ((dup_msgid = strdup(g_hook_mcast_array[i].msgid)) == NULL) {
+			free(info);
 			return NULL;
+		}
 
 		if (add_mom_deferred_list(conn, minfo, post_sendhookRPP,
 					dup_msgid, minfo, info) == NULL) {
@@ -7361,7 +7363,7 @@ get_server_hook_results(char *input_file, int *accept_flag, int *reject_flag, ch
 			}
 
 			/* if the hook is rejected we can go out now */
-			if((*reject_flag == 1) && (reject_msg != NULL))
+			if((reject_flag != NULL) && (*reject_flag == 1) && (reject_msg != NULL))
 				goto get_hook_results_end;
 		} else if (strncmp(obj_name, EVENT_VNODELIST_OBJECT,
 			vn_obj_len) == 0) {
@@ -7421,7 +7423,7 @@ get_server_hook_results(char *input_file, int *accept_flag, int *reject_flag, ch
 				pnode = find_nodebyname(vname_str);
 				if (pnode == NULL) {
 					log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_HOOK,
-						LOG_INFO, phook->hook_name, "node_name not found");
+						LOG_INFO, vname_str, "node_name not found");
 				} else if ((pnode->nd_state & INUSE_DELETED) == 0) {
 					save_characteristic(pnode);
 

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7046,7 +7046,7 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 			return PBSE_BADNODESPEC;
 
 		if (!strlen(execvnod))
-                        return PBSE_UNKNODE;
+			return PBSE_UNKNODE;
 
 		/* are we to allocate the nodes "excl" ? */
 		prsdef = find_resc_def(svr_resc_def, "place", svr_resc_size);

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1112,7 +1112,7 @@ arrayfree(char **array)
 
 	if (array == NULL)
 		return;
-	for (i=0; array[i]; i++)
+	for (i = 0; array[i]; i++)
 		free(array[i]);
 	free(array);
 }

--- a/src/server/req_holdjob.c
+++ b/src/server/req_holdjob.c
@@ -483,6 +483,7 @@ post_hold(struct work_task *pwt)
 			if (pjob->ji_pmt_preq != NULL)
 				reply_preempt_jobs_request(PBSE_SYSTEM, PREEMPT_METHOD_CHECKPOINT, pjob);
 			req_reject(PBSE_SYSTEM, 0, preq);
+			return;
 		}
 
 		conn->cn_authen &= ~PBS_NET_CONN_NOTIMEOUT;

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -2166,6 +2166,7 @@ RetryJob:
 
 				FREE_RUU(pruu)
 				free(mailbuf);
+				free(acctbuf);
 				return;
 
 			case JOB_EXEC_INITRMG:

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -208,7 +208,7 @@ setup_cpyfiles(struct batch_request *preq, job  *pjob, char *from, char *to, int
 
 		/* check that certain required attributues are valid */
 
-		if ((pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str==NULL) ||
+		if ((pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str == NULL) ||
 			(pjob->ji_wattr[(int)JOB_ATR_euser].at_val.at_str == NULL)) {
 			/* this case shouldn't happen, log it and don't do copy     */
 			/* use null jobid, if attr missing, jobid is likely bad too */
@@ -309,6 +309,8 @@ setup_cpyfiles(struct batch_request *preq, job  *pjob, char *from, char *to, int
 
 	pair = (struct rqfpair *)malloc(sizeof(struct rqfpair));
 	if (pair == NULL) {
+		free(from);
+		free(to);
 		free_br(preq);
 		return NULL;
 	}
@@ -2206,6 +2208,7 @@ RetryJob:
 					svr_setjobstate(pjob, JOB_STATE_HELD, JOB_SUBSTATE_HELD);
 					FREE_RUU(pruu)
 					free(mailbuf);
+					free(acctbuf);
 					return;
 		}
 	}

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1730,6 +1730,7 @@ mgr_server_unset(struct batch_request *preq)
 					tm_list = attrlist_create(plist->al_name, "ncpus", 8);
 					if (tm_list == NULL) {
 						reply_badattr(-1, bad_attr, plist, preq);
+						return;
 					}
 					tm_list->al_link.ll_next->ll_struct = NULL;
 					sprintf(tm_list->al_value, "%d", 1);
@@ -2748,7 +2749,7 @@ mgr_node_unset(struct batch_request *preq)
 						strncpy(hostname, pnode->nd_name, (sizeof(hostname) - 1));
 					}
 					clear_attr(&tmp, &node_attr_def[(int)ND_ATR_Mom]);
-					rc = decode_arst(&tmp, ND_ATR_Mom, NULL, hostname);
+					rc = decode_arst(&tmp, ATTR_NODE_Mom, NULL, hostname);
 					if (rc == 0) {
 						set_arst(&pnode->nd_attr[(int)ND_ATR_Mom], &tmp, INCR);
 						pnode->nd_attr[(int)ND_ATR_Mom].at_flags |= ATR_VFLAG_DEFLT;
@@ -2915,7 +2916,7 @@ make_host_addresses_list(char *phost, u_long **pul)
 	len = sizeof(u_long) * (i + 1);
 	*pul = (u_long *)malloc(len);
 	if (*pul == NULL) {
-		strcat(log_buffer, "out of  memory ");
+		strcat(log_buffer, "Out of memory ");
 		return (PBSE_SYSTEM);
 	}
 
@@ -2932,7 +2933,7 @@ make_host_addresses_list(char *phost, u_long **pul)
 	}
 	(*pul)[i] = 0; /* null term array ip adrs */
 
-	freeaddrinfo( pai);
+	freeaddrinfo(pai);
 
 	tpul = malloc(sizeof(struct pul_store));
 	if (!tpul) {
@@ -3025,7 +3026,7 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 	char		*pc;
 	char		*phost;		/* trial host name */
 	char		*pname;		/* node name w/o any :ts       */
-	u_long		*pul;		/* 0 terminated host adrs array*/
+	u_long		*pul = NULL;	/* 0 terminated host adrs array*/
 	int		 rc;
 	int		 j;
 	int		 iht;
@@ -3290,10 +3291,11 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 				 * an "empty" pul list
 				 */
 				pul = malloc(sizeof(u_long) * (1));
-				pul[0]=0;
+				pul[0] = 0;
 				ret = PBSE_UNKNODE; /* set return of function to this, so that error is logged */
 			} else {
 				effective_node_delete(pnode);
+				free(pul);
 				return (rc); /* return the error code from make_host_addresses_list */
 			}
 		}
@@ -3305,7 +3307,7 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 
 		nport = pnode->nd_attr[(int)ND_ATR_Port].at_val.at_long;
 
-		if ((pmom = create_svrmom_entry(phost , nport, pul)) == NULL) {
+		if ((pmom = create_svrmom_entry(phost, nport, pul)) == NULL) {
 			effective_node_delete(pnode);
 			return (PBSE_SYSTEM);
 		}
@@ -3531,9 +3533,9 @@ struct batch_request *preq;
 	/*remove the IP address array hanging from the node               */
 
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
-	for (i=0; i<svr_totnodes; i++) {
+	for (i = 0; i < svr_totnodes; i++) {
 		if (numnodes > 1)
-			pnode=pbsndlist[i];
+			pnode = pbsndlist[i];
 
 		rc = 0;
 

--- a/src/server/req_preemptjob.c
+++ b/src/server/req_preemptjob.c
@@ -345,10 +345,8 @@ req_preemptjobs(struct batch_request *preq)
 	}
 	preq->rq_reply.brp_un.brp_preempt_jobs.count = preempt_index;
 	/* check if all jobs failed */
-	if (preempt_index == preempt_total) {
+	if (preempt_index == preempt_total)
 		reply_send(preq);
-		pjob->ji_pmt_preq = NULL;
-	}
 }
 
 /**

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -279,7 +279,7 @@ action_sched_priv(attribute *pattr, void *pobj, int actmode)
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
 	}
-	if (actmode != ATR_ACTION_RECOV)
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER)
 		(void)contact_sched(SCH_ATTRS_CONFIGURE, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port);
 	return PBSE_NONE;
 }

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4995,13 +4995,13 @@ alter_eligibletime(attribute *pattr, void *pobject, int actmode)
 			 * this is for log message, we have the new value anyways.
 			 */
 			strtime = convert_long_to_time(pattr->at_val.at_long);
-			if (strtime == NULL)
-				strtime = errtime;
 
 			sprintf(logstr, "Accrue type is %s, previous accrue type was %s for %ld secs, due to qalter total eligible_time=%s",
-				msg[newaccruetype], msg[oldaccruetype], accrued_time, strtime);
+				msg[newaccruetype], msg[oldaccruetype], accrued_time, strtime != NULL ? strtime: errtime);
 			log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 				pjob->ji_qs.ji_jobid, logstr);
+
+			free(strtime);
 
 			return PBSE_NONE;
 		}

--- a/src/server/svr_migrate_data.c
+++ b/src/server/svr_migrate_data.c
@@ -651,6 +651,7 @@ svr_migrate_data_from_fs(void)
 			return (-1);
 		}
 		(void) closedir(dir);
+		free(scrbuf);
 		fprintf(stderr, msg_init_exptjobs, recovered);
 		fprintf(stderr, "\n");
 	}

--- a/src/server/vnparse.c
+++ b/src/server/vnparse.c
@@ -2753,7 +2753,7 @@ intmap_need_to_have_resources(char *buf, size_t buf_sz,
 		return;
 
 	have_int = (int)strtol(have_val, &endp, 10);
-	if ((*endp != '\0') || (have_int == LONG_MIN) || (have_int == LONG_MAX)) {
+	if (*endp != '\0') {
 		log_err(errno, __func__, "strtoul error"); 
 		return;
 	}

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -2399,8 +2399,7 @@ main(int argc, char *argv[], char *envp[])
 
 		/* Copy envp to lenvp */
 		found_pyhome = 0;
-		i = 0;
-		for (i=0; envp[i] != NULL; i++) {
+		for (i = 0; envp[i] != NULL; i++) {
 			if (strncmp(envp[i], PYHOME_EQUAL,
 				sizeof(PYHOME_EQUAL)-1) == 0) {
 				printf("[%d] found py_home %s resetting to %s\n",
@@ -2851,8 +2850,8 @@ main(int argc, char *argv[], char *envp[])
 			 * strcat() instead.
 			 */
 			snprintf(full_logname, sizeof(full_logname), "%s", curdir);
-			strncat(full_logname, slash, sizeof(full_logname) - strlen(full_logname));
-			strncat(full_logname, logname, sizeof(full_logname) - strlen(full_logname));
+			strncat(full_logname, slash, sizeof(full_logname) - strlen(full_logname) - 1);
+			strncat(full_logname, logname, sizeof(full_logname) - strlen(full_logname) - 1);
 			snprintf(logname, sizeof(logname), "%s", full_logname);
 		}
 


### PR DESCRIPTION
#### Describe Bug or Feature
Clang (alternate compiler to gcc) has a static analyzer.  I ran it on PBS and it came up with many warnings.  I fixed two types: Possible memory leaks and possible NULL pointer dereferences.

Mostly the possible memory leaks were in error cases where you needed to clean up, and some variables weren't being freed.
Possible NULL pointer dereferences usually were some strange path through the code that could lead to a pointer being NULL and being dereferenced.

There is a 3rd I fixed here and there (but not all of them): Variables being set and never used.

For testing I am currently running tests through an internal test harness tool.  It takes time, so I thought I'd put the PR out for review before it is done.