### PR TITLE
PBS upgrade is failing due to the non availability of hstore function

### DIFF
--- a/src/cmds/scripts/pbs_schema_upgrade
+++ b/src/cmds/scripts/pbs_schema_upgrade
@@ -161,9 +161,9 @@ upgrade_pbs_schema_from_v1_3_0() {
 
 	${PGSQL_DIR}/bin/psql -p ${PBS_DATA_SERVICE_PORT} -d pbs_datastore -U ${PBS_DATA_SERVICE_USER} <<-EOF > /dev/null
 		
-		CREATE EXTENSION hstore SCHEMA pbs;
+		CREATE EXTENSION hstore SCHEMA public;
 		
-		ALTER TABLE pbs.job ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
+		ALTER TABLE pbs.job ADD attributes hstore DEFAULT ''::hstore;
 		UPDATE pbs.job SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
@@ -172,7 +172,7 @@ upgrade_pbs_schema_from_v1_3_0() {
 		UPDATE pbs.job SET attributes='' WHERE attributes IS NULL;
 		ALTER TABLE pbs.job ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.node ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
+		ALTER TABLE pbs.node ADD attributes hstore DEFAULT ''::hstore;
 		UPDATE pbs.node SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
@@ -181,7 +181,7 @@ upgrade_pbs_schema_from_v1_3_0() {
 		UPDATE pbs.node SET attributes='' WHERE attributes IS NULL;
 		ALTER TABLE pbs.node ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.queue ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
+		ALTER TABLE pbs.queue ADD attributes hstore DEFAULT ''::hstore;
 		UPDATE pbs.queue SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
@@ -190,7 +190,7 @@ upgrade_pbs_schema_from_v1_3_0() {
 		UPDATE pbs.queue SET attributes='' WHERE attributes IS NULL;
 		ALTER TABLE pbs.queue ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.resv ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
+		ALTER TABLE pbs.resv ADD attributes hstore DEFAULT ''::hstore;
 		UPDATE pbs.resv SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
@@ -199,7 +199,7 @@ upgrade_pbs_schema_from_v1_3_0() {
 		UPDATE pbs.resv SET attributes='' WHERE attributes IS NULL;
 		ALTER TABLE pbs.resv ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.scheduler ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
+		ALTER TABLE pbs.scheduler ADD attributes hstore DEFAULT ''::hstore;
 		UPDATE pbs.scheduler SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,
@@ -208,7 +208,7 @@ upgrade_pbs_schema_from_v1_3_0() {
 		UPDATE pbs.scheduler SET attributes='' WHERE attributes IS NULL;
 		ALTER TABLE pbs.scheduler ALTER COLUMN attributes SET NOT NULL;
 
-		ALTER TABLE pbs.server ADD attributes pbs.hstore DEFAULT ''::pbs.hstore;
+		ALTER TABLE pbs.server ADD attributes hstore DEFAULT ''::hstore;
 		UPDATE pbs.server SET attributes=(
 			SELECT hstore(array_agg(attr.key ), array_agg(attr.value))
 				FROM ( SELECT concat(attr_name, '.' , attr_resource) AS key,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Upgrade to 19.x.x is failing due to the unavailability of hstore function/s after the upgrade. As a result not able to start PBS.

#### Describe Your Change
#### Cause / Analysis

We are creating hstore extension specifically under schema 'pbs' which is not actually available in search_path and hence queries which use hstore function/s without the qualifier 'pbs' are failing.
#### Solution description

Creating the hstore extension in public schema which is always available in search_path. Also removed all occurrences of using hstore functions with the qualifier 'pbs'.
Also please note that we do not use any qualifier for hstore function/s when executing queries through our Libdb code.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Have done the following testing to make sure upgrade is working on SLES 15 and CentOS-7.
Upgrade from 14.x to 19.x
Upgrade from 18.x.x to 19.x
[14.x_19.x_Centos7_Upgrade.log](https://github.com/PBSPro/pbspro/files/3434743/14.x_19.x_Centos7_Upgrade.log)
[18.x_19.x_Centos7_Upgrade.log](https://github.com/PBSPro/pbspro/files/3434744/18.x_19.x_Centos7_Upgrade.log)
[18.x_19.x_SLES15_Upgrade.log](https://github.com/PBSPro/pbspro/files/3434745/18.x_19.x_SLES15_Upgrade.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->