### PR TITLE
Fixed race condition in test_job_array_comment

### DIFF
--- a/test/tests/functional/pbs_job_array_comment.py
+++ b/test/tests/functional/pbs_job_array_comment.py
@@ -49,7 +49,7 @@ class TestJobArrayComment(TestFunctional):
         are rejected by mom
         """
         attr = {'resources_available.ncpus': 10}
-        self.server.manager(MGR_CMD_SET, NODE, attr)
+        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.shortname)
         attr = {'job_history_enable': 'true'}
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         # create a mom hook that rejects and deletes subjob 0, 5, and 7
@@ -77,7 +77,6 @@ class TestJobArrayComment(TestFunctional):
             ATTR_J: '0-9',
             'Resource_List.select': 'ncpus=1'
         })
-        test_job_array.set_sleep_time(1)
         jid = self.server.submit(test_job_array)
         attr = {
             ATTR_state: 'B',


### PR DESCRIPTION
#### Describe Bug or Feature
* TestJobArrayComment.test_job_array_comment is failing on few machines  due to race condition. In current test we submit job of sleep 1 sec, so by the time code  checking for the job to be in R state, job may  be completed sometime and test will get job_state=X instead of job_state=R  for subjob_id(jid, 1)
   
* Also Test is expected to set ncpus=10 on node  but in actual test is running with default ncpus 
  available on  Node
  2019-07-19 01:17:25,685 INFOCLI  testdev-07-r7: /opt/pbs/bin/qmgr -c set node 
   resources_available.ncpus=10
   2019-07-19 01:17:25,725 ERROR    err: ['No Active Nodes, nothing done.'] 

#### Describe Your Change
*  Submit job with default sleep time (i.e is 100) provided by PTL , anyways In test we are not  
    waiting till job execution complete or job  to be finished so even if we use sleep as 100 it will not 
     increase total execution time of test suite.
*   Provided node name while setting ncpus=10 on node

#### Attach Test and Valgrind Logs/Output
[after_fix.txt](https://github.com/PBSPro/pbspro/files/3410656/after_fix.txt)
[before_fix.txt](https://github.com/PBSPro/pbspro/files/3410657/before_fix.txt)



