### PR TITLE
Server Memleak while provisioning

### DIFF
--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -4874,7 +4874,7 @@ find_prov_vnode_list(job *pjob, exec_vnode_listtype *prov_vnodes, char **aoe_nam
 		if (*p == '+')
 			num_of_exec_vnodes++;
 	}
-	/* Allocate tempory memory to hold execvnod attribute */
+	/* Allocate temporary memory to hold execvnod attribute */
 	sbuf = strdup(execvnod);
 	if (sbuf == NULL)
 		return -1;
@@ -4931,15 +4931,27 @@ find_prov_vnode_list(job *pjob, exec_vnode_listtype *prov_vnodes, char **aoe_nam
 					DBPRT(("%s: %s\n", __func__, (*prov_vnodes)[i]))
 					++i;
 					if (aoe_name != NULL) {
-						aoe = malloc(strlen(((pkvp + k)->kv_val)) + 1);
-						if (aoe == NULL) {
-							free(sbuf);
-							free(pbuf);
-							return -1;
+						if (*aoe_name) {
+							if (strcmp(*aoe_name, ((pkvp + k)->kv_val)) != 0) {
+								/* Aoe name can not be different across chunks, it's an error */
+								free(sbuf);
+								free(pbuf);
+								free(*aoe_name);
+								return -1;
+							}
+						} else {
+							aoe = malloc(strlen(((pkvp + k)->kv_val)) + 1);
+							if (aoe == NULL) {
+								free(sbuf);
+								free(pbuf);
+								if (*aoe_name)
+									free(*aoe_name);
+								return -1;
+							}
+							strcpy(aoe, ((pkvp + k)->kv_val));
+							aoe[strlen((pkvp + k)->kv_val)] = '\0';
+							(*aoe_name) = aoe;
 						}
-						strcpy(aoe, ((pkvp + k)->kv_val));
-						aoe[strlen((pkvp + k)->kv_val)] = '\0';
-						(*aoe_name) = aoe;
 						DBPRT(("%s: %s\n", __func__, (*aoe_name)))
 					}
 					break;
@@ -5042,8 +5054,10 @@ free_prov_vnode(struct pbsnode * pnode)
 	struct prov_vnode_info * prov_vnode_info = NULL;
 
 	if (pnode->nd_state & INUSE_WAIT_PROV) {
-		if ((prov_vnode_info = find_prov_vnode(pnode)))
+		if ((prov_vnode_info = find_prov_vnode(pnode))) {
 			delete_link(&prov_vnode_info->al_link);
+			free_pvnfo(prov_vnode_info);
+		}
 
 		set_vnode_state(pnode, ~INUSE_WAIT_PROV, Nd_State_And);
 	}

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -4940,16 +4940,12 @@ find_prov_vnode_list(job *pjob, exec_vnode_listtype *prov_vnodes, char **aoe_nam
 								return -1;
 							}
 						} else {
-							aoe = malloc(strlen(((pkvp + k)->kv_val)) + 1);
+							aoe = strdup((pkvp + k)->kv_val);
 							if (aoe == NULL) {
 								free(sbuf);
 								free(pbuf);
-								if (*aoe_name)
-									free(*aoe_name);
 								return -1;
 							}
-							strcpy(aoe, ((pkvp + k)->kv_val));
-							aoe[strlen((pkvp + k)->kv_val)] = '\0';
 							(*aoe_name) = aoe;
 						}
 						DBPRT(("%s: %s\n", __func__, (*aoe_name)))
@@ -5051,7 +5047,7 @@ static struct prov_vnode_info * find_prov_vnode(struct pbsnode * pnode)
 void
 free_prov_vnode(struct pbsnode * pnode)
 {
-	struct prov_vnode_info * prov_vnode_info = NULL;
+	struct prov_vnode_info *prov_vnode_info = NULL;
 
 	if (pnode->nd_state & INUSE_WAIT_PROV) {
 		if ((prov_vnode_info = find_prov_vnode(pnode))) {

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -12791,9 +12791,8 @@ class MoM(PBSService):
             try:
                 nodes = self.server.status(NODE, id=self.shortname)
                 if nodes:
-                    self.server.expect(NODE, {'state': 'free',
-                                              'state': 'provisioning'},
-                                       id=self.shortname, attrop=PTL_OR)
+                    attr = {'state': (MATCH_RE, 'free|provisioning')}
+                    self.server.expect(NODE, attr, id=self.shortname)
             # Ignore PbsStatusError if mom daemon is up but there aren't
             # any mom nodes
             except PbsStatusError:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1739,8 +1739,8 @@ class BatchUtils(object):
                     _e = len(lines) - 1
                     lines[_e] = lines[_e].strip('\r\n\t') + \
                         l[i].strip('\r\n\t')
-                elif (not l[i].startswith(' ') and i > count
-                        and l[i-count].startswith('\t')):
+                elif (not l[i].startswith(' ') and i > count and
+                      l[i-count].startswith('\t')):
                     _e = len(lines) - count
                     lines[_e] = lines[_e] + l[i]
                     if ((i+1) < len(l) and not l[i+1].startswith(('\t', ' '))):
@@ -12791,8 +12791,9 @@ class MoM(PBSService):
             try:
                 nodes = self.server.status(NODE, id=self.shortname)
                 if nodes:
-                    self.server.expect(NODE, {'state': 'free'},
-                                       id=self.shortname)
+                    self.server.expect(NODE, {'state': 'free',
+                                              'state': 'provisioning'},
+                                       id=self.shortname, attrop=PTL_OR)
             # Ignore PbsStatusError if mom daemon is up but there aren't
             # any mom nodes
             except PbsStatusError:

--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -94,9 +94,6 @@ e.reject()
         # Remove all nodes
         self.server.manager(MGR_CMD_DELETE, NODE, None, "")
 
-        # Restart PBS
-        self.server.restart()
-
         # Create node
         self.server.manager(MGR_CMD_CREATE, NODE, None, self.hostA)
         self.server.manager(MGR_CMD_CREATE, NODE, None, self.hostB)
@@ -438,3 +435,47 @@ e.reject()
         self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
         job_state = self.server.status(JOB, id=jid3)
         self.assertEqual(job_state[0]['exec_vnode'], solution)
+
+    def test_multinode_provisioning(self):
+        """
+        Test the effect of max_concurrent_provision
+        If set to 1 and job requests a 4 node provision, the provision should
+        occur 1 node at a time
+        """
+
+        # Setup provisioning hook with smaller alarm.
+        a = {'event': 'provision', 'enabled': 'True', 'alarm': '5'}
+        rv = self.server.create_import_hook(
+            'fake_prov_hook', a, self.fake_prov_hook, overwrite=True)
+
+        # delete all nodes
+        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
+
+        a = {'max_concurrent_provision': 1}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        a = {'resources_available.aoe': 'App1,osimage1',
+             'current_aoe': 'App1',
+             'provision_enable': 'True',
+             'resources_available.ncpus': 1}
+        rv = self.server.create_vnodes('vnode', a, 4, self.momA,
+                                       sharednode=False)
+        self.assertTrue(rv)
+        j = Job(TEST_USER,
+                attrs={'Resource_List.select': '4:ncpus=1:aoe=osimage1'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R',
+                           'substate': 71}, attrop=PTL_AND, id=jid)
+        exp_msg = "Provisioning vnode vnode\[[0-3]\] with AOE osimage1 started"
+        logs = self.server.log_match(msg=exp_msg, regexp=True, allmatch=True)
+
+        # since max_concurrent_provision is 1, there should be only one
+        # log
+        self.assertEqual(len(logs), 1)
+
+        # A node in provisioning state cannot be deleted. In order to make
+        # sure that cleanup happens properly do the following -
+        # sleep for a few seconds so that provisin timesout and the node
+        # is marked offline and then delete all the nodes
+        time.sleep(8)
+        # delete all nodes
+        self.server.manager(MGR_CMD_DELETE, NODE, None, "")

--- a/test/tests/functional/pbs_provisioning_enhancement.py
+++ b/test/tests/functional/pbs_provisioning_enhancement.py
@@ -448,9 +448,6 @@ e.reject()
         rv = self.server.create_import_hook(
             'fake_prov_hook', a, self.fake_prov_hook, overwrite=True)
 
-        # delete all nodes
-        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
-
         a = {'max_concurrent_provision': 1}
         self.server.manager(MGR_CMD_SET, SERVER, a)
         a = {'resources_available.aoe': 'App1,osimage1',


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS server leaks memory on two occasions when doing provisioning
First - 
==74671== 27 bytes in 3 blocks are definitely lost in loss record 98 of 2,414
==74671==    at 0x4C29BE3: malloc (vg_replace_malloc.c:299)
==74671==    by 0x482ACB: find_prov_vnode_list (svr_func.c:4934)
==74671==    by 0x483F71: check_and_enqueue_provisioning (svr_func.c:6504)
==74671==    by 0x470225: check_and_provision_job (req_runjob.c:189)
==74671==    by 0x470225: req_runjob2 (req_runjob.c:649)
==74671==    by 0x470AB7: req_runjob (req_runjob.c:500)
==74671==    by 0x4B046B: process_socket (net_server.c:504)
==74671==    by 0x4B059D: wait_request (net_server.c:585)
==74671==    by 0x42AA29: main (pbsd_main.c:2141)

Second - 
==72496== 1,062 (1,008 direct, 54 indirect) bytes in 3 blocks are definitely lost in loss record 1,425 of 1,609
==72496==    at 0x4C2B975: calloc (vg_replace_malloc.c:711)
==72496==    by 0x484039: check_and_enqueue_provisioning (svr_func.c:6527)
==72496==    by 0x470225: check_and_provision_job (req_runjob.c:189)
==72496==    by 0x470225: req_runjob2 (req_runjob.c:649)
==72496==    by 0x470AB7: req_runjob (req_runjob.c:500)
==72496==    by 0x4B046B: process_socket (net_server.c:504)
==72496==    by 0x4B059D: wait_request (net_server.c:585)
==72496==    by 0x42AA29: main (pbsd_main.c:2141)


#### Describe Your Change
For the first leak - Server used to allocate memory to note the aoe name that it is going to provision the node info but when aoe name is present in multiple chunks of execvnode, it used to overwrite the previously allocated memory with newer aoe_name. This is not needed because for a job all chunks have to request the same aoe_name.
For the second leak - PBS server used to add prov_vnode_info structure corresponding to each vnode into a list. When free_prov_vnode() gets called to clear up this list, it used to just unlink the prov_vnode_info structure from the list and not delete it.

In addition to the above two problems, there is a fix in PTL framework as well.
In the framework mom.restart() fails to restart the mom when it is in provisioning state. This is because mom.isUP() function returns True only when mom is in 'free' state. This means for provisioning state isUp() function was returning False and thus mom.restart() was not working properly.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[svr_leak_before_fix.txt](https://github.com/PBSPro/pbspro/files/3518116/svr_leak_before_fix.txt)
[svr_leak_after_fix.txt](https://github.com/PBSPro/pbspro/files/3518117/svr_leak_after_fix.txt)
[test_prov.txt](https://github.com/PBSPro/pbspro/files/3518118/test_prov.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
