### PR TITLE
Changed class name PtlTestRunner to PtlTextTestRunner

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -410,7 +410,7 @@ class _PtlTestResult(unittest.TestResult):
         self.logger.info('\n'.join(msg))
 
 
-class PtlTestRunner(TextTestRunner):
+class PtlTextTestRunner(TextTestRunner):
 
     """
     Test runner that uses ``PtlTestResult`` to enable errorClasses,
@@ -529,7 +529,7 @@ class PTLTestRunner(Plugin):
         """
         Prepare test runner
         """
-        return PtlTestRunner(verbosity=3, config=self.config)
+        return PtlTextTestRunner(verbosity=3, config=self.config)
 
     def prepareTestResult(self, result):
         """


### PR DESCRIPTION
#### Describe Bug or Feature
The ptl_test_runner.py file contains two classes with the same name and different capitalization.  
ptl_test_runner.py contains class PtlTestRunner and  class PTLTestRunner
They do different things which is  confusing.  
We  should probably name these two classes differently.


#### Describe Your Change
Changed class name PtlTestRunner to PtlTextTestRunner in ptl_test_runner.py file



#### Attach Test and Valgrind Logs/Output





