### PR TITLE
Fix memory leak due to unfreed batch request in end of job processing

### DIFF
--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -830,6 +830,8 @@ on_job_exit(struct work_task *ptask)
 					(preq->rq_reply.brp_code == DIS_EOD)) {
 					/* connection to Mom broken */
 					conn_to_mom_failed(pjob, on_job_exit);
+					free_br(preq);
+					preq = NULL;
 					return;
 				}
 
@@ -859,7 +861,7 @@ on_job_exit(struct work_task *ptask)
 			 */
 
 			free_br(preq);
-			preq = 0;
+			preq = NULL;
 			(void)svr_setjobstate(pjob, JOB_STATE_EXITING,
 				JOB_SUBSTATE_STAGEDEL);
 			ptask->wt_type = WORK_Immed;
@@ -920,6 +922,8 @@ on_job_exit(struct work_task *ptask)
 					(preq->rq_reply.brp_code == DIS_EOD)) {
 					/* tcp connection to Mom broken */
 					conn_to_mom_failed(pjob, on_job_exit);
+					free_br(preq);
+					preq = NULL;
 					return;
 				}
 				if (preq->rq_reply.brp_code == PBSE_TRYAGAIN) {
@@ -929,8 +933,10 @@ on_job_exit(struct work_task *ptask)
 					t = pjob->ji_retryok++;
 					t = time_now + (t * t);
 					ptask = set_task(WORK_Timed, t, on_job_exit, pjob);
-					append_link(&pjob->ji_svrtask, &ptask->wt_linkobj, ptask
-						);
+					append_link(&pjob->ji_svrtask, &ptask->wt_linkobj, ptask);
+
+					free_br(preq);
+					preq = NULL;
 					return;
 				}
 
@@ -948,7 +954,7 @@ on_job_exit(struct work_task *ptask)
 				svr_mailowner(pjob, MAIL_OTHER, MAIL_FORCE, log_buffer);
 			}
 			free_br(preq);
-			preq = 0;
+			preq = NULL;
 			(void)svr_setjobstate(pjob, JOB_STATE_EXITING,
 				JOB_SUBSTATE_EXITED);
 
@@ -1017,6 +1023,8 @@ on_job_exit(struct work_task *ptask)
 				(preq->rq_reply.brp_code == DIS_EOD)) {
 				/* tcp connection to Mom broken */
 				conn_to_mom_failed(pjob, on_job_exit);
+				free_br(preq);
+				preq = NULL;
 				return;
 			} else if (preq->rq_reply.brp_code == PBSE_TRYAGAIN) {
 				/* Mom hasn't finished her post processing yet,
@@ -1025,8 +1033,10 @@ on_job_exit(struct work_task *ptask)
 				t = pjob->ji_retryok++;
 				t = time_now + (t * t);
 				ptask = set_task(WORK_Timed, t, on_job_exit, pjob);
-				append_link(&pjob->ji_svrtask, &ptask->wt_linkobj, ptask
-					);
+				append_link(&pjob->ji_svrtask, &ptask->wt_linkobj, ptask);
+				
+				free_br(preq);
+				preq = NULL;
 				return;
 			} else {
 				/* all went ok with the delete by Mom(s) */
@@ -1250,6 +1260,8 @@ on_job_rerun(struct work_task *ptask)
 					(preq->rq_reply.brp_code == DIS_EOD)) {
 					/* tcp connection to Mom broken */
 					conn_to_mom_failed(pjob, on_job_rerun);
+					free_br(preq);
+					NULL;
 					return;
 				}
 				on_exitrerun_msg(pjob, msg_obitnocpy);
@@ -1258,7 +1270,7 @@ on_job_rerun(struct work_task *ptask)
 				JOB_SUBSTATE_RERUN1);
 			ptask->wt_type = WORK_Immed;
 			free_br(preq);
-			preq = 0;
+			preq = NULL;
 
 			/* NO BREAK, FALL THROUGH TO NEXT CASE, including the request */
 
@@ -1306,6 +1318,8 @@ on_job_rerun(struct work_task *ptask)
 					(preq->rq_reply.brp_code == DIS_EOD)) {
 					/* tcp connection to Mom broken */
 					conn_to_mom_failed(pjob, on_job_rerun);
+					free_br(preq);
+					preq = NULL;
 					return;
 				}
 				on_exitrerun_msg(pjob, msg_obitnocpy);
@@ -1328,7 +1342,7 @@ on_job_rerun(struct work_task *ptask)
 			 */
 
 			free_br(preq);
-			preq = 0;
+			preq = NULL;
 			(void)svr_setjobstate(pjob, JOB_STATE_EXITING,
 				JOB_SUBSTATE_RERUN2);
 			ptask->wt_type = WORK_Immed;
@@ -1372,13 +1386,15 @@ on_job_rerun(struct work_task *ptask)
 					(preq->rq_reply.brp_code == DIS_EOD)) {
 					/* tcp connection to Mom broken */
 					conn_to_mom_failed(pjob, on_job_rerun);
+					free_br(preq);
+					preq = NULL;
 					return;
 				}
 				/* for other errors, just log it */
 				on_exitrerun_msg(pjob, msg_obitnocpy);
 			}
 			free_br(preq);
-			preq = 0;
+			preq = NULL;
 			(void)svr_setjobstate(pjob, JOB_STATE_EXITING,
 				JOB_SUBSTATE_RERUN3);
 			ptask->wt_type = WORK_Immed;
@@ -1438,6 +1454,8 @@ on_job_rerun(struct work_task *ptask)
 				(preq->rq_reply.brp_code == DIS_EOD)) {
 				/* tcp connection to Mom broken */
 				conn_to_mom_failed(pjob, on_job_rerun);
+				free_br(preq);
+				preq = NULL;
 				return;
 			} else {
 				/* all went ok with the delete by Mom(s) */

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -1261,7 +1261,7 @@ on_job_rerun(struct work_task *ptask)
 					/* tcp connection to Mom broken */
 					conn_to_mom_failed(pjob, on_job_rerun);
 					free_br(preq);
-					NULL;
+					preq = NULL;
 					return;
 				}
 				on_exitrerun_msg(pjob, msg_obitnocpy);

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -191,7 +191,10 @@ extern long 	svr_history_duration;
 
 extern void resv_retry_handler(struct work_task *);
 
-/* Global Data Items */
+/* external functions */
+#ifndef PBS_MOM
+extern void free_job_work_tasks(job *);
+#endif
 
 /* Private Functions */
 
@@ -5343,7 +5346,6 @@ svr_setjob_histinfo(job *pjob, histjob_type type)
 	int newstate = 0;
 	int newsubstate = 0;
 	struct ajtrkhd *ptbl = NULL;
-	struct work_task *pwt = NULL;
 
 	if (type == T_MOV_JOB) { /* MOVED job */
 		char *destination = pjob->ji_qs.ji_destin;
@@ -5503,14 +5505,9 @@ svr_setjob_histinfo(job *pjob, histjob_type type)
 
 	/*
 	 * Work tasks on history jobs are not required and may change the
-	 * history info which is dangerous, so better delete them. Walk
-	 * through the work task list of the job and delete them using
-	 * delete_task().
+	 * history info which is dangerous, so better delete them.
 	 */
-	while ((pwt = (struct work_task *)GET_NEXT(pjob->ji_svrtask)) != NULL) {
-		free(pwt->wt_event2);	/* wt_event2 either has additional data (like msgid) or NULL */
-		delete_task(pwt);
-	}
+	free_job_work_tasks(pjob);
 
 }
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Memory growth is observed at several customer sites related to post job processing errors.
When post_cpyfile() on mom detects that a stageout failed, it sends a second obit to server, which makes it traverse through on_job_exit() once more, this causes a second batch request to be sent out to mom at whatever exiting stage the job is - could be a deletefiles or deletejob batch request (depends on timing). 

When the mom responds to the first deletejob request, the on_job_exit() routine goes to save the job in history, and in that process clears off ALL PENDING tasks on the job. (however, it DOES NOT free any associated batch requests, which free_job does)

However, by the time the mom responds to the second (duplicate) batch request, the job's tasks are all deleted and thus on_job_exit is never triggered, and the allocated batch structure is never freed. 

Another related issue is when the tpp connection between the server and mom is broken while a deletejob or copyfiles operation is pending, we fall into error path, but do not free the previously allocated batch request.

The test to reproduce these leaks is by breaking ssh (so scp stageout fails, say by breaking passwordless ssh) or by breaking the TPP connection between the server and mom (e.g. by killing pbs_comm). These are quite corner cases and we probably do not need PTL tests to cover these for detecting leaks.

On Valgrind this shows up as reachable memory, because server will continue to have a pointer to it, but will never free it, and this will accumulate, and thus is a leak: **(seen in svr_before_fix.log)**
_==124338== 2,264 bytes in 1 blocks are still reachable in loss record 1,437 of 1,555
==124338==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
==124338==    by 0x46933B: alloc_br (process_request.c:1010)
==124338==    by 0x470B4F: on_job_exit (req_jobobit.c:977)
==124338==    by 0x4DD377: dispatch_task (work_task.c:142)
==124338==    by 0x444EB5: process_DreplyRPP (issue_request.c:899)
==124338==    by 0x457448: is_request (node_manager.c:4650)
==124338==    by 0x463C37: do_rpp (pbsd_main.c:462)
==124338==    by 0x463CC5: rpp_request (pbsd_main.c:510)
==124338==    by 0x4E1F48: process_socket (net_server.c:504)
==124338==    by 0x4E2257: wait_request (net_server.c:620)
==124338==    by 0x466F0B: main (pbsd_main.c:2137)_

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The fix is to add the code block from free_job(or rather make it a function to be called from both places) so that pending batch requests are deleted when job is freed or when job goes to history.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[svr_before_fix.log](https://github.com/PBSPro/pbspro/files/3376793/svr_before_fix.log)
[svr_fixed.log](https://github.com/PBSPro/pbspro/files/3376794/svr_fixed.log)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
