### PR TITLE
build fails as make attempts to copy multiple __init__.py

### DIFF
--- a/test/fw/Makefile.am
+++ b/test/fw/Makefile.am
@@ -45,7 +45,7 @@ dist_ptlpkg_bin_SCRIPTS = $(wildcard $(srcdir)/bin/*)
 
 ptlpkg_pylib_topdir = ${ptl_prefix}/lib/python$(PYTHON_VERSION)/site-packages/ptl
 
-dist_ptlpkg_pylib_top_PYTHON = $(wildcard $(srcdir)/ptl/*.py $(builddir)/ptl/*.py)
+dist_ptlpkg_pylib_top_PYTHON = $(wildcard $(builddir)/ptl/*.py)
 
 ptlpkg_pylib_libdir = $(ptlpkg_pylib_topdir)/lib
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Build was failing as make was  trying to copy __init__.py file multiple times.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Removed $(srcdir)/ptl/__init__.py and now taking it only from $(builddir)

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[build.txt](https://github.com/PBSPro/pbspro/files/3511608/build.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
