### PR TITLE
Test 'test_arrayjob_Erecord_startval' of TestJobarray is failing while verifying the log msg in accounting logs

### DIFF
--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -48,7 +48,7 @@ class TestJobArray(TestFunctional):
         Check that an arrayjob's E record's 'start' value is not set to 0
         """
         j = Job(TEST_USER, attrs={
-            ATTR_J: '1-2',
+            ATTR_J: '1-2', ATTR_k: 'oe',
             'Resource_List.select': 'ncpus=1'
         })
         j.set_sleep_time(1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test is trying to search for E record in accounting logs for a job array but on few machines few of the sub jobs are in E state due to which the parent subjob is not completed by the time the test is searching for E record in accounting logs.

#### Describe Your Change

- submit job with -koe option.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_TestJobArray_aftr_fix.txt](https://github.com/PBSPro/pbspro/files/3520184/Execution_logs_TestJobArray_aftr_fix.txt)

- [Execution_logs_TestJobArray_bfr_fix.txt](https://github.com/PBSPro/pbspro/files/3520185/Execution_logs_TestJobArray_bfr_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
