### PR TITLE
Add autogen.sh to the %build of the spec file

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -281,6 +281,7 @@ functionality of PBS Professional®.
 %setup
 
 %build
+[ -f configure ] || ./autogen.sh
 [ -d build ] && rm -rf build
 mkdir build
 cd build

--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -281,6 +281,7 @@ functionality of PBS Professional®.
 %setup
 
 %build
+[ -f configure ] || ./autogen.sh
 [ -d build ] && rm -rf build
 mkdir build
 cd build


### PR DESCRIPTION
Add [ -f configure ] || ./autogen.sh
to the %build section of both pbspro.spec and pbspro.spec.in

With above modification,
we can build RPMs with rpmbuild -ta SOURCE/pbspro-19.1.2.tar.gz
where pbspro-19.1.2.tar.gz is from
https://github.com/PBSPro/pbspro/archive/v19.1.2.tar.gz
[ -f configure ] is to avoid wasty autogen.sh
when pbspro-19.1.2.tar.gz is generated by "make dist"

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
https://github.com/PBSPro/pbspro/issues/1205

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Run ./autogen.sh when the configure file is not present in the %build section of the spec file.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Successful TravisCI build.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
