### PR TITLE
Allow jobs with $reject_root_scripts to get held

### DIFF
--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -204,6 +204,7 @@ extern char *form_attr_comment(const char *template, const char *execvnode);
 extern void complete_running(job *);
 extern void am_jobs_add(job *);
 extern int  was_job_alteredmoved(job *);
+extern void check_failed_attempts(job *);
 #endif
 #ifdef	_QUEUE_H
 extern int   check_entity_ct_limit_max(job *pjob, pbs_queue *pque);

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -2116,38 +2116,7 @@ RetryJob:
 					/* and requeue job				*/
 					pjob->ji_qs.ji_substate = JOB_SUBSTATE_RERUN2;
 				}
-				if (pjob->ji_wattr[(int)JOB_ATR_runcount].at_val.at_long >
-#ifdef NAS /* localmod 083 */
-					PBS_MAX_HOPCOUNT
-#else
-					PBS_MAX_HOPCOUNT + PBS_MAX_HOPCOUNT
-#endif /* localmod 083 */
-				) {
-					pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long |= HOLD_s;
-					pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |=
-						ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
-					job_attr_def[(int)JOB_ATR_Comment].at_decode(
-						&pjob->ji_wattr[(int)JOB_ATR_Comment],
-						NULL, NULL,
-						"job held, too many failed attempts to run");
-
-					if (pjob->ji_parentaj) {
-						char comment_buf[100 + PBS_MAXSVRJOBID];
-						svr_setjobstate(pjob->ji_parentaj, JOB_STATE_HELD, JOB_SUBSTATE_HELD);
-						pjob->ji_parentaj->ji_wattr[(int)JOB_ATR_hold].\
-						      at_val.at_long |= HOLD_s;
-						pjob->ji_parentaj->ji_wattr[(int)JOB_ATR_hold].\
-							at_flags |=
-							ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
-						sprintf(comment_buf, "Job Array Held, too many failed attempts to run subjob %s",
-								pjob->ji_qs.ji_jobid);
-						job_attr_def[(int)JOB_ATR_Comment].\
-						at_decode(\
-							&pjob->ji_parentaj->ji_wattr[(int)JOB_ATR_Comment],
-							NULL, NULL,
-							comment_buf);
-					}
-				}
+				check_failed_attempts(pjob);
 				break;
 
 			case JOB_EXEC_BADRESRT:

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1278,6 +1278,34 @@ parse_hook_rejectmsg(char *reject_msg, char *hook_name, int hook_name_size)
 
 /**
  * @brief
+ *		Check and put a hold on a job if it has already been run
+ *		too many times.
+ *
+ * @param[in,out]	pjob	-	job pointer
+ *
+ * @return	void
+ */
+static void
+check_failed_attempts(job *jobp)
+{
+	if (jobp->ji_wattr[(int)JOB_ATR_runcount].at_val.at_long > PBS_MAX_HOPCOUNT + PBS_MAX_HOPCOUNT) {
+		jobp->ji_wattr[(int)JOB_ATR_hold].at_val.at_long |= HOLD_s;
+		jobp->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		job_attr_def[(int)JOB_ATR_Comment].at_decode(&jobp->ji_wattr[(int)JOB_ATR_Comment], NULL, NULL, "job held, too many failed attempts to run");
+
+		if (jobp->ji_parentaj) {
+			char comment_buf[100 + PBS_MAXSVRJOBID];
+			svr_setjobstate(jobp->ji_parentaj, JOB_STATE_HELD, JOB_SUBSTATE_HELD);
+			jobp->ji_parentaj->ji_wattr[(int)JOB_ATR_hold].at_val.at_long |= HOLD_s;
+			jobp->ji_parentaj->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+			sprintf(comment_buf, "Job Array Held, too many failed attempts to run subjob %s", jobp->ji_qs.ji_jobid);
+			job_attr_def[(int)JOB_ATR_Comment].at_decode(&jobp->ji_parentaj->ji_wattr[(int)JOB_ATR_Comment], NULL, NULL, comment_buf);
+		}
+	}
+}
+
+/**
+ * @brief
  * 		post_sendmom - clean up action for child started in send_job
  *		which was sending a job "home" to MOM
  * @par
@@ -1459,6 +1487,9 @@ post_sendmom(struct work_task *pwt)
 			/* if the job is a normal job or a subjob */
 			set_attr_svr(&(jobp->ji_wattr[(int) JOB_ATR_Comment]), &job_attr_def[(int) JOB_ATR_Comment], log_buffer);
 
+			if (pbs_errno == PBSE_MOM_REJECT_ROOT_SCRIPTS)
+				check_failed_attempts(jobp);
+
 		}
 
 		/* in the case of hook error we parse the hook_name and hook msg */
@@ -1591,39 +1622,7 @@ post_sendmom(struct work_task *pwt)
 				} else if ((r == SEND_JOB_HOOKERR) ||
 					(r == SEND_JOB_HOOK_REJECT) ||
 					(r == SEND_JOB_HOOK_REJECT_RERUNJOB)) {
-
-					if (jobp->ji_wattr[(int)JOB_ATR_runcount].\
-				     at_val.at_long >
-						PBS_MAX_HOPCOUNT + PBS_MAX_HOPCOUNT) {
-						jobp->ji_wattr[(int)JOB_ATR_hold].\
-						      at_val.at_long |= HOLD_s;
-						jobp->ji_wattr[(int)JOB_ATR_hold].\
-							at_flags |=
-							ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
-						job_attr_def[(int)JOB_ATR_Comment].\
-						at_decode(\
-							&jobp->ji_wattr[(int)JOB_ATR_Comment],
-							NULL, NULL,
-							"job held, too many failed attempts to run");
-
-						if (jobp->ji_parentaj) {
-							char comment_buf[100 + PBS_MAXSVRJOBID];
-							svr_setjobstate(jobp->ji_parentaj, JOB_STATE_HELD, JOB_SUBSTATE_HELD);
-							jobp->ji_parentaj->ji_wattr[(int)JOB_ATR_hold].\
-							      at_val.at_long |= HOLD_s;
-							jobp->ji_parentaj->ji_wattr[(int)JOB_ATR_hold].\
-								at_flags |=
-								ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
-							sprintf(comment_buf, "Job Array Held, too many failed attempts to run subjob %s",
-									jobp->ji_qs.ji_jobid);
-							job_attr_def[(int)JOB_ATR_Comment].\
-							at_decode(\
-								&jobp->ji_parentaj->ji_wattr[(int)JOB_ATR_Comment],
-								NULL, NULL,
-								comment_buf);
-						}
-					}
-
+					check_failed_attempts(jobp);
 					if (r == SEND_JOB_HOOKERR) {
 						hook	*phook;
 						phook = find_hook(hook_name);

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -59,6 +59,7 @@
  *	where_to_runjob()
  *	assign_hosts()
  *	req_defschedreply()
+ *	check_failed_attempts()
  *
  */
 
@@ -1285,10 +1286,16 @@ parse_hook_rejectmsg(char *reject_msg, char *hook_name, int hook_name_size)
  *
  * @return	void
  */
-static void
+void
 check_failed_attempts(job *jobp)
 {
-	if (jobp->ji_wattr[(int)JOB_ATR_runcount].at_val.at_long > PBS_MAX_HOPCOUNT + PBS_MAX_HOPCOUNT) {
+	if (jobp->ji_wattr[(int)JOB_ATR_runcount].at_val.at_long >
+#ifdef NAS /* localmod 083 */
+		PBS_MAX_HOPCOUNT
+#else
+		PBS_MAX_HOPCOUNT + PBS_MAX_HOPCOUNT
+#endif /* localmod 083 */
+	) {
 		jobp->ji_wattr[(int)JOB_ATR_hold].at_val.at_long |= HOLD_s;
 		jobp->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
 		job_attr_def[(int)JOB_ATR_Comment].at_decode(&jobp->ji_wattr[(int)JOB_ATR_Comment], NULL, NULL, "job held, too many failed attempts to run");


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Jobs submitted as root with job script, and mom's config file has $reject_root_scripts turned true, indefinitely gets reject and rerun.
* It's expected for the job to get rejected, but it should also eventually get held after too many retries (21).


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* When server received a PBSE_REJECT_ROOT_SCRIPTS error from mom trying to start a job, the code for checking failed attempts must be called and allow job to be held after too many retries.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [ptl.root_owned_scripts.td-08.txt](https://github.com/PBSPro/pbspro/files/3526809/ptl.root_owned_scripts.td-08.txt)
* [ptl.pbs_root_owned_script.PASS.txt](https://github.com/PBSPro/pbspro/files/3526826/ptl.pbs_root_owned_script.PASS.txt)
* [ptl.pbs_root_owned_script.FAIL.txt](https://github.com/PBSPro/pbspro/files/3526827/ptl.pbs_root_owned_script.FAIL.txt)
* [valgrind.server.31375.txt](https://github.com/PBSPro/pbspro/files/3526829/valgrind.server.31375.txt)






<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
