### PR TITLE
Optimize scheduler for 1M jobs/50k nodes

### DIFF
--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -74,15 +74,15 @@ enum sort_status
 };
 
 
-/* enum used to find out what to skip while searching for the next job to schedule */
+/* enum used to find out what to skip while searching for the next job to schedule.  Values are bits in a bitfield */
 
 enum skip
 {
 	SKIP_NOTHING,
 	/* Value used to know whether reservations are already scheduled or not */
-	SKIP_RESERVATIONS,
+	SKIP_RESERVATIONS = 1,
 	/* Value used to know whether express, preempted, starving jobs are already scheduled or not */
-	SKIP_NON_NORMAL_JOBS
+	SKIP_NON_NORMAL_JOBS = 2
 };
 
 /* return value of select_index_to_preempt function */
@@ -360,6 +360,11 @@ enum add_resource_list_flags
 	ADD_AVAIL_ASSIGNED = 8,
 	ADD_ALL_BOOL = 16
 	/* next flag 32 */
+};
+
+enum incr_decr {
+	SCHD_INCR,
+	SCHD_DECR
 };
 
 /* run update resresv flags is a bitfield = 0, 1, 2, 4, 8, ...*/

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -622,17 +622,18 @@ struct node_info
 
 	char *current_aoe;		/* AOE name instantiated on node */
 	char *current_eoe;		/* EOE name instantiated on node */
-	char *nodesig;                /* resource signature */
-	int nodesig_ind;              /* resource signature index in server array */
+	char *nodesig;			/* resource signature */
+	int nodesig_ind;		/* resource signature index in server array */
 	node_info *svr_node;		/* ptr to svr's node if we're a resv node */
-	node_partition *hostset;      /* other vnodes on on the same host */
-	node_scratch nscr;            /* scratch space local to node search code */
-	char *partition;	      /* partition to which node belongs to */
+	node_partition *hostset;	/* other vnodes on on the same host */
+	node_scratch nscr;		/* scratch space local to node search code */
+	char *partition;		/* partition to which node belongs to */
 	time_t last_state_change_time;	/* Node state change at time stamp */
 	time_t last_used_time;		/* Node was last active at this time */
 	te_list *node_events;		/* list of events that affect the node */
 	int bucket_ind;			/* index in server's bucket array */
 	int node_ind;			/* node's index into sinfo->unordered_nodes */
+	node_partition **np_arr;	/* array of node partitions node is in */
 };
 
 struct resv_info
@@ -714,6 +715,8 @@ struct resource_resv
 	enum site_j_share_type share_type;	/* How resv counts against group share */
 #endif /* localmod 034 */
 	int		resresv_ind;		/* resource_resv index in all_resresv array */
+	timed_event 	*run_event;		/* run event in calendar */
+	timed_event	*end_event;		/* end event in calendar */
 };
 
 
@@ -1121,6 +1124,7 @@ struct event_list
 	unsigned int eol:1;		/* we've reached the end of time */
 	timed_event *events;		/* the calendar of events */
 	timed_event *next_event;	/* the next event to be performed */
+	timed_event *first_run_event;	/* The first run event in the calendar */
 	time_t *current_time;		/* [reference] current time in the calendar */
 };
 

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -630,7 +630,7 @@ struct node_info
 	char *partition;		/* partition to which node belongs to */
 	time_t last_state_change_time;	/* Node state change at time stamp */
 	time_t last_used_time;		/* Node was last active at this time */
-	te_list *node_events;		/* list of events that affect the node */
+	te_list *node_events;		/* list of run events that affect the node */
 	int bucket_ind;			/* index in server's bucket array */
 	int node_ind;			/* node's index into sinfo->unordered_nodes */
 	node_partition **np_arr;	/* array of node partitions node is in */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1049,7 +1049,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 			schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_WARNING,
 				njob->name, "Job will never run with the resources currently configured in the complex");
 		}
-		if ((rc != SUCCESS) && njob->job->resv ==NULL) {
+		if ((rc != SUCCESS) && njob->job->resv == NULL) {
 			/* jobs in reservations are outside of the law... they don't cause
 			 * the rest of the system to idle waiting for them
 			 */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2255,7 +2255,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 		skip = SKIP_NOTHING;
 		sort_jobs(policy, sinfo);
 		sort_status = SORTED;
-		last_job_index = 0;
+		last_job_index = -1; /* We search from last_job_index + 1 */
 		return NULL;
 	}
 
@@ -2279,7 +2279,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 		|| (flag == MUST_RESORT_JOBS)) {
 		sort_jobs(policy, sinfo);
 		sort_status = SORTED;
-		last_job_index = 0;
+		last_job_index = -1;
 	}
 	if (policy->round_robin) {
 		/* Below is a pictorial representation of how queue_list
@@ -2353,11 +2353,11 @@ next_job(status *policy, server_info *sinfo, int flag)
 		}
 	} else if (policy->by_queue) {
 		if (!(skip & SKIP_NON_NORMAL_JOBS)) {
-			ind = find_non_normal_job_ind(sinfo->jobs, last_job_index);
+			ind = find_non_normal_job_ind(sinfo->jobs, last_job_index + 1);
 			if (ind == -1) {
 				/* No more preempted jobs */
 				skip |= SKIP_NON_NORMAL_JOBS;
-				last_job_index = 0;
+				last_job_index = -1;
 			} else {
 				rjob = sinfo->jobs[ind];
 				last_job_index = ind;
@@ -2365,9 +2365,9 @@ next_job(status *policy, server_info *sinfo, int flag)
 		}
 		if (skip & SKIP_NON_NORMAL_JOBS) {
 			while(last_queue < sinfo->num_queues &&
-			     ((ind = find_runnable_resresv_ind(sinfo->queues[last_queue]->jobs, last_job_index)) == -1)) {
+			     ((ind = find_runnable_resresv_ind(sinfo->queues[last_queue]->jobs, last_job_index + 1)) == -1)) {
 				last_queue++;
-				last_job_index = 0;
+				last_job_index = -1;
 			}
 			if (last_queue < sinfo->num_queues && ind != -1) {
 				rjob = sinfo->queues[last_queue]->jobs[ind];

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1655,12 +1655,15 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 		}
 
 		if (ns != NULL) {
+			int update_nodepart = 0;
 			for (i = 0; ns[i] != NULL; i++) {
 				int j;
 				update_node_on_run(ns[i], rr, &old_state);
 				if (ns[i]->ninfo->np_arr != NULL) {
-					for (j = 0; ns[i]->ninfo->np_arr[j] != NULL; j++)
+					for (j = 0; ns[i]->ninfo->np_arr[j] != NULL; j++) {
 						modify_resource_list(ns[i]->ninfo->np_arr[j]->res, ns[i]->resreq, SCHD_INCR);
+						update_nodepart = 1;
+					}
 				}
 				/* if the node is being provisioned, it's brought down in
 				 * update_node_on_run().  We need to add an event in the calendar to
@@ -1673,6 +1676,8 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 					}
 				}
 			}
+			if (update_nodepart)
+				sort_all_nodepart(policy, sinfo);
 		}
 
 		update_queue_on_run(qinfo, rr, &old_state);

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1655,14 +1655,14 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 		}
 
 		if (ns != NULL) {
-			int update_nodepart = 0;
+			int sort_nodepart = 0;
 			for (i = 0; ns[i] != NULL; i++) {
 				int j;
 				update_node_on_run(ns[i], rr, &old_state);
 				if (ns[i]->ninfo->np_arr != NULL) {
 					for (j = 0; ns[i]->ninfo->np_arr[j] != NULL; j++) {
 						modify_resource_list(ns[i]->ninfo->np_arr[j]->res, ns[i]->resreq, SCHD_INCR);
-						update_nodepart = 1;
+						sort_nodepart = 1;
 					}
 				}
 				/* if the node is being provisioned, it's brought down in
@@ -1676,7 +1676,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 					}
 				}
 			}
-			if (update_nodepart)
+			if (sort_nodepart)
 				sort_all_nodepart(policy, sinfo);
 		}
 
@@ -2381,7 +2381,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 				rjob = NULL;
 		}
 	} else { /* treat the entire system as one large queue */
-		ind = find_runnable_resresv_ind(sinfo->jobs, last_job_index);
+		ind = find_runnable_resresv_ind(sinfo->jobs, last_job_index + 1);
 		if(ind != -1) {
 			rjob = sinfo->jobs[ind];
 			last_job_index = ind;

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3224,7 +3224,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 		return NULL;
 	}
 
-	skipto=0;
+	skipto = 0;
 	while ((indexfound = select_index_to_preempt(npolicy, nhjob, rjobs_subset, skipto, err, fail_list)) != NO_JOB_FOUND) {
 		struct preempt_ordering *po;
 
@@ -3252,12 +3252,9 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 
 		update_universe_on_end(npolicy, pjob,  "S", NO_ALLPART);
 		rjobs_count--;
-		if (nsinfo->calendar != NULL) {
-			te = find_timed_event(nsinfo->calendar->events, 0, pjob->name, TIMED_END_EVENT, 0);
-			if (te != NULL) {
-				if (delete_event(nsinfo, te, DE_NO_FLAGS) == 0)
+		if (pjob->end_event != NULL) {
+				if (delete_event(nsinfo, pjob->end_event, DE_NO_FLAGS) == 0)
 					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO, pjob->name, "Failed to delete end event for job.");
-			}
 		}
 
 		pjobs[j] = pjob;

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3021,7 +3021,6 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 
 	schd_error *full_err = NULL;
 	schd_error *cur_err = NULL;
-	timed_event *te = NULL;
 
 	resource_req *preempt_targets_req = NULL;
 	char **preempt_targets_list = NULL;

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -1007,17 +1007,25 @@ clear_schd_error(schd_error *err)
 	set_schd_error_codes(err, SCHD_UNKWN, SUCCESS);
 	err->rdef = NULL;
 
-	free(err->arg1);
-	err->arg1 = NULL;
+	if (err->arg1 != NULL) {
+		free(err->arg1);
+		err->arg1 = NULL;
+	}
 
-	free(err->arg2);
-	err->arg2 = NULL;
+	if (err->arg2 != NULL) {
+		free(err->arg2);
+		err->arg2 = NULL;
+	}
 
-	free(err->arg3);
-	err->arg3 = NULL;
+	if (err->arg3 != NULL) {
+		free(err->arg3);
+		err->arg3 = NULL;
+	}
 
-	free(err->specmsg);
-	err->specmsg = NULL;
+	if (err->specmsg != NULL) {
+		free(err->specmsg);
+		err->specmsg = NULL;
+	}
 }
 
 /**

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -1144,6 +1144,7 @@ void move_schd_error(schd_error *err, schd_error *oerr)
 	oerr->arg3 = NULL;
 	oerr->specmsg = NULL;
 	oerr->next = NULL;
+	clear_schd_error(oerr);
 }
 
 /**

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -3330,7 +3330,7 @@ eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 	 * Actually return an a real error */
 	if (err->status_code == SCHD_UNKWN && failerr->status_code != SCHD_UNKWN)
 		move_schd_error(err, failerr);
-	/* don't be so specific in the comment since it's only for a single node*/
+	/* don't be so specific in the comment since it's only for a single node */
 	free(err->arg1);
 	err->arg1 = NULL;
 	return 0;

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -2205,6 +2205,7 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 	char				reason[MAX_LOG_SIZE] = {0};
 	int				i = 0;
 	static struct schd_error	*failerr = NULL;
+	nspec **tmp;
 
 	if (spec == NULL || ninfo_arr == NULL || resresv == NULL || placespec == NULL || nspec_arr == NULL)
 		return 0;
@@ -2266,7 +2267,12 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 		if (rc == 0) {
 			free_nspecs(*nspec_arr);
 			*nspec_arr = NULL;
+		} else {
+			tmp = realloc(*nspec_arr, count_array((void **)*nspec_arr) * sizeof(nspec *) + 1);
+			if (tmp != NULL)
+				*nspec_arr = tmp;
 		}
+
 		if (pass_flags & EVAL_EXCLSET)
 			alloc_rest_nodepart(*nspec_arr, ninfo_arr);
 
@@ -2354,6 +2360,10 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 	if (!rc) {
 		free_nspecs(*nspec_arr);
 		*nspec_arr = NULL;
+	} else {
+		tmp = realloc(*nspec_arr, count_array((void **)*nspec_arr) * sizeof(nspec *) + 1);
+		if (tmp != NULL)
+			*nspec_arr = tmp;
 	}
 
 	if (err->status_code == SCHD_UNKWN && failerr->status_code != SCHD_UNKWN)

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -295,13 +295,14 @@ copy_node_partition_ptr_array(node_partition **onp_arr, node_partition **new_nps
 		return NULL;
 
 	cnt = count_array((void **)onp_arr);
-	if ((nnp_arr = calloc(cnt + 1, sizeof(node_partition *))) == NULL) {
+	if ((nnp_arr = malloc((cnt + 1) * sizeof(node_partition *))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
 		return NULL;
 	}
 
 	for (i = 0; i < cnt; i++)
 		nnp_arr[i] = find_node_partition_by_rank(new_nps, onp_arr[i]->rank);
+	nnp_arr[i] = NULL;
 
 	return nnp_arr;
 }
@@ -453,7 +454,7 @@ create_node_partitions(status *policy, node_info **nodes, char **resnames, unsig
 			}
 			if (res != NULL) {
 				/* Incase of indirect resource, point it to the right place */
-			        if (res->indirect_res != NULL)
+				if (res->indirect_res != NULL)
 					res = res->indirect_res;
 				for (val_i = 0; res->str_avail[val_i] != NULL; val_i++) {
 					/* 2: 1 for '=' 1 for '\0' */
@@ -751,7 +752,7 @@ node_partition_update(status *policy, node_partition *np)
 
 	if (policy->node_sort[0].res_name != NULL && conf.node_sort_unused) {
 		/* Resort the nodes in the partition so that selection works correctly. */
-		qsort(np->ninfo_arr, np->tot_nodes, sizeof(node_info*),
+		qsort(np->ninfo_arr, np->tot_nodes, sizeof(node_info *),
 			multi_node_sort);
 	}
 

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -1311,7 +1311,7 @@ sort_all_nodepart(status *policy, server_info *sinfo)
 {
 	int i;
 
-	if (sinfo == NULL || sinfo->queues == NULL)
+	if (policy == NULL || sinfo == NULL || sinfo->queues == NULL)
 		return;
 
 	if (sinfo->node_group_enable && sinfo->node_group_key != NULL)

--- a/src/scheduler/node_partition.h
+++ b/src/scheduler/node_partition.h
@@ -221,6 +221,8 @@ int create_placement_sets(status *policy, server_info *sinfo);
 /* Update placement sets and allparts */
 void update_all_nodepart(status *policy, server_info *sinfo, unsigned int flags);
 
+/* Sort all placement sets (server's psets, queue's psets, and hostsets) */
+void sort_all_nodepart(status *policy, server_info *sinfo);
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/node_partition.h
+++ b/src/scheduler/node_partition.h
@@ -102,6 +102,9 @@ node_partition **dup_node_partition_array(node_partition **onp_arr, server_info 
  */
 node_partition *dup_node_partition(node_partition *onp, server_info *nsinfo);
 
+/* copy a node partition array from pointers out of another.*/
+node_partition **copy_node_partition_ptr_array(node_partition **onp_arr, node_partition **new_nps);
+
 /*
  *
  *      create_node_partitions - break apart nodes into partitions
@@ -116,9 +119,8 @@ node_partition *dup_node_partition(node_partition *onp, server_info *nsinfo);
  *
  *
  */
-node_partition **
-create_node_partitions(status *policy, node_info **nodes, char **resnames,
-	unsigned int flags, int *num_parts);
+node_partition **create_node_partitions(status *policy, node_info **nodes, char **resnames,
+					unsigned int flags, int *num_parts);
 
 /*
  *

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -189,6 +189,8 @@ new_resource_resv()
 	resresv->node_set_str = NULL;
 	resresv->node_set = NULL;
 	resresv->resresv_ind = -1;
+	resresv->run_event = NULL;
+	resresv->end_event = NULL;
 
 	return resresv;
 }
@@ -1282,9 +1284,6 @@ update_resresv_on_end(resource_resv *resresv, char *job_state)
 	int ret;
 	int i;
 
-	/* used for calendar correction */
-	timed_event *te;
-
 	if (resresv == NULL)
 		return;
 
@@ -1330,13 +1329,10 @@ update_resresv_on_end(resource_resv *resresv, char *job_state)
 			resresv->execselect = NULL;
 		}
 		/* We need to correct our calendar */
-		if (resresv->server->calendar != NULL) {
-			te = find_timed_event(resresv->server->calendar->events, 0, resresv->name, TIMED_END_EVENT, 0);
-			if (te != NULL)
-				set_timed_event_disabled(te, 1);
-		}
+			if (resresv->end_event != NULL)
+				set_timed_event_disabled(resresv->end_event, 1);
 	}
-	else if (resresv->is_resv && resresv->resv !=NULL) {
+	else if (resresv->is_resv && resresv->resv != NULL) {
 		resresv->resv->resv_state = RESV_DELETED;
 
 		resv_queue = find_queue_info(resresv->server->queues,
@@ -1508,7 +1504,7 @@ add_resresv_to_array(resource_resv **resresv_arr,
 		return NULL;
 
 	if (resresv_arr == NULL && resresv != NULL) {
-		new_arr = malloc(2*sizeof(resource_resv *));
+		new_arr = malloc(2 * sizeof(resource_resv *));
 		if (new_arr == NULL)
 			return NULL;
 		new_arr[0] = resresv;

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -1329,8 +1329,8 @@ update_resresv_on_end(resource_resv *resresv, char *job_state)
 			resresv->execselect = NULL;
 		}
 		/* We need to correct our calendar */
-			if (resresv->end_event != NULL)
-				set_timed_event_disabled(resresv->end_event, 1);
+		if (resresv->end_event != NULL)
+			set_timed_event_disabled(resresv->end_event, 1);
 	}
 	else if (resresv->is_resv && resresv->resv != NULL) {
 		resresv->resv->resv_state = RESV_DELETED;

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1420,6 +1420,38 @@ create_resource(char *name, char *value, enum resource_fields field)
 	return nres;
 }
 
+int
+modify_resource_list(schd_resource *res_list, resource_req *req_list, int type)
+{
+	schd_resource *cur_res;
+	resource_req *cur_req;
+	schd_resource *end_res = NULL;
+
+	if (res_list == NULL || req_list == NULL)
+		return 0;
+	
+	for(cur_req = req_list; cur_req != NULL; cur_req = cur_req->next) {
+		if (cur_req->type.is_consumable) {
+			cur_res = find_resource(res_list, cur_req->def);
+			if (cur_res == NULL) {
+				if (end_res == NULL)
+					for (end_res = res_list; end_res->next != NULL; end_res = end_res->next)
+						;
+				end_res->next = create_resource(cur_req->name, cur_req->res_str, RF_AVAIL);
+				if (end_res->next == NULL)
+					return 0;
+				end_res = end_res->next;
+			} else {
+				if (type == SCHD_INCR)
+					cur_res->avail += cur_req->amount;
+				else if (type == SCHD_DECR)
+					    cur_res->avail -= cur_req->amount;
+			}
+		}
+	}
+	return 1;
+}
+
 /**
  * @brief
  * 		add_resource_list - add one resource list to another
@@ -1455,6 +1487,8 @@ add_resource_list(status *policy, schd_resource *r1, schd_resource *r2, unsigned
 		return 0;
 
 	for (cur_r2 = r2; cur_r2 != NULL; cur_r2 = cur_r2->next) {
+		if ((flags & NO_UPDATE_NON_CONSUMABLE) && cur_r2->def->type.is_non_consumable)
+			continue;
 		if ((flags & USE_RESOURCE_LIST)) {
 			if (!resdef_exists_in_array(policy->resdef_to_check, cur_r2->def) &&
 				!cur_r2->type.is_boolean)
@@ -2419,11 +2453,11 @@ dup_server_info(server_info *osinfo)
 	 */
 	for (i = 0; osinfo->nodes[i] != NULL; i++) {
 		nsinfo->nodes[i]->run_resvs_arr =
-			copy_resresv_array(osinfo->nodes[i]->run_resvs_arr,
-			nsinfo->resvs);
-		if(nsinfo->calendar != NULL)
+			copy_resresv_array(osinfo->nodes[i]->run_resvs_arr, nsinfo->resvs);
+		nsinfo->nodes[i]->np_arr = 
+			copy_node_partition_ptr_array(osinfo->nodes[i]->np_arr, nsinfo->nodepart);
+		if (nsinfo->calendar != NULL)
 			nsinfo->nodes[i]->node_events = dup_te_lists(osinfo->nodes[i]->node_events, nsinfo->calendar->next_event);
-
 	}
 	nsinfo->buckets = dup_node_bucket_array(osinfo->buckets, nsinfo);
 
@@ -3811,7 +3845,7 @@ add_queue_to_list(queue_info **** qlhead, queue_info * qinfo)
  * @retval	NULL	: when function is not able to find the array.
  *
  */
-struct queue_info *** find_queue_list_by_priority(queue_info *** list_head, int priority)
+struct queue_info ***find_queue_list_by_priority(queue_info *** list_head, int priority)
 {
 	int i;
 	if (list_head == NULL)
@@ -3836,7 +3870,7 @@ struct queue_info *** find_queue_list_by_priority(queue_info *** list_head, int 
  * @retval	NULL	: when realloc fails.
  *           			pointer to appended list.
  */
-struct queue_info** append_to_queue_list(queue_info ***list, queue_info *add)
+struct queue_info **append_to_queue_list(queue_info ***list, queue_info *add)
 {
 	int count = 0;
 	queue_info ** temp = NULL;
@@ -4069,4 +4103,41 @@ dup_unordered_nodes(node_info **old_unordered_nodes, node_info **nnodes)
 	new_unordered_nodes[ct1] = NULL;
 
 	return new_unordered_nodes;
+}
+
+/**
+ * @brief add pointer to NULL terminated pointer array
+ * @param[in] ptr_arr - pointer array to add to
+ * @param[in] ptr - pointer to add
+ * 
+ * @return void *
+ * @retval pointer array with new element added
+ * @retval NULL on error
+ */
+void *
+add_ptr_to_array(void *ptr_arr, void *ptr)
+{
+	void **arr;
+	int cnt;
+
+	cnt = count_array((void **)ptr_arr);
+
+	if (cnt == 0) {
+		arr = malloc(sizeof(void *) * 2);
+		if (arr == NULL) {
+			log_err(errno, __func__, MEM_ERR_MSG);
+			return NULL;
+		}
+		arr[0] = ptr;
+		arr[1] = NULL;
+	} else {
+		arr = realloc(ptr_arr, (cnt + 1));
+		if (arr == NULL) {
+			log_err(errno, __func__, MEM_ERR_MSG);
+			return NULL;
+		}
+		arr[cnt] = ptr;
+		arr[cnt + 1] = NULL;
+	}
+	return arr;
 }

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -4131,13 +4131,13 @@ add_ptr_to_array(void *ptr_arr, void *ptr)
 		arr[0] = ptr;
 		arr[1] = NULL;
 	} else {
-		arr = realloc(ptr_arr, (cnt + 1));
+		arr = realloc(ptr_arr, (cnt + 1) * sizeof(void *));
 		if (arr == NULL) {
 			log_err(errno, __func__, MEM_ERR_MSG);
 			return NULL;
 		}
-		arr[cnt] = ptr;
-		arr[cnt + 1] = NULL;
+		arr[cnt - 1] = ptr;
+		arr[cnt] = NULL;
 	}
 	return arr;
 }

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1420,6 +1420,19 @@ create_resource(char *name, char *value, enum resource_fields field)
 	return nres;
 }
 
+/**
+ * @brief modify the resources_assigned values for a resource_list 
+ * 		(e.g. either A += B or A -= B) where
+ * 		A is a resource list and B is a resource_req list.
+ * 
+ * @param[in] res_list - The schd_resource list which is modified
+ * @param[in] req_list - What is modifing the schd_resource list
+ * @param[in] type - SCHD_INCR for += or SCHD_DECR for -=
+ * 
+ * @return int
+ * @retval 1 - success
+ * @retval 0 - failure
+ */
 int
 modify_resource_list(schd_resource *res_list, resource_req *req_list, int type)
 {
@@ -1433,7 +1446,7 @@ modify_resource_list(schd_resource *res_list, resource_req *req_list, int type)
 	for(cur_req = req_list; cur_req != NULL; cur_req = cur_req->next) {
 		if (cur_req->type.is_consumable) {
 			cur_res = find_resource(res_list, cur_req->def);
-			if (cur_res == NULL) {
+			if (cur_res == NULL && type == SCHD_INCR) {
 				if (end_res == NULL)
 					for (end_res = res_list; end_res->next != NULL; end_res = end_res->next)
 						;
@@ -1443,9 +1456,9 @@ modify_resource_list(schd_resource *res_list, resource_req *req_list, int type)
 				end_res = end_res->next;
 			} else {
 				if (type == SCHD_INCR)
-					cur_res->avail += cur_req->amount;
+					cur_res->assigned += cur_req->amount;
 				else if (type == SCHD_DECR)
-					    cur_res->avail -= cur_req->amount;
+					    cur_res->assigned -= cur_req->amount;
 			}
 		}
 	}

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -345,13 +345,14 @@ void update_preemption_on_run(server_info *sinfo, resource_resv *resresv);
  */
 int add_resource_list(status *policy, schd_resource *r1, schd_resource *r2, unsigned int flags);
 
+int modify_resource_list(schd_resource *res_list, resource_req *req_list, int type);
+
 /*
  *	add_resource_value - add a resource value to another
  *				i.e. val1 += val2
  */
-void
-add_resource_value(sch_resource_t *val1, sch_resource_t *val2,
-	sch_resource_t default_val);
+void add_resource_value(sch_resource_t *val1, sch_resource_t *val2,
+			sch_resource_t default_val);
 
 /*
  *  add_resource_string_arr - add values from a string array to
@@ -451,7 +452,7 @@ int add_queue_to_list(queue_info **** qlhead, queue_info * qinfo);
  * append_to_queue_list - function that will reallocate and append
  *                        "add" to the list provided.
  */
-struct queue_info** append_to_queue_list(queue_info ***list, queue_info *add);
+struct queue_info **append_to_queue_list(queue_info ***list, queue_info *add);
 
 /*
  * find_queue_list_by_priority - function finds out the array of queues
@@ -459,7 +460,7 @@ struct queue_info** append_to_queue_list(queue_info ***list, queue_info *add);
  *                               function. It returns the base address of matching
  *                               array.
  */
-struct queue_info *** find_queue_list_by_priority(queue_info ***list_head, int priority);
+struct queue_info ***find_queue_list_by_priority(queue_info ***list_head, int priority);
 
 /*
  * free_queue_list - to free two dimensional queue_list array
@@ -475,7 +476,7 @@ int compare_resource_avail(schd_resource *r1, schd_resource *r2);
 
 node_info **dup_unordered_nodes(node_info **old_unordered_nodes, node_info **nnodes);
 
-
+void *add_ptr_to_array(void *ptr_arr, void *ptr);
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -621,8 +621,6 @@ perform_event(status *policy, timed_event *event)
 int
 exists_run_event(event_list *calendar, time_t end)
 {
-	timed_event *te;
-
 	if (calendar == NULL || calendar->first_run_event == NULL)
 		return 0;
 	

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -207,8 +207,8 @@ simulate_events(status *policy, server_info *sinfo,
 		event = next_event(sinfo, ADVANCE);
 	}
 
-	if (cur_sim_time > calendar->first_run_event->event_time) 
-		calendar->first_run_event = find_init_timed_event(calendar->next_event, 0, TIMED_RUN_EVENT)
+	if (cur_sim_time > calendar->first_run_event->event_time)
+		calendar->first_run_event = find_init_timed_event(calendar->next_event, 0, TIMED_RUN_EVENT);
 
 	(*sim_time) = cur_sim_time;
 

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -207,7 +207,7 @@ simulate_events(status *policy, server_info *sinfo,
 		event = next_event(sinfo, ADVANCE);
 	}
 
-	if (calendar->first_run_event == NULL || cur_sim_time > calendar->first_run_event->event_time)
+	if (calendar->first_run_event != NULL && cur_sim_time > calendar->first_run_event->event_time)
 		calendar->first_run_event = find_init_timed_event(calendar->next_event, 0, TIMED_RUN_EVENT);
 
 	(*sim_time) = cur_sim_time;
@@ -644,6 +644,7 @@ exists_run_event_on_node(node_info *ninfo, time_t end)
 	if (ninfo == NULL || ninfo->node_events == NULL)
 		return 0;
 	
+	/* node_events contains an ordered list of run events.  We only have the check the first one */
 	if (ninfo->node_events->event->event_time < end)
 		return 1;
 

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -638,7 +638,7 @@ exists_run_event(event_list *calendar, time_t end)
 int
 exists_run_event_on_node(node_info *ninfo, time_t end)
 {
-	if (ninfo == NULL && ninfo->node_events == NULL)
+	if (ninfo == NULL || ninfo->node_events == NULL)
 		return 0;
 	
 	if (ninfo->node_events->event->event_time < end)

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -207,7 +207,7 @@ simulate_events(status *policy, server_info *sinfo,
 		event = next_event(sinfo, ADVANCE);
 	}
 
-	if (cur_sim_time > calendar->first_run_event->event_time)
+	if (calendar->first_run_event == NULL || cur_sim_time > calendar->first_run_event->event_time)
 		calendar->first_run_event = find_init_timed_event(calendar->next_event, 0, TIMED_RUN_EVENT);
 
 	(*sim_time) = cur_sim_time;

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -207,6 +207,9 @@ simulate_events(status *policy, server_info *sinfo,
 		event = next_event(sinfo, ADVANCE);
 	}
 
+	if (cur_sim_time > calendar->first_run_event->event_time) 
+		calendar->first_run_event = find_init_timed_event(calendar->next_event, 0, TIMED_RUN_EVENT)
+
 	(*sim_time) = cur_sim_time;
 
 	if (cmd == SIM_TIME) {
@@ -371,7 +374,7 @@ find_init_timed_event(timed_event *event, int ignore_disabled, unsigned int sear
 	for (e = event; e != NULL; e = e->next) {
 		if (ignore_disabled && e->disabled)
 			continue;
-		else if ((e->event_type & search_type_mask) ==0)
+		else if ((e->event_type & search_type_mask) == 0)
 			continue;
 		else
 			break;

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -623,25 +623,30 @@ exists_run_event(event_list *calendar, time_t end)
 {
 	timed_event *te;
 
-	if (calendar == NULL)
+	if (calendar == NULL || calendar->first_run_event == NULL)
 		return 0;
+	
+	if (calendar->first_run_event->event_time < end)
+		return 1;
+	return 0;
+}
 
-	te = get_next_event(calendar);
-
-	if (te == NULL) /* no events in our calendar */
+/**
+ * @brief
+ * 		returns 1 if there is a run event before the end time on a node
+ * @param[in]	ninfo - the node to check for
+ * @param[in]	search between now and end
+ */
+int
+exists_run_event_on_node(node_info *ninfo, time_t end)
+{
+	if (ninfo == NULL && ninfo->node_events == NULL)
 		return 0;
+	
+	if (ninfo->node_events->event->event_time < end)
+		return 1;
 
-	te = find_init_timed_event(te, IGNORE_DISABLED_EVENTS, TIMED_RUN_EVENT);
-
-	if (te == NULL) /* no run event */
-		return 0;
-
-	/* there is a run event, but it's after end */
-	if (end != 0 && te->event_time > end)
-		return 0;
-
-	/* if we got here, we have a happy run event */
-	return 1;
+	return 0;
 }
 
 /**
@@ -662,8 +667,8 @@ exists_resv_event(event_list *calendar, time_t end)
 	if (calendar == NULL)
 		return 0;
 
-	te_list = get_next_event(calendar);
-	if (te_list == NULL) /* no events in our calendar */
+	te_list = calendar->first_run_event;
+	if (te_list == NULL) /* no run events in our calendar */
 		return 0;
 
 	for (te = te_list; te != NULL && te->event_time <= end;
@@ -833,6 +838,7 @@ create_event_list(server_info *sinfo)
 	elist->events = create_events(sinfo);
 
 	elist->next_event = elist->events;
+	elist->first_run_event = find_timed_event(elist->events, 0, NULL, TIMED_RUN_EVENT, 0);
 	elist->current_time = &sinfo->server_time;
 	add_dedtime_events(elist, sinfo->policy);
 
@@ -950,6 +956,7 @@ new_event_list()
 	elist->eol = 0;
 	elist->events = NULL;
 	elist->next_event = NULL;
+	elist->first_run_event = NULL;
 	elist->current_time = NULL;
 
 	return elist;
@@ -998,6 +1005,21 @@ dup_event_list(event_list *oelist, server_info *nsinfo)
 			schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED,
 				LOG_WARNING, oelist->next_event->name,
 				"can't find next event in duplicated list");
+			free_event_list(nelist);
+			return NULL;
+		}
+	}
+
+	if (oelist->first_run_event != NULL) {
+		nelist->first_run_event =
+		    find_timed_event(nelist->events, 0,
+				     oelist->first_run_event->name,
+				     TIMED_RUN_EVENT,
+				     oelist->first_run_event->event_time);
+		if (nelist->first_run_event == NULL) {
+			schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED,
+				LOG_WARNING, oelist->first_run_event->name,
+				"can't find first run event event in duplicated list");
 			free_event_list(nelist);
 			return NULL;
 		}
@@ -1347,6 +1369,11 @@ dup_timed_event_list(timed_event *ote_list, server_info *nsinfo)
 
 	for (ote = ote_list; ote != NULL; ote = ote->next) {
 		nte = dup_timed_event(ote, nsinfo);
+		if (nte->event_type & TIMED_RUN_EVENT)
+			((resource_resv *)nte->event_ptr)->run_event = nte;
+		if (nte->event_type & TIMED_END_EVENT)
+			((resource_resv *)nte->event_ptr)->end_event = nte;
+
 		if (nte_prev != NULL)
 			nte_prev->next = nte;
 		else
@@ -1424,6 +1451,11 @@ add_event(event_list *calendar, timed_event *te)
 
 	calendar->events = add_timed_event(calendar->events, te);
 
+	if (te->event_type & TIMED_RUN_EVENT)
+		((resource_resv *)te->event_ptr)->run_event = te;
+	else if (te->event_type & TIMED_END_EVENT)
+		((resource_resv *)te->event_ptr)->end_event = te;
+
 	/* empty event list - the new event is the only event */
 	if (events_is_null)
 		calendar->next_event = te;
@@ -1444,11 +1476,15 @@ add_event(event_list *calendar, timed_event *te)
 	/* if next_event == NULL, then we've simulated to the end. */
 	else if (te->event_time >= current_time)
 		calendar->next_event = te;
+	
+	if (te->event_type == TIMED_RUN_EVENT)
+		if (calendar->first_run_event == NULL || te->event_time < calendar->first_run_event->event_time)
+			calendar->first_run_event = te;
 
 	/* if we had previously run to the end of the list
 	 * and now we have more work to do, clear the eol bit
 	 */
-	if (calendar->eol && calendar->next_event !=NULL)
+	if (calendar->eol && calendar->next_event != NULL)
 		calendar->eol = 0;
 
 	return 1;
@@ -1544,8 +1580,14 @@ delete_event(server_info *sinfo, timed_event *e, unsigned int flags)
 		else
 			prev_e->next = cur_e->next;
 
-		if ((flags & DE_UNLINK) == 0)
+		if ((flags & DE_UNLINK) == 0) {
+			if (cur_e->event_type & TIMED_RUN_EVENT)
+				((resource_resv *)cur_e->event_ptr)->run_event = NULL;
+			else if (cur_e->event_type & TIMED_END_EVENT)
+				((resource_resv *)cur_e->event_ptr)->run_event = NULL;
+
 			free_timed_event(cur_e);
+		}
 
 		return 1;
 	}

--- a/src/scheduler/simulate.h
+++ b/src/scheduler/simulate.h
@@ -183,6 +183,9 @@ event_list *create_event_list(server_info *sinfo);
  */
 int exists_run_event(event_list *calendar, time_t end_time);
 
+/* Checks to see if there is a run event on a node before the end time */
+int exists_run_event_on_node(node_info *ninf, time_t end);
+
 /* Checks if a reservation run event exists between now and 'end' */
 int exists_resv_event(event_list *calendar, time_t end);
 

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -166,13 +166,13 @@ class TestSchedPerf(TestPerformance):
         self.compare_normal_path_to_buckets('free', num_jobs)
 
     @timeout(3600)
-    def test_run_10000_jobs(self):
+    def test_run_many_jobs(self):
         """
-        Submit 10000 jobs and time the cycle that runs all of them.
+        Submit many jobs and time the cycle that runs all of them.
         """
         num_jobs = 10000
         a = {'Resource_List.select': '1:ncpus=1'}
-        jids = self.submit_jobs(a, num_jobs)
+        jids = self.submit_jobs(a, num_jobs, wt_start=1000)
         t = self.run_cycle()
         self.server.expect(JOB, {'state=R': num_jobs})
         self.logger.info('#' * 80)

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -170,22 +170,25 @@ class TestSchedPerf(TestPerformance):
         """
         Submit 10000 jobs and time the cycle that runs all of them.
         """
-
+        num_jobs = 10000
         a = {'Resource_List.select': '1:ncpus=1'}
-        jids = self.submit_jobs(a, 10000)
+        jids = self.submit_jobs(a, num_jobs)
         t = self.run_cycle()
         self.logger.info('#' * 80)
-        m = 'Time taken in cycle to run 10000 normal jobs: %.2f'
-        self.logger.info(m % (t))
+        m = 'Time taken in cycle to run %d normal jobs: %.2f' % (num_jobs, t)
+        self.logger.info(m)
         self.logger.info('#' * 80)
 
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+
         for j in jids:
+            self.server.rerunjob(j)
             self.server.alterjob(j, {'Resource_List.place': 'excl'})
 
         t = self.run_cycle()
         self.logger.info('#' * 80)
-        m = 'Time taken in cycle to run 10000 bucket jobs: %.2f'
-        self.logger.info(m % (t))
+        m = 'Time taken in cycle to run %d bucket jobs: %.2f' % (num_jobs, t)
+        self.logger.info(m)
         self.logger.info('#' * 80)
 
     @timeout(3600)

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -165,17 +165,27 @@ class TestSchedPerf(TestPerformance):
         num_jobs = 3000
         self.compare_normal_path_to_buckets('free', num_jobs)
 
-    @timeout(10000)
-    def test_run_10000_normal_jobs(self):
+    @timeout(3600)
+    def test_run_10000_jobs(self):
         """
         Submit 10000 jobs and time the cycle that runs all of them.
         """
 
         a = {'Resource_List.select': '1:ncpus=1'}
-        self.submit_jobs(a, 10000)
+        jids = self.submit_jobs(a, 10000)
         t = self.run_cycle()
         self.logger.info('#' * 80)
-        self.logger.info('Time taken in cycle to run 10000 jobs: %.2f' % (t))
+        m = 'Time taken in cycle to run 10000 normal jobs: %.2f'
+        self.logger.info(m % (t))
+        self.logger.info('#' * 80)
+
+        for j in jids:
+            self.server.alterjob(j, {'Resource_List.place': 'excl'})
+
+        t = self.run_cycle()
+        self.logger.info('#' * 80)
+        m = 'Time taken in cycle to run 10000 bucket jobs: %.2f'
+        self.logger.info(m % (t))
         self.logger.info('#' * 80)
 
     @timeout(3600)

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -174,6 +174,7 @@ class TestSchedPerf(TestPerformance):
         a = {'Resource_List.select': '1:ncpus=1'}
         jids = self.submit_jobs(a, num_jobs)
         t = self.run_cycle()
+        self.server.expect(JOB, {'state=R': num_jobs})
         self.logger.info('#' * 80)
         m = 'Time taken in cycle to run %d normal jobs: %.2f' % (num_jobs, t)
         self.logger.info(m)
@@ -185,7 +186,11 @@ class TestSchedPerf(TestPerformance):
             self.server.rerunjob(j)
             self.server.alterjob(j, {'Resource_List.place': 'excl'})
 
+        self.server.expect(JOB, {'state=Q': num_jobs})
+
         t = self.run_cycle()
+
+        self.server.expect(JOB, {'state=R': num_jobs})
         self.logger.info('#' * 80)
         m = 'Time taken in cycle to run %d bucket jobs: %.2f' % (num_jobs, t)
         self.logger.info(m)

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -165,6 +165,19 @@ class TestSchedPerf(TestPerformance):
         num_jobs = 3000
         self.compare_normal_path_to_buckets('free', num_jobs)
 
+    @timeout(10000)
+    def test_run_10000_normal_jobs(self):
+        """
+        Submit 10000 jobs and time the cycle that runs all of them.
+        """
+
+        a = {'Resource_List.select': '1:ncpus=1'}
+        self.submit_jobs(a, 10000)
+        t = self.run_cycle()
+        self.logger.info('#' * 80)
+        self.logger.info('Time taken in cycle to run 10000 jobs: %.2f' % (t))
+        self.logger.info('#' * 80)
+
     @timeout(3600)
     def test_pset_fuzzy_perf(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Your Change
Several scheduler optimizations when running many jobs on many nodes.  The system I was using had 950k jobs and 50k nodes.

The following optimizations were done:
1) Before the placement set meta data (including the allpart) was recomputed every time a job runs.  The snapshot I was using ran 50k jobs in one cycle.  Even though we were only updating the allpart, this slowed things down.  Instead of walking down each placement set and each node in the placement set to recalculate the metadata, we walk down the exec_vnode of the job we just run and update the correct placement sets.  Each node now knows which placement sets it is part of.  The previous code was O(N^3) (jobs\*psets\*nodes).  The worst case scenario of the new case is the same.  The best case is with no placement sets (just the allpart) and only single node jobs.  This is O(N) (jobs).   Even with placement sets enabled, we only update the placement sets we need to update instead of all of them.

2) The function exists_run_event() checked to see if a run event existed during a jobs lifetime.  This would walk down the calendar looking for a run event.  The calendar is 99.9% made up of end events, so we'd walk past mostly end events looking for the run event.  Now the calendar keeps track of the the first run event.  The function changed from O(N) to O(1).

3) Deep in the node searching code, the scheduler used to call esists_run_event() to determine if there was a run event in the calendar before doing a simulation.  This wouldn't tell it if there was a run event on the node, so we still might not have needed to do the simulation.  The node bucket code added a list of run events on each node.  This allowed me to look at the first run event on that node to check if we need to do the simulation.  Since we were calling exists_run_event(), before it was O(N).  It is now O(1).  This is significant since this is deep in node search which is one of the most expensive areas of the scheduler.

4) A job now knows its run and end event in the calendar.  These were used in several places where we were searching for the event.  It turned several O(N) searches into O(1).

5) Fixed a bug when the scheduler was selecting the next job to run.  The code should have been O(N) (jobs) since next_job() kept track of where it was in the list so it can jump back there.  The bug had us reset our last used index.  It turned what should have been O(N) into O(N^2).

6) The normal node code path would allocate an array of pointers for the exec_vnode.  Since it might need to split chunks across vnodes of the same host, it allocates the worst case scenario.  The number of chunks * number of vnodes (every chunk split across every vnode).  In the case of 50k nodes, this is 390kb per job.  With 50k jobs running, that is 18.6gb.  I now trim down the exec_vnode to the size needed at the end of eval_selspec().

Running 10k jobs on 10k nodes:
Old code: 56.5 seconds
New code: 21.5 seconds

Simulation of new code in 950k jobs with 50k nodes:
5.5m to run 50k jobs.  This is longer than 21.5 * 5 since 50k nodes requires more searching.
30s to dismiss the other 900k jobs using equivalence classes.  All the jobs were in the same class, so we didn't have to do any work.  It dismissed jobs at a rate of 29000/sec.

I will eventually create the numbers from master (most likely released 19).  When I started, the simulation only ran a partial number of the jobs in a 20m cycle.  It now makes it all the way through the cycle in 6.5m.
