### PR TITLE
Storing performance_test output into json file

### DIFF
--- a/test/tests/performance/pbs_client_nagle_performance.py
+++ b/test/tests/performance/pbs_client_nagle_performance.py
@@ -139,8 +139,8 @@ class TestClientNagles(TestPerformance):
         self.logger.info("qdel performance: " + str(qdel_perf))
         self.logger.info(
             "qdel performance after setting manager: " + str(qdel_perf2))
-        self.perf_test_result(qdel_perf1, "qdel_perf", "sec")
-        self.perf_test_result(qdel_perf2, "qdel_perf_with_manager", "sec")
+        self.perf_test_result(float(qdel_perf), "qdel_perf", "sec")
+        self.perf_test_result(float(qdel_perf2), "qdel_perf_with_manager", "sec")
 
     @timeout(600)
     def test_qsub_perf(self):

--- a/test/tests/performance/pbs_client_nagle_performance.py
+++ b/test/tests/performance/pbs_client_nagle_performance.py
@@ -139,6 +139,8 @@ class TestClientNagles(TestPerformance):
         self.logger.info("qdel performance: " + str(qdel_perf))
         self.logger.info(
             "qdel performance after setting manager: " + str(qdel_perf2))
+        self.perf_test_result(qdel_perf1, "qdel_perf", "sec")
+        self.perf_test_result(qdel_perf2, "qdel_perf_with_manager", "sec")
 
     @timeout(600)
     def test_qsub_perf(self):
@@ -174,3 +176,5 @@ class TestClientNagles(TestPerformance):
         elap_time2 = timeit.default_timer() - float(start_time)
         self.logger.info("Time taken by qsub -f is " + str(elap_time2) +
                          " and time taken by qsub is " + str(elap_time1))
+        self.perf_test_result(elap_time1, "qsub_-f_time", "sec")
+        self.perf_test_result(elap_time2, "qsub_time", "sec")

--- a/test/tests/performance/pbs_client_nagle_performance.py
+++ b/test/tests/performance/pbs_client_nagle_performance.py
@@ -140,7 +140,8 @@ class TestClientNagles(TestPerformance):
         self.logger.info(
             "qdel performance after setting manager: " + str(qdel_perf2))
         self.perf_test_result(float(qdel_perf), "qdel_perf", "sec")
-        self.perf_test_result(float(qdel_perf2), "qdel_perf_with_manager", "sec")
+        self.perf_test_result(float(qdel_perf2),
+                              "qdel_perf_with_manager", "sec")
 
     @timeout(600)
     def test_qsub_perf(self):

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -118,7 +118,7 @@ class TestJobEquivClassPerf(TestPerformance):
         self.perf_test_result(cycle1_time, "different_equi_class", "sec")
         self.perf_test_result(cycle2_time, "single_equi_class", "sec")
         self.perf_test_result(time_diff,
-         " time_diff_bn_single_diff_equi_classes", "sec")
+                              "time_diff_bn_single_diff_equi_classes", "sec")
 
     @timeout(10000)
     def test_server_queue_limit(self):

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -117,7 +117,8 @@ class TestJobEquivClassPerf(TestPerformance):
         time_diff = cycle1_time - cycle2_time
         self.perf_test_result(cycle1_time, "different_equi_class", "sec")
         self.perf_test_result(cycle2_time, "single_equi_class", "sec")
-        self.perf_test_result(time_diff, "time _difference", "sec")
+        self.perf_test_result(time_diff,
+         " time_diff_bn_single_diff_equi_classes", "sec")
 
     @timeout(10000)
     def test_server_queue_limit(self):

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -114,6 +114,10 @@ class TestJobEquivClassPerf(TestPerformance):
         self.logger.info('Cycle 1: %d Cycle 2: %d Cycle time difference: %d' %
                          (cycle1_time, cycle2_time, cycle1_time - cycle2_time))
         self.assertGreaterEqual(cycle1_time, cycle2_time)
+        time_diff = cycle1_time - cycle2_time
+        self.perf_test_result(cycle1_time, "different_equi_class", "sec")
+        self.perf_test_result(cycle2_time, "single_equi_class", "sec")
+        self.perf_test_result(time_diff, "time _difference", "sec")
 
     @timeout(10000)
     def test_server_queue_limit(self):
@@ -265,3 +269,11 @@ class TestJobEquivClassPerf(TestPerformance):
                          "\n700 classes is %d,"
                          "\n800 classes is %d"
                          % (cyc1, cyc2, cyc3, cyc4, cyc5, cyc6, cyc7, cyc8))
+        self.perf_test_result(cyc1, "100_class_time", "sec")
+        self.perf_test_result(cyc2, "200_class_time", "sec")
+        self.perf_test_result(cyc3, "300_class_time", "sec")
+        self.perf_test_result(cyc4, "400_class_time", "sec")
+        self.perf_test_result(cyc5, "500_class_time", "sec")
+        self.perf_test_result(cyc6, "600_class_time", "sec")
+        self.perf_test_result(cyc7, "700_class_time", "sec")
+        self.perf_test_result(cyc8, "800_class_time", "sec")

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -115,10 +115,10 @@ class TestJobEquivClassPerf(TestPerformance):
                          (cycle1_time, cycle2_time, cycle1_time - cycle2_time))
         self.assertGreaterEqual(cycle1_time, cycle2_time)
         time_diff = cycle1_time - cycle2_time
-        self.perf_test_result(cycle1_time, "different_equi_class", "sec")
-        self.perf_test_result(cycle2_time, "single_equi_class", "sec")
+        self.perf_test_result(cycle1_time, "different_equiv_class", "sec")
+        self.perf_test_result(cycle2_time, "single_equiv_class", "sec")
         self.perf_test_result(time_diff,
-                              "time_diff_bn_single_diff_equi_classes", "sec")
+                              "time_diff_bn_single_diff_equiv_classes", "sec")
 
     @timeout(10000)
     def test_server_queue_limit(self):

--- a/test/tests/performance/pbs_history_cleanup_quasihang.py
+++ b/test/tests/performance/pbs_history_cleanup_quasihang.py
@@ -102,3 +102,4 @@ class HistoryCleanupQuasihang(TestPerformance):
 
         self.logger.info("qstat took %d seconds to return\n",
                          (now2 - now1))
+        self.perf_test_result((now2 - now1), "qstat_return_time", "sec")

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -240,6 +240,7 @@ class TestPreemptPerformance(TestPerformance):
         self.logger.info(res_str)
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
+        self.perf_test_result(time_diff, "preemp_time:nonconsume_resc", "sec")
 
     @timeout(3600)
     @tags('sched', 'scheduling_policy')
@@ -331,6 +332,7 @@ class TestPreemptPerformance(TestPerformance):
         self.logger.info(res_str)
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
+        self.perf_test_result(time_diff, "multi_nonconsumable_resc", "sec")
 
     @timeout(3600)
     @tags('sched', 'scheduling_policy')
@@ -406,6 +408,7 @@ class TestPreemptPerformance(TestPerformance):
         self.logger.info(res_str)
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
+        self.perf_test_result(time_diff, "High_priority_preemption", "sec")
 
     @timeout(7200)
     def test_preemption_basic(self):
@@ -469,6 +472,7 @@ class TestPreemptPerformance(TestPerformance):
             self.logger.info('#' * 80)
             ncpus *= 3
             S_jobs += ncpus
+            self.perf_test_result(time_diff, "preemption_time", "sec")
 
     @timeout(3600)
     def test_preemption_with_unrelated_soft_limits(self):
@@ -627,6 +631,7 @@ class TestPreemptPerformance(TestPerformance):
         self.logger.info(res_str)
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
+        self.perf_test_result(time_diff, "preempt_time_soft_limits", "sec")
 
     def tearDown(self):
         TestPerformance.tearDown(self)

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -240,7 +240,8 @@ class TestPreemptPerformance(TestPerformance):
         self.logger.info(res_str)
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
-        self.perf_test_result(time_diff, "preemp_time:nonconsume_resc", "sec")
+        self.perf_test_result(time_diff,
+         "preempt_time_nonconsumable_resc", "sec")
 
     @timeout(3600)
     @tags('sched', 'scheduling_policy')
@@ -332,7 +333,8 @@ class TestPreemptPerformance(TestPerformance):
         self.logger.info(res_str)
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
-        self.perf_test_result(time_diff, "multi_nonconsumable_resc", "sec")
+        self.perf_test_result(time_diff,
+         "preempt_time_multiplenonconsumable_resc", "sec")
 
     @timeout(3600)
     @tags('sched', 'scheduling_policy')

--- a/test/tests/performance/pbs_preemptperformance.py
+++ b/test/tests/performance/pbs_preemptperformance.py
@@ -241,7 +241,7 @@ class TestPreemptPerformance(TestPerformance):
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
         self.perf_test_result(time_diff,
-         "preempt_time_nonconsumable_resc", "sec")
+                              "preempt_time_nonconsumable_resc", "sec")
 
     @timeout(3600)
     @tags('sched', 'scheduling_policy')
@@ -334,7 +334,8 @@ class TestPreemptPerformance(TestPerformance):
         self.logger.info('#' * 80)
         self.logger.info('#' * 80)
         self.perf_test_result(time_diff,
-         "preempt_time_multiplenonconsumable_resc", "sec")
+                              "preempt_time_multiplenonconsumable_resc",
+                              "sec")
 
     @timeout(3600)
     @tags('sched', 'scheduling_policy')

--- a/test/tests/performance/pbs_qsub_performance.py
+++ b/test/tests/performance/pbs_qsub_performance.py
@@ -76,3 +76,5 @@ class TestQsubPerformance(TestPerformance):
         self.logger.info(
             "Submission time without env is %d and with env is %d sec"
             % (sub_time1, sub_time2))
+        self.perf_test_result(sub_time1, "submission_time_without_env", "sec")
+        self.perf_test_result(sub_time2, "submission_time_with_env", "sec")

--- a/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
+++ b/test/tests/performance/pbs_rerunjob_file_transfer_perf.py
@@ -87,6 +87,7 @@ class JobRerunFileTransferPerf(TestPerformance):
         now2 = int(time.time())
         self.logger.info("Job %s took %d seconds to start\n",
                          jid, (now2 - now1))
+        self.perf_test_result((now2 - now1), "job_start_time", "sec")
 
         # give a few seconds to job to create large spool file
         time.sleep(5)
@@ -99,3 +100,4 @@ class JobRerunFileTransferPerf(TestPerformance):
         now2 = int(time.time())
         self.logger.info("Job %s took %d seconds to rerun\n",
                          jid, (now2 - now1))
+        self.perf_test_result((now2 - now1), "job_return_time", "sec")

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -248,4 +248,4 @@ class TestSchedPerf(TestPerformance):
         self.assertLess(cycle2_time, cycle1_time,
                         'Optimization was not faster')
         self.perf_test_result(((cycle1_time / cycle2_time) * 100),
-         "optimized_percentage", "percentage")
+                              "optimized_percentage", "percentage")

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -242,8 +242,10 @@ class TestSchedPerf(TestPerformance):
 
         cycle2 = self.scheduler.cycles(lastN=1)[0]
         cycle2_time = cycle2.end - cycle2.start
+        percentage = (cycle1_time / cycle2_time) * 100
 
         self.logger.info('Cycle 1: %f Cycle 2: %f Perc %.2f%%' % (
             cycle1_time, cycle2_time, (cycle1_time / cycle2_time) * 100))
         self.assertLess(cycle2_time, cycle1_time,
                         'Optimization was not faster')
+        self.perf_test_result(percentage, "optimized_%", "percentage")

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -242,10 +242,10 @@ class TestSchedPerf(TestPerformance):
 
         cycle2 = self.scheduler.cycles(lastN=1)[0]
         cycle2_time = cycle2.end - cycle2.start
-        percentage = (cycle1_time / cycle2_time) * 100
 
         self.logger.info('Cycle 1: %f Cycle 2: %f Perc %.2f%%' % (
             cycle1_time, cycle2_time, (cycle1_time / cycle2_time) * 100))
         self.assertLess(cycle2_time, cycle1_time,
                         'Optimization was not faster')
-        self.perf_test_result(percentage, "optimized_%", "percentage")
+        self.perf_test_result(((cycle1_time / cycle2_time) * 100),
+         "optimized_percentage", "percentage")

--- a/test/tests/performance/pbs_standing_resv_quasihang.py
+++ b/test/tests/performance/pbs_standing_resv_quasihang.py
@@ -98,3 +98,4 @@ class StandingResvQuasihang(TestPerformance):
         now2 = int(time.time())
         self.logger.info("pbs_rstat took %d seconds to return\n",
                          (now2 - now1))
+        self.perf_test_result((now2 - now1), "pbs_rstat_return_time", "sec")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
storing performance test output in json file.


#### Describe Your Change
storing output of performance_test in PTL json file. Which store the updated output of the performance_tests.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[json_report.txt](https://github.com/PBSPro/pbspro/files/3472384/json_report.txt)
[pbs_history_cleanup_quasihang.txt](https://github.com/PBSPro/pbspro/files/3472407/pbs_history_cleanup_quasihang.txt)
[pbs_client_nagle_performance.txt](https://github.com/PBSPro/pbspro/files/3472456/pbs_client_nagle_performance.txt)
[pbs_qsub_performance.txt](https://github.com/PBSPro/pbspro/files/3472411/pbs_qsub_performance.txt)
[pbs_standing_resv_quasihang.txt](https://github.com/PBSPro/pbspro/files/3472413/pbs_standing_resv_quasihang.txt)
[preemption_test.txt](https://github.com/PBSPro/pbspro/files/3472415/preemption_test.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
