### PR TITLE
Fixed bug in exclhost

### DIFF
--- a/src/scheduler/buckets.c
+++ b/src/scheduler/buckets.c
@@ -1017,7 +1017,7 @@ find_correct_buckets(status *policy, node_bucket **buckets, resource_resv *resre
 					total += buckets[j]->total * c;
 				} else {
 					if (failerr->status_code == SCHD_UNKWN)
-						move_schd_error(failerr, err);
+						copy_schd_error(failerr, err);
 				}
 				clear_schd_error(err);
 			}
@@ -1117,7 +1117,7 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
 				return nspecs;
 			if (err->status_code == NOT_RUN) {
 				if (failerr->status_code == SCHD_UNKWN)
-					move_schd_error(failerr, err);
+					copy_schd_error(failerr, err);
 				can_run = 1;
 			}
 		}

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -5875,12 +5875,6 @@ check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, plac
 			clear_schd_error(err);
 			if (is_vnode_eligible(ninfo_arr[i], resresv, pl, err) == 0) {
 				ninfo_arr[i]->nscr.ineligible = 1;
-				if (err->status_code != SCHD_UNKWN) {
-					if (misc_err->status_code == SCHD_UNKWN)
-						move_schd_error(misc_err, err);
-					schdlogerr(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_DEBUG,
-						ninfo_arr[i]->name, NULL, err);
-				}
 				if (ninfo_arr[i]->hostset != NULL) {
 					if ((err->error_code == NODE_NOT_EXCL &&
 					    is_exclhost(pl, ninfo_arr[i]->sharing)) ||
@@ -5892,6 +5886,12 @@ check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, plac
 								n->name, exclerr_buf);
 						}
 					}
+				}
+				if (err->status_code != SCHD_UNKWN) {
+					if (misc_err->status_code == SCHD_UNKWN)
+						copy_schd_error(misc_err, err);
+					schdlogerr(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_DEBUG,
+						   ninfo_arr[i]->name, NULL, err);
 				}
 			}
 		}

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -2359,7 +2359,7 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 			else {
 				empty_nspec_array(*nspec_arr);
 				if (failerr->status_code == SCHD_UNKWN)
-					move_schd_error(failerr, err);
+					copy_schd_error(failerr, err);
 			}
 		}
 		else {
@@ -2379,7 +2379,7 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 			set_schd_error_arg(err, ARG2, nodepart[i]->name);
 #endif /* localmod 031 */
 			if (failerr->status_code == SCHD_UNKWN)
-				move_schd_error(failerr, err);
+				copy_schd_error(failerr, err);
 		}
 
 		if (!can_fit && !rc &&
@@ -2402,7 +2402,7 @@ eval_selspec(status *policy, selspec *spec, place *placespec,
 			set_schd_error_codes(err, NEVER_RUN, CANT_SPAN_PSET);
 			/* CANT_SPAN_PSET is more important than any other error we may have encountered -- keep it*/
 			clear_schd_error(failerr);
-			move_schd_error(failerr, err);
+			copy_schd_error(failerr, err);
 		}
 	}
 
@@ -2578,7 +2578,7 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 				else {
 					empty_nspec_array(nsa);
 					if(failerr->status_code == SCHD_UNKWN)
-						move_schd_error(failerr, err);
+						copy_schd_error(failerr, err);
 					clear_schd_error(err);
 
 				}
@@ -2626,7 +2626,7 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 							else {
 								empty_nspec_array(nsa);
 								if (failerr->status_code == SCHD_UNKWN)
-									move_schd_error(failerr, err);
+									copy_schd_error(failerr, err);
 								clear_schd_error(err);
 							}
 						}
@@ -3296,13 +3296,13 @@ eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 				else {
 					ninfo_arr[i]->nscr.visited = 1;
 					if (failerr->status_code == SCHD_UNKWN)
-						move_schd_error(failerr, err);
+						copy_schd_error(failerr, err);
 				}
 			}
 			else {
 				ninfo_arr[i]->nscr.visited = 1;
 				if (failerr->status_code == SCHD_UNKWN)
-					move_schd_error(failerr, err);
+					copy_schd_error(failerr, err);
 			}
 
 			if (licenses_allocated > 0)


### PR DESCRIPTION
#### Describe Bug or Feature
Exclusivity of exclhost is not being honored.  This means if a job is running on one host, a job requesting exclhost can be run on the same host.

#### Describe Your Change
The way we check for exclhost is we look at every vnode and look to see if there is a job running on it.  If there is, we then check the rest of the vnodes on that host and mark them as ineligible.  The function which checked for excl was correctly returning that there was a job on the host, but the variable that stored it was being cleared before we checked for exclhost.

The clearing of the variable (move_schd_error()) is new.  It used to not clear the schd_error, but leave it in a unstable state.

I don't clear the variable any more, and I moved it to the end of the if block to where it probably belongs.  I also turned all appropriate move_schd_error() calls into copy_schd_error().  This will copy the schd_error and not clear it.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[exclhost.log](https://github.com/PBSPro/pbspro/files/3483953/exclhost.log)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
