### PR TITLE
Fixed array jobs to run more than 1 subjob per cycle

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2280,7 +2280,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 		skip = SKIP_NOTHING;
 		sort_jobs(policy, sinfo);
 		sort_status = SORTED;
-		last_job_index = -1; /* We search from last_job_index + 1 */
+		last_job_index = 0;
 		return NULL;
 	}
 
@@ -2304,7 +2304,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 		|| (flag == MUST_RESORT_JOBS)) {
 		sort_jobs(policy, sinfo);
 		sort_status = SORTED;
-		last_job_index = -1;
+		last_job_index = 0;
 	}
 	if (policy->round_robin) {
 		/* Below is a pictorial representation of how queue_list
@@ -2378,11 +2378,11 @@ next_job(status *policy, server_info *sinfo, int flag)
 		}
 	} else if (policy->by_queue) {
 		if (!(skip & SKIP_NON_NORMAL_JOBS)) {
-			ind = find_non_normal_job_ind(sinfo->jobs, last_job_index + 1);
+			ind = find_non_normal_job_ind(sinfo->jobs, last_job_index);
 			if (ind == -1) {
 				/* No more preempted jobs */
 				skip |= SKIP_NON_NORMAL_JOBS;
-				last_job_index = -1;
+				last_job_index = 0;
 			} else {
 				rjob = sinfo->jobs[ind];
 				last_job_index = ind;
@@ -2390,9 +2390,9 @@ next_job(status *policy, server_info *sinfo, int flag)
 		}
 		if (skip & SKIP_NON_NORMAL_JOBS) {
 			while(last_queue < sinfo->num_queues &&
-			     ((ind = find_runnable_resresv_ind(sinfo->queues[last_queue]->jobs, last_job_index + 1)) == -1)) {
+			     ((ind = find_runnable_resresv_ind(sinfo->queues[last_queue]->jobs, last_job_index)) == -1)) {
 				last_queue++;
-				last_job_index = -1;
+				last_job_index = 0;
 			}
 			if (last_queue < sinfo->num_queues && ind != -1) {
 				rjob = sinfo->queues[last_queue]->jobs[ind];
@@ -2401,7 +2401,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 				rjob = NULL;
 		}
 	} else { /* treat the entire system as one large queue */
-		ind = find_runnable_resresv_ind(sinfo->jobs, last_job_index + 1);
+		ind = find_runnable_resresv_ind(sinfo->jobs, last_job_index);
 		if(ind != -1) {
 			rjob = sinfo->jobs[ind];
 			last_job_index = ind;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Only one subjob of a job array would run per cycle

#### Describe Your Change
The function to determine which is the next job to consider to run is called next_job().  We basically traverse an array until we find a job to consider.  Before a recent change, we'd start a subsequent search at the same index as the last job.  This would cause us to look at the job we just looked at, determine it was marked as can_not_run, and move to the next.  To avoid this, we started passing last_index + 1.  The problem is job arrays.  We need to return the same job over and over again until it is marked as can_not_run.

I reverted the change and now we look at the same job twice.  It is a simple comparison, so it doesn't slow things down much.

#### Attach Test and Valgrind Logs/Output
[array.log](https://github.com/PBSPro/pbspro/files/3483704/array.log)
