### PR TITLE
PTL should know if it's running on Shasta

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13123,6 +13123,15 @@ class MoM(PBSService):
         else:
             return True
 
+    def is_shasta(self):
+        """
+        Returns True if the version of PBS used is installed on Shasta platform
+        """
+        if self.platform == 'shasta':
+            return True
+        else:
+            return False
+
     def is_cpuset_mom(self):
         """
         Check for cpuset mom

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -159,8 +159,8 @@ class DshUtils(object):
         """
         Get a local or remote platform info, essentially the value of
         Python's sys.platform, in case of Cray it will return a string
-        as "cray" for actual Cray cluster and "craysim" for Cray ALPS
-        simulator
+        as "cray" or "shasta" for actual Cray cluster and "craysim"
+        for Cray ALPS simulator
 
         :param hostname: The hostname to query for platform info
         :type hostname: str or None
@@ -183,6 +183,10 @@ class DshUtils(object):
                 splatform = 'cray'
             else:
                 splatform = 'craysim'
+            found_already = True
+        if self.isfile(hostname=hostname, path='/etc/cray/xname',
+                       level=logging.DEBUG2):
+            splatform = 'shasta'
             found_already = True
         if not self.is_localhost(hostname) and not found_already:
             if pyexec is None:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Find out a way for PTL to figure out if it is running on a Shasta machine.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
PTL checks for a shasta specific file to identify if the system is Shasta or not. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1327235075/Support+PTL+on+Shasta





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
