### PR TITLE
fix mem leak introduced in commit (#1d37088)

### DIFF
--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -528,17 +528,17 @@ req_runjob(struct batch_request *preq)
 		if (sub_run_version.at_flags & ATR_VFLAG_SET) {
 			pjobsub->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long = sub_run_version.at_val.at_long;
 			pjobsub->ji_wattr[(int)JOB_ATR_run_version].at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
-
-			if (sub_prev_res.at_flags & ATR_VFLAG_SET) {
-				job_attr_def[JOB_ATR_resource].at_free(&pjobsub->ji_wattr[JOB_ATR_resource]);
-				job_attr_def[JOB_ATR_resource].at_set(&pjobsub->ji_wattr[JOB_ATR_resource], &sub_prev_res, SET);
-				job_attr_def[JOB_ATR_resource].at_free(&sub_prev_res);
-			}
 		}
 
 		if (sub_runcount.at_flags & ATR_VFLAG_SET) {
 			pjobsub->ji_wattr[(int)JOB_ATR_runcount].at_val.at_long = sub_runcount.at_val.at_long;
 			pjobsub->ji_wattr[(int)JOB_ATR_runcount].at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
+		}
+
+		if (sub_prev_res.at_flags & ATR_VFLAG_SET) {
+			job_attr_def[JOB_ATR_resource].at_free(&pjobsub->ji_wattr[JOB_ATR_resource]);
+			job_attr_def[JOB_ATR_resource].at_set(&pjobsub->ji_wattr[JOB_ATR_resource], &sub_prev_res, SET);
+			job_attr_def[JOB_ATR_resource].at_free(&sub_prev_res);
 		}
 
 		if (call_to_process_hooks(preq, hook_msg, sizeof(hook_msg),


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Memory leak got introduced in https://github.com/PBSPro/pbspro/pull/1198 at line https://github.com/PBSPro/pbspro/commit/1d370881cd852f8eea20f02fea44ef358974afe7#diff-45a3e6e8b2cc88623e332587a9fa268eR516
with below signature found while running `TestRunJobHook` PTL test suite 
```
335 (80 direct, 255 indirect) bytes in 1 blocks are definitely lost in loss record 1,284 of 1,752
   at 0x4C271B2: malloc (vg_replace_malloc.c:298)
   by 0x4ED349: add_resource_entry (attr_fn_resc.c:582)
   by 0x4ED67B: set_resc (attr_fn_resc.c:312)
   by 0x4A700E: req_runjob (req_runjob.c:516)
   by 0x503426: process_socket (net_server.c:504)
   by 0x503560: wait_request (net_server.c:585)
   by 0x48871C: main (pbsd_main.c:2137)
```
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Moved the `freeing` block out of another `if block` which was getting skipped leading to memory leakage while running `TestRunJobHook` PTL test suite



#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[valgrind_diff.zip](https://github.com/PBSPro/pbspro/files/3435479/valgrind_diff.zip)
[jobarray_related_ptls.zip](https://github.com/PBSPro/pbspro/files/3435480/jobarray_related_ptls.zip)
[SmokeTest.zip](https://github.com/PBSPro/pbspro/files/3435481/SmokeTest.zip)
[TestRunJobHook.zip](https://github.com/PBSPro/pbspro/files/3435482/TestRunJobHook.zip)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
