### PR TITLE
PTL failed to parse complete environment variable on altix machine.

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1828,7 +1828,8 @@ class BatchUtils(object):
                     _e = len(lines) - 1
                     lines[_e] = lines[_e].strip('\r\n\t') + \
                         l[i].strip('\r\n\t')
-                elif not l[i].startswith(' ') and l[i-count].startswith('\t'):
+                elif not l[i].startswith(' ') and l[i-count].startswith('\t') \
+                        and i > count:
                     _e = len(lines) - count
                     lines[_e] = lines[_e] + l[i]
                     if not l[i].endswith(','):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1822,14 +1822,19 @@ class BatchUtils(object):
 
         if mergelines:
             lines = []
+            count = 1
             for i in range(len(l)):
                 if l[i].startswith('\t'):
                     _e = len(lines) - 1
                     lines[_e] = lines[_e].strip('\r\n\t') + \
                         l[i].strip('\r\n\t')
-                elif not l[i].startswith(('\t', ' ')) and l[i].endswith(','):
-                    _e = len(lines) - 1
+                elif not l[i].startswith(' ') and l[i-count].startswith('\t'):
+                    _e = len(lines) - count
                     lines[_e] = lines[_e] + l[i]
+                    if not l[i].endswith(','):
+                        count += 1
+                    else:
+                        count = 1
                 else:
                     lines.append(l[i])
         else:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1832,7 +1832,7 @@ class BatchUtils(object):
                         and l[i-count].startswith('\t')):
                     _e = len(lines) - count
                     lines[_e] = lines[_e] + l[i]
-                    if not l[i].endswith(','):
+                    if ((i+1) < len(l) and not l[i+1].startswith(('\t', ' '))):
                         count += 1
                     else:
                         count = 1

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1827,6 +1827,9 @@ class BatchUtils(object):
                     _e = len(lines) - 1
                     lines[_e] = lines[_e].strip('\r\n\t') + \
                         l[i].strip('\r\n\t')
+                elif not l[i].startswith(('\t', ' ')) and l[i].endswith(','):
+                    _e = len(lines) - 1
+                    lines[_e] = lines[_e] + l[i]
                 else:
                     lines.append(l[i])
         else:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1828,8 +1828,8 @@ class BatchUtils(object):
                     _e = len(lines) - 1
                     lines[_e] = lines[_e].strip('\r\n\t') + \
                         l[i].strip('\r\n\t')
-                elif not l[i].startswith(' ') and l[i-count].startswith('\t') \
-                        and i > count:
+                elif (not l[i].startswith(' ') and i > count
+                        and l[i-count].startswith('\t')):
                     _e = len(lines) - count
                     lines[_e] = lines[_e] + l[i]
                     if not l[i].endswith(','):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
On Altix machine PTL is not able to parse complete environment variable, on machine if we do qstat -f of particular job then return outout will be as follows.
Job Id: 2.dinesh-altix
    ...
    ...
    ...
    Variable_List = PBS_O_HOME=/home/pbsroot,PBS_O_LANG=en_US.UTF-8,
        PBS_O_LOGNAME=pbsroot,
        PBS_O_PATH=/sbin:/opt/tools/wrappers:/home/pbsroot/PTL/bin:/usr/lib64/
        qt-3.3/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/opt/
        pbs/bin:/home/pbsroot/TEST/tmp/PBSPro_19.4.0/19.4.0.20190718160957/bin:
        /sbin:/opt/tools/wrappers:/home/pbsroot/PTL/bin:/usr/lib64/qt-3.3/bin:/
        usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/opt/pbs/bin,
        PBS_O_MAIL=/var/spool/mail/pbsroot,PBS_O_SHELL=/bin/bash,
        PBS_O_WORKDIR=/home/pbsroot,PBS_O_SYSTEM=Linux,
        MANPATH=:/opt/pbs/share/man,XDG_SESSION_ID=195865,
        HOSTNAME=dinesh-altix.pbspro.com,SHELL=/bin/bash,TERM=xterm,
        HISTSIZE=1000,
        PERL5LIB=/home/pbsroot/AUTO/lib/perl5/site_perl:/home/pbsroot/AUTO/lib
        /site_perl:/home/pbsroot/AUTO/share/perl5:/home/pbsroot/AUTO/share/perl
        ,QTDIR=/usr/lib64/qt-3.3,
        OLDPWD=/home/pbsroot/TEST/tmp/PBSPro_19.4.0/19.4.0.20190718160957,
        QTINC=/usr/lib64/qt-3.3/include,QT_GRAPHICSSYSTEM_CHECKED=1,
        USER=pbsroot,
        LS_COLORS=rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=4
        0;33;01:cd=40;33;01:or=40;31;01:mi=01;05;37;41:su=37;41:sg=30;43:ca=30;
        41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01
        ;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=
        01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=0
        1;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31
        :*.xz=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:
        *.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31
        :*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;3
        1:*.rz=01;31:*.cab=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;
        35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01
        ;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng
        =01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.m
        kv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:
        *.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*
        .rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:
        *.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:
        *.axv=01;35:*.anx=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=01;36:*.au=01;36:
        *.flac=01;36:*.mid=01;36:*.midi=01;36:*.mka=01;36:*.mp3=01;36:*.mpc=01;
        36:*.ogg=01;36:*.ra=01;36:*.wav=01;36:*.axa=01;36:*.oga=01;36:*.spx=01;
        36:*.xspf=01;36:,MAIL=/var/spool/mail/pbsroot,
        PATH=/sbin:/opt/tools/wrappers:/home/pbsroot/PTL/bin:/usr/lib64/qt-3.3
        /bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/opt/pbs/bi
        n:/home/pbsroot/TEST/tmp/PBSPro_19.4.0/19.4.0.20190718160957/bin:/sbin:
        /opt/tools/wrappers:/home/pbsroot/PTL/bin:/usr/lib64/qt-3.3/bin:/usr/lo
        cal/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/opt/pbs/bin,
        PWD=/home/pbsroot/TEST/tmp/PBSPro_19.4.0/tests/functional,
        LANG=en_US.UTF-8,
        MODULEPATH=/usr/share/Modules/modulefiles:/etc/modulefiles,
        LOADEDMODULES=,HISTCONTROL=ignoredups,SHLVL=1,HOME=/home/pbsroot,
        PYTHONPATH=/home/pbsroot/TEST/tmp/PBSPro_19.4.0/19.4.0.20190718160957/
        lib/python2.7/site-packages/,LOGNAME=pbsroot,
        QTLIB=/usr/lib64/qt-3.3/lib,MODULESHOME=/usr/share/Modules,
        LESSOPEN=||/usr/bin/lesspipe.sh %s,
        BASH_FUNC_module()=() {  eval `/usr/bin/modulecmd bash $*`
},
        _=/home/pbsroot/TEST/tmp/PBSPro_19.4.0/19.4.0.20190718160957/bin/pbs_b
        enchpress,PTL_RSH_CMD=ssh,PTL_SUDO_CMD=sudo -H,
        PTL_EXPECT_MAX_ATTEMPTS=60,PTL_UPDATE_ATTRIBUTES=True,
        PTL_CP_CMD=scp -p,PTL_EXPECT_INTERVAL=0.5,
        NOSE_TESTMATCH=(^(?:[\\w]+|^)Test|pbs_|^test_[\\(]*),NOSE_VERBOSE=2,
        SET_IN_SUBMISSION=true,PBS_O_QUEUE=workq,
        PBS_O_HOST=dinesh-altix.pbspro.com
    comment = Job run at Mon Jul 22 at 04:11 on (dinesh-altix:ncpus=1)
    etime = Mon Jul 22 04:11:22 2019
    run_count = 1
    Submit_arguments = -V -- /bin/sleep 100
    executable = <jsdl-hpcpa:Executable>/bin/sleep</jsdl-hpcpa:Executable>
    argument_list = <jsdl-hpcpa:Argument>100</jsdl-hpcpa:Argument>
    project = _pbs_project_default

but PTL is able to parse environment variable till line "},". PTL is considering "}," as new element of qstat -f output and return as new element in output list. As a result user cannot get expected environment variable in 'variable_List' and test got failed.
"Test_passing_environment_variable_via_qsub" is failing on Altix machine due to above issue.

#### Describe Your Change
Check that if element in list is not starting with tab, space and ends with comma then append the element to the previous element of list.

#### Attach Test and Valgrind Logs/Output
[res_Test_passing_environment_variable_via_qsub_after_fix.txt](https://github.com/PBSPro/pbspro/files/3435136/res_Test_passing_environment_variable_via_qsub_after_fix.txt)
[res_Test_passing_environment_variable_via_qsub_before_fix.txt](https://github.com/PBSPro/pbspro/files/3435166/res_Test_passing_environment_variable_via_qsub_before_fix.txt)
