### PR TITLE
Reorder python path so Altair's python comes first in the path.

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -210,10 +210,10 @@ schedinit(void)
 	path = PySys_GetObject("path");
 
 	snprintf(buf, sizeof(buf), "%s/python/lib/python2.7", pbs_conf.pbs_exec_path);
-	PyList_Append(path, PyString_FromString(buf));
+	PyList_Insert(path, 0, PyString_FromString(buf));
 
 	snprintf(buf, sizeof(buf), "%s/python/lib/python2.7/lib-dynload", pbs_conf.pbs_exec_path);
-	PyList_Append(path, PyString_FromString(buf));
+	PyList_Insert(path, 0, PyString_FromString(buf));
 
 	PySys_SetObject("path", path);
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The scheduler's python path was a little messed up.  We would append two PBSEXEC/python paths onto it.  This is since Altair ships python with its packages.  The problem with this is python would use the system python first, and if anything further was needed, it'd use Altair's python.  Combining two versions of python is bad.

#### Describe Your Change
I now prepend PBSEXEC's python to the python path.  If it is there (Altair's packages), it will be used.  If it is not (OSS packages), it will be skipped and the system python will be used.

The smoke test from Travis should be enough to show python isn't broken.  There are formula tests in there.