### PR TITLE
Check substate also for job, when count=True

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8128,18 +8128,18 @@ class Server(PBSService):
 
         # Add check for substate=42 for jobstate=R, if not added explicitly.
         if obj_type == JOB:
-            add_attribs = {'substate': False}
+            add_attribs = {}
             substate = False
             for k, v in attrib.items():
                 if k == 'job_state' and ((isinstance(v, tuple) and
                                           'R' in v[-1]) or v == 'R'):
                     add_attribs['substate'] = 42
                 elif k == 'job_state=R':
-                    add_attribs['substate=42'] = v
+                    attrib['substate=42'] = v
                 elif 'substate' in k:
                     substate = True
-            if add_attribs['substate'] and not substate:
-                attrib['substate'] = add_attribs['substate']
+            if add_attribs and not substate:
+                attrib.update(add_attribs)
                 attrop = PTL_AND
             del add_attribs, substate
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8135,7 +8135,7 @@ class Server(PBSService):
                                           'R' in v[-1]) or v == 'R'):
                     add_attribs['substate'] = 42
                 elif k == 'job_state=R':
-                    attrib['substate=42'] = v
+                    add_attribs['substate=42'] = v
                 elif 'substate' in k:
                     substate = True
             if add_attribs and not substate:

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -675,7 +675,8 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, SERVER, a)
         # Given node configuration of 8 cpus the only jobs that could run are
         # j4id j1id and j3id
-        self.server.expect(JOB, {'job_state=R': 3})
+        self.server.expect(JOB, {'job_state=R': 3},
+                           trigger_sched_cycle=False)
         cycle = self.scheduler.cycles(start=self.server.ctime, lastN=2)
         if len(cycle) > 0:
             i = len(cycle) - 1


### PR DESCRIPTION

#### Describe Bug or Feature

- self.server.expect(JOB, {'job_state=R': 10}) is not confirm substate for job ,even count=True

From logs we found  that its only looking for job_state=R not substate 
2019-06-08 10:59:49,779 INFO expect on server a01: job_state=R = 10 job ... OK

#### Describe Your Change

-  Did need full changes to handle this failure in def expect( ) in pbs_testlib.py
after changes done ,its verifying substate also
2019-07-02 07:07:38,418 INFO     expect on server a01: job_state=R = 10 && substate=42 = 10 job attempt: 5 ...  OK


#### Attach Test and Valgrind Logs/Output

-  [without_fix.txt](https://github.com/PBSPro/pbspro/files/3350633/without_fix.txt)

-  [with_fix.txt](https://github.com/PBSPro/pbspro/files/3350635/with_fix.txt)

