### PR TITLE
ptl.sh/csh does net set environment correctly when installed via make

### DIFF
--- a/test/fw/ptl.sh
+++ b/test/fw/ptl.sh
@@ -47,5 +47,25 @@ if [ "x${ptl_prefix_lib}" != "x" ]; then
 	prefix=$( dirname ${ptl_prefix_lib} )
 
 	export PATH=${prefix}/bin/:${PATH} 
-	export PYTHONPATH=${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH 
+	export PYTHONPATH=${prefix}/lib/${python_dir}/site-packages/:$PYTHONPATH
+	unset python_dir
+	unset prefix
+	unset ptl_prefix_lib
+else
+	conf="${PBS_CONF_FILE:-/etc/pbs.conf}"
+	if [ -r "${conf}" ]; then
+		# we only need PBS_EXEC from pbs.conf
+		__PBS_EXEC=$( grep '^[[:space:]]*PBS_EXEC=' "$conf" | tail -1 | sed 's/^[[:space:]]*PBS_EXEC=\([^[:space:]]*\)[[:space:]]*/\1/' )
+		if [ "X${__PBS_EXEC}" != "X" ]; then
+			# Define PATH and PYTHONPATH for the users
+			PTL_PREFIX=$( dirname ${__PBS_EXEC} )/ptl
+			python_dir=$( /bin/ls -1 ${PTL_PREFIX}/lib )/site-packages
+			[ -d "${PTL_PREFIX}/bin" ] && export PATH="${PATH}:${PTL_PREFIX}/bin"
+			[ -d "${PTL_PREFIX}/lib/${python_dir}" ] && export PYTHONPATH="${PYTHONPATH}:${PTL_PREFIX}/lib/${python_dir}"
+		fi
+		unset __PBS_EXEC
+		unset PTL_PREFIX
+		unset conf
+		unset python_dir
+	fi
 fi


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Paths were not being correctly set when installed via make

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Previously ptl.sh file was only checking for rpm installation, made it so that it checks for ptl installation as well and sets corresponding path.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[o/p log of ptl.sh](https://github.com/PBSPro/pbspro/files/3456160/ptlsh.op.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
