### PR TITLE
Ubuntu nodes from container jobs offlined by pbs_cgroups

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -4102,30 +4102,30 @@ class CgroupUtils(object):
                     pass
         # Give the OS a moment to update the tasks file
         time.sleep(0.1)
-        # After killing processes, tasks file could disappear when cgroup
-        # parent dir is cleaned up,
-        if not os.path.isfile(tasks_file):
-            return 0
         count = 0
-        with open(tasks_file, 'r') as tasks_desc:
-            for line in tasks_desc:
-                count += 1
-                pid = line.strip()
-                filename = os.path.join(os.sep, 'proc', pid, 'status')
-                statlist = []
-                try:
-                    with open(filename, 'r') as status_desc:
-                        for line2 in status_desc:
-                            if line2.find('Name:') != -1:
-                                statlist.append(line2.strip())
-                            if line2.find('State:') != -1:
-                                statlist.append(line2.strip())
-                            if line2.find('Uid:') != -1:
-                                statlist.append(line2.strip())
-                except Exception:
-                    pass
-                pbs.logmsg(pbs.EVENT_DEBUG2, '%s: PID %s survived: %s' %
-                           (caller_name(), pid, statlist))
+        try:
+            with open(tasks_file, 'r') as tasks_desc:
+                for line in tasks_desc:
+                    count += 1
+                    pid = line.strip()
+                    filename = os.path.join(os.sep, 'proc', pid, 'status')
+                    statlist = []
+                    try:
+                        with open(filename, 'r') as status_desc:
+                            for line2 in status_desc:
+                                if line2.find('Name:') != -1:
+                                    statlist.append(line2.strip())
+                                if line2.find('State:') != -1:
+                                    statlist.append(line2.strip())
+                                if line2.find('Uid:') != -1:
+                                    statlist.append(line2.strip())
+                    except Exception:
+                        pass
+                    pbs.logmsg(pbs.EVENT_DEBUG2, '%s: PID %s survived: %s' %
+                               (caller_name(), pid, statlist))
+        except Exception as exc:
+            if exc.errno != errno.ENOENT:
+                raise
         return count
 
     def _delete_cgroup_children(self, path):

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -4102,6 +4102,10 @@ class CgroupUtils(object):
                     pass
         # Give the OS a moment to update the tasks file
         time.sleep(0.1)
+        # After killing processes, tasks file could disappear when cgroup
+        # parent dir is cleaned up,
+        if not os.path.isfile(tasks_file):
+            return 0
         count = 0
         with open(tasks_file, 'r') as tasks_desc:
             for line in tasks_desc:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Running container jobs (PBS_hpc_container enabled) on Ubuntu with pbs_cgroups hook enabled, result in nodes to get offlined.
* Mom_logs show:
07/11/2019 22:37:54;0080;pbs_python;Hook;pbs_python;delete: Error removing cgroup for 201.scc-ubuntu18: [Errno 2] No such file or directory: '/sys/fs/cgroup/memory/pbspro.slice/pbspro-201.scc\\x2dubuntu18.slice/a39c075877720bad8dc30e2c6979e206157f2d8947bd507e2f69196ca6fa3f0f/tasks'
07/11/2019 22:37:54;0100;pbs_python;Hook;pbs_python;take_node_offline: Taking vnode(s) offline

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* As job is ending, there's a call to delete() function in pbs_cgroup.PY, which eventually calls _kill_tasks(). 
* kill_tasks() opens the cgroup mem tasks file, and proceeds to kill each process still listed in the file.
* Then it does a sleep(0.1), and then tries to open the file again. Under Ubuntu systems and with container jobs, the open fails (gets an exception) as the tasks file is no longer accessible because the parent cgroup directory got deleted after all the processes have been killed.
* Because of the exception encountered, pbs_cgroups proceeds to offline the node.
* The simple fix is to try...except on the second open of tasks file call, ignoring the "no such file" error condition.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
Manual test logs:
* [19.4.0_offline_ubuntu_PASS.run2.txt](https://github.com/PBSPro/pbspro/files/3390061/19.4.0_offline_ubuntu_PASS.run2.txt)

* [19.4.0_offline_ubuntu_FAIL.txt](https://github.com/PBSPro/pbspro/files/3384283/19.4.0_offline_ubuntu_FAIL.txt)
* [r8_cgroups_hook_test.txt](https://github.com/PBSPro/pbspro/files/3390186/r8_cgroups_hook_test.txt)
* [ubuntu16_cgroups_hook_test.txt](https://github.com/PBSPro/pbspro/files/3390187/ubuntu16_cgroups_hook_test.txt)
* [ubuntu18_cgroups_hook_test.txt](https://github.com/PBSPro/pbspro/files/3390190/ubuntu18_cgroups_hook_test.txt)

* [s12_cgroups_hook_test.txt](https://github.com/PBSPro/pbspro/files/3390648/s12_cgroups_hook_test.txt)


<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
