### PR TITLE
Fixing test_max_hooks from TestPythonRestartSettings

### DIFF
--- a/test/tests/functional/pbs_python_restart_settings.py
+++ b/test/tests/functional/pbs_python_restart_settings.py
@@ -36,6 +36,7 @@
 # trademark licensing policies.
 
 from tests.functional import *
+from ptl.utils.pbs_logutils import PBSLogUtils
 
 
 class TestPythonRestartSettings(TestFunctional):
@@ -48,6 +49,7 @@ class TestPythonRestartSettings(TestFunctional):
     This test suite is to validate the server attributes. Actual memory
     leak test is still manual
     """
+    logutils = PBSLogUtils()
 
     def test_non_integer(self):
         """
@@ -306,12 +308,11 @@ pbs.event().accept()
         self.assertTrue(len(logs) > 1)
         log1 = logs[0][1]
         log2 = logs[1][1]
-        pattern = '%m/%d/%Y %H:%M:%S.%f'
         tmp = log1.split(';')
         # Convert the time into epoch time
-        time1 = int(time.mktime(time.strptime(tmp[0], pattern)))
+        time1 = int(self.logutils.convert_date_time(tmp[0]))
         tmp = log2.split(';')
-        time2 = int(time.mktime(time.strptime(tmp[0], pattern)))
+        time2 = int(self.logutils.convert_date_time(tmp[0]))
         # Difference between log message should not be less than 3
         diff = time2 - time1
         self.logger.info("Time difference between log message is " +

--- a/test/tests/functional/pbs_python_restart_settings.py
+++ b/test/tests/functional/pbs_python_restart_settings.py
@@ -306,7 +306,7 @@ pbs.event().accept()
         self.assertTrue(len(logs) > 1)
         log1 = logs[0][1]
         log2 = logs[1][1]
-        pattern = '%m/%d/%Y %H:%M:%S'
+        pattern = '%m/%d/%Y %H:%M:%S.%f'
         tmp = log1.split(';')
         # Convert the time into epoch time
         time1 = int(time.mktime(time.strptime(tmp[0], pattern)))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This test was failing because microsecond logging was turned on by default in PTL. The test was considering that log date pattern is _%m/%d/%Y %H:%M:%S_  which was causing time.mktime() to fail.

#### Attach Test and Valgrind Logs/Output
[test_max_hooks.txt](https://github.com/PBSPro/pbspro/files/3484092/test_max_hooks.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
