### PR TITLE
PTL: Fixing race condition around scheduling=True

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -10904,14 +10904,16 @@ class Scheduler(PBSService):
                             'scheduling': 'True'}, id=sched)
         self.log_match("Starting Scheduling",
                        starttime=tbefore)
-        self.log_match("Leaving Scheduling",
-                       starttime=tbefore, interval=1,
-                       max_attempts=1200)
 
-        # Restore original value of scheduling
         if old_val == 'False':
+            # This will also ensure that the sched cycle is over before
+            # returning
             self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'False'},
                                 id=sched)
+        else:
+            self.server.expect(SCHED, {'state': 'scheduling'}, op=NE,
+                               id=sched, interval=1, max_attempts=1200,
+                               trigger_sched_cycle=False)
 
     def pbs_version(self):
         """

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -10889,8 +10889,6 @@ class Scheduler(PBSService):
     def run_scheduling_cycle(self):
         """
         Convenience method to start and finish a sched cycle
-
-        :return start time of the new sched cycle
         """
         sched = self.attributes['id']
         old_val = self.server.status(SCHED, 'scheduling', id=sched)[
@@ -10904,29 +10902,16 @@ class Scheduler(PBSService):
         tbefore = time.time()
         self.server.manager(MGR_CMD_SET, SCHED, {
                             'scheduling': 'True'}, id=sched)
-        msg = self.log_match("Starting Scheduling",
-                             starttime=tbefore)
+        self.log_match("Starting Scheduling",
+                       starttime=tbefore)
         self.log_match("Leaving Scheduling",
                        starttime=tbefore, interval=1,
                        max_attempts=1200)
-
-        # Get start timestamp of the sched cycle
-        if self.logutils is None:
-            try:
-                from ptl.utils.pbs_logutils import PBSLogUtils
-            except:
-                _msg = 'error loading ptl.utils.pbs_logutils'
-                raise PtlLogMatchError(rc=1, rv=False, msg=_msg)
-            self.logutils = PBSLogUtils()
-        startt = msg[1].split(";", 1)[0]
-        startt = self.logutils.convert_date_time(startt)
 
         # Restore original value of scheduling
         if old_val == 'False':
             self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'False'},
                                 id=sched)
-
-        return startt
 
     def pbs_version(self):
         """

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4040,7 +4040,7 @@ class PBSService(PBSObject):
             from ptl.utils.pbs_logutils import PBSLogUtils
         except:
             _msg = 'error loading ptl.utils.pbs_logutils'
-            raise PtlLogMatchError(rc=1, rv=False, msg=_msg)
+            raise ImportError(_msg)
 
         if self.logutils is None:
             self.logutils = PBSLogUtils()

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -234,7 +234,8 @@ class PBSLogUtils(object):
         :type dt: str or None
         :param fmt: Format to which datetime is to be converted
         :type fmt: str
-        :returns: None if conversion fails
+        :returns: timestamp in seconds since epoch,
+                or None if conversion fails
         """
         if dt is None:
             return None

--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -313,7 +313,7 @@ class TestFairshare(TestFunctional):
         J2 = Job(TEST_USER1)
         jid2 = self.server.submit(J2)
 
-        self.server.run_sched_cycle()
+        self.scheduler.run_scheduling_cycle()
 
         c = self.scheduler.cycles(lastN=1)[0]
         job_order = [jid2, jid1]
@@ -343,7 +343,7 @@ class TestFairshare(TestFunctional):
         J4 = Job(TEST_USER1)
         jid4 = self.server.submit(J4)
 
-        self.server.run_sched_cycle()
+        self.scheduler.run_scheduling_cycle()
 
         c = self.scheduler.cycles(lastN=1)[0]
         job_order = [jid3, jid4]

--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -313,8 +313,7 @@ class TestFairshare(TestFunctional):
         J2 = Job(TEST_USER1)
         jid2 = self.server.submit(J2)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+        self.server.run_sched_cycle()
 
         c = self.scheduler.cycles(lastN=1)[0]
         job_order = [jid2, jid1]
@@ -344,8 +343,7 @@ class TestFairshare(TestFunctional):
         J4 = Job(TEST_USER1)
         jid4 = self.server.submit(J4)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+        self.server.run_sched_cycle()
 
         c = self.scheduler.cycles(lastN=1)[0]
         job_order = [jid3, jid4]


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
- manager() checks that scheduler is not scheduling when scheduling is set to False. However, expect(), by default, triggers sched cycles in between each attempt. This means that manager() can potentially trigger multiple sched cycles before it catches the scheduler's state = Idle and returns.
- Often tests set scheduling=True and assume that the operation is instantaneous. This leads to race conditions in the tests which want to trigger one sched cycle completely leading to intermittent test failures.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Set expect()'s trigger_sched_cycle arg to False inside manager() when checking for scheduling to be off.
- Added a convenience method called 'run_sched_cycle' in Server class to kick and finish a new scheduling cycle reliably. It takes care of any race conditions and returns a tuple of the start and end times of the sched cycle that's run, which can aid in further log matches for that cycle.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
http://community.pbspro.org/t/new-ptl-method-to-run-a-sched-cycle-to-completion/1704

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_pbsfs.log](https://github.com/PBSPro/pbspro/files/3400986/test_pbsfs.log)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
