### PR TITLE
Increase max_attempts in test_hook_send

### DIFF
--- a/test/tests/functional/pbs_hook_timeout.py
+++ b/test/tests/functional/pbs_hook_timeout.py
@@ -147,12 +147,12 @@ class TestHookTimeout(TestFunctional):
                 exist = False
             m.log_match(
                 "test.HK;copy hook-related file request received",
-                regexp=True, max_attempts=3, interval=1,
+                regexp=True, max_attempts=10, interval=1,
                 existence=exist, starttime=start_time)
 
             m.log_match(
                 "test.PY;copy hook-related file request received",
-                regexp=True, max_attempts=3, interval=1,
+                regexp=True, max_attempts=10, interval=1,
                 existence=exist, starttime=start_time)
 
         # Ensure that hook send updates are retried for


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test_hook_send test failed due to race condition.
try to log match "test.HK;copy hook-related file request received" in log file with max_attempts:3. but unable to log match within 3 attempts and failed.
This failure has not been seen since ticket was logged but fixing it here just in case. 

#### Describe Your Change
Increase max_attempts in test_hook_send log match to 10

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->