### PR TITLE
Incorrect gpu count

### DIFF
--- a/src/cmds/scripts/pbs_topologyinfo.py
+++ b/src/cmds/scripts/pbs_topologyinfo.py
@@ -257,7 +257,7 @@ def socketXMLstart(name, attrs):
             inventory.gpudevices += 1
         if (name == "object" and attrs.get("type") == "OSDev" and
             attrs.get("osdev_type") == "1" and
-                attrs.get("name").startswith("control")):
+                attrs.get("name").startswith("controlD")):
             if (inventory.gpudevices > 0):
                 inventory.gpudevices -= 1
         if (name == "object" and attrs.get("type") == "OSDev" and

--- a/src/cmds/scripts/pbs_topologyinfo.py
+++ b/src/cmds/scripts/pbs_topologyinfo.py
@@ -56,6 +56,7 @@ class Inventory(object):
         self.hwloclatest = 0
         self.CrayVersion = "0.0"
         self.ndevices = 0
+        self.gpudevices = 0
 
     def __init__(self):
         self.reset()
@@ -89,6 +90,7 @@ class Inventory(object):
         """
         Returns the number of licenses required based on specific formula
         """
+        self.ndevices += self.gpudevices
         return(int(math.ceil(self.ndevices / 4.0)))
 
     def reportsockets(self, dirs, files, options):
@@ -171,6 +173,8 @@ class Inventory(object):
         packagepattern = r'<\s*object\s+type="Package"'
         gpupattern = r'<\s*object\s+type="OSDev"\s+name="card\d+"\s+' \
             'osdev_type="1"'
+        nongpupattern = r'<\s*object\s+type="OSDev"\s+name="controlD\d+"\s+' \
+            'osdev_type="1"'
         micpattern = r'<\s*object\s+type="OSDev"\s+name="mic\d+"\s+' \
             'osdev_type="5"'
         craypattern = r'<\s*BasilResponse\s+'
@@ -209,7 +213,10 @@ class Inventory(object):
                                                             line))):
                     self.nsockets += 1
                     self.ndevices += 1
-                self.ndevices += 1 if re.search(gpupattern, line) else 0
+                self.gpudevices += 1 if re.search(gpupattern, line) else 0
+                if re.search(nongpupattern, line):
+                    if (self.gpudevices > 0):
+                        self.gpudevices -= 1
                 self.ndevices += 1 if re.search(micpattern, line) else 0
 
 
@@ -247,7 +254,12 @@ def socketXMLstart(name, attrs):
         if (name == "object" and attrs.get("type") == "OSDev" and
             attrs.get("osdev_type") == "1" and
                 attrs.get("name").startswith("card")):
-            inventory.ndevices += 1
+            inventory.gpudevices += 1
+        if (name == "object" and attrs.get("type") == "OSDev" and
+            attrs.get("osdev_type") == "1" and
+                attrs.get("name").startswith("control")):
+            if (inventory.gpudevices > 0):
+                inventory.gpudevices -= 1
         if (name == "object" and attrs.get("type") == "OSDev" and
             attrs.get("osdev_type") == "5" and
                 attrs.get("name").startswith("mic")):


### PR DESCRIPTION
#### Describe Bug or Feature
* all 'osdev_type="1"' devices are being counted as devices.
* It was the issue while counting the number of gpu devices, we were also counting the non gpu devices in number of gpu's.

#### Describe Your Change
* Counting the gpu devices seperately before adding it to ndevices so that if there is a non gpu device it should not get added in the gpu devices.


#### Attach Test and Valgrind Logs/Output
*  [topology_output_brfore.txt](https://github.com/PBSPro/pbspro/files/3381123/topology_output_brfore.txt)
* [topology_output_after.txt](https://github.com/PBSPro/pbspro/files/3381124/topology_output_after.txt)



 Topology_file
* [jitendra.txt](https://github.com/PBSPro/pbspro/files/3380922/jitendra.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
