### PR TITLE
tpp packet headers initialization

### DIFF
--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -522,6 +522,7 @@ leaf_post_connect_handler(int tfd, void *data, void *c)
 			int alen;
 
 			/* send a TPP_CTL_AUTH message */
+			memset(&ahdr, 0, sizeof(tpp_auth_pkt_hdr_t)); /* only to satisfy valgrind */
 			ahdr.type = TPP_CTL_AUTH;
 			ahdr.auth_type = tpp_conf->auth_type;
 			if (tpp_conf->get_ext_auth_data == NULL) {
@@ -554,6 +555,7 @@ leaf_post_connect_handler(int tfd, void *data, void *c)
 		}
 
 		/* send a TPP_CTL_JOIN message */
+		memset(&hdr, 0, sizeof(tpp_join_pkt_hdr_t)); /* only to satisfy valgrind */
 		hdr.type = TPP_CTL_JOIN;
 		hdr.node_type = tpp_conf->node_type;
 		hdr.hop = 1;
@@ -2199,6 +2201,7 @@ tpp_mcast_send(int mtfd, void *data, unsigned int len, unsigned int full_len, un
 #endif
 
 	/* header data */
+	memset(&mhdr, 0, sizeof(tpp_mcast_pkt_hdr_t)); /* only to satisfy valgrind */
 	mhdr.type = TPP_MCAST_DATA;
 	mhdr.hop = 0;
 	mhdr.data_cmprsd_len = htonl(cmprsd_len);
@@ -2820,6 +2823,7 @@ shelve_mcast_pkt(tpp_mcast_pkt_hdr_t *mcast_hdr, int sd, int seq, tpp_packet_t *
 	if (!strm)
 		return -1;
 
+	memset(&indiv_dhdr, 0, sizeof(tpp_data_pkt_hdr_t)); /* only to satisfy valgrind */
 	indiv_dhdr.type = TPP_DATA;
 	indiv_dhdr.src_sd = htonl(strm->sd);
 	indiv_dhdr.src_magic = htonl(strm->src_magic);

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -506,6 +506,7 @@ router_post_connect_handler(int tfd, void *data, void *c)
 			int alen;
 
 			/* send a TPP_CTL_AUTH message */
+			memset(&ahdr, 0, sizeof(tpp_auth_pkt_hdr_t)); /* only to satisfy valgrind */
 			ahdr.type = TPP_CTL_AUTH;
 			ahdr.auth_type = tpp_conf->auth_type;
 			if (tpp_conf->get_ext_auth_data == NULL) {
@@ -539,6 +540,7 @@ router_post_connect_handler(int tfd, void *data, void *c)
 		}
 
 		/* send a TPP_CTL_JOIN message */
+		memset(&hdr, 0, sizeof(tpp_join_pkt_hdr_t)); /* only to satisfy valgrind */
 		hdr.type = TPP_CTL_JOIN;
 		hdr.node_type = TPP_ROUTER_NODE;
 		hdr.hop = 1;
@@ -624,6 +626,8 @@ router_close_handler_inner(int tfd, int error, void *c, int hop)
 		TPP_DBPRT(("tfd = %d, No context, leaving", tfd));
 		return 0;
 	}
+
+	memset(&hdr, 0, sizeof(tpp_leave_pkt_hdr_t)); /* only to satisfy valgrind */
 
 	if (ctx->type == TPP_LEAF_NODE || ctx->type == TPP_LEAF_NODE_LISTEN) {
 
@@ -997,6 +1001,7 @@ router_timer_handler(time_t now)
 	if (send_update == 1) {
 		int len;
 
+		memset(&hdr, 0, sizeof(tpp_ctl_pkt_hdr_t)); /* only to satisfy valgrind */
 		hdr.type = TPP_CTL_MSG;
 		hdr.code = TPP_MSG_UPDATE;
 
@@ -1527,6 +1532,7 @@ router_pkt_handler(int tfd, void *data, int len, void *c)
 			tpp_log_func(LOG_INFO, NULL, tpp_get_logbuf());
 
 			/* set common things here */
+			memset(&shdr, 0, sizeof(tpp_data_pkt_hdr_t)); /* only to satisfy valgrind */
 			shdr.type = TPP_DATA;
 			shdr.ack_seq = htonl(UNINITIALIZED_INT);
 			shdr.dup = 0;

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -875,6 +875,7 @@ tpp_send_ctl_msg(int fd, int code, tpp_addr_t *src, tpp_addr_t *dest, unsigned i
 	/* send a packet back to where the original packet came from
 	 * basically reverse src and dest
 	 */
+	memset(&lhdr, 0, sizeof(tpp_ctl_pkt_hdr_t)); /* only to satisfy valgrind */
 	lhdr.type = TPP_CTL_MSG;
 	lhdr.code = code;
 	lhdr.src_sd = htonl(src_sd);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Not a bug or feature. This contribution is only to satisfy valgrind for future feature(s). While implementing another feature, I face some valgrind errors like:

==3512== Use of uninitialised value of size 8
==3512==    at 0x6F4B917: ??? (in /usr/lib/x86_64-linux-gnu/libhcrypto.so.4.1.0)
==3512==    by 0x6F3D59C: hc_AES_cbc_encrypt (in /usr/lib/x86_64-linux-gnu/libhcrypto.so.4.1.0)
==3512==    by 0x6F46924: ??? (in /usr/lib/x86_64-linux-gnu/libhcrypto.so.4.1.0)
==3512==    by 0x529FE55: ??? (in /usr/lib/x86_64-linux-gnu/libkrb5.so.26.0.0)
==3512==    by 0x529D27E: krb5_encrypt_ivec (in /usr/lib/x86_64-linux-gnu/libkrb5.so.26.0.0)
==3512==    by 0x529D2EA: krb5_encrypt (in /usr/lib/x86_64-linux-gnu/libkrb5.so.26.0.0)
==3512==    by 0x551002F: ??? (in /usr/lib/x86_64-linux-gnu/libgssapi.so.3.0.0)
==3512==    by 0x5519920: ??? (in /usr/lib/x86_64-linux-gnu/libgssapi.so.3.0.0)
==3512==    by 0x420030: pbs_gss_wrap (pbs_gss.c:680)
==3512==    by 0x411207: gss_pkt_presend_handler (tpp_gss.c:262)
==3512==    by 0x40E638: send_data (tpp_transport.c:2150)
==3512==    by 0x40D75A: handle_cmd (tpp_transport.c:1513)

#### Describe Your Change
There are uninitialized packet headers on several places in the code. This is not dangerous now but is better to address it. In this contribution, I found and initialized all *_pkt_hdr structures that are not initialized yet (some *_pkt_hdr are already initialized with a short note that it is only for valgrind). 

#### Link to Design Doc
None


#### Attach Test and Valgrind Logs/Output
[ptl_smoke_pkt_hdr_init.txt](https://github.com/PBSPro/pbspro/files/3505086/ptl_smoke_pkt_hdr_init.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
