### PR TITLE
PTL fails to capture post analysis data

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_data.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_data.py
@@ -198,8 +198,8 @@ class PTLTestData(Plugin):
         ret = self.du.run_cmd(current_host, cmd, level=logging.DEBUG2,
                               logerr=False)
         if ret['rc'] != 0:
-            _msg = 'Failed to get analysis information for '
-            _msg += 'on %s:' % servers_host
+            _msg = 'Failed to get analysis information '
+            _msg += 'on %s:' % server_host
             _msg += '\n\n' + '\n'.join(ret['err']) + '\n\n'
             f.write(_msg + '\n')
             self.logger.error(_msg)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
While capturing post analysis data of a failed test case in PTL, pbs_snapshot command failed to execute and failed with error "NameError: global name 'servers_host' is not defined"  


#### Describe Your Change
In code, server_host is getting initialized but used servers_host while printing error message. Changed variable name to server_host.

#### Attach Test and Valgrind Logs/Output
[pbs_expect_failure_logs_with_post_analysis_data.txt](https://github.com/PBSPro/pbspro/files/3385567/pbs_expect_failure_logs_with_post_analysis_data.txt)
