### PR TITLE
Fixed test_multiple_res_invalid_value for fixed comment

### DIFF
--- a/test/tests/functional/pbs_mom_dynamic_resource.py
+++ b/test/tests/functional/pbs_mom_dynamic_resource.py
@@ -222,7 +222,7 @@ class TestMomDynRes(TestFunctional):
 
         # The job should run
         self.server.expect(JOB, {'job_state': 'R',
-                           'Resource_List.'+resc_name[0]: '2'},
+                                 'Resource_List.'+resc_name[0]: '2'},
                            id=jid, attrop=PTL_AND, interval=1)
 
     def test_multiple_res_valid_value(self):
@@ -283,7 +283,7 @@ class TestMomDynRes(TestFunctional):
 
         # The job shouldn't run
         c = "Can Never Run:"
-        c += " Insufficient amount of resource: foo1 (R: 1kb A: 0kb T: 0kb)"
+        c += " Insufficient amount of resource: foo1 (R: 1kb A: -2kb T: -2kb)"
         self.server.expect(JOB, {'job_state': 'Q', 'comment': c},
                            id=jid, attrop=PTL_AND)
 
@@ -379,9 +379,9 @@ class TestMomDynRes(TestFunctional):
         # give write permission to user only
         self.du.chmod(path=fp, mode=0744, sudo=True)
         if os.getuid() != 0:
-                self.check_access_log(fp, exist=True)
+            self.check_access_log(fp, exist=True)
         else:
-                self.check_access_log(fp, exist=False)
+            self.check_access_log(fp, exist=False)
 
         # Create script in a directory which has more open privileges
         # This should make loading of this file fail in all cases.


### PR DESCRIPTION
## Describe Bug or Feature
The scheduler used to use -2 as a special number.  This test randomly uses -2 to test a negative condition.  The scheduler no longer uses -2 as a special value.  The comment for the job in this test changed to report -2 instead of 0.

#### Describe Your Change
Updated the log_match() to search for -2 instead of 0.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[mom_dyn_res.log](https://github.com/PBSPro/pbspro/files/3429316/mom_dyn_res.log)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
