### PR TITLE
pbs_habitat does not call postinstall if PBS_HOME is empty

### DIFF
--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -514,15 +514,7 @@ if [ -z "$PBS_HOME" ]; then
 	echo "*** PBS_HOME is not set"
 	exit 1
 fi
-
-update_home=0
-if [ ! -d "$PBS_HOME" ]; then
-        update_home=1
-else
-	# Check if PBS_HOME is empty.
-        [ ! "$(/bin/ls -A $PBS_HOME)" ] && update_home=1
-fi
-if [ $update_home -eq 1 ]; then
+if [ ! -d "$PBS_HOME" -o ! "$(/bin/ls -A $PBS_HOME)" ]; then
 	echo "*** WARNING: PBS_HOME not found in $PBS_HOME"
 	if [ -x "$PBS_EXEC/sbin/pbs_server" ]; then
 		component="server"

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -514,7 +514,15 @@ if [ -z "$PBS_HOME" ]; then
 	echo "*** PBS_HOME is not set"
 	exit 1
 fi
+
+update_home=0
 if [ ! -d "$PBS_HOME" ]; then
+        update_home=1
+else
+	# Check if PBS_HOME is empty.
+        [ ! "$(/bin/ls -A $PBS_HOME)" ] && update_home=1
+fi
+if [ $update_home -eq 1 ]; then
 	echo "*** WARNING: PBS_HOME not found in $PBS_HOME"
 	if [ -x "$PBS_EXEC/sbin/pbs_server" ]; then
 		component="server"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
If PBS_HOME directory is empty and pbs_habitat is run, script does not invoke pbs_postinstall and fails during db creation.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
As part PBS_HOME directory extstance check also see if the directory is empty or not. If empty call pbs_postinstall.




Manual Test Output:
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_log.txt](https://github.com/PBSPro/pbspro/files/3449526/test_log.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
