### PR TITLE
Create a configuration/environment variable for the scheduler host name

### DIFF
--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -224,6 +224,7 @@ struct pbs_config
 	char *pbs_tmpdir;			/* temporary file directory */
 	char *pbs_server_host_name;	/* name of host on which Server is running */
 	char *pbs_public_host_name;	/* name of the local host for outgoing connections */
+	char *pbs_scheduler_host_name;  /* name of the host on which sched is running */
 	char *pbs_mail_host_name;	/* name of host to which to address mail */
 	char *pbs_smtp_server_name;   /* name of SMTP host to which to send mail */
 	char *pbs_output_host_name;	/* name of host to which to stage std out/err */
@@ -293,6 +294,7 @@ extern struct pbs_config pbs_conf;
 #define PBS_CONF_CORE_LIMIT	"PBS_CORE_LIMIT"      /* RLIMIT_CORE setting */
 #define PBS_CONF_SERVER_HOST_NAME "PBS_SERVER_HOST_NAME"
 #define PBS_CONF_PUBLIC_HOST_NAME "PBS_PUBLIC_HOST_NAME"
+#define PBS_CONF_SCHEDULER_HOST_NAME "PBS_SCHEDULER_HOST_NAME"
 #define PBS_CONF_MAIL_HOST_NAME "PBS_MAIL_HOST_NAME"
 #define PBS_CONF_OUTPUT_HOST_NAME "PBS_OUTPUT_HOST_NAME"
 #define PBS_CONF_SMTP_SERVER_NAME "PBS_SMTP_SERVER_NAME" /* Name of SMTP Host to send mail to */

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -107,6 +107,7 @@ struct pbs_config pbs_conf = {
 	NULL,					/* pbs_tmpdir */
 	NULL,					/* pbs_server_host_name */
 	NULL,					/* pbs_public_host_name */
+	NULL,					/* pbs_scheduler_host_name */
 	NULL,					/* pbs_mail_host_name */
 	NULL,					/* pbs_output_host_name */
 	NULL,					/* pbs_smtp_server_name */
@@ -541,6 +542,10 @@ __pbs_loadconf(int reload)
 				free(pbs_conf.pbs_public_host_name);
 				pbs_conf.pbs_public_host_name = strdup(conf_value);
 			}
+			else if (!strcmp(conf_name, PBS_CONF_SCHEDULER_HOST_NAME)) {
+				free(pbs_conf.pbs_scheduler_host_name);
+				pbs_conf.pbs_scheduler_host_name = strdup(conf_value);
+			}
 			else if (!strcmp(conf_name, PBS_CONF_MAIL_HOST_NAME)) {
 				free(pbs_conf.pbs_mail_host_name);
 				pbs_conf.pbs_mail_host_name = strdup(conf_value);
@@ -766,6 +771,10 @@ __pbs_loadconf(int reload)
 	if ((gvalue = getenv(PBS_CONF_PUBLIC_HOST_NAME)) != NULL) {
 		free(pbs_conf.pbs_public_host_name);
 		pbs_conf.pbs_public_host_name = strdup(gvalue);
+	}
+	if ((gvalue = getenv(PBS_CONF_SCHEDULER_HOST_NAME)) != NULL) {
+		free(pbs_conf.pbs_scheduler_host_name);
+		pbs_conf.pbs_scheduler_host_name = strdup(gvalue);
 	}
 	if ((gvalue = getenv(PBS_CONF_MAIL_HOST_NAME)) != NULL) {
 		free(pbs_conf.pbs_mail_host_name);

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1074,6 +1074,11 @@ main(int argc, char **argv)
 		pbs_scheduler_addr = get_hostaddr(pbs_conf.pbs_primary);
 	}
 
+	/* set the scheduler name if it is set in an env var or conf file */
+	if (pbs_conf.pbs_scheduler_host_name != NULL) {
+		pbs_scheduler_addr = get_hostaddr(pbs_conf.pbs_scheduler_host_name);
+	}
+
 	/* parse the parameters from the command line */
 
 	while ((c = getopt(argc, argv, "A:a:Cd:e:F:p:t:lL:M:NR:S:g:G:s:P:-:")) != -1) {

--- a/test/tests/functional/pbs_conf_var.py
+++ b/test/tests/functional/pbs_conf_var.py
@@ -65,12 +65,10 @@ class TestConf(TestFunctional):
         self.server.log_match(logmsg, starttime=now)
 
         # Now set it to cvs and show that the server can't talk to the sched
-        self.server.stop()
         self.du.set_pbs_config(
             self.server.hostname,
             confs={'PBS_SCHEDULER_HOST_NAME': 'cvs.pbspro.com'})
         now = int(time.time())
         self.server.restart()
-        self.assertTrue(self.server.isUp(), 'Failed to start PBS')
         logmsg = 'Could not contact Scheduler'
         self.server.log_match(logmsg, starttime=now)

--- a/test/tests/functional/pbs_conf_var.py
+++ b/test/tests/functional/pbs_conf_var.py
@@ -54,9 +54,6 @@ class TestConf(TestFunctional):
         the server can't talk to the sched, to prove that the
         variable is being used.
         """
-        self.server.stop()
-        self.assertFalse(self.server.isUp(), "Failed to stop PBS")
-
         conf = self.du.parse_pbs_config(self.server.hostname)
         self.du.set_pbs_config(
             self.server.hostname,
@@ -64,16 +61,16 @@ class TestConf(TestFunctional):
         now = int(time.time())
         self.server.restart()
         self.assertTrue(self.server.isUp(), 'Failed to start PBS')
-        logmsg = "request received from Scheduler@%s" % (self.server.hostname)
+        logmsg = 'request received from Scheduler@%s' % (self.server.hostname)
         self.server.log_match(logmsg, starttime=now)
 
         # Now set it to cvs and show that the server can't talk to the sched
         self.server.stop()
         self.du.set_pbs_config(
             self.server.hostname,
-            confs={'PBS_SCHEDULER_HOST_NAME': "cvs.pbspro.com"})
+            confs={'PBS_SCHEDULER_HOST_NAME': 'cvs.pbspro.com'})
         now = int(time.time())
         self.server.restart()
         self.assertTrue(self.server.isUp(), 'Failed to start PBS')
-        logmsg = "Could not contact Scheduler"
+        logmsg = 'Could not contact Scheduler'
         self.server.log_match(logmsg, starttime=now)

--- a/test/tests/functional/pbs_conf_var.py
+++ b/test/tests/functional/pbs_conf_var.py
@@ -79,3 +79,4 @@ class TestConf(TestFunctional):
         self.assertTrue(self.server.isUp(), 'Failed to start PBS')
         logmsg = "Could not contact Scheduler"
         self.server.log_match(logmsg, starttime=now)
+

--- a/test/tests/functional/pbs_conf_var.py
+++ b/test/tests/functional/pbs_conf_var.py
@@ -79,4 +79,3 @@ class TestConf(TestFunctional):
         self.assertTrue(self.server.isUp(), 'Failed to start PBS')
         logmsg = "Could not contact Scheduler"
         self.server.log_match(logmsg, starttime=now)
-

--- a/test/tests/functional/pbs_conf_var.py
+++ b/test/tests/functional/pbs_conf_var.py
@@ -1,0 +1,81 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+import os
+
+from tests.functional import *
+
+
+class TestConf(TestFunctional):
+    """
+    This test suite tests the PBS configuration file
+    """
+
+    def test_sched_host_name_envvar(self):
+        """
+        Start the server with the PBS_SCHEDULER_HOST_NAME
+        set to the name of the local host to show the variable works
+        Also set it to some other existing machine that isn't set up
+        to work with this machine (e.g. cvs.pbspro.com) and show
+        the server can't talk to the sched, to prove that the
+        variable is being used.
+        """
+        self.server.stop()
+        self.assertFalse(self.server.isUp(), "Failed to stop PBS")
+
+        conf = self.du.parse_pbs_config(self.server.hostname)
+        self.du.set_pbs_config(
+            self.server.hostname,
+            confs={'PBS_SCHEDULER_HOST_NAME': conf['PBS_SERVER']})
+        now = int(time.time())
+        self.server.start()
+        self.assertTrue(self.server.isUp(), 'Failed to start PBS')
+        logmsg = "request received from Scheduler@%s" % (self.server.hostname)
+        self.server.log_match(logmsg, starttime=now)
+
+        """
+        Now set it to cvs and show that the server can't talk to the sched
+        """
+        self.server.stop()
+        self.du.set_pbs_config(
+            self.server.hostname,
+            confs={'PBS_SCHEDULER_HOST_NAME': "cvs.pbspro.com"})
+        now = int(time.time())
+        self.server.start()
+        self.assertTrue(self.server.isUp(), 'Failed to start PBS')
+        logmsg = "Could not contact Scheduler"
+        self.server.log_match(logmsg, starttime=now)

--- a/test/tests/functional/pbs_conf_var.py
+++ b/test/tests/functional/pbs_conf_var.py
@@ -62,20 +62,18 @@ class TestConf(TestFunctional):
             self.server.hostname,
             confs={'PBS_SCHEDULER_HOST_NAME': conf['PBS_SERVER']})
         now = int(time.time())
-        self.server.start()
+        self.server.restart()
         self.assertTrue(self.server.isUp(), 'Failed to start PBS')
         logmsg = "request received from Scheduler@%s" % (self.server.hostname)
         self.server.log_match(logmsg, starttime=now)
 
-        """
-        Now set it to cvs and show that the server can't talk to the sched
-        """
+        # Now set it to cvs and show that the server can't talk to the sched
         self.server.stop()
         self.du.set_pbs_config(
             self.server.hostname,
             confs={'PBS_SCHEDULER_HOST_NAME': "cvs.pbspro.com"})
         now = int(time.time())
-        self.server.start()
+        self.server.restart()
         self.assertTrue(self.server.isUp(), 'Failed to start PBS')
         logmsg = "Could not contact Scheduler"
         self.server.log_match(logmsg, starttime=now)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When running the PBS server and scheduler in a Kubernetes pod the scheduler can’t connect to the server because it looks like the connections are coming from a different IP address than the server’s.


#### Describe Your Change
Created a new PBS configuration variable called PBS_SCHEDULER_HOST_NAME.
This configuration/environment variable can be set by admins when starting PBS.


#### Link to Design Doc
There is a design, located here: [project documentation area](https://pbspro.atlassian.net/wiki/spaces/PD/pages/1318387715/New+scheduler+service+name+conf+variable)


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
[ptl_output.txt](https://github.com/PBSPro/pbspro/files/3388059/ptl_output.txt)

<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->