### PR TITLE
'test_non_manager' of 'TestPythonRestartSettings' fails while verifying the error msg

### DIFF
--- a/test/tests/functional/pbs_python_restart_settings.py
+++ b/test/tests/functional/pbs_python_restart_settings.py
@@ -117,51 +117,52 @@ class TestPythonRestartSettings(TestFunctional):
 
     def test_non_manager(self):
         """
-        Test that values are not set as operator or users
+        Test that hook values can not be set as operator or users.
         """
+        exp_err = "Cannot set attribute, read only or insufficient permission"
+        try:
+            self.server.manager(MGR_CMD_SET, SERVER,
+                                {'python_restart_max_hooks': 30},
+                                runas=OPER_USER, logerr=True)
+        except PbsManagerError, e:
+            self.assertIn(exp_err, e.msg[0],
+                          "Error message is not expected")
+        try:
+            self.server.manager(MGR_CMD_SET, SERVER,
+                                {'python_restart_max_objects': 2000},
+                                runas=OPER_USER, logerr=True)
+        except PbsManagerError, e:
+            self.assertIn(exp_err, e.msg[0],
+                          "Error message is not expected")
+        try:
+            self.server.manager(MGR_CMD_SET, SERVER,
+                                {'python_restart_min_interval': 10},
+                                runas=OPER_USER, logerr=True)
+        except PbsManagerError, e:
+            self.assertIn(exp_err, e.msg[0],
+                          "Error message is not expected")
         exp_err = "Unauthorized Request"
         try:
             self.server.manager(MGR_CMD_SET, SERVER,
                                 {'python_restart_max_hooks': 30},
-                                runas=OPER_USER, logerr=True)
-        except PbsManagerError, e:
-            self.assertTrue(exp_err in e.msg[0],
-                            "Error message is not expected")
-        try:
-            self.server.manager(MGR_CMD_SET, SERVER,
-                                {'python_restart_max_objects': 2000},
-                                runas=OPER_USER, logerr=True)
-        except PbsManagerError, e:
-            self.assertTrue(exp_err in e.msg[0],
-                            "Error message is not expected")
-        try:
-            self.server.manager(MGR_CMD_SET, SERVER,
-                                {'python_restart_min_interval': 10},
-                                runas=OPER_USER, logerr=True)
-        except PbsManagerError, e:
-            self.assertTrue(exp_err in e.msg[0],
-                            "Error message is not expected")
-        try:
-            self.server.manager(MGR_CMD_SET, SERVER,
-                                {'python_restart_max_hooks': 30},
                                 runas=TEST_USER, logerr=True)
         except PbsManagerError, e:
-            self.assertTrue(exp_err in e.msg[0],
-                            "Error message is not expected")
+            self.assertIn(exp_err, e.msg[0],
+                          "Error message is not expected")
         try:
             self.server.manager(MGR_CMD_SET, SERVER,
                                 {'python_restart_max_objects': 2000},
                                 runas=TEST_USER, logerr=True)
         except PbsManagerError, e:
-            self.assertTrue(exp_err in e.msg[0],
-                            "Error message is not expected")
+            self.assertIn(exp_err, e.msg[0],
+                          "Error message is not expected")
         try:
             self.server.manager(MGR_CMD_SET, SERVER,
                                 {'python_restart_min_interval': 10},
                                 runas=TEST_USER, logerr=True)
         except PbsManagerError, e:
-            self.assertTrue(exp_err in e.msg[0],
-                            "Error message is not expected")
+            self.assertIn(exp_err, e.msg[0],
+                          "Error message is not expected")
 
     def test_log_message(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test 'test_non_manager' of 'TestPythonRestartSettings' fails while verifying the error msg


#### Describe Your Change

- test_non_manager() tests that operator users and other non manager users cannot set attribute in server. But in this test the operators were never set in the server. So the error message we got was -"Unauthorized Request". 

- The error message we get when an operator user added to the server list of operators tries to set the attribute is - "Cannot set attribute, read only or insufficient permission python_restart_max_hooks"

- Now by default the operator user in the server will be pbsoper. We need to update the test and the error message accordingly.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[Execution_logs_TestPythonRestartSettings.txt](https://github.com/PBSPro/pbspro/files/3460290/Execution_logs_TestPythonRestartSettings.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
