### PR TITLE
In PTL, set $usecp if on Shasta

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -12822,6 +12822,10 @@ class MoM(PBSService):
                                 '$vnodedef_additive': 0,
                                 '$alps_client': alps_client,
                                 '$usecp': '*:%s %s' % (usecp, usecp)}
+        elif self.platform == 'shasta':
+            usecp = os.path.realpath('/lus')
+            self.dflt_config = {'$clienthost': self.server.hostname,
+                                '$usecp': '*:%s %s' % (usecp, usecp)}
         else:
             self.dflt_config = {'$clienthost': self.server.hostname}
         self.version = None


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If we're on shasta, PTL needs to set $usecp as the default on the moms.


#### Describe Your Change
Check if we're on shasta, if so, set default config to have $usecp


#### Link to Design Doc
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1327235075/Support+PTL+on+Shasta


#### Attach Test and Valgrind Logs/Output
[shasta-usecp-noshasta.txt](https://github.com/PBSPro/pbspro/files/3488153/shasta-usecp-noshasta.txt)
[shasta-usecp-test.txt](https://github.com/PBSPro/pbspro/files/3488154/shasta-usecp-test.txt)
[shasta-usecp-yesshasta.txt](https://github.com/PBSPro/pbspro/files/3488155/shasta-usecp-yesshasta.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
