### PR TITLE
Adding multi sched support for Scheduler::cycles()

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -12176,6 +12176,10 @@ class Scheduler(PBSService):
             self.logger.error('error loading ptl.utils.pbs_logutils')
             return None
 
+        if self.id != "default":
+            day = time.strftime("%Y%m%d", time.localtime())
+            self.logfile = os.path.join(self.attributes['sched_log'], day)
+
         if start is not None or end is not None:
             analyze_path = os.path.dirname(self.logfile)
         else:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -12178,13 +12178,16 @@ class Scheduler(PBSService):
 
         if 'sched_log' in self.attributes:
             logdir = self.attributes['sched_log']
-            tm = time.strftime("%Y%m%d", time.localtime())
-            self.logfile = os.path.join(logdir, tm)
+        else:
+            logdir = os.path.join(self.pbs_conf['PBS_HOME'], 'sched_logs')
+
+        tm = time.strftime("%Y%m%d", time.localtime())
+        log_file = os.path.join(logdir, tm)
 
         if start is not None or end is not None:
-            analyze_path = os.path.dirname(self.logfile)
+            analyze_path = os.path.dirname(log_file)
         else:
-            analyze_path = self.logfile
+            analyze_path = log_file
 
         sl = PBSSchedulerLog()
         sl.analyze(analyze_path, start, end, self.hostname)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -3570,6 +3570,9 @@ class PBSService(PBSObject):
         if elmt is None:
             return
 
+        if isinstance(self, Scheduler) and self.sc_name != "default":
+            elmt = elmt + "_" + self.sc_name
+
         if conf is not None and 'PBS_HOME' in conf:
             tm = time.strftime("%Y%m%d", time.localtime())
             self.logfile = os.path.join(conf['PBS_HOME'], elmt, tm)
@@ -10641,6 +10644,7 @@ class Scheduler(PBSService):
         self.server = None
         self.logger = logging.getLogger(__name__)
         self.db_access = None
+        self.sc_name = id
 
         if server is not None:
             self.server = server
@@ -10666,7 +10670,6 @@ class Scheduler(PBSService):
         self.pi = PBSInitServices(hostname=self.hostname,
                                   conf=self.pbs_conf_file)
         self.pbs_conf = self.server.pbs_conf
-        self.sc_name = id
 
         self.dflt_sched_config_file = os.path.join(self.pbs_conf['PBS_EXEC'],
                                                    'etc', 'pbs_sched_config')
@@ -12176,9 +12179,10 @@ class Scheduler(PBSService):
             self.logger.error('error loading ptl.utils.pbs_logutils')
             return None
 
-        if self.id != "default":
-            day = time.strftime("%Y%m%d", time.localtime())
-            self.logfile = os.path.join(self.attributes['sched_log'], day)
+        if 'sched_log' in self.attributes:
+            logdir = self.attributes['sched_log']
+            tm = time.strftime("%Y%m%d", time.localtime())
+            self.logfile = os.path.join(logdir, tm)
 
         if start is not None or end is not None:
             analyze_path = os.path.dirname(self.logfile)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -3570,9 +3570,6 @@ class PBSService(PBSObject):
         if elmt is None:
             return
 
-        if isinstance(self, Scheduler) and self.sc_name != "default":
-            elmt = elmt + "_" + self.sc_name
-
         if conf is not None and 'PBS_HOME' in conf:
             tm = time.strftime("%Y%m%d", time.localtime())
             self.logfile = os.path.join(conf['PBS_HOME'], elmt, tm)
@@ -10644,7 +10641,6 @@ class Scheduler(PBSService):
         self.server = None
         self.logger = logging.getLogger(__name__)
         self.db_access = None
-        self.sc_name = id
 
         if server is not None:
             self.server = server
@@ -10670,6 +10666,7 @@ class Scheduler(PBSService):
         self.pi = PBSInitServices(hostname=self.hostname,
                                   conf=self.pbs_conf_file)
         self.pbs_conf = self.server.pbs_conf
+        self.sc_name = id
 
         self.dflt_sched_config_file = os.path.join(self.pbs_conf['PBS_EXEC'],
                                                    'etc', 'pbs_sched_config')

--- a/test/tests/selftest/pbs_cycles_test.py
+++ b/test/tests/selftest/pbs_cycles_test.py
@@ -38,7 +38,7 @@
 from tests.selftest import *
 
 
-class Test_cycle(TestSelf):
+class PBSTestCycle(TestSelf):
     """
     Tests to check that the cycle function returns correct information
     for schedulers

--- a/test/tests/selftest/pbs_cycles_test.py
+++ b/test/tests/selftest/pbs_cycles_test.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.selftest import *
+
+
+class Test_cycle(TestSelf):
+    """
+    Tests to check that the cycle function returns correct information
+    for schedulers
+    """
+
+    def test_cycle_multi_sched(self):
+        """
+        Test that scheduler.cycle() reads the correct multisched log file
+        This test will check the start time and political order from the
+        cycles() output to test the correct log file is being read.
+        """
+        # Create a queue, vnode and link them to the newly created sched
+        a = {'queue_type': 'execution',
+             'started': 'True',
+             'enabled': 'True'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq')
+
+        a = {'resources_available.ncpus': 2}
+        self.server.create_vnodes('vnode', a, 1, self.mom)
+
+        p1 = {'partition': 'P1'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq')
+        self.server.manager(MGR_CMD_SET, NODE, p1, id='vnode[0]')
+
+        a = {'partition': 'P1',
+             'sched_host': self.server.hostname,
+             'sched_port': '15050'}
+        self.server.manager(MGR_CMD_CREATE, SCHED,
+                            a, id="sc")
+        self.scheds['sc'].create_scheduler()
+        self.scheds['sc'].start()
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id="sc")
+        self.scheds['sc'].set_sched_config({'log_filter': 2048})
+
+        # Turn off scheduling for all the scheds.
+        for name in self.scheds:
+            self.server.manager(MGR_CMD_SET, SCHED,
+                                {'scheduling': 'False'}, id=name)
+        st = time.time()
+
+        # submit jobs and check political order
+        a = {ATTR_queue: 'wq'}
+
+        j1 = Job(TEST_USER1, attrs=a)
+        jid1 = self.server.submit(j1)
+        j2 = Job(TEST_USER1, attrs=a)
+        jid2 = self.server.submit(j2)
+
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {'scheduling': 'True'}, id='sc')
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+
+        cycle = self.scheds['sc'].cycles(start=self.server.ctime, lastN=1)[0]
+
+        firstconsidered = cycle.political_order[0]
+        self.assertEqual(firstconsidered, jid1.split('.')[0])
+
+        # Check that the cycle start time is after st
+        self.assertGreater(cycle.start, st)

--- a/test/tests/selftest/pbs_cycles_test.py
+++ b/test/tests/selftest/pbs_cycles_test.py
@@ -93,10 +93,13 @@ class PBSTestCycle(TestSelf):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
 
-        cycle = self.scheds['sc'].cycles(start=self.server.ctime, lastN=1)[0]
+        cycles = self.scheds['sc'].cycles(start=st, lastN=1)
+        self.assertNotEqual(len(cycles), 0)
+        cycle = cycles[0]
 
-        firstconsidered = cycle.political_order[0]
-        self.assertEqual(firstconsidered, jid1.split('.')[0])
+        political_order = cycle.political_order
+        self.assertNotEqual(len(political_order), 0)
+        firstconsidered = political_order[0]
 
         # Check that the cycle start time is after st
         self.assertGreater(cycle.start, st)

--- a/test/tests/selftest/pbs_cycles_test.py
+++ b/test/tests/selftest/pbs_cycles_test.py
@@ -93,7 +93,7 @@ class PBSTestCycle(TestSelf):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
 
-        cycles = self.scheds['sc'].cycles(start=st, lastN=1)
+        cycles = self.scheds['sc'].cycles(start=st, firstN=1)
         self.assertNotEqual(len(cycles), 0)
         cycle = cycles[0]
 
@@ -103,3 +103,6 @@ class PBSTestCycle(TestSelf):
 
         # Check that the cycle start time is after st
         self.assertGreater(cycle.start, st)
+
+        # check the first considered is jid1
+        self.assertEqual(firstconsidered, jid1.split('.')[0])


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Currently scheduler.cycles() reads into the default sched_log file to read cycle info. This is to the update the cycle() to read into the sched_log file of the scheduler object which is calling the function.


#### Attach Test and Valgrind Logs/Output
[cycles_selftest.txt](https://github.com/PBSPro/pbspro/files/3455722/cycles_selftest.txt)

[multi_sched_logs.txt](https://github.com/PBSPro/pbspro/files/3448845/multi_sched_logs.txt)
[smoketests_log.txt](https://github.com/PBSPro/pbspro/files/3448846/smoketests_log.txt)


