### PR TITLE
Fixed over-limit jobs accruing eligible time with dependencies

### DIFF
--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4851,12 +4851,6 @@ determine_accruetype(job* pjob)
 			return newaccruetype;
 		}
 
-	/* handling qsub -Wdepend, state H with substate 22 ; accrue eligible_time */
-	if (pjob->ji_wattr[(int)JOB_ATR_depend].at_flags & ATR_VFLAG_SET) {
-		newaccruetype = (long)JOB_ELIGIBLE;
-		return newaccruetype;
-	}
-
 	/* return */
 	return newaccruetype;
 }


### PR DESCRIPTION
## Describe Bug or Feature
Job's over their limit do not accrue eligible time.  The bug is when such a job was the parent of a dependency (i.e. another job has an after dependency on it), the job starts accruing eligible time.

#### Describe Your Change
The server has a function called determine_accruetype().  This will set the accrue type depending on certain criteria.  There are two based on dependencies.  One is if there is a system hold on the job and it is in substate 22 to not accrue eligible time.  This is correct.  The second is if the depend attribute is set to accrue eligible time.  This is not correct.  This is because when you apply an after dependency, the parent job gets a before dependency.  This will always force the job to accrue eligible time regardless of what the scheduler thinks about the job.

I fixed this by removing check in determine_accruetype() that checked if the depend attribute is set.  I can't think of any reason why this was a good idea.

It is a little more complicated than this.  The determine_accruetype() function is only called when the job state changes or when qalter is done.  This means you have to force the function to be called after the dependency is applied to see the bug.

#### Attach Test and Valgrind Logs/Output
[eligible_before.log](https://github.com/PBSPro/pbspro/files/3469014/eligible_before.log)
[eligible_after.log](https://github.com/PBSPro/pbspro/files/3469013/eligible_after.log)
