### PR TITLE
installed ptl (via make install) is not usable because missing __init__.py in ptl folder && PTL rpm does not include utils/jobs dir

### DIFF
--- a/test/fw/Makefile.am
+++ b/test/fw/Makefile.am
@@ -59,6 +59,10 @@ ptlpkg_pylib_pluginsdir = $(ptlpkg_pylib_utilsdir)/plugins
 
 dist_ptlpkg_pylib_plugins_PYTHON = $(wildcard $(srcdir)/ptl/utils/plugins/*.py)
 
+ptlpkg_pylib_jobsdir = $(ptlpkg_pylib_utilsdir)/jobs
+
+dist_ptlpkg_pylib_jobs_PYTHON = $(wildcard $(srcdir)/ptl/utils/jobs/*.py)
+
 sysprofiledir = /etc/profile.d
 
 dist_sysprofile_DATA = \

--- a/test/fw/Makefile.am
+++ b/test/fw/Makefile.am
@@ -45,7 +45,7 @@ dist_ptlpkg_bin_SCRIPTS = $(wildcard $(srcdir)/bin/*)
 
 ptlpkg_pylib_topdir = ${ptl_prefix}/lib/python$(PYTHON_VERSION)/site-packages/ptl
 
-dist_ptlpkg_pylib_top_PYTHON = ptl/__init__.py
+dist_ptlpkg_pylib_top_PYTHON = $(wildcard $(srcdir)/ptl/*.py $(builddir)/ptl/*.py)
 
 ptlpkg_pylib_libdir = $(ptlpkg_pylib_topdir)/lib
 

--- a/test/fw/Makefile.am
+++ b/test/fw/Makefile.am
@@ -45,7 +45,7 @@ dist_ptlpkg_bin_SCRIPTS = $(wildcard $(srcdir)/bin/*)
 
 ptlpkg_pylib_topdir = ${ptl_prefix}/lib/python$(PYTHON_VERSION)/site-packages/ptl
 
-dist_ptlpkg_pylib_top_PYTHON = $(wildcard $(srcdir)/ptl/*.py)
+dist_ptlpkg_pylib_top_PYTHON = ptl/__init__.py
 
 ptlpkg_pylib_libdir = $(ptlpkg_pylib_topdir)/lib
 


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* 1->The \_\_init\_\_.py file is not being installed via make when ran from a different folder
* 2->The newly added jobs/utils folder was missing from makefile, thus the files were missing from rpm.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* 1->It was not able to find the file in the specified directory, made it so that it is able to locate the correct file.
* 2-> Made suitable changes to the makefile to include these files.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

* Found after make install:
~/git_chng/pbspro$ ls /opt/ptl/lib/python2.7/site-packages/ptl/
\_\_init_\_\.py  \_\_init_\_\.pyc  \_\_init\_\_.pyo  lib  utils
* [sanidhya@centos7 commercial_build]$ rpm -qlp buildwork/17.2.0.20190816143014/cdrom/pbspro-ptl-17.2.0.20190816143014-0.el7.x86_64.rpm | grep utils/j
/opt/ptl/lib/python2.7/site-packages/ptl/utils/jobs
/opt/ptl/lib/python2.7/site-packages/ptl/utils/jobs/eatcpu.py
/opt/ptl/lib/python2.7/site-packages/ptl/utils/jobs/eatcpu.pyc
/opt/ptl/lib/python2.7/site-packages/ptl/utils/jobs/eatcpu.pyo

* Find both logs in comments.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
