### PR TITLE
Fix preemption with requeue on Cray

### DIFF
--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -1490,6 +1490,8 @@ on_job_rerun(struct work_task *ptask)
 
 				}
 				rel_resc(pjob);		/* free resc assigned to job */
+
+				/* Respond to pending preemption request from the scheduler, if any */
 				if (pjob->ji_pmt_preq != NULL)
 					reply_preempt_jobs_request(PBSE_NONE, PREEMPT_METHOD_REQUEUE, pjob);
 

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -627,6 +627,9 @@ rel_resc(job *pjob)
 		if (pjob->ji_rerun_preq->rq_conn != PBS_LOCAL_CONNECTION)
 			conn = get_conn(pjob->ji_rerun_preq->rq_conn);
 
+		if (pjob->ji_pmt_preq != NULL)
+			reply_preempt_jobs_request(PBSE_NONE, PREEMPT_METHOD_REQUEUE, pjob);
+
 		reply_ack(pjob->ji_rerun_preq);
 
 		/* clear no-timeout flag on connection to prevent stale connections */

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -627,9 +627,6 @@ rel_resc(job *pjob)
 		if (pjob->ji_rerun_preq->rq_conn != PBS_LOCAL_CONNECTION)
 			conn = get_conn(pjob->ji_rerun_preq->rq_conn);
 
-		if (pjob->ji_pmt_preq != NULL)
-			reply_preempt_jobs_request(PBSE_NONE, PREEMPT_METHOD_REQUEUE, pjob);
-
 		reply_ack(pjob->ji_rerun_preq);
 
 		/* clear no-timeout flag on connection to prevent stale connections */
@@ -1493,6 +1490,9 @@ on_job_rerun(struct work_task *ptask)
 
 				}
 				rel_resc(pjob);		/* free resc assigned to job */
+				if (pjob->ji_pmt_preq != NULL)
+					reply_preempt_jobs_request(PBSE_NONE, PREEMPT_METHOD_REQUEUE, pjob);
+
 				unset_extra_attributes(pjob);
 
 

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -122,8 +122,6 @@ post_rerun(struct work_task *pwt)
 				force_reque(pjob);
 			}
 		}
-		else if (pjob->ji_pmt_preq != NULL)
-			reply_preempt_jobs_request(PBSE_NONE, PREEMPT_METHOD_REQUEUE, pjob);
 	}
 
 	release_req(pwt);

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -202,6 +202,23 @@ exit 1
         """
         self.submit_and_preempt_jobs(preempt_order='R')
 
+    def test_preempt_requeue_exclhost(self):
+        """
+        Test that a job is preempted by requeue on node
+        where attribute share is set to force_exclhost
+        """
+        # set node share attribute to force_exclhost
+        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
+        self.mom.delete_vnode_defs()
+        vnode_prefix = self.mom.shortname
+        a = {'resources_available.ncpus': '1',
+             'sharing': 'force_exclhost'}
+        vnodedef = self.mom.create_vnode_def(vnode_prefix, a, 0)
+        self.assertNotEqual(vnodedef, None)
+        self.mom.insert_vnode_def(vnodedef, 'vnode.def')
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom.shortname)
+        self.submit_and_preempt_jobs(preempt_order='R')
+
     def test_preempt_requeue_ja(self):
         """
         Test that a subjob is preempted by requeue
@@ -268,9 +285,11 @@ exit 1
         Test that a job is preempted by requeue and the scheduler does not
         report the job as can never run
         """
+        start_time = int(time.time())
         self.submit_and_preempt_jobs(preempt_order='R')
         self.scheduler.log_match(
-            ";Job will never run", existence=False, max_attempts=5)
+            ";Job will never run", existence=False, starttime=start_time,
+            max_attempts=5)
 
     def test_preempt_multiple_jobs(self):
         """

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -208,16 +208,16 @@ exit 1
         where attribute share is set to force_exclhost
         """
         # set node share attribute to force_exclhost
-        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
-        self.mom.delete_vnode_defs()
-        vnode_prefix = self.mom.shortname
         a = {'resources_available.ncpus': '1',
              'sharing': 'force_exclhost'}
-        vnodedef = self.mom.create_vnode_def(vnode_prefix, a, 0)
-        self.assertNotEqual(vnodedef, None)
-        self.mom.insert_vnode_def(vnodedef, 'vnode.def')
-        self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom.shortname)
+        self.server.create_vnodes(name=self.mom.shortname, attrib=a, num=0,
+                                  mom=self.mom)
+        start_time = time.time()
         self.submit_and_preempt_jobs(preempt_order='R')
+        self.scheduler.log_match(
+            "Failed to run: Resource temporarily unavailable (15044)",
+            existence=False, starttime=start_time,
+            max_attempts=5)
 
     def test_preempt_requeue_ja(self):
         """
@@ -285,7 +285,7 @@ exit 1
         Test that a job is preempted by requeue and the scheduler does not
         report the job as can never run
         """
-        start_time = int(time.time())
+        start_time = time.time()
         self.submit_and_preempt_jobs(preempt_order='R')
         self.scheduler.log_match(
             ";Job will never run", existence=False, starttime=start_time,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
*Preemption with preempt_order 'R' is not working on Cray.
(it is also reproducable on non-Cray by setting node's share attribute to force_excelhost)*

*Server replies to preemption request to scheduler immediately after sending requeue signal to mom, while mom and server still in obituary process of the preempting job.  Since scheduler receives confirmation of preemption it asks server to run the high priority job and end up with server's response resource unavailable (15044) and fails to preempt the job.*


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
*Replying to preemption batch request only after resources are released by the preempting job.*

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
[test_preempt_requeue_exclhost.txt](https://github.com/PBSPro/pbspro/files/3440204/test_preempt_requeue_exclhost.txt)
[Testpreemption.txt](https://github.com/PBSPro/pbspro/files/3440205/Testpreemption.txt)


<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
