### PR TITLE
Enable Microsecond logging by default in PTL

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5063,6 +5063,7 @@ class Server(PBSService):
         ignore_attrs += [ATTR_status, ATTR_total, ATTR_count]
         ignore_attrs += [ATTR_rescassn, ATTR_FLicenses, ATTR_SvrHost]
         ignore_attrs += [ATTR_license_count, ATTR_version, ATTR_managers]
+        ignore_attrs += [ATTR_operators]
         ignore_attrs += [ATTR_pbs_license_info, ATTR_power_provisioning]
         unsetlist = []
         setdict = {}

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -107,6 +107,7 @@ OPER_USER = PbsUser('pbsoper', uid=4356, groups=[TSTGRP0, TSTGRP2, GRP_PBS,
 ADMIN_USER = PbsUser('pbsadmin', uid=4357, groups=[TSTGRP0, TSTGRP2, GRP_PBS,
                                                    GRP_AGT])
 PBSROOT_USER = PbsUser('pbsroot', uid=4371, groups=[TSTGRP0, TSTGRP2])
+
 ROOT_USER = PbsUser('root', uid=0, groups=[ROOT_GRP])
 
 PBS_USERS = (TEST_USER, TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
@@ -1286,10 +1287,10 @@ class PBSTestSuite(unittest.TestCase):
         except PbsManagerError as e:
             self.logger.error(e.msg)
         a = {ATTR_managers: (INCR, current_user + '@*,' +
-             MGR_USER.name + '@*')}
+             str(MGR_USER) + '@*')}
         server.manager(MGR_CMD_SET, SERVER, a, sudo=True)
 
-        a1 = {ATTR_operators: (INCR, OPER_USER.name + '@*')}
+        a1 = {ATTR_operators: (INCR, str(OPER_USER) + '@*')}
         server.manager(MGR_CMD_SET, SERVER, a1, sudo=True)
         if ((self.revert_to_defaults and self.server_revert_to_defaults) or
                 force):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1281,10 +1281,16 @@ class PBSTestSuite(unittest.TestCase):
         try:
             # Unset managers list
             server.manager(MGR_CMD_UNSET, SERVER, 'managers', sudo=True)
+            # Unset operators list
+            server.manager(MGR_CMD_UNSET, SERVER, 'operators', sudo=True)
         except PbsManagerError as e:
             self.logger.error(e.msg)
-        a = {ATTR_managers: (INCR, current_user + '@*')}
+        a = {ATTR_managers: (INCR, current_user + '@*,' +
+             MGR_USER.name + '@*')}
         server.manager(MGR_CMD_SET, SERVER, a, sudo=True)
+
+        a1 = {ATTR_operators: (INCR, OPER_USER.name + '@*')}
+        server.manager(MGR_CMD_SET, SERVER, a1, sudo=True)
         if ((self.revert_to_defaults and self.server_revert_to_defaults) or
                 force):
             server.revert_to_defaults(reverthooks=self.revert_hooks,

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -917,6 +917,8 @@ class PBSTestSuite(unittest.TestCase):
             scppath = self.du.which(hostobj.hostname, "scp")
             if scppath != "scp":
                 return scppath
+        elif conf == "PBS_LOG_HIGHRES_TIMESTAMP":
+            return "1"
 
         return None
 
@@ -981,6 +983,10 @@ class PBSTestSuite(unittest.TestCase):
                 if scppath != "scp":
                     new_pbsconf["PBS_SCP"] = scppath
                     restart_comm = True
+            if "PBS_LOG_HIGHRES_TIMESTAMP" not in new_pbsconf  or \
+            new_pbsconf["PBS_LOG_HIGHRES_TIMESTAMP"] != "1":
+                new_pbsconf["PBS_LOG_HIGHRES_TIMESTAMP"] = "1"
+                restart_pbs = True
 
             # Check if existing pbs.conf has more/less entries than the
             # default list
@@ -1055,6 +1061,10 @@ class PBSTestSuite(unittest.TestCase):
                 if scppath != "scp":
                     new_pbsconf["PBS_SCP"] = scppath
                     restart_mom = True
+            if "PBS_LOG_HIGHRES_TIMESTAMP" not in new_pbsconf  or \
+            new_pbsconf["PBS_LOG_HIGHRES_TIMESTAMP"] != "1":
+                new_pbsconf["PBS_LOG_HIGHRES_TIMESTAMP"] = "1"
+                restart_pbs = True
 
             # Check if existing pbs.conf has more/less entries than the
             # default list
@@ -1143,7 +1153,8 @@ class PBSTestSuite(unittest.TestCase):
                 # instead of making PTL start each of them one at a time
                 restart_pbs = True
 
-            # Set PBS_CORE_LIMIT, PBS_SCP and PBS_SERVER
+            # Set PBS_CORE_LIMIT, PBS_SCP, PBS_SERVER 
+            # and PBS_LOG_HIGHRES_TIMESTAMP
             if new_pbsconf["PBS_CORE_LIMIT"] != "unlimited":
                 new_pbsconf["PBS_CORE_LIMIT"] = "unlimited"
                 restart_pbs = True
@@ -1155,6 +1166,10 @@ class PBSTestSuite(unittest.TestCase):
                 if scppath != "scp":
                     new_pbsconf["PBS_SCP"] = scppath
                     restart_pbs = True
+            if "PBS_LOG_HIGHRES_TIMESTAMP" not in new_pbsconf  or \
+            new_pbsconf["PBS_LOG_HIGHRES_TIMESTAMP"] != "1":
+                new_pbsconf["PBS_LOG_HIGHRES_TIMESTAMP"] = "1"
+                restart_pbs = True
 
             # Check if existing pbs.conf has more/less entries than the
             # default list
@@ -1228,7 +1243,8 @@ class PBSTestSuite(unittest.TestCase):
             "PBS_START_SERVER": None,
             "PBS_START_MOM": None,
             "PBS_CORE_LIMIT": None,
-            "PBS_SCP": None
+            "PBS_SCP": None,
+            "PBS_LOG_HIGHRES_TIMESTAMP": None
         }
 
         self._revert_pbsconf_server(vals_to_set)

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -963,12 +963,12 @@ class TestMultipleSchedulers(TestFunctional):
         j2 = Job(TEST_USER1, attrs={ATTR_queue: 'wq1'})
         jid2 = self.server.submit(j2)
 
-        t_start = int(time.time())
+        t_start = time.time()
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
         self.scheds['sc1'].log_match(
             'Leaving Scheduling Cycle', starttime=t_start)
-        t_end = int(time.time())
+        t_end = time.time()
         job_list = self.scheds['sc1'].log_match(
             'Considering job to run', starttime=t_start,
             allmatch=True, endtime=t_end)
@@ -1002,12 +1002,12 @@ class TestMultipleSchedulers(TestFunctional):
         j2 = Job(TEST_USER1, attrs={ATTR_queue: 'wq1'})
         jid2 = self.server.submit(j2)
 
-        t_start = int(time.time())
+        t_start = time.time()
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id='sc1')
         self.scheds['sc1'].log_match(
             'Leaving Scheduling Cycle', starttime=t_start)
-        t_end = int(time.time())
+        t_end = time.time()
         job_list = self.scheds['sc1'].log_match(
             'Considering job to run', starttime=t_start,
             allmatch=True, endtime=t_end)

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -177,7 +177,7 @@ class TestQstatFormats(TestFunctional):
             #        "PBS_O_QUEUE":"workq",
             #    },
 
-            if ',' in val and key != 'managers':
+            if key == ATTR_v:
                 for v in val.split(','):
                     qstat_attrs.append(str(v).split('=')[0])
         return qstat_attrs

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -177,7 +177,7 @@ class TestQstatFormats(TestFunctional):
             #        "PBS_O_QUEUE":"workq",
             #    },
 
-            if ',' in val:
+            if ',' in val and key != 'managers':
                 for v in val.split(','):
                     qstat_attrs.append(str(v).split('=')[0])
         return qstat_attrs

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -807,9 +807,6 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
 
         # We will try to set all attributes which --obfuscate anonymizes
         manager1 = str(MGR_USER) + '@*'
-        self.server.manager(MGR_CMD_SET, SERVER,
-                            {ATTR_managers: (INCR, manager1)},
-                            sudo=True)
         manager2 = str(TEST_USER) + "@*"
         self.server.manager(MGR_CMD_SET, SERVER,
                             {ATTR_managers: (INCR, manager2)},
@@ -817,8 +814,6 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
         real_values[ATTR_managers] = [manager1, manager2]
 
         operator = str(OPER_USER) + '@*'
-        self.server.manager(MGR_CMD_SET, SERVER,
-                            {ATTR_operators: (INCR, operator)})
         real_values[ATTR_operators] = [operator]
 
         real_values[ATTR_SvrHost] = [self.server.hostname]

--- a/test/tests/selftest/pbs_managers_operators.py
+++ b/test/tests/selftest/pbs_managers_operators.py
@@ -73,7 +73,6 @@ class TestManagersOperators(TestSelf):
         """
         Check that default operator user is set on PTL setup
         """
-        svr_opr = self.server.status(SERVER, 'operators')[0]['operators'] \
-            .split(",")
-        opr_usr = {str(OPER_USER) + '@*'}
-        self.assertEqual(opr_usr, set(svr_opr))
+        svr_opr = str(self.server.status(SERVER, 'operators'))
+        opr_usr = str(OPER_USER) + '@*'
+        self.assertEqual(opr_usr, svr_opr)

--- a/test/tests/selftest/pbs_managers_operators.py
+++ b/test/tests/selftest/pbs_managers_operators.py
@@ -73,6 +73,6 @@ class TestManagersOperators(TestSelf):
         """
         Check that default operator user is set on PTL setup
         """
-        svr_opr = str(self.server.status(SERVER, 'operators'))
+        svr_opr = self.server.status(SERVER, 'operators')[0].get('operators')
         opr_usr = str(OPER_USER) + '@*'
         self.assertEqual(opr_usr, svr_opr)

--- a/test/tests/selftest/pbs_managers_operators.py
+++ b/test/tests/selftest/pbs_managers_operators.py
@@ -53,10 +53,10 @@ class TestManagersOperators(TestSelf):
         manager_usr_str = str(MGR_USER) + '@*'
         current_usr = pwd.getpwuid(os.getuid())[0]
         current_usr_str = str(current_usr) + '@*'
-        mgr_users = [manager_usr_str, current_usr_str]
+        mgr_users = {manager_usr_str, current_usr_str}
         svr_mgr = self.server.status(SERVER, 'managers')[0]['managers']\
             .split(",")
-        self.assertEqual(mgr_users, svr_mgr)
+        self.assertEqual(mgr_users, set(svr_mgr))
 
         mgr_user1 = str(TEST_USER)
         mgr_user2 = str(TEST_USER1)
@@ -67,7 +67,7 @@ class TestManagersOperators(TestSelf):
 
         svr_mgr = self.server.status(SERVER, 'managers')[0]['managers'] \
             .split(",")
-        self.assertEqual(mgr_users, svr_mgr)
+        self.assertEqual(mgr_users, set(svr_mgr))
 
     def test_default_oper(self):
         """
@@ -75,5 +75,5 @@ class TestManagersOperators(TestSelf):
         """
         svr_opr = self.server.status(SERVER, 'operators')[0]['operators'] \
             .split(",")
-        opr_usr = [str(OPER_USER) + '@*']
-        self.assertEqual(opr_usr, svr_opr)
+        opr_usr = {str(OPER_USER) + '@*'}
+        self.assertEqual(opr_usr, set(svr_opr))

--- a/test/tests/selftest/pbs_managers_operators_ext.py
+++ b/test/tests/selftest/pbs_managers_operators_ext.py
@@ -53,12 +53,12 @@ class TestManagersOperators(TestSelf):
         manager_usr_str = str(MGR_USER) + '@*'
         current_usr = pwd.getpwuid(os.getuid())[0]
         current_usr_str = str(current_usr) + '@*'
-        svr_mgr = self.server.status(SERVER, 'managers')
-        if str(manager_usr_str) not in str(svr_mgr):
-            raise ValueError
-        if str(current_usr_str) not in str(svr_mgr):
-            raise ValueError
+        svr_mgr = str(self.server.status(SERVER, 'managers'))
+        self.assertIn(str(manager_usr_str), svr_mgr)
+        self.assertIn(str(current_usr_str), svr_mgr)
 
+        print("server is ++++++++++++++")
+        print(str(self.server.status()))
         mgr_user1 = str(TEST_USER)
         mgr_user2 = str(TEST_USER1)
         a = {ATTR_managers: (INCR, mgr_user1 + '@*,' + mgr_user2 + '@*')}
@@ -66,16 +66,13 @@ class TestManagersOperators(TestSelf):
         self.logger.info("Calling test setUp:")
         TestSelf.setUp(self)
 
-        svr_mgr = self.server.status(SERVER, 'managers')
-        if str(manager_usr_str) not in str(svr_mgr):
-            raise ValueError
-        if str(current_usr_str) not in str(svr_mgr):
-            raise ValueError
+        svr_mgr = str(self.server.status(SERVER, 'managers'))
+        self.assertIn(str(manager_usr_str), svr_mgr)
+        self.assertIn(str(current_usr_str), svr_mgr)
 
     def test_default_oper(self):
         """
         Check that default operator user is set on PTL setup
         """
-        svr_opr = self.server.status(SERVER, 'operators')
-        if str(OPER_USER) not in str(svr_opr):
-            raise ValueError
+        svr_opr = str(self.server.status(SERVER, 'operators'))
+        self.assertIn(str(OPER_USER) + '@*', svr_opr)

--- a/test/tests/selftest/pbs_managers_operators_ext.py
+++ b/test/tests/selftest/pbs_managers_operators_ext.py
@@ -41,21 +41,22 @@ from tests.selftest import *
 class TestManagersOperators(TestSelf):
 
     """
-    This test suite contains tests related to managers and operators
-
+        Additional managers users, except current user and MGR_USER
+        should get unset after test setUp run
     """
     def test_managers_unset_setup(self):
         """
-        Additional managers users, except current user should get unset
-        after test setUp run
+        Additional managers users, except current user and MGR_USER should
+        get unset after test setUp run
         """
         runas = ROOT_USER
         manager_usr_str = str(MGR_USER) + '@*'
         current_usr = pwd.getpwuid(os.getuid())[0]
         current_usr_str = str(current_usr) + '@*'
-        svr_mgr = str(self.server.status(SERVER, 'managers'))
-        self.assertIn(str(manager_usr_str), svr_mgr)
-        self.assertIn(str(current_usr_str), svr_mgr)
+        mgr_users = [manager_usr_str, current_usr_str]
+        svr_mgr = self.server.status(SERVER, 'managers')[0]['managers']\
+            .split(",")
+        self.assertEqual(mgr_users, svr_mgr)
 
         mgr_user1 = str(TEST_USER)
         mgr_user2 = str(TEST_USER1)
@@ -64,13 +65,15 @@ class TestManagersOperators(TestSelf):
         self.logger.info("Calling test setUp:")
         TestSelf.setUp(self)
 
-        svr_mgr = str(self.server.status(SERVER, 'managers'))
-        self.assertIn(str(manager_usr_str), svr_mgr)
-        self.assertIn(str(current_usr_str), svr_mgr)
+        svr_mgr = self.server.status(SERVER, 'managers')[0]['managers'] \
+            .split(",")
+        self.assertEqual(mgr_users, svr_mgr)
 
     def test_default_oper(self):
         """
         Check that default operator user is set on PTL setup
         """
-        svr_opr = str(self.server.status(SERVER, 'operators'))
-        self.assertIn(str(OPER_USER) + '@*', svr_opr)
+        svr_opr = self.server.status(SERVER, 'operators')[0]['operators'] \
+            .split(",")
+        opr_usr = [str(OPER_USER) + '@*']
+        self.assertEqual(opr_usr, svr_opr)

--- a/test/tests/selftest/pbs_managers_operators_ext.py
+++ b/test/tests/selftest/pbs_managers_operators_ext.py
@@ -57,8 +57,6 @@ class TestManagersOperators(TestSelf):
         self.assertIn(str(manager_usr_str), svr_mgr)
         self.assertIn(str(current_usr_str), svr_mgr)
 
-        print("server is ++++++++++++++")
-        print(str(self.server.status()))
         mgr_user1 = str(TEST_USER)
         mgr_user2 = str(TEST_USER1)
         a = {ATTR_managers: (INCR, mgr_user1 + '@*,' + mgr_user2 + '@*')}

--- a/test/tests/selftest/pbs_managers_operators_ext.py
+++ b/test/tests/selftest/pbs_managers_operators_ext.py
@@ -38,7 +38,7 @@
 from tests.selftest import *
 
 
-class ManagersOperators(TestSelf):
+class TestManagersOperators(TestSelf):
 
     """
     This test suite contains tests related to managers and operators
@@ -50,13 +50,32 @@ class ManagersOperators(TestSelf):
         after test setUp run
         """
         runas = ROOT_USER
+        manager_usr_str = str(MGR_USER) + '@*'
         current_usr = pwd.getpwuid(os.getuid())[0]
-        attr = {ATTR_managers: current_usr + '@*'}
-        self.server.expect(SERVER, attrib=attr)
+        current_usr_str = str(current_usr) + '@*'
+        svr_mgr = self.server.status(SERVER, 'managers')
+        if str(manager_usr_str) not in str(svr_mgr):
+            raise ValueError
+        if str(current_usr_str) not in str(svr_mgr):
+            raise ValueError
+
         mgr_user1 = str(TEST_USER)
         mgr_user2 = str(TEST_USER1)
         a = {ATTR_managers: (INCR, mgr_user1 + '@*,' + mgr_user2 + '@*')}
         self.server.manager(MGR_CMD_SET, SERVER, a, runas=runas)
         self.logger.info("Calling test setUp:")
         TestSelf.setUp(self)
-        self.server.expect(SERVER, attrib=attr)
+
+        svr_mgr = self.server.status(SERVER, 'managers')
+        if str(manager_usr_str) not in str(svr_mgr):
+            raise ValueError
+        if str(current_usr_str) not in str(svr_mgr):
+            raise ValueError
+
+    def test_default_oper(self):
+        """
+        Check that default operator user is set on PTL setup
+        """
+        svr_opr = self.server.status(SERVER, 'operators')
+        if str(OPER_USER) not in str(svr_opr):
+            raise ValueError

--- a/test/tests/selftest/pbs_pbstestsuite.py
+++ b/test/tests/selftest/pbs_pbstestsuite.py
@@ -225,13 +225,13 @@ class TestPBSTestSuite(TestSelf):
         # Set a non-default pbs.conf variables, let's say
         # PBS_LOG_HIGHRES_TIMESTAMP, and restart PBS
         self.server.pi.stop()
-        pbs_conf_val["PBS_LOG_HIGHRES_TIMESTAMP"] = "1"
+        pbs_conf_val["PBS_LOCALLOG"] = "1"
         self.du.set_pbs_config(confs=pbs_conf_val)
         self.server.pi.start()
 
         # Confirm that the pbs.conf variable is set
         pbs_conf_val = self.du.parse_pbs_config(self.server.hostname)
-        self.assertEqual(pbs_conf_val["PBS_LOG_HIGHRES_TIMESTAMP"], "1")
+        self.assertEqual(pbs_conf_val["PBS_LOCALLOG"], "1")
 
         # Now, call self.revert_pbsconf()
         self.revert_pbsconf()
@@ -239,7 +239,7 @@ class TestPBSTestSuite(TestSelf):
         # Confirm that the value gets removed from the list as it is not
         # a default setting
         pbs_conf_val = self.du.parse_pbs_config(self.server.hostname)
-        self.assertFalse("PBS_LOG_HIGHRES_TIMESTAMP" in pbs_conf_val)
+        self.assertFalse("PBS_LOCALLOG" in pbs_conf_val)
 
     def test_revert_pbsconf_fewer_vars(self):
         """

--- a/test/tests/selftest/pbs_setup_test.py
+++ b/test/tests/selftest/pbs_setup_test.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.selftest import *
+
+
+class TestPTLSetup(TestSelf):
+
+    def test_ms_logging_default_value(self):
+        ms_log_conf_value = self.server.pbs_conf["PBS_LOG_HIGHRES_TIMESTAMP"]
+        self.assertEqual("1", str(ms_log_conf_value))
+
+        a = {'PBS_LOG_HIGHRES_TIMESTAMP': "0"}
+        self.du.set_pbs_config(confs=a, append=True)
+        PBSInitServices().restart()
+        self.assertTrue(self.server.isUp(), 'Failed to restart PBS Daemons')
+        pbs_conf = self.du.parse_pbs_config().get("PBS_LOG_HIGHRES_TIMESTAMP")
+        self.assertEqual("0", str(pbs_conf))
+
+        TestSelf.setUp(self)
+        pbs_conf = self.du.parse_pbs_config().get("PBS_LOG_HIGHRES_TIMESTAMP")
+        self.assertEqual("1", str(pbs_conf))


### PR DESCRIPTION
Currently in PTL tests we do not have microsecond logging turned while during running tests. This causes difficulty to differentiate the message log times between PTL and PBS log files.
This change will turn microsecond logging on by default in PTL. This will help us compare between PTL execution time and PBS event time better.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area] http://community.pbspro.org/t/enabling-microsecond-logging-by-default-for-ptl/1679


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
