### PR TITLE
Test "test_qalter_remove_files" of "TestQsub_remove_files" is failing due to race condition

### DIFF
--- a/test/tests/functional/pbs_qsub_remove_files.py
+++ b/test/tests/functional/pbs_qsub_remove_files.py
@@ -198,7 +198,7 @@ class TestQsub_remove_files(TestFunctional):
         alter the job with -Roe and check whether it is
         reflecting in qstat -f output.
         """
-        mydate = int(time.time()) + 60
+        mydate = int(time.time()) + 120
         j = Job(TEST_USER)
         attribs = {
             ATTR_a: time.strftime(

--- a/test/tests/functional/pbs_qsub_remove_files.py
+++ b/test/tests/functional/pbs_qsub_remove_files.py
@@ -198,22 +198,14 @@ class TestQsub_remove_files(TestFunctional):
         alter the job with -Roe and check whether it is
         reflecting in qstat -f output.
         """
-        mydate = int(time.time()) + 120
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         j = Job(TEST_USER)
-        attribs = {
-            ATTR_a: time.strftime(
-                '%m%d%H%M',
-                time.localtime(
-                    float(mydate)))}
-        j.set_attributes(attribs)
         jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
         attribs = {ATTR_R: 'oe'}
         try:
             self.server.alterjob(jid, attribs)
-            if self.server.expect(JOB, {'job_state': 'W'},
-                                  id=jid):
-                self.server.expect(JOB, attribs,
-                                   id=jid)
+            self.server.expect(JOB, attribs, id=jid)
         except PbsAlterError as e:
             print str(e)
 


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test "test_qalter_remove_files" of "TestQsub_remove_files" is failing while verifying the job's state. 

- Intent of the test is to submit a job and alter the job's "Remove_Files" attribute to oe before the job starts running and check whether the changes are reflecting in qstat -f output.

- In the failed scenario, job started running before qalter command was issued

- In the test we are capturing the current time,rounding off the value(using int) and adding up 1 min to the above captured time and passing this value to qsub option in -a parameter(which is job's start time)

- By the time test is altering the job, the job has already started its execution hence the mismatch in the job state

#### Describe Your Change

- Change the start time of the job(current time+2 mins)
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[Execution_logs_TestQsub_remove_files.txt](https://github.com/PBSPro/pbspro/files/3417858/Execution_logs_TestQsub_remove_files.txt)
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
