### PR TITLE
Revert PBS_cray_jacs HK and CF files in PTL on Shasta

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5087,6 +5087,20 @@ class Server(PBSService):
                                           'lib', 'python', 'altair',
                                           'pbs_hooks',
                                           'PBS_translate_mpp.HK')
+        self.jacs_hk = os.path.join(self.pbs_conf['PBS_HOME'],
+                                     'server_priv', 'hooks',
+                                     'PBS_cray_jacs.HK')
+        self.dflt_jacs_hk = os.path.join(self.pbs_conf['PBS_EXEC'],
+                                          'lib', 'python', 'altair',
+                                          'pbs_hooks',
+                                          'PBS_cray_jacs.HK')
+        self.jacs_cf = os.path.join(self.pbs_conf['PBS_HOME'],
+                                     'server_priv', 'hooks',
+                                     'PBS_cray_jacs.CF')
+        self.dflt_jacs_cf = os.path.join(self.pbs_conf['PBS_EXEC'],
+                                          'lib', 'python', 'altair',
+                                          'pbs_hooks',
+                                          'PBS_cray_jacs.CF')
         if server_stat is None:
             server_stat = self.status(SERVER, level=logging.DEBUG)[0]
         for k in server_stat.keys():
@@ -5105,7 +5119,8 @@ class Server(PBSService):
         if self.platform == 'cray' or self.platform == 'craysim':
             setdict[ATTR_restrict_res_to_release_on_suspend] = 'ncpus'
         if delhooks:
-            if self.platform == 'cray' or self.platform == 'craysim':
+            if (self.platform == 'cray' or self.platform == 'craysim' or 
+               self.platform == 'shasta'):
                 reverthooks = True
             else:
                 reverthooks = False
@@ -5163,6 +5178,20 @@ class Server(PBSService):
                     self.du.run_copy(self.hostname, self.dflt_mpp_hook,
                                      self.mpp_hook, mode=0644, sudo=True)
                     self.signal('-HUP')
+            if self.platform == 'shasta':
+                dohup = False
+                if (self.du.cmp(self.hostname, self.dflt_jacs_hk,
+                               self.jacs_hk, sudo=True) != 0):
+                    self.du.run_copy(self.hostname, self.dflt_jacs_hk,
+                                     self.jacs_hk, mode=0644, sudo=True)
+                    dohup = True
+                if self.du.cmp(self.hostname, self.dflt_jacs_cf,
+                               self.jacs_cf, sudo=True) != 0:
+                    self.du.run_copy(self.hostname, self.dflt_jacs_cf,
+                                     self.jacs_cf, mode=0644, sudo=True)
+                    dohup = True
+                if dohup:
+                    self.signal('-HUP')               
             hooks = self.status(HOOK, level=logging.DEBUG)
             hooks = [h['id'] for h in hooks]
             a = {ATTR_enable: 'false'}

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5088,19 +5088,19 @@ class Server(PBSService):
                                           'pbs_hooks',
                                           'PBS_translate_mpp.HK')
         self.jacs_hk = os.path.join(self.pbs_conf['PBS_HOME'],
-                                     'server_priv', 'hooks',
-                                     'PBS_cray_jacs.HK')
+                                    'server_priv', 'hooks',
+                                    'PBS_cray_jacs.HK')
         self.dflt_jacs_hk = os.path.join(self.pbs_conf['PBS_EXEC'],
-                                          'lib', 'python', 'altair',
-                                          'pbs_hooks',
-                                          'PBS_cray_jacs.HK')
+                                         'lib', 'python', 'altair',
+                                         'pbs_hooks',
+                                         'PBS_cray_jacs.HK')
         self.jacs_cf = os.path.join(self.pbs_conf['PBS_HOME'],
-                                     'server_priv', 'hooks',
-                                     'PBS_cray_jacs.CF')
+                                    'server_priv', 'hooks',
+                                    'PBS_cray_jacs.CF')
         self.dflt_jacs_cf = os.path.join(self.pbs_conf['PBS_EXEC'],
-                                          'lib', 'python', 'altair',
-                                          'pbs_hooks',
-                                          'PBS_cray_jacs.CF')
+                                         'lib', 'python', 'altair',
+                                         'pbs_hooks',
+                                         'PBS_cray_jacs.CF')
         if server_stat is None:
             server_stat = self.status(SERVER, level=logging.DEBUG)[0]
         for k in server_stat.keys():
@@ -5119,7 +5119,7 @@ class Server(PBSService):
         if self.platform == 'cray' or self.platform == 'craysim':
             setdict[ATTR_restrict_res_to_release_on_suspend] = 'ncpus'
         if delhooks:
-            if (self.platform == 'cray' or self.platform == 'craysim' or 
+            if (self.platform == 'cray' or self.platform == 'craysim' or
                self.platform == 'shasta'):
                 reverthooks = True
             else:
@@ -5181,7 +5181,7 @@ class Server(PBSService):
             if self.platform == 'shasta':
                 dohup = False
                 if (self.du.cmp(self.hostname, self.dflt_jacs_hk,
-                               self.jacs_hk, sudo=True) != 0):
+                                self.jacs_hk, sudo=True) != 0):
                     self.du.run_copy(self.hostname, self.dflt_jacs_hk,
                                      self.jacs_hk, mode=0644, sudo=True)
                     dohup = True
@@ -5191,7 +5191,7 @@ class Server(PBSService):
                                      self.jacs_cf, mode=0644, sudo=True)
                     dohup = True
                 if dohup:
-                    self.signal('-HUP')               
+                    self.signal('-HUP')
             hooks = self.status(HOOK, level=logging.DEBUG)
             hooks = [h['id'] for h in hooks]
             a = {ATTR_enable: 'false'}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
revert_to_defaults needed modification so the PBS_cray_jacs.HK and PBS_cray_jacs.CF files would be reverted to the original settings before each test.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added code to check what platform, and on "shasta" platforms revert the above files.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1327235075/Support+PTL+on+Shasta


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

I tested by changing the HK and CF files in PBS_HOME to make sure they reverted.
And I didn't change anything to ensure no reverting (copy) was necessary.
[revert_copy_needed.txt](https://github.com/PBSPro/pbspro/files/3494729/revert_copy_needed.txt)
[revert_no_copy.txt](https://github.com/PBSPro/pbspro/files/3494730/revert_no_copy.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->