### PR TITLE
Support win_2019 server OS

### DIFF
--- a/src/lib/Libwin/ruserok.c
+++ b/src/lib/Libwin/ruserok.c
@@ -280,7 +280,7 @@ ruserok(const char *rhost, int superuser, const char *ruser, const char *luser)
 
 	/* check hosts.equiv file if luser is not superuser */
 	if( !superuser && \
-		chk_file_sec(hosts_equiv, 0, 0, WRITES_MASK, 0) == 0 && \
+		chk_file_sec(hosts_equiv, 0, 0, WRITES_MASK^FILE_WRITE_EA, 0) == 0 && \
 		  match_hosts_equiv_entry(hosts_equiv, rhost, ruser, luser) )
 		return (0);
 

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -2697,7 +2697,7 @@ do_mom_action_script(int	ae,	/* index into action table */
 		if (pnoq)
 			free(pnoq);
 		return -1;
-	} else if (pnoq && chk_file_sec(pnoq, 0, 0, WRITES_MASK, 0)) {
+	} else if (pnoq && chk_file_sec(pnoq, 0, 0, WRITES_MASK^FILE_WRITE_EA, 0)) {
 		sprintf(log_buffer, "action %s script %s cannot be executed "
 			"due to permissions", ma->ma_name, ma->ma_script);
 		log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_JOB, LOG_INFO,
@@ -4191,7 +4191,7 @@ set_checkpoint_path(char *value)
 	}
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
 #ifdef	WIN32
-	rc = chk_file_sec(newpath, 1, 0, WRITES_MASK, 0);
+	rc = chk_file_sec(newpath, 1, 0, WRITES_MASK^FILE_WRITE_EA, 0);
 #else
 	rc = chk_file_sec(newpath, 1, 0, S_IWGRP|S_IWOTH, 0);
 #endif	/* WIN32 */
@@ -5005,7 +5005,7 @@ read_config(char *file)
 	}
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
 #ifdef	WIN32
-	if (chk_file_sec(file, 0, 0, WRITES_MASK, 0)) {
+	if (chk_file_sec(file, 0, 0, WRITES_MASK^FILE_WRITE_EA, 0)) {
 		sprintf(log_buffer,
 			"warning: %s file has a non-secure file access mask", file);
 		log_err(errno, __func__, log_buffer);
@@ -8777,11 +8777,11 @@ main(int argc, char *argv[])
 #ifdef	WIN32
 	/* For windows, don't check full path. Let system put in default */
 	/* permissions for top-level directories */
-	c |= chk_file_sec(path_jobs,   1, 0, WRITES_MASK, 0);
-	c |= chk_file_sec(path_hooks,   1, 0, WRITES_MASK, 0);
-	c |= chk_file_sec(path_hooks_workdir,   1, 0, WRITES_MASK, 0);
+	c |= chk_file_sec(path_jobs,   1, 0, WRITES_MASK^FILE_WRITE_EA, 0);
+	c |= chk_file_sec(path_hooks,   1, 0, WRITES_MASK^FILE_WRITE_EA, 0);
+	c |= chk_file_sec(path_hooks_workdir,   1, 0, WRITES_MASK^FILE_WRITE_EA, 0);
 	c |= chk_file_sec(path_spool,  1, 1, 0, 0);
-	c |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, WRITES_MASK, 0);
+	c |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, WRITES_MASK^FILE_WRITE_EA, 0);
 #else
 	c |= chk_file_sec(path_jobs,   1, 0, S_IWGRP|S_IWOTH, 1);
 	c |= chk_file_sec(path_hooks,   1, 0, S_IWGRP|S_IWOTH, 1);
@@ -10395,9 +10395,10 @@ main(int argc, char *argv[])
 		int	i, j;
 
 		pap = create_arg_param();
-		if (pap == NULL)
+		if (pap == NULL) {
 			ErrorMessage("create_arg_param");
 			return 1;
+		}
 
 		pap->argc = argc-1;	/* don't pass the second argument */
 		for (i=j=0; i < argc; i++) {

--- a/src/resmom/prolog.c
+++ b/src/resmom/prolog.c
@@ -276,7 +276,7 @@ int   pe_io_type;
 			return (pelog_err(pjob, pelog, errno, "cannot stat"));
 	}
 #ifdef WIN32
-	else if (chk_file_sec(pelog, 0, 0, WRITES_MASK, 0))
+	else if (chk_file_sec(pelog, 0, 0, WRITES_MASK^FILE_WRITE_EA, 0))
 #else
 	else if ((sbuf.st_uid != 0) ||
 		(! S_ISREG(sbuf.st_mode)) ||

--- a/src/scheduler/pbs_sched_win.c
+++ b/src/scheduler/pbs_sched_win.c
@@ -386,7 +386,7 @@ read_config(char *file)
 
 #if !defined(DEBUG) && !defined(NO_SECURITY_CHECK)
 #ifdef WIN32
-	if (chk_file_sec(file, 0, 0, WRITES_MASK, 0))
+	if (chk_file_sec(file, 0, 0, WRITES_MASK^FILE_WRITE_EA, 0))
 #else
 	if (chk_file_sec(file, 0, 0, S_IWGRP|S_IWOTH, 1))
 #endif
@@ -1124,8 +1124,8 @@ main(int argc, char *argv[])
 #ifdef WIN32
 	/* For windows, do not check full path. Allow system to put in */
 	/* default permissions for top-level directories */
-	c  = chk_file_sec(log_buffer, 1, 0, WRITES_MASK, 0);
-	c |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, WRITES_MASK, 0);
+	c  = chk_file_sec(log_buffer, 1, 0, WRITES_MASK^FILE_WRITE_EA, 0);
+	c |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, WRITES_MASK^FILE_WRITE_EA, 0);
 #else
 	c  = chk_file_sec(log_buffer, 1, 0, S_IWGRP|S_IWOTH, 1);
 	c |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, S_IWGRP|S_IWOTH, 0);
@@ -1747,9 +1747,10 @@ main(int argc, char *argv[])
 		int	i, j;
 
 		pap = create_arg_param();
-		if (pap == NULL)
+		if (pap == NULL) {
 			ErrorMessage("create_arg_param");
 			return 1;
+		}
 
 		pap->argc = argc-1;	/* don't pass the second argument */
 		for (i=j=0; i < argc; i++) {

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -612,7 +612,7 @@ pbsd_init(int type)
 #ifdef WIN32
 	/* For windows, DO NOT check full path - allow Windows system */
 	/* to put in appropriate defaults for permission */
-	rc  = chk_file_sec(path_jobs,   1, 0, WRITES_MASK, 0);
+	rc  = chk_file_sec(path_jobs,   1, 0, WRITES_MASK^FILE_WRITE_EA, 0);
 
 	/* my version of lstat() using Windows call is more reliable */
 	if (lstat(path_users, &statbuf) != 0) {
@@ -620,12 +620,12 @@ pbsd_init(int type)
 		secure_file(path_users, NULL, 0);
 	}
 
-	rc |= chk_file_sec(path_users,  1, 0, WRITES_MASK, 0);
-	rc |= chk_file_sec(path_hooks,  1, 0, WRITES_MASK, 0);
-	rc |= chk_file_sec(path_hooks_workdir,  1, 0, WRITES_MASK, 0);
+	rc |= chk_file_sec(path_users,  1, 0, WRITES_MASK^FILE_WRITE_EA, 0);
+	rc |= chk_file_sec(path_hooks,  1, 0, WRITES_MASK^FILE_WRITE_EA, 0);
+	rc |= chk_file_sec(path_hooks_workdir,  1, 0, WRITES_MASK^FILE_WRITE_EA, 0);
 	rc |= chk_file_sec(path_spool,  1, 1, 0, 0);	/* allows others to write */
-	rc |= chk_file_sec(path_acct,	1, 1, WRITES_MASK, 0);
-	rc |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, WRITES_MASK, 0);
+	rc |= chk_file_sec(path_acct,	1, 1, WRITES_MASK^FILE_WRITE_EA, 0);
+	rc |= chk_file_sec(pbs_conf.pbs_environment, 0, 0, WRITES_MASK^FILE_WRITE_EA, 0);
 #else
 	rc  = chk_file_sec(path_jobs,   1, 0, S_IWGRP|S_IWOTH, 1);
 	if (stat(path_users, &statbuf) != 0)
@@ -1204,7 +1204,7 @@ pbsd_init(int type)
 #ifdef WIN32
 	secure_file(path_track, "Administrators", READS_MASK|WRITES_MASK|STANDARD_RIGHTS_REQUIRED);
 	setmode(fd, O_BINARY);
-	if (chk_file_sec(path_track,  0, 0, WRITES_MASK, 0) != 0)
+	if (chk_file_sec(path_track,  0, 0, WRITES_MASK^FILE_WRITE_EA, 0) != 0)
 #else
 	if (chk_file_sec(path_track,  0, 0, S_IWGRP|S_IWOTH, 0) != 0)
 #endif
@@ -1276,7 +1276,7 @@ pbsd_init(int type)
 #ifdef WIN32
 	secure_file(path_prov_track, "Administrators", READS_MASK|WRITES_MASK|STANDARD_RIGHTS_REQUIRED);
 	setmode(fd, O_BINARY);
-	if (chk_file_sec(path_prov_track,  0, 0, WRITES_MASK, 0) != 0)
+	if (chk_file_sec(path_prov_track,  0, 0, WRITES_MASK^FILE_WRITE_EA, 0) != 0)
 #else
 	if (chk_file_sec(path_prov_track,  0, 0, S_IWGRP|S_IWOTH, 0) != 0)
 #endif

--- a/src/tools/chk_tree.c
+++ b/src/tools/chk_tree.c
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 	for (i=optind; i < argc; ++i) {
 #ifdef WIN32
 		/* we're not checking fullpath */
-		j = chk_file_sec(argv[i], dir, sticky, WRITES_MASK, 0);
+		j = chk_file_sec(argv[i], dir, sticky, WRITES_MASK^FILE_WRITE_EA, 0);
 #else
 		j = chk_file_sec(argv[i], dir, sticky, S_IWGRP|S_IWOTH, 1);
 #endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Support Windows server 2019

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* All the Microsoft Windows operating systems(WIN 10 Desktop OS [Version **10.0.17763.615**] & Windows **server 2019**) which are based 1809v code line has security enhancement feature(undocumented, but there is official response in this forum. [link](https://social.technet.microsoft.com/Forums/azure/en-US/e9b94c25-631b-4923-b318-b5a29704437b/file-and-folder-permission-problem-in-windows-10-v1809?forum=win10itprosecurity))
* This feature is about granting "special permissions" to protect the files & folders for Universal Windows Platform(UWP) applications. 
* As part of this, there is an extra permission bit enabled namely "FILE_WRITE_EA" (File write for entended attributes; this is totally **different from file write permission**) for all the files.
* Our PBS Pro security module would generally check the file permissions on PBS_HOME folder before starting the services.  Those checks are failing at new windows machines and preventing the services at starting phase. (On Linux machines, the security module would check just 2 bits, write permission for others and groups)
* The fix for this problem would be validating the file against following bits "FILE_WRITE_DATA|FILE_ADD_FILE|FILE_APPEND_DATA|FILE_ADD_SUBDIRECTORY|FILE_DELETE_CHILD|FILE_WRITE_ATTRIBUTES" and ignoring special bit "FILE_WRITE_EA" for supporting latest OS's with UWP apps.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_logs.txt](https://github.com/PBSPro/pbspro/files/3508117/test_logs.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
