### PR TITLE
queues have their own has_user/grp/proj_limits flags

### DIFF
--- a/src/include/limits_if.h
+++ b/src/include/limits_if.h
@@ -238,7 +238,7 @@ void update_soft_limits(server_info *, queue_info *, resource_resv *);
  *		the counts structure
  * @return	int
  */
-int find_preempt_bit(counts *, char *, resource_resv *);
+int find_preempt_bits(counts *, char *, resource_resv *);
 #ifdef	__cplusplus
 }
 #endif

--- a/src/include/limits_if.h
+++ b/src/include/limits_if.h
@@ -226,7 +226,19 @@ extern void 	clear_limres(void);
  */
 extern schd_resource *query_limres(void);
 
+ /**
+  *  @brief check the soft limit using soft limit function.
+  *
+  *  @return void
+  */
+void update_soft_limits(server_info *, queue_info *, resource_resv *);
 
+/**
+ * @brief	find the value of preempt bit with matching entity and resource in
+ *		the counts structure
+ * @return	int
+ */
+int find_preempt_bit(counts *, char *, resource_resv *);
 #ifdef	__cplusplus
 }
 #endif

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1333,6 +1333,7 @@ sch_resource_t
 count_res_by_user(resource_resv **resresv_arr, char *user,
 	char *res, counts *cts_list)
 {
+	resource_count *res_c;			/* the resource count of the matching user and resource */
 	resource_req *req;			/* the resource of the current job */
 	sch_resource_t used = 0;
 	counts *cts;
@@ -1343,8 +1344,8 @@ count_res_by_user(resource_resv **resresv_arr, char *user,
 		return 0;
 
 	if ((cts = find_counts(cts_list, user)) != NULL) {
-		if ((req = find_resource_req_by_str(cts->rescts, res)) != NULL)
-			return req->amount;
+		if ((res_c = find_resource_count_by_str(cts->rescts, res)) != NULL)
+			return res_c->amount;
 	}
 
 	for (i = 0; resresv_arr[i] != NULL; i++) {
@@ -1365,26 +1366,31 @@ count_res_by_user(resource_resv **resresv_arr, char *user,
  *
  * @param[in]	cts_list	-	counts list to search
  * @param[in]	name	-	name of counts structure to find
- * @param[in]	res	-	resource to find or if NULL,
- *						return number of running
+ * @param[in]	rdef	-	resource definition to find or if NULL,
+ *				return number of running
+ * @param[out]  cnt	-	address of the counts structure found in the list
+ * @param[out]  rreq	-	address of matching resource count structure
  *
  * @return	resource amount
  */
 sch_resource_t
-find_counts_elm(counts *cts_list, char *name, char *res)
+find_counts_elm(counts *cts_list, char *name, resdef *rdef, counts **cnt, resource_count **rreq)
 {
-	resource_req *req;
+	resource_count *req;
 	counts *cts;
 
 	if (cts_list == NULL || name == NULL)
 		return 0;
 
 	if ((cts = find_counts(cts_list, name)) != NULL) {
-
-		if (res == NULL)
+		if (cnt != NULL)
+			*cnt = cts;
+		if (rdef == NULL)
 			return cts->running;
 		else {
-			if ((req = find_resource_req_by_str(cts->rescts, res)) != NULL)
+			if ((req = find_resource_count(cts->rescts, rdef)) != NULL)
+				if (rreq != NULL)
+					*rreq = req;
 				return req->amount;
 		}
 	}

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -54,7 +54,6 @@
  *	is_ok_to_run()
  *	check_avail_resources()
  *	dynamic_avail()
- *	count_res_by_user()
  *	find_counts_elm()
  *	check_ded_time_boundary()
  *	dedtime_conflict()
@@ -1315,47 +1314,6 @@ dynamic_avail(schd_resource *res)
 		return 0;
 	else
 		return res->avail - res->assigned;
-}
-
-/**
- * @brief
- *		count_res_by_user - count a user's current running resource usage
- *
- * @param[in]	resresv_arr	-	the resource resvs to accumulate from
- * @param[in]	user	-	the user
- * @param[in]	res	-	the resource name
- * @param[in]	cts_list	-	the user counts list
- *
- * @return	the amount of the resource used by the user
- *
- */
-sch_resource_t
-count_res_by_user(resource_resv **resresv_arr, char *user,
-	char *res, counts *cts_list)
-{
-	resource_count *res_c;			/* the resource count of the matching user and resource */
-	resource_req *req;			/* the resource of the current job */
-	sch_resource_t used = 0;
-	counts *cts;
-
-	int i;
-
-	if (resresv_arr == NULL || user == NULL || res == NULL)
-		return 0;
-
-	if ((cts = find_counts(cts_list, user)) != NULL) {
-		if ((res_c = find_resource_count_by_str(cts->rescts, res)) != NULL)
-			return res_c->amount;
-	}
-
-	for (i = 0; resresv_arr[i] != NULL; i++) {
-		if (!strcmp(resresv_arr[i]->user, user)) {
-			req = find_resource_req_by_str(resresv_arr[i]->resreq, res);
-			if (req != NULL)
-				used += req->amount;
-		}
-	}
-	return used;
 }
 
 /**

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1391,7 +1391,7 @@ find_counts_elm(counts *cts_list, char *name, resdef *rdef, counts **cnt, resour
 			if ((req = find_resource_count(cts->rescts, rdef)) != NULL)
 				if (rreq != NULL)
 					*rreq = req;
-				return req->amount;
+			return req->amount;
 		}
 	}
 

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1369,14 +1369,14 @@ count_res_by_user(resource_resv **resresv_arr, char *user,
  * @param[in]	rdef	-	resource definition to find or if NULL,
  *				return number of running
  * @param[out]  cnt	-	address of the counts structure found in the list
- * @param[out]  rreq	-	address of matching resource count structure
+ * @param[out]  rcount	-	address of matching resource count structure
  *
  * @return	resource amount
  */
 sch_resource_t
-find_counts_elm(counts *cts_list, char *name, resdef *rdef, counts **cnt, resource_count **rreq)
+find_counts_elm(counts *cts_list, char *name, resdef *rdef, counts **cnt, resource_count **rcount)
 {
-	resource_count *req;
+	resource_count *res_lim;
 	counts *cts;
 
 	if (cts_list == NULL || name == NULL)
@@ -1388,10 +1388,10 @@ find_counts_elm(counts *cts_list, char *name, resdef *rdef, counts **cnt, resour
 		if (rdef == NULL)
 			return cts->running;
 		else {
-			if ((req = find_resource_count(cts->rescts, rdef)) != NULL)
-				if (rreq != NULL)
-					*rreq = req;
-			return req->amount;
+			if ((res_lim = find_resource_count(cts->rescts, rdef)) != NULL)
+				if (rcount != NULL)
+					*rcount = res_lim;
+			return res_lim->amount;
 		}
 	}
 

--- a/src/scheduler/check.h
+++ b/src/scheduler/check.h
@@ -125,8 +125,10 @@ sch_resource_t dynamic_avail(schd_resource *res);
  *	name     - name of counts structure to find
  *	res      - resource to find or if NULL, return number of running
  *			resource amount
+ *	cnt	- output param for address of the matching counts structure
+ *	rreq	- output param for address of the matching resource_count structure
  */
-sch_resource_t find_counts_elm(counts *cts_list, char *name, char *res);
+sch_resource_t find_counts_elm(counts *cts_list, char *name, resdef *res, counts **cnt, resource_count **rreq);
 
 
 /*

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -72,6 +72,7 @@ struct node_info;
 struct job_info;
 struct schd_resource;
 struct resource_req;
+struct resource_count;
 struct holiday;
 struct prev_job_info;
 struct group_info;
@@ -106,6 +107,7 @@ typedef struct job_info job_info;
 typedef struct node_info node_info;
 typedef struct schd_resource schd_resource;
 typedef struct resource_req resource_req;
+typedef struct resource_count resource_count;
 typedef struct usage_info usage_info;
 typedef struct group_info group_info;
 typedef struct prev_job_info prev_job_info;
@@ -372,6 +374,7 @@ struct server_info
 	resresv_set **equiv_classes;
 	node_bucket **buckets;		/* node bucket array */
 	node_info **unordered_nodes;
+	int preempt_bit;		/* Overall preempt bit to mark server is over max run softlimits */
 #ifdef NAS
 	/* localmod 049 */
 	node_info **nodes_by_NASrank;	/* nodes indexed by NASrank */
@@ -439,6 +442,7 @@ struct queue_info
 	int num_topjobs;	/* current number of top jobs in this queue */
 	int backfill_depth;	/* total allowable topjobs in this queue*/
 	char *partition;	/* partition to which queue belongs to */
+	int preempt_bit;	/* Overall preempt bit to mark queue is over max run softlimits */
 };
 
 struct job_info
@@ -739,7 +743,6 @@ struct resource_type
 	unsigned is_time:1;
 };
 
-
 struct schd_resource
 {
 	char *name;			/* name of the resource - reference to the definition name */
@@ -796,8 +799,18 @@ struct counts
 {
 	char *name;		/* name of entitiy */
 	int running;		/* count of running jobs in object */
-	resource_req *rescts;	/* resources used */
+	int preempt_bit;	/* Place to store preempt bit if entity is over limits */
+	resource_count *rescts;	/* resources used */
 	counts *next;
+};
+
+struct resource_count
+{
+	char *name;		    /* resource name */
+	resdef *def;		    /* definition of resource */
+	sch_resource_t amount;	    /* amount of resource used */
+	int preempt_bit;	    /* Place to store preempt bit if resource of an entity is over limits */
+	struct resource_count *next;
 };
 
 /* global data types */

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -374,7 +374,7 @@ struct server_info
 	resresv_set **equiv_classes;
 	node_bucket **buckets;		/* node bucket array */
 	node_info **unordered_nodes;
-	int preempt_bit;		/* Overall preempt bit to mark server is over max run softlimits */
+	int soft_limit_preempt_bit;	/* Overall preempt bit to mark server is over max run softlimits */
 #ifdef NAS
 	/* localmod 049 */
 	node_info **nodes_by_NASrank;	/* nodes indexed by NASrank */
@@ -438,11 +438,11 @@ struct queue_info
 	char **node_group_key;		/* node grouping resources */
 	struct node_partition **nodepart; /* array pointers to node partitions */
 	struct node_partition *allpart;   /* partition w/ all nodes assoc with queue*/
-	int num_parts;		/* number of node partitions(node_group_key) */
-	int num_topjobs;	/* current number of top jobs in this queue */
-	int backfill_depth;	/* total allowable topjobs in this queue*/
-	char *partition;	/* partition to which queue belongs to */
-	int preempt_bit;	/* Overall preempt bit to mark queue is over max run softlimits */
+	int num_parts;			/* number of node partitions(node_group_key) */
+	int num_topjobs;		/* current number of top jobs in this queue */
+	int backfill_depth;		/* total allowable topjobs in this queue*/
+	char *partition;		/* partition to which queue belongs to */
+	int soft_limit_preempt_bit;	/* Overall preempt bit to mark queue is over max run softlimits */
 };
 
 struct job_info
@@ -797,10 +797,10 @@ struct mom_res
 
 struct counts
 {
-	char *name;		/* name of entitiy */
-	int running;		/* count of running jobs in object */
-	int preempt_bit;	/* Place to store preempt bit if entity is over limits */
-	resource_count *rescts;	/* resources used */
+	char *name;			/* name of entitiy */
+	int running;			/* count of running jobs in object */
+	int soft_limit_preempt_bit;	/* Place to store preempt bit if entity is over limits */
+	resource_count *rescts;		/* resources used */
 	counts *next;
 };
 
@@ -809,7 +809,7 @@ struct resource_count
 	char *name;		    /* resource name */
 	resdef *def;		    /* definition of resource */
 	sch_resource_t amount;	    /* amount of resource used */
-	int preempt_bit;	    /* Place to store preempt bit if resource of an entity is over limits */
+	int soft_limit_preempt_bit; /* Place to store preempt bit if resource of an entity is over limits */
 	struct resource_count *next;
 };
 

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -393,7 +393,10 @@ struct queue_info
 	unsigned has_soft_limit:1;	/* queue has a soft user/grp limit set */
 	unsigned has_hard_limit:1;	/* queue has a hard user/grp limit set */
 	unsigned is_peer_queue:1;	/* queue is a peer queue */
-	unsigned has_resav_limit:1;		/* queue has resources_available limits */
+	unsigned has_resav_limit:1;	/* queue has resources_available limits */
+	unsigned has_user_limit:1;	/* queue has user hard or soft limit */
+	unsigned has_grp_limit:1;	/* queue has group hard or soft limit */
+	unsigned has_proj_limit:1;	/* queue has project hard or soft limit */
 	struct server_info *server;	/* server where queue resides */
 	char *name;			/* queue name */
 	state_count sc;			/* number of jobs in different states */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -458,12 +458,18 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 	 * 2. we need all the jobs to be created and up to date for soft run limits
 	 */
 
+	/* Before setting preempt priorities on all jobs, make sure that entity's preempt bit
+	 * is updated for all running jobs
+	 */
+	if ((sinfo->running_jobs != NULL) && (policy->preempting)) {
+		for (i = 0; sinfo->running_jobs[i] != NULL; i++)
+			update_soft_limits (sinfo, sinfo->running_jobs[i]->job->queue, sinfo->running_jobs[i]);
+	}
 	if (sinfo->jobs != NULL) {
 		for (i = 0; sinfo->jobs[i] != NULL; i++) {
 			resource_resv *resresv = sinfo->jobs[i];
 			if (resresv->job != NULL) {
 				if (policy->preempting) {
-					update_soft_limits(sinfo, resresv->job->queue, resresv);
 					set_preempt_prio(resresv, resresv->job->queue, sinfo);
 					if (resresv->job->is_running)
 						if (!resresv->job->can_not_preempt)
@@ -911,7 +917,10 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 			if (rc != SCHD_ERROR) {
 				if(run_update_resresv(policy, sd, sinfo, qinfo, tj, ns_arr, RURR_ADD_END_EVENT, err) > 0 ) {
 					rc = SUCCESS;
-					sort_again = MAY_RESORT_JOBS;
+					if (sinfo->has_soft_limit || qinfo->has_soft_limit)
+						sort_again = MUST_RESORT_JOBS;
+					else
+						sort_again = MAY_RESORT_JOBS;
 				} else {
 					/* if run_update_resresv() returns 0 and pbs_errno == PBSE_HOOKERROR,
 					 * then this job is required to be ignored in this scheduling cycle

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -463,6 +463,7 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 			resource_resv *resresv = sinfo->jobs[i];
 			if (resresv->job != NULL) {
 				if (policy->preempting) {
+					update_soft_limits(sinfo, resresv->job->queue, resresv);
 					set_preempt_prio(resresv, resresv->job->queue, sinfo);
 					if (resresv->job->is_running)
 						if (!resresv->job->can_not_preempt)
@@ -1683,6 +1684,14 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 		update_queue_on_run(qinfo, rr, &old_state);
 
 		update_server_on_run(policy, sinfo, qinfo, rr, &old_state);
+
+		/* update soft limits for jobs that are not in reservation */
+		if (rr->is_job && rr->job->resv_id == NULL) {
+			/* update the entity preempt bit */
+			update_soft_limits(sinfo, qinfo, resresv);
+			/* update the job preempt status */
+			set_preempt_prio(resresv, qinfo, sinfo);
+		}
 
 		/* update_preemption_on_run() must be called post queue/server update */
 		update_preemption_on_run(sinfo, rr);

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -462,8 +462,10 @@ init_scheduling_cycle(status *policy, int pbs_sd, server_info *sinfo)
 	 * is updated for all running jobs
 	 */
 	if ((sinfo->running_jobs != NULL) && (policy->preempting)) {
-		for (i = 0; sinfo->running_jobs[i] != NULL; i++)
-			update_soft_limits (sinfo, sinfo->running_jobs[i]->job->queue, sinfo->running_jobs[i]);
+		for (i = 0; sinfo->running_jobs[i] != NULL; i++) {
+			if (sinfo->running_jobs[i]->job->resv_id == NULL)
+				update_soft_limits(sinfo, sinfo->running_jobs[i]->job->queue, sinfo->running_jobs[i]);
+		}
 	}
 	if (sinfo->jobs != NULL) {
 		for (i = 0; sinfo->jobs[i] != NULL; i++) {

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -5215,6 +5215,8 @@ resource_resv **filter_preemptable_jobs(resource_resv **arr, resource_resv *job,
 		case QUEUE_BYPROJECT_JOB_LIMIT_REACHED:
 
 		case INSUFFICIENT_RESOURCE:
+		case INSUFFICIENT_QUEUE_RESOURCE:
+		case INSUFFICIENT_SERVER_RESOURCE:
 			arg.job = job;
 			arg.err = err;
 			temp = resource_resv_filter(arr, arr_length, cull_preemptible_jobs, &arg, 0);

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2185,15 +2185,16 @@ dup_resresv_set_array(resresv_set **osets, server_info *nsinfo)
 /**
  * @brief should a resresv_set use the user
  * @param sinfo - server info
+ * @param qinfo - queue info
  * @retval 1 - yes
  * @retval 0 - no
  */
 int
-resresv_set_use_user(server_info *sinfo)
+resresv_set_use_user(server_info *sinfo, queue_info *qinfo)
 {
-	if (sinfo == NULL)
-		return 0;
-	if (sinfo->has_user_limit)
+	if ((sinfo != NULL) && (sinfo->has_user_limit))
+		return 1;
+	if ((qinfo != NULL) && (qinfo->has_user_limit))
 		return 1;
 
 
@@ -2203,15 +2204,16 @@ resresv_set_use_user(server_info *sinfo)
 /**
  * @brief should a resresv_set use the group
  * @param sinfo - server info
+ * @param qinfo - queue info
  * @retval 1 - yes
  * @retval 0 - no
  */
 int
-resresv_set_use_grp(server_info *sinfo)
+resresv_set_use_grp(server_info *sinfo, queue_info *qinfo)
 {
-	if (sinfo == NULL)
-		return 0;
-	if (sinfo->has_grp_limit)
+	if ((sinfo != NULL) && (sinfo->has_grp_limit))
+		return 1;
+	if ((qinfo != NULL) && (qinfo->has_grp_limit))
 		return 1;
 
 
@@ -2221,15 +2223,16 @@ resresv_set_use_grp(server_info *sinfo)
 /**
  * @brief should a resresv_set use the project
  * @param sinfo - server info
+ * @param qinfo - queue info
  * @retval 1 - yes
  * @retval 0 - no
  */
 int
-resresv_set_use_proj(server_info *sinfo)
+resresv_set_use_proj(server_info *sinfo, queue_info *qinfo)
 {
-	if (sinfo == NULL)
-		return 0;
-	if (sinfo->has_proj_limit)
+	if ((sinfo != NULL) && (sinfo->has_proj_limit))
+		return 1;
+	if ((qinfo != NULL) && (qinfo->has_proj_limit))
 		return 1;
 
 
@@ -2365,11 +2368,16 @@ create_resresv_set_by_resresv(status *policy, server_info *sinfo, resource_resv 
 	if (rset == NULL)
 		return NULL;
 
-	if (resresv_set_use_user(sinfo))
+	if (resresv->is_job && resresv->job != NULL) {
+		if (resresv_set_use_queue(resresv->job->queue))
+			rset->qinfo = resresv->job->queue;
+	}
+
+	if (resresv_set_use_user(sinfo, rset->qinfo))
 		rset->user = string_dup(resresv->user);
-	if (resresv_set_use_grp(sinfo))
+	if (resresv_set_use_grp(sinfo, rset->qinfo))
 		rset->group = string_dup(resresv->group);
-	if (resresv_set_use_proj(sinfo))
+	if (resresv_set_use_proj(sinfo, rset->qinfo))
 		rset->project = string_dup(resresv->project);
 
 	if (resresv->is_job && resresv->job != NULL) {
@@ -2390,10 +2398,6 @@ create_resresv_set_by_resresv(status *policy, server_info *sinfo, resource_resv 
 	/* rset->req may be NULL if the intersection of resresv->resreq and policy->equiv_class_resdef is the NULL set */
 	rset->req = dup_selective_resource_req_list(resresv->resreq, policy->equiv_class_resdef);
 
-	if (resresv->is_job && resresv->job != NULL) {
-		if (resresv_set_use_queue(resresv->job->queue))
-			rset->qinfo = resresv->job->queue;
-	}
 
 	return rset;
 }
@@ -2481,13 +2485,17 @@ find_resresv_set_by_resresv(status *policy, resresv_set **rsets, resource_resv *
 	if (policy == NULL || rsets == NULL || resresv == NULL)
 		return -1;
 
-	if (resresv_set_use_user(resresv->server))
+	if (resresv->is_job && resresv->job != NULL)
+		if (resresv_set_use_queue(resresv->job->queue))
+			qinfo = resresv->job->queue;
+
+	if (resresv_set_use_user(resresv->server, qinfo))
 		user = resresv->user;
 
-	if (resresv_set_use_grp(resresv->server))
+	if (resresv_set_use_grp(resresv->server, qinfo))
 		grp = resresv->group;
 
-	if (resresv_set_use_proj(resresv->server))
+	if (resresv_set_use_proj(resresv->server, qinfo))
 		proj = resresv->project;
 
 	if (resresv->is_job && resresv->job != NULL) {
@@ -2496,10 +2504,6 @@ find_resresv_set_by_resresv(status *policy, resresv_set **rsets, resource_resv *
 	}
 
 	sspec = resresv_set_which_selspec(resresv);
-
-	if (resresv->is_job && resresv->job != NULL)
-		if (resresv_set_use_queue(resresv->job->queue))
-			qinfo = resresv->job->queue;
 
 	return find_resresv_set(policy, rsets, user, grp, proj, partition, sspec, resresv->place_spec, resresv->resreq, qinfo);
 }

--- a/src/scheduler/limits.c
+++ b/src/scheduler/limits.c
@@ -1216,7 +1216,7 @@ check_soft_limits(server_info *si, queue_info *qi, resource_resv *rr)
 		return 0;
 
 #ifdef NAS /* localmod 097 */
-	if (! si->has_soft_limit) {
+	if (!si->has_soft_limit) {
 		return rc;
 	}
 #endif /* localmod 097 */
@@ -1274,7 +1274,7 @@ check_server_max_user_run(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((si == NULL) || (user == NULL) || (sc == NULL))
 		return (SCHD_ERROR);
 
-	if (si->has_user_limit != 1)
+	if (!si->has_user_limit)
 	    return (0);
 
 	cts = sc->user;
@@ -1344,7 +1344,7 @@ check_server_max_group_run(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((si == NULL) || (group == NULL) || (sc == NULL))
 		return (SCHD_ERROR);
 
-	if (si->has_grp_limit != 1)
+	if (!si->has_grp_limit)
 	    return (0);
 
 	cts = sc->group;
@@ -1414,7 +1414,7 @@ check_server_max_user_res(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((si == NULL) || (rr == NULL) ||(sc==NULL))
 		return (SCHD_ERROR);
 
-	if (si->has_user_limit != 1)
+	if (!si->has_user_limit)
 	    return (0);
 
 	cts = sc->user;
@@ -1473,7 +1473,7 @@ check_server_max_group_res(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((si == NULL) || (rr == NULL) || (sc == NULL))
 		return (SCHD_ERROR);
 
-	if (si->has_grp_limit != 1)
+	if (!si->has_grp_limit)
 	    return (0);
 
 	cts = sc->group;
@@ -1533,7 +1533,7 @@ check_queue_max_user_run(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((qi == NULL) || (user == NULL) || (qc == NULL))
 		return (SCHD_ERROR);
 
-	if (qi->has_user_limit != 1)
+	if (!qi->has_user_limit)
 	    return (0);
 
 	cts = qc->user;
@@ -1603,7 +1603,7 @@ check_queue_max_group_run(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((qi == NULL) || (group == NULL) || (qc == NULL))
 		return (SCHD_ERROR);
 
-	if (qi->has_grp_limit != 1)
+	if (!qi->has_grp_limit)
 	    return (0);
 
 	cts = qc->group;
@@ -1672,7 +1672,7 @@ check_queue_max_user_res(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((qi == NULL) || (rr == NULL) || (qc == NULL))
 		return (SCHD_ERROR);
 
-	if (qi->has_user_limit != 1)
+	if (!qi->has_user_limit)
 	    return (0);
 
 	cts = qc->user;
@@ -1731,7 +1731,7 @@ check_queue_max_group_res(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((qi == NULL) || (rr == NULL) || (qc == NULL))
 		return (SCHD_ERROR);
 
-	if (qi->has_grp_limit != 1)
+	if (!qi->has_grp_limit)
 	    return (0);
 
 	cts = qc->group;
@@ -2089,7 +2089,7 @@ check_queue_max_user_run_soft(server_info *si, queue_info *qi, resource_resv *rr
 	if ((qi == NULL) || (user == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
-	if (qi->has_user_limit != 1)
+	if (!qi->has_user_limit)
 	    return (0);
 
 	if ((key = entlim_mk_runkey(LIM_USER, user)) == NULL)
@@ -2164,7 +2164,7 @@ check_queue_max_group_run_soft(server_info *si, queue_info *qi,
 	if ((qi == NULL) || (group == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
-	if (qi->has_grp_limit != 1)
+	if (!qi->has_grp_limit)
 	    return (0);
 
 	if ((key = entlim_mk_runkey(LIM_GROUP, group)) == NULL)
@@ -2232,7 +2232,7 @@ check_queue_max_user_res_soft(server_info *si, queue_info *qi, resource_resv *rr
 	if ((qi == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
-	if (qi->has_user_limit != 1)
+	if (!qi->has_user_limit)
 	    return (0);
 
 	return (check_max_user_res_soft(qi->running_jobs, rr, qi->user_counts,
@@ -2262,7 +2262,7 @@ check_queue_max_group_res_soft(server_info *si, queue_info *qi,
 	if ((qi == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
-	if (qi->has_grp_limit != 1)
+	if (!qi->has_grp_limit)
 	    return (0);
 
 	return (check_max_group_res_soft(rr, qi->group_counts,
@@ -2338,7 +2338,7 @@ check_server_max_user_run_soft(server_info *si, queue_info *qi,
 	if ((si == NULL) || (user == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
-	if (si->has_user_limit != 1)
+	if (!si->has_user_limit)
 	    return (0);
 
 	if ((key = entlim_mk_runkey(LIM_USER, user)) == NULL)
@@ -2413,7 +2413,7 @@ check_server_max_group_run_soft(server_info *si, queue_info *qi,
 	if ((si == NULL) || (group == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
-	if (si->has_grp_limit != 1)
+	if (!si->has_grp_limit)
 	    return (0);
 
 	if ((key = entlim_mk_runkey(LIM_GROUP, group)) == NULL)
@@ -2482,7 +2482,7 @@ check_server_max_user_res_soft(server_info *si, queue_info *qi,
 	if ((si == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
-	if (si->has_user_limit != 1)
+	if (!si->has_user_limit)
 	    return (0);
 
 	return (check_max_user_res_soft(si->running_jobs, rr, si->user_counts,
@@ -2512,7 +2512,7 @@ check_server_max_group_res_soft(server_info *si, queue_info *qi,
 	if ((si == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
-	if (si->has_grp_limit != 1)
+	if (!si->has_grp_limit)
 	    return (0);
 
 	return (check_max_group_res_soft(rr, si->group_counts,
@@ -3677,7 +3677,7 @@ check_server_max_project_res(server_info *si, queue_info *qi, resource_resv *rr,
 	if (rr->project == NULL)
 		return 0;
 
-	if (si->has_proj_limit != 1)
+	if (!si->has_proj_limit)
 	    return (0);
 
 	cts = sc->project;
@@ -3739,7 +3739,7 @@ check_server_max_project_run_soft(server_info *si, queue_info *qi,
 	if (rr->project == NULL)
 		return 0;
 
-	if (si->has_proj_limit != 1)
+	if (!si->has_proj_limit)
 	    return (0);
 
 	project = rr->project;
@@ -3810,7 +3810,7 @@ check_server_max_project_res_soft(server_info *si, queue_info *qi,
 	if ((si == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
-	if (si->has_proj_limit != 1)
+	if (!si->has_proj_limit)
 	    return (0);
 
 	return (check_max_project_res_soft(rr, si->project_counts,
@@ -3850,7 +3850,7 @@ check_queue_max_project_res(server_info *si, queue_info *qi, resource_resv *rr,
 	if (rr->project == NULL)
 		return 0;
 
-	if (qi->has_proj_limit != 1)
+	if (!qi->has_proj_limit)
 	    return (0);
 
 	cts = qc->project;
@@ -3911,7 +3911,7 @@ check_queue_max_project_run_soft(server_info *si, queue_info *qi,
 	if (rr->project == NULL)
 		return 0;
 
-	if (qi->has_proj_limit != 1)
+	if (!qi->has_proj_limit)
 	    return (0);
 
 	project = rr->project;
@@ -3982,7 +3982,7 @@ check_queue_max_project_res_soft(server_info *si, queue_info *qi,
 	if ((qi == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
-	if (qi->has_proj_limit != 1)
+	if (!qi->has_proj_limit)
 	    return (0);
 
 	return (check_max_project_res_soft(rr, qi->project_counts,
@@ -4027,7 +4027,7 @@ check_server_max_project_run(server_info *si, queue_info *qi, resource_resv *rr,
 	if (rr->project == NULL)
 		return 0;
 
-	if (si->has_proj_limit != 1)
+	if (!si->has_proj_limit)
 	    return (0);
 
 	project = rr->project;
@@ -4105,7 +4105,7 @@ check_queue_max_project_run(server_info *si, queue_info *qi, resource_resv *rr,
 	if (project == NULL)
 		return 0;
 
-	if (qi->has_proj_limit != 1)
+	if (!qi->has_proj_limit)
 	    return (0);
 
 	if ((key = entlim_mk_runkey(LIM_PROJECT, project)) == NULL)

--- a/src/scheduler/limits.c
+++ b/src/scheduler/limits.c
@@ -1203,6 +1203,9 @@ check_server_max_user_run(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((si == NULL) || (user == NULL) || (sc == NULL))
 		return (SCHD_ERROR);
 
+	if (si->has_user_limit != 1)
+	    return (0);
+
 	cts = sc->user;
 
 	if ((key = entlim_mk_runkey(LIM_USER, user)) == NULL)
@@ -1269,6 +1272,9 @@ check_server_max_group_run(server_info *si, queue_info *qi, resource_resv *rr,
 
 	if ((si == NULL) || (group == NULL) || (sc == NULL))
 		return (SCHD_ERROR);
+
+	if (si->has_grp_limit != 1)
+	    return (0);
 
 	cts = sc->group;
 
@@ -1337,6 +1343,9 @@ check_server_max_user_res(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((si == NULL) || (rr == NULL) ||(sc==NULL))
 		return (SCHD_ERROR);
 
+	if (si->has_user_limit != 1)
+	    return (0);
+
 	cts = sc->user;
 
 	ret = check_max_user_res(rr, cts, &rdef,
@@ -1392,6 +1401,9 @@ check_server_max_group_res(server_info *si, queue_info *qi, resource_resv *rr,
 
 	if ((si == NULL) || (rr == NULL) || (sc == NULL))
 		return (SCHD_ERROR);
+
+	if (si->has_grp_limit != 1)
+	    return (0);
 
 	cts = sc->group;
 
@@ -1449,6 +1461,9 @@ check_queue_max_user_run(server_info *si, queue_info *qi, resource_resv *rr,
 
 	if ((qi == NULL) || (user == NULL) || (qc == NULL))
 		return (SCHD_ERROR);
+
+	if (qi->has_user_limit != 1)
+	    return (0);
 
 	cts = qc->user;
 
@@ -1517,6 +1532,9 @@ check_queue_max_group_run(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((qi == NULL) || (group == NULL) || (qc == NULL))
 		return (SCHD_ERROR);
 
+	if (qi->has_grp_limit != 1)
+	    return (0);
+
 	cts = qc->group;
 
 	if ((key = entlim_mk_runkey(LIM_GROUP, group)) == NULL)
@@ -1583,6 +1601,9 @@ check_queue_max_user_res(server_info *si, queue_info *qi, resource_resv *rr,
 	if ((qi == NULL) || (rr == NULL) || (qc == NULL))
 		return (SCHD_ERROR);
 
+	if (qi->has_user_limit != 1)
+	    return (0);
+
 	cts = qc->user;
 
 	ret = check_max_user_res(rr, cts, &rdef, LI2RESCTX(qi->liminfo));
@@ -1638,6 +1659,9 @@ check_queue_max_group_res(server_info *si, queue_info *qi, resource_resv *rr,
 
 	if ((qi == NULL) || (rr == NULL) || (qc == NULL))
 		return (SCHD_ERROR);
+
+	if (qi->has_grp_limit != 1)
+	    return (0);
 
 	cts = qc->group;
 
@@ -1990,6 +2014,9 @@ check_queue_max_user_run_soft(server_info *si, queue_info *qi, resource_resv *rr
 	if ((qi == NULL) || (user == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
+	if (qi->has_user_limit != 1)
+	    return (0);
+
 	if ((key = entlim_mk_runkey(LIM_USER, user)) == NULL)
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 	max_user_run_soft = (int) lim_get(key, LI2RUNCTXSOFT(qi->liminfo));
@@ -2051,6 +2078,9 @@ check_queue_max_group_run_soft(server_info *si, queue_info *qi,
 	if ((qi == NULL) || (group == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
+	if (qi->has_grp_limit != 1)
+	    return (0);
+
 	if ((key = entlim_mk_runkey(LIM_GROUP, group)) == NULL)
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 	max_group_run_soft = (int) lim_get(key, LI2RUNCTXSOFT(qi->liminfo));
@@ -2104,6 +2134,10 @@ check_queue_max_user_res_soft(server_info *si, queue_info *qi, resource_resv *rr
 {
 	if ((qi == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
+
+	if (qi->has_user_limit != 1)
+	    return (0);
+
 	if (check_max_user_res_soft(qi->running_jobs, rr, qi->user_counts,
 		LI2RESCTXSOFT(qi->liminfo)))
 		return (PREEMPT_TO_BIT(PREEMPT_OVER_QUEUE_LIMIT));
@@ -2133,6 +2167,10 @@ check_queue_max_group_res_soft(server_info *si, queue_info *qi,
 {
 	if ((qi == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
+
+	if (qi->has_grp_limit != 1)
+	    return (0);
+
 	if (check_max_group_res_soft(rr, qi->group_counts,
 		LI2RESCTXSOFT(qi->liminfo)))
 		return (PREEMPT_TO_BIT(PREEMPT_OVER_QUEUE_LIMIT));
@@ -2205,6 +2243,9 @@ check_server_max_user_run_soft(server_info *si, queue_info *qi,
 	if ((si == NULL) || (user == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
+	if (si->has_user_limit != 1)
+	    return (0);
+
 	if ((key = entlim_mk_runkey(LIM_USER, user)) == NULL)
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 	max_user_run_soft = (int) lim_get(key, LI2RUNCTXSOFT(si->liminfo));
@@ -2266,6 +2307,9 @@ check_server_max_group_run_soft(server_info *si, queue_info *qi,
 	if ((si == NULL) || (group == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 
+	if (si->has_grp_limit != 1)
+	    return (0);
+
 	if ((key = entlim_mk_runkey(LIM_GROUP, group)) == NULL)
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
 	max_group_run_soft = (int) lim_get(key, LI2RUNCTXSOFT(si->liminfo));
@@ -2321,6 +2365,10 @@ check_server_max_user_res_soft(server_info *si, queue_info *qi,
 {
 	if ((si == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
+
+	if (si->has_user_limit != 1)
+	    return (0);
+
 	if (check_max_user_res_soft(si->running_jobs, rr, si->user_counts,
 		LI2RESCTXSOFT(si->liminfo)))
 		return (PREEMPT_TO_BIT(PREEMPT_OVER_SERVER_LIMIT));
@@ -2350,6 +2398,10 @@ check_server_max_group_res_soft(server_info *si, queue_info *qi,
 {
 	if ((si == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
+
+	if (si->has_grp_limit != 1)
+	    return (0);
+
 	if (check_max_group_res_soft(rr, si->group_counts,
 		LI2RESCTXSOFT(si->liminfo)))
 		return (PREEMPT_TO_BIT(PREEMPT_OVER_SERVER_LIMIT));
@@ -3470,6 +3522,9 @@ check_server_max_project_res(server_info *si, queue_info *qi, resource_resv *rr,
 	if (rr->project == NULL)
 		return 0;
 
+	if (si->has_proj_limit != 1)
+	    return (0);
+
 	cts = sc->project;
 
 	ret = check_max_project_res(rr, cts,
@@ -3528,6 +3583,9 @@ check_server_max_project_run_soft(server_info *si, queue_info *qi,
 	if (rr->project == NULL)
 		return 0;
 
+	if (si->has_proj_limit != 1)
+	    return (0);
+
 	project = rr->project;
 	if ((key = entlim_mk_runkey(LIM_PROJECT, project)) == NULL)
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
@@ -3585,6 +3643,10 @@ check_server_max_project_res_soft(server_info *si, queue_info *qi,
 {
 	if ((si == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
+
+	if (si->has_proj_limit != 1)
+	    return (0);
+
 	if (check_max_project_res_soft(rr, si->project_counts,
 		LI2RESCTXSOFT(si->liminfo)))
 		return (PREEMPT_TO_BIT(PREEMPT_OVER_SERVER_LIMIT));
@@ -3624,6 +3686,9 @@ check_queue_max_project_res(server_info *si, queue_info *qi, resource_resv *rr,
 
 	if (rr->project == NULL)
 		return 0;
+
+	if (qi->has_proj_limit != 1)
+	    return (0);
 
 	cts = qc->project;
 
@@ -3682,6 +3747,9 @@ check_queue_max_project_run_soft(server_info *si, queue_info *qi,
 	if (rr->project == NULL)
 		return 0;
 
+	if (qi->has_proj_limit != 1)
+	    return (0);
+
 	project = rr->project;
 	if ((key = entlim_mk_runkey(LIM_PROJECT, project)) == NULL)
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
@@ -3738,6 +3806,10 @@ check_queue_max_project_res_soft(server_info *si, queue_info *qi,
 {
 	if ((qi == NULL) || (rr == NULL))
 		return (PREEMPT_TO_BIT(PREEMPT_ERR));
+
+	if (qi->has_proj_limit != 1)
+	    return (0);
+
 	if (check_max_project_res_soft(rr, qi->project_counts,
 		LI2RESCTXSOFT(qi->liminfo)))
 		return (PREEMPT_TO_BIT(PREEMPT_OVER_QUEUE_LIMIT));
@@ -3782,6 +3854,9 @@ check_server_max_project_run(server_info *si, queue_info *qi, resource_resv *rr,
 
 	if (rr->project == NULL)
 		return 0;
+
+	if (si->has_proj_limit != 1)
+	    return (0);
 
 	project = rr->project;
 	if ((key = entlim_mk_runkey(LIM_PROJECT, project)) == NULL)
@@ -3857,6 +3932,9 @@ check_queue_max_project_run(server_info *si, queue_info *qi, resource_resv *rr,
 	project = rr->project;
 	if (project == NULL)
 		return 0;
+
+	if (qi->has_proj_limit != 1)
+	    return (0);
 
 	if ((key = entlim_mk_runkey(LIM_PROJECT, project)) == NULL)
 		return (SCHD_ERROR);

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -3472,13 +3472,13 @@ is_vnode_eligible(node_info *node, resource_resv *resresv,
 			}
 
 			if (node->max_user_run != SCHD_INFINITY &&
-			    node->max_user_run <= find_counts_elm(node->user_counts, resresv->user, NULL)) {
+			    node->max_user_run <= find_counts_elm(node->user_counts, resresv->user, NULL, NULL, NULL)) {
 				set_schd_error_codes(err, NOT_RUN, NODE_USER_LIMIT_REACHED);
 				return 0;
 			}
 
 			if (node->max_group_run != SCHD_INFINITY &&
-			    node->max_group_run <= find_counts_elm(node->group_counts, resresv->group, NULL)) {
+			    node->max_group_run <= find_counts_elm(node->group_counts, resresv->group, NULL, NULL, NULL)) {
 				set_schd_error_codes(err, NOT_RUN, NODE_GROUP_LIMIT_REACHED);
 				return 0;
 			}

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -404,20 +404,20 @@ query_queue_info(status *policy, struct batch_status *queue, server_info *sinfo)
 		else if (is_reslimattr(attrp)) {
 			(void) lim_setlimits(attrp, LIM_RES, qinfo->liminfo);
 			if(strstr(attrp->value, "u:") != NULL)
-				sinfo->has_user_limit = 1;
+				qinfo->has_user_limit = 1;
 			if(strstr(attrp->value, "g:") != NULL)
-				sinfo->has_grp_limit = 1;
+				qinfo->has_grp_limit = 1;
 			if(strstr(attrp->value, "p:") != NULL)
-				sinfo->has_proj_limit = 1;
+				qinfo->has_proj_limit = 1;
 		}
 		else if (is_runlimattr(attrp)) {
 			(void) lim_setlimits(attrp, LIM_RUN, qinfo->liminfo);
 			if(strstr(attrp->value, "u:") != NULL)
-				sinfo->has_user_limit = 1;
+				qinfo->has_user_limit = 1;
 			if(strstr(attrp->value, "g:") != NULL)
-				sinfo->has_grp_limit = 1;
+				qinfo->has_grp_limit = 1;
 			if(strstr(attrp->value, "p:") != NULL)
-				sinfo->has_proj_limit = 1;
+				qinfo->has_proj_limit = 1;
 
 		}
 		else if (is_oldlimattr(attrp)) {
@@ -425,9 +425,9 @@ query_queue_info(status *policy, struct batch_status *queue, server_info *sinfo)
 			(void) lim_setlimits(attrp, LIM_OLD, qinfo->liminfo);
 
 			if(strstr(limname, "u:") != NULL)
-				sinfo->has_user_limit = 1;
+				qinfo->has_user_limit = 1;
 			if(strstr(limname, "g:") != NULL)
-				sinfo->has_grp_limit = 1;
+				qinfo->has_grp_limit = 1;
 			/* no need to check for project limits because there were no old style project limits */
 		}
 		else if (!strcmp(attrp->name, ATTR_p)) { /* priority */
@@ -550,6 +550,9 @@ new_queue_info(int limallocflag)
 	qinfo->has_hard_limit = 0;
 	qinfo->is_peer_queue = 0;
 	qinfo->has_resav_limit = 0;
+	qinfo->has_user_limit = 0;
+	qinfo->has_grp_limit = 0;
+	qinfo->has_proj_limit = 0;
 	init_state_count(&(qinfo->sc));
 	if ((limallocflag != 0))
 		qinfo->liminfo = lim_alloc_liminfo();
@@ -930,6 +933,9 @@ dup_queue_info(queue_info *oqinfo, server_info *nsinfo)
 	nqinfo->has_hard_limit = oqinfo->has_hard_limit;
 	nqinfo->is_peer_queue = oqinfo->is_peer_queue;
 	nqinfo->has_resav_limit = oqinfo->has_resav_limit;
+	nqinfo->has_user_limit = oqinfo->has_user_limit;
+	nqinfo->has_grp_limit = oqinfo->has_grp_limit;
+	nqinfo->has_proj_limit = oqinfo->has_proj_limit;
 	nqinfo->sc = oqinfo->sc;
 	nqinfo->liminfo = lim_dup_liminfo(oqinfo->liminfo);
 	nqinfo->priority = oqinfo->priority;

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -590,6 +590,7 @@ new_queue_info(int limallocflag)
 	qinfo->ignore_nodect_sort	 = 0;
 #endif
 	qinfo->partition = NULL;
+	qinfo->preempt_bit = 0;
 	return qinfo;
 }
 
@@ -994,6 +995,7 @@ dup_queue_info(queue_info *oqinfo, server_info *nsinfo)
 			return NULL;
 		}
 	}
+	nqinfo->preempt_bit = oqinfo->preempt_bit;
 
 	return nqinfo;
 }

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -590,7 +590,7 @@ new_queue_info(int limallocflag)
 	qinfo->ignore_nodect_sort	 = 0;
 #endif
 	qinfo->partition = NULL;
-	qinfo->preempt_bit = 0;
+	qinfo->soft_limit_preempt_bit = 0;
 	return qinfo;
 }
 
@@ -760,7 +760,7 @@ update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 		state_count_add(&(qinfo->sc), job_state, 1);
 	}
 
-	if ((job_state != NULL) && (*job_state == 'S'))
+	if ((job_state != NULL) && (*job_state == 'S') && (resresv->server->policy->rel_on_susp != NULL))
 		req = resresv->job->resreq_rel;
 	else
 		req = resresv->resreq;
@@ -995,7 +995,7 @@ dup_queue_info(queue_info *oqinfo, server_info *nsinfo)
 			return NULL;
 		}
 	}
-	nqinfo->preempt_bit = oqinfo->preempt_bit;
+	nqinfo->soft_limit_preempt_bit = oqinfo->soft_limit_preempt_bit;
 
 	return nqinfo;
 }

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -753,6 +753,10 @@ dup_resource_req_list(resource_req *oreq)
 				prev->next = nreq;
 			prev = nreq;
 		}
+		else {
+			free_resource_req_list(head);
+			return NULL;
+		}
 		req = req->next;
 	}
 
@@ -786,6 +790,10 @@ resource_count *dup_resource_count_list(resource_count *orcount)
 			else
 				prev->next = nrcount;
 			prev = nrcount;
+		}
+		else {
+			free_resource_count_list(head);
+			return NULL;
 		}
 		rcount = rcount->next;
 	}
@@ -1146,31 +1154,6 @@ find_resource_req(resource_req *reqlist, resdef *def)
 		resreq = resreq->next;
 
 	return resreq;
-}
-
-/**
- * @brief
- *		find a resource_count from a resource_count list by string name
- *
- * @param[in]	rcountlist	-	the resource_count list
- * @param[in]	name		-	resource name to look for
- *
- * @return	resource_count *
- * @retval	found resource count
- * @retval NULL	: if not found
- *
- */
-resource_count *
-find_resource_count_by_str(resource_count *rcountlist, const char *name)
-{
-	resource_count *rcount;
-
-	rcount = rcountlist;
-
-	while (rcount != NULL && strcmp(rcount->name, name))
-		rcount = rcount->next;
-
-	return rcount;
 }
 
 /**

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -103,9 +103,19 @@ resource_resv *find_resource_resv_by_time(resource_resv **resresv_arr, char *nam
 resource_req *find_resource_req_by_str(resource_req *reqlist, const char *name);
 
 /*
+ *      find_resource_count_by_str - find a resource_count from a resource_count list
+ */
+resource_count *find_resource_count_by_str(resource_count *reqlist, const char *name);
+
+/*
  *	find resource_req by resource definition
  */
 resource_req *find_resource_req(resource_req *reqlist, resdef *def);
+
+/*
+ *	find resource_count by resource definition
+ */
+resource_count *find_resource_count(resource_count *reqlist, resdef *def);
 
 /*
  *      new_resource_req - allocate and initalize new resoruce_req
@@ -117,12 +127,22 @@ resource_req *new_resource_req();
 #endif /* localmod 005 */
 
 /*
+ * new_resource_count - allocate and initalize new resource_count
+ */
+resource_count *new_resource_count();
+
+/*
  * find_alloc_resource_req[_by_str] -
  * find resource_req by name/resource definition  or allocate and
  * initialize a new resource_req also adds new one to the list
  */
 resource_req *find_alloc_resource_req(resource_req *reqlist, resdef *def);
 resource_req *find_alloc_resource_req_by_str(resource_req *reqlist, char *name);
+
+/*
+ * find resource_count by resource definition or allocate
+ */
+resource_count *find_alloc_resource_count(resource_count *reqlist, resdef *def);
 
 /*
  *      free_resource_req_list - frees memory used by a resource_req list
@@ -133,6 +153,16 @@ void free_resource_req_list(resource_req *list);
  *	free_resource_req - free memory used by a resource_req structure
  */
 void free_resource_req(resource_req *req);
+
+/*
+ *      free_resource_count_list - frees memory used by a resource_count list
+ */
+void free_resource_count_list(resource_count *list);
+
+/*
+ *	free_resource_count - free memory used by a resource_count structure
+ */
+void free_resource_count(resource_count *req);
 
 /*
  *	set_resource_req - set the value and type of a resource req
@@ -149,9 +179,19 @@ resource_req *dup_selective_resource_req_list(resource_req *oreq, resdef **defli
 
 
 /*
+ *	dup_resource_count_list - duplicate a resource_req list
+ */
+resource_count *dup_resource_count_list(resource_count *oreq);
+
+/*
  *      dup_resource_req - duplicate a resource_req struct
  */
 resource_req *dup_resource_req(resource_req *oreq);
+
+/*
+ *	dup_resource_count - duplicate a resource_count struct
+ */
+resource_count *dup_resource_count(resource_count *oreq);
 
 /*
  *      update_resresv_on_run - update information kept in a resource_resv

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -103,11 +103,6 @@ resource_resv *find_resource_resv_by_time(resource_resv **resresv_arr, char *nam
 resource_req *find_resource_req_by_str(resource_req *reqlist, const char *name);
 
 /*
- *      find_resource_count_by_str - find a resource_count from a resource_count list
- */
-resource_count *find_resource_count_by_str(resource_count *reqlist, const char *name);
-
-/*
  *	find resource_req by resource definition
  */
 resource_req *find_resource_req(resource_req *reqlist, resdef *def);

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1320,7 +1320,7 @@ new_server_info(int limallocflag)
 	sinfo->num_hostsets = 0;
 	sinfo->flt_lic = 0;
 	sinfo->server_time = 0;
-	sinfo->preempt_bit = 0;
+	sinfo->soft_limit_preempt_bit = 0;
 
 	if ((limallocflag != 0))
 		sinfo->liminfo = lim_alloc_liminfo();
@@ -1907,7 +1907,8 @@ update_server_on_end(status *policy, server_info *sinfo, queue_info *qinfo,
 	 */
 	if (resresv->is_resv || (qinfo != NULL && qinfo->resv ==NULL)) {
 
-		if (resresv->is_job && (job_state != NULL) && (*job_state == 'S'))
+		if (resresv->is_job && (job_state != NULL) && (*job_state == 'S') &&
+		    (policy->rel_on_susp != NULL))
 			req = resresv->job->resreq_rel;
 		else
 			req = resresv->resreq;
@@ -2478,7 +2479,7 @@ dup_server_info(server_info *osinfo)
 			nsinfo->nodes[i]->node_events = dup_te_lists(osinfo->nodes[i]->node_events, nsinfo->calendar->next_event);
 	}
 	nsinfo->buckets = dup_node_bucket_array(osinfo->buckets, nsinfo);
-	nsinfo->preempt_bit = osinfo->preempt_bit;
+	nsinfo->soft_limit_preempt_bit = osinfo->soft_limit_preempt_bit;
 
 	return nsinfo;
 }
@@ -2709,7 +2710,7 @@ new_counts(void)
 	cts->name = NULL;
 	cts->running = 0;
 	cts->rescts = NULL;
-	cts->preempt_bit = 0;
+	cts->soft_limit_preempt_bit = 0;
 	cts->next = NULL;
 
 	return cts;
@@ -2789,7 +2790,7 @@ dup_counts(counts *octs)
 			ncts->name = string_dup(octs->name);
 
 		ncts->running = octs->running;
-		ncts->preempt_bit = octs->preempt_bit;
+		ncts->soft_limit_preempt_bit = octs->soft_limit_preempt_bit;
 
 		ncts->rescts = dup_resource_count_list(octs->rescts);
 	}
@@ -3388,12 +3389,6 @@ update_preemption_on_run(server_info *sinfo, resource_resv *resresv)
 						set_preempt_prio(sinfo->jobs[i],
 							sinfo->jobs[i]->job->queue, sinfo);
 				}
-			}
-			qsort(sinfo->jobs, sinfo->sc.total,
-				sizeof(resource_resv *), cmp_sort);
-			for (i = 0; sinfo->queues[i] != NULL; i++) {
-				qsort(sinfo->queues[i]->jobs, sinfo->queues[i]->sc.total,
-					sizeof(resource_resv *), cmp_sort);
 			}
 
 			/* now that we've set all the preempt levels, we need to count them */

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1976,9 +1976,13 @@ update_server_on_end(status *policy, server_info *sinfo, queue_info *qinfo,
 		if (sinfo->has_soft_limit || resresv->job->queue->has_soft_limit) {
 			for (i = 0; sinfo->jobs[i] != NULL; i++) {
 				if (sinfo->jobs[i]->job !=NULL) {
-					if (!strcmp(resresv->user, sinfo->jobs[i]->user) ||
-						!strcmp(resresv->group, sinfo->jobs[i]->group) ||
-						!strcmp(resresv->project, sinfo->jobs[i]->project))
+					if (((resresv->job->queue->has_user_limit || sinfo->has_user_limit) &&
+					    (!strcmp(resresv->user, sinfo->jobs[i]->user))) ||
+					    ((resresv->job->queue->has_grp_limit || sinfo->has_grp_limit) &&
+					    (!strcmp(resresv->group, sinfo->jobs[i]->group))) ||
+					    ((resresv->job->queue->has_proj_limit || sinfo->has_proj_limit) &&
+					    (!strcmp(resresv->project, sinfo->jobs[i]->project))))
+
 						set_preempt_prio(sinfo->jobs[i],
 							sinfo->jobs[i]->job->queue, sinfo);
 				}
@@ -3369,9 +3373,12 @@ update_preemption_on_run(server_info *sinfo, resource_resv *resresv)
 		if (sinfo->has_soft_limit || resresv->job->queue->has_soft_limit) {
 			for (i = 0; sinfo->jobs[i] != NULL; i++) {
 				if (sinfo->jobs[i]->job !=NULL) {
-					if (!strcmp(resresv->user, sinfo->jobs[i]->user) ||
-						!strcmp(resresv->group, sinfo->jobs[i]->group) ||
-						!strcmp(resresv->project, sinfo->jobs[i]->project))
+					if (((resresv->job->queue->has_user_limit || sinfo->has_user_limit) &&
+					    (!strcmp(resresv->user, sinfo->jobs[i]->user))) ||
+					    ((resresv->job->queue->has_grp_limit || sinfo->has_grp_limit) &&
+					    (!strcmp(resresv->group, sinfo->jobs[i]->group))) ||
+					    ((resresv->job->queue->has_proj_limit || sinfo->has_proj_limit) &&
+					    (!strcmp(resresv->project, sinfo->jobs[i]->project))))
 						set_preempt_prio(sinfo->jobs[i],
 							sinfo->jobs[i]->job->queue, sinfo);
 				}

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1978,9 +1978,9 @@ update_server_on_end(status *policy, server_info *sinfo, queue_info *qinfo,
 		if (sinfo->has_soft_limit || resresv->job->queue->has_soft_limit) {
 			for (i = 0; sinfo->jobs[i] != NULL; i++) {
 				if (sinfo->jobs[i]->job != NULL) {
-					int usrlim = resresv->job->queue->has_user_limit | sinfo->has_user_limit;
-					int grplim = resresv->job->queue->has_grp_limit | sinfo->has_grp_limit;
-					int projlim = resresv->job->queue->has_proj_limit | sinfo->has_proj_limit;
+					int usrlim = resresv->job->queue->has_user_limit || sinfo->has_user_limit;
+					int grplim = resresv->job->queue->has_grp_limit || sinfo->has_grp_limit;
+					int projlim = resresv->job->queue->has_proj_limit || sinfo->has_proj_limit;
 					if ((usrlim && (!strcmp(resresv->user, sinfo->jobs[i]->user))) ||
 					    (grplim && (!strcmp(resresv->group, sinfo->jobs[i]->group))) ||
 					    (projlim && (!strcmp(resresv->project, sinfo->jobs[i]->project))))
@@ -3380,9 +3380,9 @@ update_preemption_on_run(server_info *sinfo, resource_resv *resresv)
 		if (sinfo->has_soft_limit || resresv->job->queue->has_soft_limit) {
 			for (i = 0; sinfo->jobs[i] != NULL; i++) {
 				if (sinfo->jobs[i]->job !=NULL) {
-					int usrlim = resresv->job->queue->has_user_limit | sinfo->has_user_limit;
-					int grplim = resresv->job->queue->has_grp_limit | sinfo->has_grp_limit;
-					int projlim = resresv->job->queue->has_proj_limit | sinfo->has_proj_limit;
+					int usrlim = resresv->job->queue->has_user_limit || sinfo->has_user_limit;
+					int grplim = resresv->job->queue->has_grp_limit || sinfo->has_grp_limit;
+					int projlim = resresv->job->queue->has_proj_limit || sinfo->has_proj_limit;
 					if ((usrlim && (!strcmp(resresv->user, sinfo->jobs[i]->user))) ||
 					    (grplim && (!strcmp(resresv->group, sinfo->jobs[i]->group))) ||
 					    (projlim && (!strcmp(resresv->project, sinfo->jobs[i]->project))))

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1320,6 +1320,7 @@ new_server_info(int limallocflag)
 	sinfo->num_hostsets = 0;
 	sinfo->flt_lic = 0;
 	sinfo->server_time = 0;
+	sinfo->preempt_bit = 0;
 
 	if ((limallocflag != 0))
 		sinfo->liminfo = lim_alloc_liminfo();
@@ -2477,6 +2478,7 @@ dup_server_info(server_info *osinfo)
 			nsinfo->nodes[i]->node_events = dup_te_lists(osinfo->nodes[i]->node_events, nsinfo->calendar->next_event);
 	}
 	nsinfo->buckets = dup_node_bucket_array(osinfo->buckets, nsinfo);
+	nsinfo->preempt_bit = osinfo->preempt_bit;
 
 	return nsinfo;
 }
@@ -2707,6 +2709,7 @@ new_counts(void)
 	cts->name = NULL;
 	cts->running = 0;
 	cts->rescts = NULL;
+	cts->preempt_bit = 0;
 	cts->next = NULL;
 
 	return cts;
@@ -2732,7 +2735,7 @@ free_counts(counts *cts)
 		free(cts->name);
 
 	if (cts->rescts != NULL)
-		free_resource_req_list(cts->rescts);
+		free_resource_count_list(cts->rescts);
 
 	cts->next = NULL;
 
@@ -2786,8 +2789,9 @@ dup_counts(counts *octs)
 			ncts->name = string_dup(octs->name);
 
 		ncts->running = octs->running;
+		ncts->preempt_bit = octs->preempt_bit;
 
-		ncts->rescts = dup_resource_req_list(octs->rescts);
+		ncts->rescts = dup_resource_count_list(octs->rescts);
 	}
 
 	return ncts;
@@ -2917,7 +2921,7 @@ find_alloc_counts(counts *ctslist, char *name)
 void
 update_counts_on_run(counts *cts, resource_req *resreq)
 {
-	resource_req *ctsreq;			/* rescts to update */
+	resource_count *ctsreq;			/* rescts to update */
 	resource_req *req;			/* current in resreq */
 
 	if (cts == NULL)
@@ -2931,7 +2935,7 @@ update_counts_on_run(counts *cts, resource_req *resreq)
 	req = resreq;
 
 	while (req != NULL) {
-		ctsreq = find_alloc_resource_req(cts->rescts, req->def);
+		ctsreq = find_alloc_resource_count(cts->rescts, req->def);
 
 		if (ctsreq != NULL) {
 			if (cts->rescts == NULL)
@@ -2959,7 +2963,7 @@ update_counts_on_run(counts *cts, resource_req *resreq)
 void
 update_counts_on_end(counts *cts, resource_req *resreq)
 {
-	resource_req *ctsreq;			/* rescts to update */
+	resource_count *ctsreq;			/* rescts to update */
 	resource_req *req;			/* current in resreq */
 
 	if (cts == NULL || resreq == NULL)
@@ -2969,7 +2973,7 @@ update_counts_on_end(counts *cts, resource_req *resreq)
 
 	req = resreq;
 	while (req != NULL) {
-		ctsreq = find_resource_req(cts->rescts, req->def);
+		ctsreq = find_resource_count(cts->rescts, req->def);
 		if (ctsreq != NULL)
 			ctsreq->amount -= req->amount;
 
@@ -2998,8 +3002,8 @@ counts_max(counts *cmax, counts *new)
 	counts *cur;
 	counts *cur_fmax;
 	counts *cmax_head;
-	resource_req *cur_res;
-	resource_req *cur_res_max;
+	resource_count *cur_res;
+	resource_count *cur_res_max;
 
 	if (new == NULL)
 		return cmax;
@@ -3025,9 +3029,9 @@ counts_max(counts *cmax, counts *new)
 				cur_fmax->running = cur->running;
 
 			for (cur_res = cur->rescts; cur_res != NULL; cur_res = cur_res->next) {
-				cur_res_max = find_resource_req(cur_fmax->rescts, cur_res->def);
+				cur_res_max = find_resource_count(cur_fmax->rescts, cur_res->def);
 				if (cur_res_max == NULL) {
-					cur_res_max = dup_resource_req(cur_res);
+					cur_res_max = dup_resource_count(cur_res);
 					if (cur_res_max == NULL) {
 						free_counts_list(cmax_head);
 						return NULL;
@@ -3120,7 +3124,9 @@ update_universe_on_end(status *policy, resource_resv *resresv, char *job_state, 
 
 	if (qinfo != NULL)
 		update_queue_on_end(qinfo, resresv, job_state);
-
+	/* update soft limits for jobs that are not in reservation */
+	if (resresv->is_job && resresv->job->resv_id == NULL)
+		update_soft_limits(sinfo, qinfo, resresv);
 	/* Mark the metadata stale.  It will be updated in the next call to is_ok_to_run() */
 	sinfo->pset_metadata_stale = 1;
 

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1977,13 +1977,13 @@ update_server_on_end(status *policy, server_info *sinfo, queue_info *qinfo,
 	if (cstat.preempting && resresv->is_job) {
 		if (sinfo->has_soft_limit || resresv->job->queue->has_soft_limit) {
 			for (i = 0; sinfo->jobs[i] != NULL; i++) {
-				if (sinfo->jobs[i]->job !=NULL) {
-					if (((resresv->job->queue->has_user_limit || sinfo->has_user_limit) &&
-					    (!strcmp(resresv->user, sinfo->jobs[i]->user))) ||
-					    ((resresv->job->queue->has_grp_limit || sinfo->has_grp_limit) &&
-					    (!strcmp(resresv->group, sinfo->jobs[i]->group))) ||
-					    ((resresv->job->queue->has_proj_limit || sinfo->has_proj_limit) &&
-					    (!strcmp(resresv->project, sinfo->jobs[i]->project))))
+				if (sinfo->jobs[i]->job != NULL) {
+					int usrlim = resresv->job->queue->has_user_limit | sinfo->has_user_limit;
+					int grplim = resresv->job->queue->has_grp_limit | sinfo->has_grp_limit;
+					int projlim = resresv->job->queue->has_proj_limit | sinfo->has_proj_limit;
+					if ((usrlim && (!strcmp(resresv->user, sinfo->jobs[i]->user))) ||
+					    (grplim && (!strcmp(resresv->group, sinfo->jobs[i]->group))) ||
+					    (projlim && (!strcmp(resresv->project, sinfo->jobs[i]->project))))
 
 						set_preempt_prio(sinfo->jobs[i],
 							sinfo->jobs[i]->job->queue, sinfo);
@@ -3380,12 +3380,12 @@ update_preemption_on_run(server_info *sinfo, resource_resv *resresv)
 		if (sinfo->has_soft_limit || resresv->job->queue->has_soft_limit) {
 			for (i = 0; sinfo->jobs[i] != NULL; i++) {
 				if (sinfo->jobs[i]->job !=NULL) {
-					if (((resresv->job->queue->has_user_limit || sinfo->has_user_limit) &&
-					    (!strcmp(resresv->user, sinfo->jobs[i]->user))) ||
-					    ((resresv->job->queue->has_grp_limit || sinfo->has_grp_limit) &&
-					    (!strcmp(resresv->group, sinfo->jobs[i]->group))) ||
-					    ((resresv->job->queue->has_proj_limit || sinfo->has_proj_limit) &&
-					    (!strcmp(resresv->project, sinfo->jobs[i]->project))))
+					int usrlim = resresv->job->queue->has_user_limit | sinfo->has_user_limit;
+					int grplim = resresv->job->queue->has_grp_limit | sinfo->has_grp_limit;
+					int projlim = resresv->job->queue->has_proj_limit | sinfo->has_proj_limit;
+					if ((usrlim && (!strcmp(resresv->user, sinfo->jobs[i]->user))) ||
+					    (grplim && (!strcmp(resresv->group, sinfo->jobs[i]->group))) ||
+					    (projlim && (!strcmp(resresv->project, sinfo->jobs[i]->project))))
 						set_preempt_prio(sinfo->jobs[i],
 							sinfo->jobs[i]->job->queue, sinfo);
 				}

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -390,6 +390,39 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    def test_user_queue_without_limits(self):
+        """
+        Test that jobs from different users submitted to a queue without
+        a user limit set, will not create a multiple equivalence classes.
+        """
+
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'scheduling': 'False'})
+
+        self.server.manager(MGR_CMD_SET, QUEUE,
+                            {'max_run': '[u:PBS_GENERIC=4]'}, id='workq')
+
+        # Eat up all the resources, this job will make first equiv class
+        a = {'Resource_List.select': '1:ncpus=8'}
+        J = Job(TEST_USER, attrs=a)
+        self.server.submit(J)
+
+        # Create a new queue and submit jobs to this queue
+        a = {'queue_type': 'e', 'started': 't', 'enabled': 't'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
+
+        a = {'Resource_List.select': '1:ncpus=1', ATTR_q: 'workq2'}
+        jids1 = self.submit_jobs(3, user=TEST_USER, attrs=a)
+        jids2 = self.submit_jobs(3, user=TEST_USER2, attrs=a)
+
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'scheduling': 'True'})
+
+        # Two equivalence classes.  One for the resource eating job and
+        # one for all jobs in workq2.
+        self.scheduler.log_match("Number of job equivalence classes: 2",
+                                 starttime=self.t)
+
     def test_user_queue_soft(self):
         """
         Test to see that jobs from different users fall into different
@@ -416,6 +449,39 @@ class TestEquivClass(TestFunctional):
         # Three equivalence classes.  One for the resource eating job and
         # one for each user.
         self.scheduler.log_match("Number of job equivalence classes: 3",
+                                 starttime=self.t)
+
+    def test_user_queue_without_soft_limits(self):
+        """
+        Test that jobs from different users submitted to a queue without
+        a user soft limit set, will not create a multiple equivalence classes.
+        """
+
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'scheduling': 'False'})
+
+        self.server.manager(MGR_CMD_SET, QUEUE,
+                            {'max_run_soft': '[u:PBS_GENERIC=4]'}, id='workq')
+
+        # Eat up all the resources, this job will make first equiv class
+        a = {'Resource_List.select': '1:ncpus=8'}
+        J = Job(TEST_USER, attrs=a)
+        self.server.submit(J)
+
+        # Create a new queue and submit jobs to this queue
+        a = {'queue_type': 'e', 'started': 't', 'enabled': 't'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
+
+        a = {'Resource_List.select': '1:ncpus=1', ATTR_q: 'workq2'}
+        jids1 = self.submit_jobs(3, user=TEST_USER, attrs=a)
+        jids2 = self.submit_jobs(3, user=TEST_USER2, attrs=a)
+
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'scheduling': 'True'})
+
+        # Two equivalence classes.  One for the resource eating job and
+        # one for all jobs in workq2.
+        self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
     def test_group(self):
@@ -1577,6 +1643,9 @@ else:
              'enabled': 't', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
 
+        a = {'preempt_sort': 'min_time_since_start'}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+
         (jid1,) = self.submit_jobs(1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
@@ -1633,6 +1702,9 @@ else:
         a = {'queue_type': 'execution', 'started': 'true',
              'enabled': 'true', 'Priority': 150}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='expressq')
+
+        a = {'preempt_sort': 'min_time_since_start'}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
 
         # Submit 3 jobs with delay of 1 sec
         # Delay of 1 sec will preempt jid3 and then jid2.

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -408,19 +408,22 @@ class TestEquivClass(TestFunctional):
         self.server.submit(J)
 
         # Create a new queue and submit jobs to this queue
-        a = {'queue_type': 'e', 'started': 't', 'enabled': 't'}
+        a = {'queue_type': 'e', 'started': 'True', 'enabled': 'True'}
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='workq2')
 
         a = {'Resource_List.select': '1:ncpus=1', ATTR_q: 'workq2'}
         jids1 = self.submit_jobs(3, user=TEST_USER, attrs=a)
         jids2 = self.submit_jobs(3, user=TEST_USER2, attrs=a)
+        a = {'Resource_List.select': '1:ncpus=1'}
+        J3 = Job(TEST_USER3, attrs=a)
+        self.server.submit(J3)
 
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'scheduling': 'True'})
 
-        # Two equivalence classes.  One for the resource eating job and
-        # one for all jobs in workq2.
-        self.scheduler.log_match("Number of job equivalence classes: 2",
+        # Three equivalence classes.  One for the resource eating job and
+        # one for all jobs in workq2 and one for TEST_USER3
+        self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
     def test_user_queue_soft(self):

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -495,7 +495,6 @@ class TestPreemptPerformance(TestPerformance):
             j = Job(TEST_USER2, attrs=a)
             j.set_sleep_time(3000)
             self.server.submit(j)
-        time.sleep(15)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {'job_state=R': 2000}, interval=10, offset=5,
                            max_attempts=100)
@@ -558,7 +557,8 @@ class TestPreemptPerformance(TestPerformance):
         """
         a = {'resources_available.ncpus': 4,
              'resources_available.mem': '6400mb'}
-        self.server.create_vnodes('vn', a, 500, self.mom, usenatvnode=False)
+        self.server.create_vnodes('vn', a, 500, self.mom, usenatvnode=False,
+                                  sharednode=False)
         p = "express_queue, normal_jobs, server_softlimits, queue_softlimits"
         a = {'preempt_prio': p}
         self.server.manager(MGR_CMD_SET, SCHED, a)

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -553,7 +553,7 @@ class TestPreemptPerformance(TestPerformance):
         # submit a bunch of jobs as different users
         a = {ATTR_l + '.select=1:ncpus': 1}
         usr_list = [TEST_USER, TEST_USER2, TEST_USER3, TEST_USER4]
-        num_usr = 4
+        num_usr = len(usr_list)
         for ind in range(2000):
             j = Job(usr_list[ind % num_usr], attrs=a)
             j.set_sleep_time(3000)

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -495,6 +495,7 @@ class TestPreemptPerformance(TestPerformance):
             j = Job(TEST_USER2, attrs=a)
             j.set_sleep_time(3000)
             self.server.submit(j)
+        time.sleep(15)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {'job_state=R': 2000}, interval=10, offset=5,
                            max_attempts=100)
@@ -519,6 +520,19 @@ class TestPreemptPerformance(TestPerformance):
         # make sure 2000 jobs were suspended
         self.server.expect(JOB, {'job_state=S': 2000}, interval=10, offset=5,
                            max_attempts=100)
+
+        # check when server received the request
+        (_, req_svr) = self.server.log_match(";Type 93 request received",
+                                             starttime=epoch1)
+        date_time_svr = req_svr.split(";")[0]
+        epoch_svr = self.lu.convert_date_time(date_time_svr)
+        # check when scheduler gets first reply from server
+        (_, resp_sched) = self.scheduler.log_match(";Job preempted ",
+                                                   starttime=epoch1)
+        date_time_sched = resp_sched.split(";")[0]
+        epoch_sched = self.lu.convert_date_time(date_time_sched)
+        svr_delay = epoch_sched - epoch_svr
+
         # record the start time of high priority job
         (_, str2) = self.scheduler.log_match(hjid + ";Job run",
                                              n='ALL', interval=2)
@@ -527,7 +541,10 @@ class TestPreemptPerformance(TestPerformance):
         time_diff = epoch2 - epoch1
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
-        res_str = "RESULT: THE TIME TAKEN IS : " + str(time_diff) + " SECONDS"
+        res_str = "RESULT: TOTAL PREEMPTION TIME: " + \
+                  str(time_diff) + " SECONDS, SERVER TOOK: " + \
+                  str(svr_delay) + " , SCHED TOOK: " + \
+                  str(time_diff - svr_delay)
         self.logger.info(res_str)
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
@@ -582,6 +599,19 @@ class TestPreemptPerformance(TestPerformance):
         # make sure 2000 jobs were suspended
         self.server.expect(JOB, {'job_state=S': 2000}, interval=10, offset=5,
                            max_attempts=100)
+
+        # check when server received the request
+        (_, req_svr) = self.server.log_match(";Type 93 request received",
+                                             starttime=epoch1)
+        date_time_svr = req_svr.split(";")[0]
+        epoch_svr = self.lu.convert_date_time(date_time_svr)
+        # check when scheduler gets first reply from server
+        (_, resp_sched) = self.scheduler.log_match(";Job preempted ",
+                                                   starttime=epoch1)
+        date_time_sched = resp_sched.split(";")[0]
+        epoch_sched = self.lu.convert_date_time(date_time_sched)
+        svr_delay = epoch_sched - epoch_svr
+
         # record the start time of high priority job
         (_, str2) = self.scheduler.log_match(hjid + ";Job run",
                                              n='ALL', interval=2)
@@ -590,7 +620,10 @@ class TestPreemptPerformance(TestPerformance):
         time_diff = epoch2 - epoch1
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
-        res_str = "RESULT: THE TIME TAKEN IS : " + str(time_diff) + " SECONDS"
+        res_str = "RESULT: TOTAL PREEMPTION TIME: " + \
+                  str(time_diff) + " SECONDS, SERVER TOOK: " + \
+                  str(svr_delay) + " , SCHED TOOK: " + \
+                  str(time_diff - svr_delay)
         self.logger.info(res_str)
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -479,7 +479,8 @@ class TestPreemptPerformance(TestPerformance):
         """
         a = {'resources_available.ncpus': 4,
              'resources_available.mem': '6400mb'}
-        self.server.create_vnodes('vn', a, 500, self.mom, usenatvnode=False, sharednode=False)
+        self.server.create_vnodes('vn', a, 500, self.mom, usenatvnode=False,
+                                  sharednode=False)
         p = "express_queue, normal_jobs, server_softlimits, queue_softlimits"
         a = {'preempt_prio': p}
         self.server.manager(MGR_CMD_SET, SCHED, a)

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -51,16 +51,6 @@ class TestPreemptPerformance(TestPerformance):
         # set poll cycle to a high value because mom spends a lot of time
         # in gathering job's resources used. We don't need that in this test
         self.mom.add_config({'$min_check_poll': 7200, '$max_check_poll': 9600})
-        abort_script = """#!/bin/bash
-kill $1
-exit 0
-"""
-        self.abort_file = self.du.create_temp_file(body=abort_script)
-        self.du.chmod(path=self.abort_file, mode=0755)
-        self.du.chown(path=self.abort_file, uid=0, gid=0, runas=ROOT_USER)
-        c = {'$action': 'checkpoint_abort 30 !' + self.abort_file + ' %sid'}
-        self.mom.add_config(c)
-        self.platform = self.du.get_platform()
 
     def create_workload_and_preempt(self):
         a = {
@@ -106,7 +96,7 @@ exit 0
         sched_on = {'scheduling': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, sched_on)
 
-        self.server.expect(JOB, {'job_state=R': 1590},
+        self.server.expect(JOB, {'substate=42': 1590},
                            offset=15, interval=20)
 
         a = {'Resource_List.select': '1:ncpus=90:mem=1350mb',
@@ -214,7 +204,7 @@ exit 0
         jid = self.server.submit(j)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
-        self.server.expect(JOB, {'job_state=R': 3201}, interval=20,
+        self.server.expect(JOB, {'substate=42': 3201}, interval=20,
                            offset=15)
 
         qname = 'highp'
@@ -304,7 +294,7 @@ exit 0
         jid2 = self.server.submit(j2)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
-        self.server.expect(JOB, {'job_state=R': 3202}, interval=20,
+        self.server.expect(JOB, {'substate=42': 3202}, interval=20,
                            offset=15)
 
         qname = 'highp'
@@ -380,7 +370,7 @@ exit 0
         jid = self.server.submit(j)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.expect(JOB, {'job_state=R': 3201}, interval=20,
+        self.server.expect(JOB, {'substate=42': 3201}, interval=20,
                            offset=15)
 
         qname = 'highp'
@@ -437,7 +427,7 @@ exit 0
             self.server.submit(j)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.expect(JOB, {'job_state=R': 3200}, interval=20,
+        self.server.expect(JOB, {'substate=42': 3200}, interval=20,
                            offset=15)
 
         qname = 'highp'
@@ -481,10 +471,72 @@ exit 0
             S_jobs += ncpus
 
     @timeout(3600)
-    def test_preemption_with_soft_limits(self):
+    def test_preemption_with_unrelated_soft_limits(self):
         """
-        Measure the time scheduler takes to preempt when the high priority
-        job hits soft limits under a considerable amount of workload.
+        Measure the time scheduler takes to preempt when there are user
+        soft limits in the system and preemptor and preemptee jobs are
+        submitted as different user.
+        """
+        a = {'resources_available.ncpus': 4,
+             'resources_available.mem': '6400mb'}
+        self.server.create_vnodes('vn', a, 500, self.mom, usenatvnode=False)
+        p = "express_queue, normal_jobs, server_softlimits, queue_softlimits"
+        a = {'preempt_prio': p}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+
+        a = {'max_run_res_soft.ncpus': "[u:" + str(TEST_USER) + "=1]"}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq')
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+
+        # submit a bunch of jobs as TEST_USER2
+        a = {ATTR_l + '.select=1:ncpus': 1}
+        for _ in range(2000):
+            j = Job(TEST_USER2, attrs=a)
+            j.set_sleep_time(3000)
+            self.server.submit(j)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+        self.server.expect(JOB, {'substate=42': 2000}, interval=10, offset=5,
+                           max_attempts=100)
+
+        qname = 'highp'
+        a = {'queue_type': 'execution', 'priority': '200',
+             'started': 'True', 'enabled': 'True'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, qname)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+        a = {ATTR_l + '.select=2000:ncpus': 1, ATTR_q: qname}
+        j = Job(TEST_USER3, attrs=a)
+        j.set_sleep_time(3000)
+        hjid = self.server.submit(j)
+        scycle = time.time()
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+
+        (_, str1) = self.scheduler.log_match(hjid + ";Considering job to run")
+
+        date_time1 = str1.split(";")[0]
+        epoch1 = self.lu.convert_date_time(date_time1)
+        # make sure 2000 jobs were suspended
+        self.server.expect(JOB, {'job_state=S': 2000}, interval=10, offset=5,
+                           max_attempts=100)
+        # record the start time of high priority job
+        (_, str2) = self.scheduler.log_match(hjid + ";Job run",
+                                             n='ALL', interval=2)
+        date_time2 = str2.split(";")[0]
+        epoch2 = self.lu.convert_date_time(date_time2)
+        time_diff = epoch2 - epoch1
+        self.logger.info('#' * 80)
+        self.logger.info('#' * 80)
+        res_str = "RESULT: THE TIME TAKEN IS : " + str(time_diff) + " SECONDS"
+        self.logger.info(res_str)
+        self.logger.info('#' * 80)
+        self.logger.info('#' * 80)
+
+    @timeout(3600)
+    def test_preemption_with_user_soft_limits(self):
+        """
+        Measure the time scheduler takes to preempt when there are user
+        soft limits in the system for one user and only some preemptee jobs
+        are submitted as that user.
         """
         a = {'resources_available.ncpus': 4,
              'resources_available.mem': '6400mb'}
@@ -497,14 +549,16 @@ exit 0
         self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq')
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
-        # submit a bunch of jobs as TEST_USER2
+        # submit a bunch of jobs as different users
         a = {ATTR_l + '.select=1:ncpus': 1}
-        for _ in range(2000):
-            j = Job(TEST_USER2, attrs=a)
+        usr_list = [TEST_USER, TEST_USER2, TEST_USER3, TEST_USER4]
+        num_usr = 4
+        for ind in range(2000):
+            j = Job(usr_list[ind % num_usr], attrs=a)
             j.set_sleep_time(3000)
             self.server.submit(j)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.expect(JOB, {'job_state=R': 2000}, interval=10, offset=5,
+        self.server.expect(JOB, {'substate=42': 2000}, interval=10, offset=5,
                            max_attempts=100)
 
         qname = 'highp'
@@ -513,29 +567,23 @@ exit 0
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, qname)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
-        a = {ATTR_l + '.select=1:ncpus': 1, ATTR_q: qname}
-        fjid = None
-        for _ in range(2000):
-            j = Job(TEST_USER2, attrs=a)
-            j.set_sleep_time(3000)
-            if fjid is None:
-                fjid = self.server.submit(j)
-            else:
-                ljid = self.server.submit(j)
+        a = {ATTR_l + '.select=2000:ncpus': 1, ATTR_q: qname}
+        j = Job(TEST_USER5, attrs=a)
+        j.set_sleep_time(3000)
+        hjid = self.server.submit(j)
         scycle = time.time()
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
-        (_, str1) = self.scheduler.log_match(fjid + ";Considering job to run")
+        (_, str1) = self.scheduler.log_match(hjid + ";Considering job to run")
 
         date_time1 = str1.split(";")[0]
         epoch1 = self.lu.convert_date_time(date_time1)
         # make sure 2000 jobs were suspended
         self.server.expect(JOB, {'job_state=S': 2000}, interval=10, offset=5,
                            max_attempts=100)
-        # record the start time of last high priority job
-        (_, str2) = self.scheduler.log_match(ljid + ";Job run",
-                                             n='ALL',
-                                             max_attempts=1, interval=2)
+        # record the start time of high priority job
+        (_, str2) = self.scheduler.log_match(hjid + ";Job run",
+                                             n='ALL', interval=2)
         date_time2 = str2.split(";")[0]
         epoch2 = self.lu.convert_date_time(date_time2)
         time_diff = epoch2 - epoch1

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -96,7 +96,7 @@ class TestPreemptPerformance(TestPerformance):
         sched_on = {'scheduling': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, sched_on)
 
-        self.server.expect(JOB, {'substate=42': 1590},
+        self.server.expect(JOB, {'job_state=R': 1590},
                            offset=15, interval=20)
 
         a = {'Resource_List.select': '1:ncpus=90:mem=1350mb',
@@ -204,7 +204,7 @@ class TestPreemptPerformance(TestPerformance):
         jid = self.server.submit(j)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
-        self.server.expect(JOB, {'substate=42': 3201}, interval=20,
+        self.server.expect(JOB, {'job_state=R': 3201}, interval=20,
                            offset=15)
 
         qname = 'highp'
@@ -294,7 +294,7 @@ class TestPreemptPerformance(TestPerformance):
         jid2 = self.server.submit(j2)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
-        self.server.expect(JOB, {'substate=42': 3202}, interval=20,
+        self.server.expect(JOB, {'job_state=R': 3202}, interval=20,
                            offset=15)
 
         qname = 'highp'
@@ -370,7 +370,7 @@ class TestPreemptPerformance(TestPerformance):
         jid = self.server.submit(j)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.expect(JOB, {'substate=42': 3201}, interval=20,
+        self.server.expect(JOB, {'job_state=R': 3201}, interval=20,
                            offset=15)
 
         qname = 'highp'
@@ -427,7 +427,7 @@ class TestPreemptPerformance(TestPerformance):
             self.server.submit(j)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.expect(JOB, {'substate=42': 3200}, interval=20,
+        self.server.expect(JOB, {'job_state=R': 3200}, interval=20,
                            offset=15)
 
         qname = 'highp'
@@ -479,7 +479,7 @@ class TestPreemptPerformance(TestPerformance):
         """
         a = {'resources_available.ncpus': 4,
              'resources_available.mem': '6400mb'}
-        self.server.create_vnodes('vn', a, 500, self.mom, usenatvnode=False)
+        self.server.create_vnodes('vn', a, 500, self.mom, usenatvnode=False, sharednode=False)
         p = "express_queue, normal_jobs, server_softlimits, queue_softlimits"
         a = {'preempt_prio': p}
         self.server.manager(MGR_CMD_SET, SCHED, a)
@@ -495,7 +495,7 @@ class TestPreemptPerformance(TestPerformance):
             j.set_sleep_time(3000)
             self.server.submit(j)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.expect(JOB, {'substate=42': 2000}, interval=10, offset=5,
+        self.server.expect(JOB, {'job_state=R': 2000}, interval=10, offset=5,
                            max_attempts=100)
 
         qname = 'highp'
@@ -558,7 +558,7 @@ class TestPreemptPerformance(TestPerformance):
             j.set_sleep_time(3000)
             self.server.submit(j)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.expect(JOB, {'substate=42': 2000}, interval=10, offset=5,
+        self.server.expect(JOB, {'job_state=R': 2000}, interval=10, offset=5,
                            max_attempts=100)
 
         qname = 'highp'


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This is a performance optimization.
Scheduler up until now used to check if there is any limit (user/group/proj) is set on queue and if so, it used to set flags on server object that there is a limit (user/group/proj) set in the complex.
This means that scheduler used to check limits on server and all the queues even when the limit was only set on one (or some) queues.
Also, while ending (or preempting) a job scheduler used to check if there is any soft limit set on server or queue object of the job that is ending and used to call set_preempt_prio() on all the jobs with matching user/group/project name. Since all the jobs in pbs by default have the same project name, the check was turning out to be true almost all the time. Checking and updating preempt priority on all the jobs was an expensive operation and takes a lot of time.


#### Describe Your Change
In this change, every queue will keep track of what kind of limit (user/group/proj) is set on it and will not update server object to show that this is a complex-wide limit.
This gives us more control in our limit checking code to return early in each function if a relevant limit is not set.
Another change is that when a job ends scheduler will now check what kind of limit is set on server/queue and then accordingly match the entity (user/group/proj) of the ending job to other jobs and update their preempt priority.

Setting the type of limit on queues also resulted in a change in job equivalence classes. Earlier any limit set on any queue used to result into setting limit flags on the server object, which would then make equivalence classes code used to consider user/group/project of the job into consideration while finding/creating an equivalence class (even when the limit was neither set on the server or the queue these jobs were in). With this change, these entities (user/group/project) are only considered when job's queue (or server) has the limit set on it.

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output

[test_equiv_classes.txt](https://github.com/PBSPro/pbspro/files/3357195/test_equiv_classes.txt)
[test_perf.txt](https://github.com/PBSPro/pbspro/files/3357196/test_perf.txt)
[test_perf_old.txt](https://github.com/PBSPro/pbspro/files/3374226/test_perf_old.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
