### PR TITLE
cgroup test update to check for memory_spread_page file

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -819,7 +819,7 @@ if %s e.job.in_ms_mom():
         """
         Returns True if path exists otherwise false
         """
-        for _ in range(5):
+        for _ in range(20):
             rv = self.du.isfile(hostname=host, path=cpath, sudo=True)
             if rv:
                 return True
@@ -2180,10 +2180,10 @@ if %s e.job.in_ms_mom():
         """
         self.load_config(self.cfg5 % ('false', '', 'true', 'false',
                                       'false', self.swapctl))
-        self.server.expect(NODE, {'state': 'free'},
-                           id=self.nodes_list[0], interval=3, offset=10)
-        a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' %
-             self.hosts_list[0]}
+        nid = self.nodes_list[0]
+        self.server.expect(NODE, {'state': 'free'}, nid, interval=3, offset=10)
+        hostname = self.hosts_list[0]
+        a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' % hostname}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
         jid = self.server.submit(j)
@@ -2193,20 +2193,18 @@ if %s e.job.in_ms_mom():
         o = j.attributes[ATTR_o]
         self.tempfile.append(o)
         spread_path = 'cpuset.memory_spread_page'
-        fn = self.get_cgroup_job_dir('cpuset', jid, self.hosts_list[0])
+        fn = self.get_cgroup_job_dir('cpuset', jid, hostname)
         if self.noprefix:
             spread_path = 'memory_spread_page'
         fn = os.path.join(fn, spread_path)
-        result = self.du.cat(hostname=self.hosts_list[0],
-                             filename=fn, sudo=True)
+        self.assertTrue(self.is_file(fn, hostname))
+        result = self.du.cat(hostname, filename=fn, sudo=True)
         self.assertEqual(result['rc'], 0)
         self.assertEqual(result['out'][0], '0')
         self.load_config(self.cfg5 % ('false', '', 'true', 'false',
                                       'true', self.swapctl))
-        self.server.expect(NODE, {'state': 'free'},
-                           id=self.nodes_list[0], interval=3, offset=10)
-        a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' %
-             self.hosts_list[0]}
+        self.server.expect(NODE, {'state': 'free'}, nid, interval=3, offset=10)
+        a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' % hostname}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
         jid = self.server.submit(j)
@@ -2215,10 +2213,9 @@ if %s e.job.in_ms_mom():
         self.server.status(JOB, ATTR_o, jid)
         o = j.attributes[ATTR_o]
         self.tempfile.append(o)
-        fn = self.get_cgroup_job_dir('cpuset', jid, self.hosts_list[0])
+        fn = self.get_cgroup_job_dir('cpuset', jid, hostname)
         fn = os.path.join(fn, spread_path)
-        result = self.du.cat(hostname=self.hosts_list[0],
-                             filename=fn, sudo=True)
+        result = self.du.cat(hostname, filename=fn, sudo=True)
         self.assertEqual(result['rc'], 0)
         self.assertEqual(result['out'][0], '1')
 

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2180,8 +2180,9 @@ if %s e.job.in_ms_mom():
         """
         self.load_config(self.cfg5 % ('false', '', 'true', 'false',
                                       'false', self.swapctl))
-        id = self.nodes_list[0]
-        self.server.expect(NODE, {'state': 'free'}, id, interval=3, offset=10)
+        nid = self.nodes_list[0]
+        self.server.expect(NODE, {'state': 'free'}, id=nid,
+                           interval=3, offset=10)
         hostn = self.hosts_list[0]
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' % hostn}
         j = Job(TEST_USER, attrs=a)
@@ -2198,12 +2199,13 @@ if %s e.job.in_ms_mom():
             spread_path = 'memory_spread_page'
         fn = os.path.join(fn, spread_path)
         self.assertTrue(self.is_file(fn, hostn))
-        result = self.du.cat(hostn, filename=fn, sudo=True)
+        result = self.du.cat(hostname=hostn, filename=fn, sudo=True)
         self.assertEqual(result['rc'], 0)
         self.assertEqual(result['out'][0], '0')
         self.load_config(self.cfg5 % ('false', '', 'true', 'false',
                                       'true', self.swapctl))
-        self.server.expect(NODE, {'state': 'free'}, id, interval=3, offset=10)
+        self.server.expect(NODE, {'state': 'free'}, id=nid,
+                           interval=3, offset=10)
         a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' % hostn}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
@@ -2215,7 +2217,7 @@ if %s e.job.in_ms_mom():
         self.tempfile.append(o)
         fn = self.get_cgroup_job_dir('cpuset', jid, hostn)
         fn = os.path.join(fn, spread_path)
-        result = self.du.cat(hostn, filename=fn, sudo=True)
+        result = self.du.cat(hostname=hostn, filename=fn, sudo=True)
         self.assertEqual(result['rc'], 0)
         self.assertEqual(result['out'][0], '1')
 

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -819,11 +819,11 @@ if %s e.job.in_ms_mom():
         """
         Returns True if path exists otherwise false
         """
-        for _ in range(20):
+        for _ in range(5):
             rv = self.du.isfile(hostname=host, path=cpath, sudo=True)
             if rv:
                 return True
-            time.sleep(0.1)
+            time.sleep(0.5)
         return False
 
     def get_cgroup_job_dir(self, subsys, jobid, host):
@@ -2180,10 +2180,10 @@ if %s e.job.in_ms_mom():
         """
         self.load_config(self.cfg5 % ('false', '', 'true', 'false',
                                       'false', self.swapctl))
-        nid = self.nodes_list[0]
-        self.server.expect(NODE, {'state': 'free'}, nid, interval=3, offset=10)
-        hostname = self.hosts_list[0]
-        a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' % hostname}
+        id = self.nodes_list[0]
+        self.server.expect(NODE, {'state': 'free'}, id, interval=3, offset=10)
+        hostn = self.hosts_list[0]
+        a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' % hostn}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
         jid = self.server.submit(j)
@@ -2193,18 +2193,18 @@ if %s e.job.in_ms_mom():
         o = j.attributes[ATTR_o]
         self.tempfile.append(o)
         spread_path = 'cpuset.memory_spread_page'
-        fn = self.get_cgroup_job_dir('cpuset', jid, hostname)
+        fn = self.get_cgroup_job_dir('cpuset', jid, hostn)
         if self.noprefix:
             spread_path = 'memory_spread_page'
         fn = os.path.join(fn, spread_path)
-        self.assertTrue(self.is_file(fn, hostname))
-        result = self.du.cat(hostname, filename=fn, sudo=True)
+        self.assertTrue(self.is_file(fn, hostn))
+        result = self.du.cat(hostn, filename=fn, sudo=True)
         self.assertEqual(result['rc'], 0)
         self.assertEqual(result['out'][0], '0')
         self.load_config(self.cfg5 % ('false', '', 'true', 'false',
                                       'true', self.swapctl))
-        self.server.expect(NODE, {'state': 'free'}, nid, interval=3, offset=10)
-        a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' % hostname}
+        self.server.expect(NODE, {'state': 'free'}, id, interval=3, offset=10)
+        a = {'Resource_List.select': '1:ncpus=1:mem=100mb:host=%s' % hostn}
         j = Job(TEST_USER, attrs=a)
         j.create_script(self.sleep15_job)
         jid = self.server.submit(j)
@@ -2213,9 +2213,9 @@ if %s e.job.in_ms_mom():
         self.server.status(JOB, ATTR_o, jid)
         o = j.attributes[ATTR_o]
         self.tempfile.append(o)
-        fn = self.get_cgroup_job_dir('cpuset', jid, hostname)
+        fn = self.get_cgroup_job_dir('cpuset', jid, hostn)
         fn = os.path.join(fn, spread_path)
-        result = self.du.cat(hostname, filename=fn, sudo=True)
+        result = self.du.cat(hostn, filename=fn, sudo=True)
         self.assertEqual(result['rc'], 0)
         self.assertEqual(result['out'][0], '1')
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestCgroupsHook.test_cgroup_cpuset_memory_spread_page intermittently fails due to missing cgroup dir cpuset.memory_spread_page.



#### Describe Your Change
Added a check if cpuset.memory_spread_page exists before proceeding with the rest of the test.



#### Attach Test Logs/Output
tests showing intermittent failure (2 out of 50):
[test_cgroup_cpuset_memory_spread_page_td-10_loop50_before.txt](https://github.com/PBSPro/pbspro/files/3387470/test_cgroup_cpuset_memory_spread_page_td-10_loop50_before.txt)

tests showing fixed issue:
[test_cgroup_cpuset_memory_spread_page_td-10_loop50_after1.txt](https://github.com/PBSPro/pbspro/files/3387472/test_cgroup_cpuset_memory_spread_page_td-10_loop50_after1.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
