### PR TITLE
Scheduler skips adding preempted job to calendar

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -854,9 +854,6 @@ struct resresv_set
 	place *place_spec;		/* place spec of set */
 	resource_req *req;		/* ATTR_L (qsub -l) resources of set.  Only contains resources on the resources line */
 	queue_info *qinfo;		/* The queue the resresv is in if the queue has nodes associated */
-
-	resource_resv **resresv_arr;	/* The resresvs in the set */
-	int num_resresvs;		/* The number of resresvs in the set */
 };
 
 struct node_partition

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1038,7 +1038,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 			/* If this job couldn't run, the mark the equiv class so the rest of the jobs are discarded quickly.*/
 			if(sinfo->equiv_classes != NULL && njob->ec_index != UNSPECIFIED) {
 				resresv_set *ec = sinfo->equiv_classes[njob->ec_index];
-				if (rc != RUN_FAILURE &&  !ec->can_not_run) {
+				if (rc != RUN_FAILURE &&  !ec->can_not_run && !(njob->job->is_susp_sched || njob->job->is_checkpointed)) {
 					ec->can_not_run = 1;
 					ec->err = dup_schd_error(err);
 				}

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1038,7 +1038,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 			/* If this job couldn't run, the mark the equiv class so the rest of the jobs are discarded quickly.*/
 			if(sinfo->equiv_classes != NULL && njob->ec_index != UNSPECIFIED) {
 				resresv_set *ec = sinfo->equiv_classes[njob->ec_index];
-				if (rc != RUN_FAILURE &&  !ec->can_not_run && !(njob->job->is_susp_sched || njob->job->is_checkpointed)) {
+				if (rc != RUN_FAILURE &&  !ec->can_not_run) {
 					ec->can_not_run = 1;
 					ec->err = dup_schd_error(err);
 				}

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2002,8 +2002,6 @@ new_resresv_set(void)
 	rset->req = NULL;
 	rset->select_spec = NULL;
 	rset->qinfo = NULL;
-	rset->resresv_arr = NULL;
-	rset->num_resresvs = 0;
 
 	return rset;
 }
@@ -2023,7 +2021,6 @@ free_resresv_set(resresv_set *rset) {
 	free_selspec(rset->select_spec);
 	free_place(rset->place_spec);
 	free_resource_req_list(rset->req);
-	free(rset->resresv_arr);
 	free(rset);
 }
 /**
@@ -2100,15 +2097,8 @@ dup_resresv_set(resresv_set *oset, server_info *nsinfo)
 		free_resresv_set(rset);
 		return NULL;
 	}
-	rset->resresv_arr = copy_resresv_array(oset->resresv_arr, nsinfo->all_resresv);
-	if (rset->resresv_arr == NULL) {
-		free_resresv_set(rset);
-		return NULL;
-	}
 	if(oset->qinfo != NULL)
 		rset->qinfo = find_queue_info(nsinfo->queues, oset->qinfo->name);
-
-	rset->num_resresvs = oset->num_resresvs;
 
 	return rset;
 }
@@ -2508,36 +2498,19 @@ create_resresv_sets(status *policy, server_info *sinfo)
 				free_resresv_set_array(rsets);
 				return NULL;
 			}
-			cur_rset->resresv_arr = malloc((len + 1) * sizeof(resource_resv *));
-			if (cur_rset->resresv_arr == NULL) {
-				log_err(errno, __func__, MEM_ERR_MSG);
-				free_resresv_set_array(rsets);
-				free_resresv_set(cur_rset);
-				return NULL;
-			}
 			cur_ind = j;
 			rsets[j++] = cur_rset;
 			rsets[j] = NULL;
 		} else
 			cur_rset = rsets[cur_ind];
 
-		cur_rset->resresv_arr[cur_rset->num_resresvs] = resresvs[i];
-		cur_rset->resresv_arr[++cur_rset->num_resresvs] = NULL;
 		resresvs[i]->ec_index = cur_ind;
-	}
-
-	/* tidy up */
-	for (i = 0; rsets[i] != NULL; i++) {
-		resource_resv **tmp_arr;
-		tmp_arr = realloc(rsets[i]->resresv_arr, (rsets[i]->num_resresvs + 1) * sizeof(resource_resv *));
-		if (tmp_arr != NULL)
-			rsets[i]->resresv_arr = tmp_arr;
 	}
 
 	tmp_rset_arr = realloc(rsets,(j + 1) * sizeof(resresv_set *));
 	if (tmp_rset_arr != NULL)
 		rsets = tmp_rset_arr;
-
+	i = count_array((void **)rsets);
 	if (i > 0) {
 		snprintf(log_buffer, sizeof(log_buffer), "Number of job equivalence classes: %d", i);
 		schdlog(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__, log_buffer);
@@ -2892,11 +2865,19 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 					job->job->is_susp_sched = 1;
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,
 						job->name, "Job preempted by suspension");
+					/* Since suspended job is not part of its current equivalence class,
+					 * break the job's association with its equivalence class.
+					 */
+					job->ec_index= UNSPECIFIED;
 				} else if (preempt_jobs_reply[i].order[0] == 'C') {
 					job->job->is_checkpointed = 1;
 					update_universe_on_end(policy, job, "Q", NO_FLAGS);
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,
 						job->name, "Job preempted by checkpointing");
+					/* Since checkpointed job is not part of its current equivalence class,
+					 * break the job's association with its equivalence class.
+					 */
+					job->ec_index = UNSPECIFIED;
 				} else if (preempt_jobs_reply[i].order[0] == 'Q') {
 					update_universe_on_end(policy, job, "Q", NO_FLAGS);
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2892,13 +2892,11 @@ find_and_preempt_jobs(status *policy, int pbs_sd, resource_resv *hjob, server_in
 					job->job->is_susp_sched = 1;
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,
 						job->name, "Job preempted by suspension");
-					job->can_not_run = 1;
 				} else if (preempt_jobs_reply[i].order[0] == 'C') {
 					job->job->is_checkpointed = 1;
 					update_universe_on_end(policy, job, "Q", NO_FLAGS);
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,
 						job->name, "Job preempted by checkpointing");
-					job->can_not_run = 1;
 				} else if (preempt_jobs_reply[i].order[0] == 'Q') {
 					update_universe_on_end(policy, job, "Q", NO_FLAGS);
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO,

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2469,6 +2469,7 @@ create_resresv_sets(status *policy, server_info *sinfo)
 	int j = 0;
 	int cur_ind;
 	int len;
+	int rset_len;
 	resource_resv **resresvs;
 	resresv_set **rsets;
 	resresv_set **tmp_rset_arr;
@@ -2510,9 +2511,9 @@ create_resresv_sets(status *policy, server_info *sinfo)
 	tmp_rset_arr = realloc(rsets,(j + 1) * sizeof(resresv_set *));
 	if (tmp_rset_arr != NULL)
 		rsets = tmp_rset_arr;
-	i = count_array((void **)rsets);
-	if (i > 0) {
-		snprintf(log_buffer, sizeof(log_buffer), "Number of job equivalence classes: %d", i);
+	rset_len = count_array((void **)rsets);
+	if (rset_len > 0) {
+		snprintf(log_buffer, sizeof(log_buffer), "Number of job equivalence classes: %d", rset_len);
 		schdlog(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SCHED, LOG_DEBUG, __func__, log_buffer);
 	}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

#1183 
#1166 made a change where scheduler started marking a preempted job as can_not_run in the cycle it gets preempted.
Due to this change, while finding the next job in the same cycle, scheduler started skipping this job because find_non_normal_job_ind and find_runnable_resresv_ind functions ignore jobs that have "can_not_run" flag set on them. 
Since these jobs were getting skipped, they were never added to the calendar and undeserving filler jobs started running on its resource resulting in delaying the start time of the preempted job.

#### Describe Your Change
Instead of checking for the job to be preempted (by suspended or checkpointed) and then marking the jobs as "can not run", we will rather change the preemption code to break the association of preempted job and the equivalence class.
This way suspended jobs will still be considered to run and get into the calendar when they cannot run and their equivalence class can still be marked as "can not run" if scheduler could not resume/rerun them.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

No new test needed, pbs_sched_preempt_enforce_resumption.py  tests and pbs_equiv_classses.py tests are enough for testing this
[test_susp_bug.txt](https://github.com/PBSPro/pbspro/files/3364072/test_susp_bug.txt)
[test_equiv.txt](https://github.com/PBSPro/pbspro/files/3364073/test_equiv.txt)
[test_susp.txt](https://github.com/PBSPro/pbspro/files/3364074/test_susp.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
