### PR TITLE
Subjob resources set in a runjob hook is not availabe when rerun

### DIFF
--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -504,12 +504,17 @@ req_runjob(struct batch_request *preq)
 	} else if (jt == IS_ARRAY_Single) {
 		attribute sub_runcount = {0};
 		attribute sub_run_version = {0};
+		attribute sub_prev_res;
+		clear_attr(&sub_prev_res, &job_attr_def[JOB_ATR_resource]);
 
 		/* single subjob, if parent qeueud, it can be run */
 
 		if ((pjobsub = parent->ji_ajtrk->tkm_tbl[offset].trk_psubjob) != NULL) {
 			sub_runcount = pjobsub->ji_wattr[JOB_ATR_runcount];
 			sub_run_version = pjobsub->ji_wattr[JOB_ATR_run_version];
+			if (pjobsub->ji_wattr[JOB_ATR_resource].at_flags & ATR_VFLAG_SET) {
+				job_attr_def[JOB_ATR_resource].at_set(&sub_prev_res, &pjobsub->ji_wattr[JOB_ATR_resource], SET);
+			}
 			job_purge(pjobsub);
 		}
 
@@ -521,6 +526,12 @@ req_runjob(struct batch_request *preq)
 		if (sub_run_version.at_flags & ATR_VFLAG_SET) {
 			pjobsub->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long = sub_run_version.at_val.at_long;
 			pjobsub->ji_wattr[(int)JOB_ATR_run_version].at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
+
+			if (sub_run_version.at_val.at_long && (sub_prev_res.at_flags & ATR_VFLAG_SET)) {
+				job_attr_def[JOB_ATR_resource].at_free(&pjobsub->ji_wattr[JOB_ATR_resource]);
+				job_attr_def[JOB_ATR_resource].at_set(&pjobsub->ji_wattr[JOB_ATR_resource], &sub_prev_res, SET);
+				job_attr_def[JOB_ATR_resource].at_free(&sub_prev_res);
+			}
 		}
 
 		if (sub_runcount.at_flags & ATR_VFLAG_SET) {

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -519,6 +519,8 @@ req_runjob(struct batch_request *preq)
 		}
 
 		if ((pjobsub = create_subjob(parent, jid, &j)) == NULL) {
+			if (sub_prev_res.at_flags & ATR_VFLAG_SET)
+				job_attr_def[JOB_ATR_resource].at_free(&sub_prev_res);
 			req_reject(j, 0, preq);
 			return;
 		}
@@ -527,7 +529,7 @@ req_runjob(struct batch_request *preq)
 			pjobsub->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long = sub_run_version.at_val.at_long;
 			pjobsub->ji_wattr[(int)JOB_ATR_run_version].at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 
-			if (sub_run_version.at_val.at_long && (sub_prev_res.at_flags & ATR_VFLAG_SET)) {
+			if (sub_prev_res.at_flags & ATR_VFLAG_SET) {
 				job_attr_def[JOB_ATR_resource].at_free(&pjobsub->ji_wattr[JOB_ATR_resource]);
 				job_attr_def[JOB_ATR_resource].at_set(&pjobsub->ji_wattr[JOB_ATR_resource], &sub_prev_res, SET);
 				job_attr_def[JOB_ATR_resource].at_free(&sub_prev_res);

--- a/test/tests/functional/pbs_runjob_hook.py
+++ b/test/tests/functional/pbs_runjob_hook.py
@@ -63,6 +63,18 @@ e = pbs.event()
 e.job.Resource_List['site'] = 'site_value'
 """
 
+    rerun_hook_script = """
+import pbs
+e = pbs.event()
+j = e.job
+if not j.run_version is None:
+    pbs.logmsg(pbs.LOG_DEBUG,
+        "rerun_job_hook %s: Resource_List.foo_str=%s" %
+        (j.id,j.Resource_List['foo_str']))
+else:
+    j.Resource_List['foo_str'] = "foo_value"
+"""
+
     def test_array_sub_job_index(self):
         """
         Submit a job array. Check the array sub-job index value
@@ -112,6 +124,67 @@ e.job.Resource_List['site'] = 'site_value'
             self.server.tracejob_match(m, id=sid, n='ALL', tail=False)
             m = 'E;' + re.escape(sid) + ';.*Resource_List.site=site_value'
             self.server.accounting_match(m, regexp=True)
+
+    def test_array_sub_res_persist_in_hook_forcereque(self):
+        """
+        set custom resource in runjob hook. Submit a job array.
+        Check if custom resource set persists after force requeue due to
+        node fail requeue
+        """
+        # configure node fail requeue to lower value
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'node_fail_requeue': 5})
+        # set three cpu for three subjobs
+        a = {'resources_available.ncpus': 3}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        # create custom non-consumable string server resource
+        attr = {'type': 'string'}
+        r = 'foo_str'
+        self.server.manager(
+            MGR_CMD_CREATE, RSC, attr, id=r, logerr=False)
+        # create and import hook
+        hook_name = "runjob_hook"
+        attrs = {'event': "runjob"}
+        rv = self.server.create_import_hook(hook_name, attrs,
+                                            self.rerun_hook_script,
+                                            overwrite=True)
+        self.assertTrue(rv)
+        # create and submit job array
+        lower = 1
+        upper = 3
+        j1 = Job(TEST_USER)
+        j1.set_attributes({ATTR_J: '%d-%d' % (lower, upper)})
+        jid = self.server.submit(j1)
+        # check if running
+        self.server.expect(JOB, {ATTR_state: 'B'}, id=jid)
+        self.server.expect(JOB, {'job_state=R': 3}, count=True,
+                           id=jid, extend='t')
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'scheduling': 'False'})
+        # kill mom
+        self.mom.stop('-KILL')
+        for i in range(lower, upper + 1):
+            sid = j1.create_subjob_id(jid, i)
+            m = "'runjob_hook' hook set job's "
+            "Resource_List.foo_str = foo_value"
+            self.server.tracejob_match(m, id=sid, n='ALL', tail=False)
+        # check subjob state change from R->Q
+        self.server.expect(JOB, {'job_state=Q': 3}, count=True,
+                           id=jid, extend='t')
+        # bring back mom
+        self.mom.start()
+        start_time = int(time.time())
+        self.mom.isUp()
+        # let subjobs get rerun from sched Q->R
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'scheduling': 'True'})
+        self.server.expect(JOB, {'job_state=R': 3}, count=True,
+                           id=jid, extend='t')
+        # log match from hook log for runversion and custom res value
+        for i in range(lower, upper + 1):
+            sid = j1.create_subjob_id(jid, i)
+            m = "rerun_job_hook %s: Resource_List.foo_str=foo_value"
+            self.server.log_match(m % (sid), start_time)
 
     def test_normal_job_index(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The custom resource values which are set by runjob hook event are resetting to None value if job gets reran for subjobs. For normal jobs works fine.

Reproduction steps:

create a hook with event 'runjob' with below contents:

import pbs

pbs.logmsg(pbs.LOG_DEBUG, "STARTED=====================")

e = pbs.event()
j = e.jobpbs.logmsg(pbs.LOG_DEBUG, "JOB ID: %s" % j.id)
if not j.run_version is None:
    pbs.logmsg(pbs.LOG_DEBUG, "I'm running again run_version %s" %j.run_version)
    pbs.logmsg(pbs.LOG_DEBUG, "cust_res resource value is %s" %j.Resource_List['cust_res'])
else:
    pbs.logmsg(pbs.LOG_DEBUG, "I'm running for first time. setting cust_res resource")
    j.Resource_List['cust_res'] = 'cust_value'
pbs.logmsg(pbs.LOG_DEBUG, "END=========================")

 

QSUB Subjob - sets cust_res resource

06/25/2019 16:47:39;0100;Server@vm1;Job;1251[1].vm1;enqueuing into workq, state 1 hop 1
06/25/2019 16:47:39;0400;Server@vm1;Hook;test;started
06/25/2019 16:47:39;0006;Server@vm1;Hook;Server@vm1;STARTED=====================
06/25/2019 16:47:39;0006;Server@vm1;Hook;Server@vm1;JOB ID: 1251[1].vm1
06/25/2019 16:47:39;0006;Server@vm1;Hook;Server@vm1;I'm running for first time. setting cust_res resource
06/25/2019 16:47:39;0006;Server@vm1;Hook;Server@vm1;END=========================
06/25/2019 16:47:39;0400;Server@vm1;Hook;test;finished
06/25/2019 16:47:39;0008;Server@vm1;Job;1251[1].vm1;'test' hook set job's Resource_List.cust_res = cust_value
06/25/2019 16:47:39;0400;Server@vm1;Job;1251[1].vm1;Allocated 1 cpu licenses, float avail global 999913, float avail local 0, used locally 1
06/25/2019 16:47:39;0008;Server@vm1;Job;1251[1].vm1;Job Run at request of Scheduler@vm1 on exec_vnode (vm1:ncpus=1)
06/25/2019 16:47:39;0400;Server@vm1;Svr;wait_request;processing priority socket
06/25/2019 16:47:39;0100;Server@vm1;Req;;Type 23 request received from Scheduler@vm1, sock=16
06/25/2019 16:47:39;0100;Server@vm1;Job;1251[2].vm1;enqueuing into workq, state 1 hop 1
06/25/2019 16:47:39;0400;Server@vm1;Hook;test;started
06/25/2019 16:47:39;0006;Server@vm1;Hook;Server@vm1;STARTED=====================
06/25/2019 16:47:39;0006;Server@vm1;Hook;Server@vm1;JOB ID: 1251[2].vm1
06/25/2019 16:47:39;0006;Server@vm1;Hook;Server@vm1;I'm running for first time. setting cust_res resource
06/25/2019 16:47:39;0006;Server@vm1;Hook;Server@vm1;END=========================
06/25/2019 16:47:39;0400;Server@vm1;Hook;test;finished
06/25/2019 16:47:39;0008;Server@vm1;Job;1251[2].vm1;'test' hook set job's Resource_List.cust_res = cust_value

 

QRERUN subjob - shows cust_res resource value which is set on previous run(**Bug: cust_res resource value is None**)

06/25/2019 16:48:15;0100;Server@vm1;Job;1251[1].vm1;dequeuing from workq, state 1
06/25/2019 16:48:15;0100;Server@vm1;Job;1251[1].vm1;enqueuing into workq, state 1 hop 1
06/25/2019 16:48:15;0400;Server@vm1;Hook;test;started
06/25/2019 16:48:15;0006;Server@vm1;Hook;Server@vm1;STARTED=====================
06/25/2019 16:48:15;0006;Server@vm1;Hook;Server@vm1;JOB ID: 1251[1].vm1
06/25/2019 16:48:15;0006;Server@vm1;Hook;Server@vm1;I'm running again run_version 1
06/25/2019 16:48:15;0006;Server@vm1;Hook;Server@vm1;**cust_res resource value is None**
06/25/2019 16:48:15;0006;Server@vm1;Hook;Server@vm1;END=========================
06/25/2019 16:48:15;0400;Server@vm1;Hook;test;finished
06/25/2019 16:48:15;0400;Server@vm1;Job;1251[1].vm1;Allocated 1 cpu licenses, float avail global 999913, float avail local 0, used locally 2
06/25/2019 16:48:15;0008;Server@vm1;Job;1251[1].vm1;Job Run at request of Scheduler@vm1 on exec_vnode (vm1:ncpus=1)

06/25/2019 16:48:21;0100;Server@vm1;Job;1251[2].vm1;dequeuing from workq, state 1
06/25/2019 16:48:21;0100;Server@vm1;Job;1251[2].vm1;enqueuing into workq, state 1 hop 1
06/25/2019 16:48:21;0400;Server@vm1;Hook;test;started
06/25/2019 16:48:21;0006;Server@vm1;Hook;Server@vm1;STARTED=====================
06/25/2019 16:48:21;0006;Server@vm1;Hook;Server@vm1;JOB ID: 1251[2].vm1
06/25/2019 16:48:21;0006;Server@vm1;Hook;Server@vm1;I'm running again run_version 1
06/25/2019 16:48:21;0006;Server@vm1;Hook;Server@vm1;**cust_res resource value is None**
06/25/2019 16:48:21;0006;Server@vm1;Hook;Server@vm1;END=========================
06/25/2019 16:48:21;0400;Server@vm1;Hook;test;finished
06/25/2019 16:48:21;0400;Server@vm1;Job;1251[2].vm1;Allocated 1 cpu licenses, float avail global 999913, float avail local 0, used locally 2
06/25/2019 16:48:21;0008;Server@vm1;Job;1251[2].vm1;Job Run at request of Scheduler@vm1 on exec_vnode (vm1:ncpus=1)
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fixed in `req_runjob()` by backing up the job attribute `JOB_ATR_resource` before purging the previous job object of the subjob in which the runjob hook has set the resource value. And then recovering it on to the newly recreated next verion of job object of the subjob


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[TestRunJobHook.zip](https://github.com/PBSPro/pbspro/files/3386003/TestRunJobHook.zip)
[smoke.zip](https://github.com/PBSPro/pbspro/files/3386005/smoke.zip)
[other_PTLs.zip](https://github.com/PBSPro/pbspro/files/3386006/other_PTLs.zip)
[valgrind.zip](https://github.com/PBSPro/pbspro/files/3386007/valgrind.zip)
[TestRunJobHook_2.zip](https://github.com/PBSPro/pbspro/files/3390412/TestRunJobHook_2.zip)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
