### PR TITLE
Error structure leaks in preemption code

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3252,6 +3252,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 		free_server(nsinfo);
 		free(pjobs);
 		free(prjobs);
+		free_schd_error(err);
 		return NULL;
 	}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Error structure leaks in scheduler's preemption code when there are no preemptible candidates found.

#### Describe Your Change
added free

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
No new test needed. Running TestJobArray tests reproduces the leak. Attached are the valgrind reports
[sched_master.txt](https://github.com/PBSPro/pbspro/files/3499300/sched_master.txt)
[sched_after_change.txt](https://github.com/PBSPro/pbspro/files/3499301/sched_after_change.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
