### PR TITLE
ncpus_are_cores=true test in TestCgroupsHook

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1522,9 +1522,9 @@ if %s e.job.in_ms_mom():
             for line in desc:
                 if re.match('^processor', line):
                     pcpus += 1
-                sibs_match = re.search(r'siblings	: ([1-9]+)', line)
-                cores_match = re.search(r'cpu cores	: ([1-9]+)', line)
-                phys_match = re.search(r'physical id	: ([1-9]+)', line)
+                sibs_match = re.search(r'siblings	: ([0-9]+)', line)
+                cores_match = re.search(r'cpu cores	: ([0-9]+)', line)
+                phys_match = re.search(r'physical id	: ([0-9]+)', line)
                 if sibs_match:
                     sibs = int(sibs_match.groups()[0])
                 if cores_match:
@@ -1547,7 +1547,7 @@ if %s e.job.in_ms_mom():
         njobs = phys * cores
         a = {'Resource_List.select': '1:ncpus=1:mem=300mb:host=%s' %
              self.hosts_list[0], ATTR_N: name + 'a'}
-        for j in range(njobs):
+        for _ in range(njobs):
             j = Job(TEST_USER, attrs=a)
             j.create_script(self.cpuset_mem_script)
             jid = self.server.submit(j)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1512,8 +1512,12 @@ if %s e.job.in_ms_mom():
         enabled system when ncpus_are_cores is set to true.
         """
         # Check that system has hyperthreading enabled and has two processors
-        pcpus = 0; sibs = 0; cores = 0
-        pval = 0; phys = 1; prev = 0
+        pcpus = 0
+        sibs = 0
+        cores = 0
+        pval = 0
+        phys = 1
+        prev = 0
         with open('/proc/cpuinfo', 'r') as desc:
             for line in desc:
                 if re.match('^processor', line):

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1524,7 +1524,7 @@ if %s e.job.in_ms_mom():
                     pcpus += 1
                 sibs_match = re.search(r'siblings	: ([1-9]+)', line)
                 cores_match = re.search(r'cpu cores	: ([1-9]+)', line)
-                phys_match = re.search(r'physical id    : ([1-9]+)', line)
+                phys_match = re.search(r'physical id	: ([1-9]+)', line)
                 if sibs_match:
                     sibs = int(sibs_match.groups()[0])
                 if cores_match:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
There is a need for a test for setting ncpus_are_cores = true in TestCgroupsHook.

#### Describe Your Change
Added a new PTL test for ncpus_are_cores = true in TestCgroupsHook.

#### Attach Test and Valgrind Logs/Output
1) test skipped on system without hyperthreading enabled:
[test_cgroup_cpuset_ncpus_are_cores_td09_19.4_after.txt](https://github.com/PBSPro/pbspro/files/3517563/test_cgroup_cpuset_ncpus_are_cores_td09_19.4_after.txt)

2) test ran and passed on system with hyperthreading enabled:
[test_cgroup_cpuset_ncpus_are_cores_td08_19.4_after.txt](https://github.com/PBSPro/pbspro/files/3517566/test_cgroup_cpuset_ncpus_are_cores_td08_19.4_after.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
