### PR TITLE
Remove hard-coded sudos and replace them with DshUtil.sudo_cmd

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14154,9 +14154,11 @@ class InteractiveJob(threading.Thread):
             current_user = pwd.getpwuid(os.getuid())[0]
             if current_user != job.username:
                 if hasattr(job, 'preserve_env') and job.preserve_env is True:
-                    cmd = ['sudo', '-E', '-u', job.username] + cmd
+                    cmd = (copy.copy(self.du.sudo_cmd) +
+                           ['-E', '-u', job.username] + cmd)
                 else:
-                    cmd = ['sudo', '-u', job.username] + cmd
+                    cmd = (copy.copy(self.du.sudo_cmd) +
+                           ['-u', job.username] + cmd)
 
             self.logger.debug(cmd)
 
@@ -14556,7 +14558,7 @@ class PBSInitServices(object):
                        sched, comm or all
         :type daemon: str
         """
-        init_cmd = ['sudo']
+        init_cmd = copy.copy(self.du.sudo_cmd)
         if daemon is not None and daemon != 'all':
             conf = self.du.parse_pbs_config(hostname, conf_file)
             dconf = {

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -43,6 +43,7 @@ import logging
 import traceback
 import math
 from subprocess import Popen, PIPE
+import copy
 
 from ptl.utils.pbs_dshutils import DshUtils
 from ptl.lib.pbs_testlib import BatchUtils, Server, NODE, JOB, SET, EQ
@@ -295,7 +296,7 @@ class PBSLogUtils(object):
         try:
             if hostname is None or self.du.is_localhost(hostname):
                 if sudo:
-                    cmd = ['sudo', 'cat', log]
+                    cmd = copy.copy(self.sudo_cmd) + ['cat', log]
                     self.logger.info('running ' + " ".join(cmd))
                     p = Popen(cmd, stdout=PIPE)
                     f = p.stdout
@@ -304,7 +305,7 @@ class PBSLogUtils(object):
             else:
                 cmd = ['ssh', hostname]
                 if sudo:
-                    cmd += ['sudo']
+                    cmd += self.du.sudo_cmd
                 cmd += ['cat', log]
                 self.logger.debug('running ' + " ".join(cmd))
                 p = Popen(cmd, stdout=PIPE)

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -1723,7 +1723,8 @@ quit()
                     # PTL run_cmd's sudo will try to run the script
                     # itself with sudo, not the cmd
                     # So, append sudo as a prefix to the cmd instead
-                    cmd_list_cpy[0] = "sudo " + cmd_list_cpy[0]
+                    cmd_list_cpy[0] = (' '.join(self.du.sudo_cmd) +
+                                       cmd_list_cpy[0])
             else:
                 as_script = False
                 if key in sudo_cmds:

--- a/test/tests/functional/pbs_highreslog.py
+++ b/test/tests/functional/pbs_highreslog.py
@@ -172,7 +172,8 @@ class TestHighResLogging(TestFunctional):
         conf_path = self.du.parse_pbs_config()
         pbs_init = os.path.join(os.sep, conf_path['PBS_EXEC'],
                                 'libexec', 'pbs_init.d')
-        cmd = ['sudo', 'PBS_LOG_HIGHRES_TIMESTAMP=1', pbs_init, 'restart']
+        cmd = copy.copy(self.du.sudo_cmd)
+        cmd += ['PBS_LOG_HIGHRES_TIMESTAMP = 1', pbs_init, 'restart']
         self.du.run_cmd(cmd=cmd, as_script=True, wait_on_script=True)
         j = Job(TEST_USER)
         jid = self.server.submit(j)

--- a/test/tests/functional/pbs_init_script.py
+++ b/test/tests/functional/pbs_init_script.py
@@ -59,9 +59,10 @@ class TestPbsInitScript(TestFunctional):
         conf['PBS_START_MOM'] = '0'
         self.du.set_pbs_config(confs=conf)
 
-        cmd = ['sudo', 'PBS_START_SERVER=0', 'PBS_START_SCHED=0',
-               'PBS_START_COMM=0', 'PBS_START_MOM=1',
-               pbs_init, 'start']
+        cmd = copy.copy(self.du.sudo_cmd)
+        cmd += ['PBS_START_SERVER=0', 'PBS_START_SCHED=0',
+                'PBS_START_COMM=0', 'PBS_START_MOM=1',
+                pbs_init, 'start']
 
         rc = self.du.run_cmd(cmd=cmd, as_script=True)
         output = rc['out']


### PR DESCRIPTION
#### Describe Bug or Feature
Some usages of `sudo` are hardcoded instead of using the one provided by `PTL_SUDO_CMD`.


#### Describe Your Change
Instead of hard-coding `sudo`, use a copy of `DshUtil.sudo_cmd`


#### Attach Test and Valgrind Logs/Output
I added a fake `sudo` to my path that would just exit, then ran smoketest with `PTL_SUDO_CMD=/usr/bin/sudo`
[smoketest2.txt](https://github.com/PBSPro/pbspro/files/3488348/smoketest2.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
