### PR TITLE
corrections to eatmem_job2 affecting mem/vmem usage

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -188,6 +188,7 @@ if sleeptime > 0:
         self.eatmem_job1 = \
             '#PBS -joe\n' \
             '#PBS -S /bin/bash\n' \
+            'sync\n' \
             'sleep 4\n' \
             'python - 80 10 10 <<EOF\n' \
             '%s\nEOF\n' % self.eatmem_script
@@ -197,15 +198,16 @@ if sleeptime > 0:
             'sync\n' \
             'let i=0; while [ $i -lt 400000 ]; do let i+=1 ; done\n' \
             'python - 200 2 10 <<EOF\n' \
-            '%s\nEOF\n' \
+            '%s EOF\n' \
             'let i=0; while [ $i -lt 400000 ]; do let i+=1 ; done\n' \
             'python - 100 4 10 <<EOF\n' \
-            '%s\nEOF\n' \
+            '%sEOF\n' \
             'let i=0; while [ $i -lt 400000 ]; do let i+=1 ; done\n' \
             'sleep 25\n' % (self.eatmem_script, self.eatmem_script)
         self.eatmem_job3 = \
             '#PBS -joe\n' \
             '#PBS -S /bin/bash\n' \
+            'sync\n' \
             'sleep 2\n' \
             'let i=0; while [ $i -lt 500000 ]; do let i+=1 ; done\n' \
             'python - 90 5 30 <<EOF\n' \

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -194,6 +194,7 @@ if sleeptime > 0:
         self.eatmem_job2 = \
             '#PBS -joe\n' \
             '#PBS -S /bin/bash\n' \
+            'sync\n' \
             'let i=0; while [ $i -lt 400000 ]; do let i+=1 ; done\n' \
             'python - 200 2 10 <<EOF\n' \
             '%s\nEOF\n' \

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -196,10 +196,10 @@ if sleeptime > 0:
             '#PBS -S /bin/bash\n' \
             'let i=0; while [ $i -lt 400000 ]; do let i+=1 ; done\n' \
             'python - 200 2 10 <<EOF\n' \
-            '%s EOF\n' \
+            '%s\nEOF\n' \
             'let i=0; while [ $i -lt 400000 ]; do let i+=1 ; done\n' \
             'python - 100 4 10 <<EOF\n' \
-            '%sEOF\n' \
+            '%s\nEOF\n' \
             'let i=0; while [ $i -lt 400000 ]; do let i+=1 ; done\n' \
             'sleep 25\n' % (self.eatmem_script, self.eatmem_script)
         self.eatmem_job3 = \

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -198,10 +198,10 @@ if sleeptime > 0:
             'sync\n' \
             'let i=0; while [ $i -lt 400000 ]; do let i+=1 ; done\n' \
             'python - 200 2 10 <<EOF\n' \
-            '%s EOF\n' \
+            '%s\nEOF\n' \
             'let i=0; while [ $i -lt 400000 ]; do let i+=1 ; done\n' \
             'python - 100 4 10 <<EOF\n' \
-            '%sEOF\n' \
+            '%s\nEOF\n' \
             'let i=0; while [ $i -lt 400000 ]; do let i+=1 ; done\n' \
             'sleep 25\n' % (self.eatmem_script, self.eatmem_script)
         self.eatmem_job3 = \


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test_cgroup_qstat_resources of TestCgroupsHook is intermittently failing when checking mem and/or vmem usage.


#### Describe Your Change
Corrected the PBS job (eatmem_job2) that affects the amount of mem and/or vmem used.


#### Attach Test Output

looped tests 50 times on ubuntu where test consistently failed:
1) before fix (failed 1 out of 50 times):
[tests4_cgroup_19.4_9Jul19_loop_before.txt](https://github.com/PBSPro/pbspro/files/3388215/tests4_cgroup_19.4_9Jul19_loop_before.txt)


2) after fix:
[tests4_cgroup_19.4_9Jul19_loop_after.txt](https://github.com/PBSPro/pbspro/files/3388217/tests4_cgroup_19.4_9Jul19_loop_after.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
