### PR TITLE
Test 'test_delete_history_subjob_server_restart' of 'TestJobArray' fails while verifying job's state

### DIFF
--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -581,7 +581,7 @@ class TestJobArray(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
-        j = Job(TEST_USER, attrs={
+        j = Job(PBSROOT_USER, attrs={
             ATTR_J: '1-2', 'Resource_List.select': 'ncpus=1'})
         j.set_sleep_time(5)
         j_id = self.server.submit(j)

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -581,8 +581,9 @@ class TestJobArray(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
-        j = Job(PBSROOT_USER, attrs={
-            ATTR_J: '1-2', 'Resource_List.select': 'ncpus=1'})
+        j = Job(TEST_USER, attrs={
+            ATTR_J: '1-2', 'Resource_List.select': 'ncpus=1',
+            ATTR_k: 'oe'})
         j.set_sleep_time(5)
         j_id = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'F'}, j_id, extend='x', offset=5)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test 'test_delete_history_subjob_server_restart' of 'TestJobArray' fails while verifying job's state


#### Describe Your Change

- In the test we are submitting job array as pbsuser with sleep of 5 secs and verifying that the job is in F state after 5secs. In failed scenario the subjobs remain in E state due to the passwordless ssh session issue. Inorder to avoid this issue submit job with -koe option.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
- [Execution_logs_job_array_bfr_fix.txt](https://github.com/PBSPro/pbspro/files/3475760/Execution_logs_job_array_bfr_fix.txt)

- [jobarray_aftr_fix.txt](https://github.com/PBSPro/pbspro/files/3476377/jobarray_aftr_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
