### PR TITLE
Refactor job's run/end_event pointers to not dangle

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3284,10 +3284,8 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 
 		update_universe_on_end(npolicy, pjob,  "S", NO_ALLPART);
 		rjobs_count--;
-		if (pjob->end_event != NULL) {
-				if (delete_event(nsinfo, pjob->end_event, DE_NO_FLAGS) == 0)
-					schdlog(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_INFO, pjob->name, "Failed to delete end event for job.");
-		}
+		if (pjob->end_event != NULL)
+			delete_event(nsinfo, pjob->end_event);
 
 		pjobs[j] = pjob;
 		j++;

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -284,6 +284,13 @@ free_resource_resv(resource_resv *resresv)
 	if (resresv->node_set != NULL)
 		free(resresv->node_set);
 
+	/* Avoid dangling pointers inside the calendar */
+	if (resresv->run_event != NULL)
+		delete_event(resresv->server, resresv->run_event);
+
+	if (resresv->end_event != NULL)
+		delete_event(resresv->server, resresv->end_event);
+
 	free(resresv);
 }
 
@@ -2329,8 +2336,8 @@ in_runnable_state(resource_resv *resresv)
 		if (resresv->job->is_susp_sched)
 			return 1;
 	}
-	else if (resresv->is_resv && resresv->resv !=NULL) {
-		if (resresv->resv->resv_state ==RESV_CONFIRMED)
+	else if (resresv->is_resv && resresv->resv != NULL) {
+		if (resresv->resv->resv_state == RESV_CONFIRMED)
 			return 1;
 	}
 

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -253,7 +253,7 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 
 		resresv->duration = resresv->resv->req_duration;
 		resresv->hard_duration = resresv->duration;
-		if (resresv->resv->resv_state !=RESV_UNCONFIRMED) {
+		if (resresv->resv->resv_state != RESV_UNCONFIRMED) {
 			resresv->start = resresv->resv->req_start;
 			if(resresv->resv->resv_state == RESV_BEING_DELETED ||
 			   resresv->start + resresv->duration <= sinfo->server_time) {

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -1554,16 +1554,17 @@ delete_event(server_info *sinfo, timed_event *e)
 
 	if (calendar->next_event == e)
 		calendar->next_event = e->next;
+	
+	if (calendar->first_run_event == e)
+		calendar->first_run_event = find_timed_event(calendar->events, 0, NULL, TIMED_RUN_EVENT, 0);
 
-	if (e->prev == NULL) {
+	if (e->prev == NULL)
 		calendar->events = e->next;
-		if (e->next != NULL)
-			e->next->prev = NULL;
-	} else {
+	else
 		e->prev->next = e->next;
-		if (e->next != NULL)
-			e->next->prev = e->prev;
-	}
+
+	if (e->next != NULL)
+		e->next->prev = e->prev;
 
 	free_timed_event(e);
 }

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -1080,6 +1080,11 @@ new_timed_event()
 /**
  * @brief
  * 		dup_timed_event() - timed_event copy constructor
+ * 
+ * @par
+ * 		dup_timed_event() modifies the run_event and end_event memebers of the resource_resv.
+ * 		If dup_timed_event() is not called as part of dup_server_info(), the resource_resvs of
+ * 		the main server_info will be modified, even if server_info->calendar is not.
  *
  * @param[in]	ote 	- timed_event to copy
  * @param[in] 	nsinfo 	- "new" universe where to find the event_ptr
@@ -1091,31 +1096,16 @@ timed_event *
 dup_timed_event(timed_event *ote, server_info *nsinfo)
 {
 	timed_event *nte;
+	event_ptr_t *event_ptr;
 
 	if (ote == NULL || nsinfo == NULL)
 		return NULL;
 
-	nte = new_timed_event();
-
-	if (nte == NULL)
+	event_ptr = find_event_ptr(ote, nsinfo);
+	if (event_ptr == NULL)
 		return NULL;
 
-	nte->disabled = ote->disabled;
-	nte->event_type = ote->event_type;
-	nte->event_time = ote->event_time;
-	nte->event_func = ote->event_func;
-	nte->event_func_arg = ote->event_func_arg;
-	nte->event_ptr = find_event_ptr(ote, nsinfo);
-
-	if (nte->event_ptr == NULL) {
-		free_timed_event(nte);
-		return NULL;
-	}
-
-	if (determine_event_name(nte) == 0) {
-		free_timed_event(nte);
-		return NULL;
-	}
+	nte = create_event(ote->event_type, ote->event_time, event_ptr, ote->event_func, ote->event_func_arg);
 
 	return nte;
 }
@@ -1371,15 +1361,12 @@ dup_timed_event_list(timed_event *ote_list, server_info *nsinfo)
 
 	for (ote = ote_list; ote != NULL; ote = ote->next) {
 		nte = dup_timed_event(ote, nsinfo);
-		if (nte->event_type & TIMED_RUN_EVENT)
-			((resource_resv *)nte->event_ptr)->run_event = nte;
-		if (nte->event_type & TIMED_END_EVENT)
-			((resource_resv *)nte->event_ptr)->end_event = nte;
 
 		if (nte_prev != NULL)
 			nte_prev->next = nte;
 		else
 			nte_head = nte;
+		nte->prev = nte_prev;
 
 		nte_prev = nte;
 	}
@@ -1398,6 +1385,12 @@ free_timed_event(timed_event *te)
 {
 	if (te == NULL)
 		return;
+	if (te->event_ptr != NULL) {
+		if (te->event_type & TIMED_RUN_EVENT)
+			((resource_resv *)te->event_ptr)->run_event = NULL;
+		if (te->event_type & TIMED_END_EVENT)
+			((resource_resv *)te->event_ptr)->end_event = NULL;
+	}
 
 	free(te);
 }
@@ -1452,11 +1445,6 @@ add_event(event_list *calendar, timed_event *te)
 		events_is_null = 1;
 
 	calendar->events = add_timed_event(calendar->events, te);
-
-	if (te->event_type & TIMED_RUN_EVENT)
-		((resource_resv *)te->event_ptr)->run_event = te;
-	else if (te->event_type & TIMED_END_EVENT)
-		((resource_resv *)te->event_ptr)->end_event = te;
 
 	/* empty event list - the new event is the only event */
 	if (events_is_null)
@@ -1530,6 +1518,7 @@ add_timed_event(timed_event *events, timed_event *te)
 
 	if (eloop_prev == NULL) {
 		te->next = events;
+		events->prev = te;
 		te->prev = NULL;
 		return te;
 	}
@@ -1537,6 +1526,8 @@ add_timed_event(timed_event *events, timed_event *te)
 	te->next = eloop;
 	eloop_prev->next = te;
 	te->prev = eloop_prev;
+	if (eloop != NULL)
+		eloop->prev = te;
 
 	return events;
 }
@@ -1547,54 +1538,34 @@ add_timed_event(timed_event *events, timed_event *te)
  *
  * @param[in] sinfo    - sinfo which contains calendar to delete from
  * @param[in] e        - event to delete
- * @param[in] flags    - flag bitfield
- *						 DE_UNLINK - unlink event and don't free
  *
- * @return int
- * @retval 1 event was successfully deleted
- * @retval 0 failure
+ * @return void
  */
 
-int
-delete_event(server_info *sinfo, timed_event *e, unsigned int flags)
+void
+delete_event(server_info *sinfo, timed_event *e)
 {
-	timed_event *cur_e;
-	timed_event *prev_e = NULL;
 	event_list *calendar;
 
 	if (sinfo == NULL || e == NULL)
-		return 0;
+		return;
 
 	calendar = sinfo->calendar;
 
+	if (calendar->next_event == e)
+		calendar->next_event = e->next;
 
-	for (cur_e = calendar->events; cur_e != e && cur_e != NULL;
-		prev_e = cur_e, cur_e = cur_e->next)
-			;
-
-	/* found our event to delete */
-	if (cur_e != NULL) {
-		if (calendar->next_event == cur_e)
-			calendar->next_event = cur_e->next;
-
-		if (prev_e == NULL)
-			calendar->events = cur_e->next;
-		else
-			prev_e->next = cur_e->next;
-
-		if ((flags & DE_UNLINK) == 0) {
-			if (cur_e->event_type & TIMED_RUN_EVENT)
-				((resource_resv *)cur_e->event_ptr)->run_event = NULL;
-			else if (cur_e->event_type & TIMED_END_EVENT)
-				((resource_resv *)cur_e->event_ptr)->run_event = NULL;
-
-			free_timed_event(cur_e);
-		}
-
-		return 1;
+	if (e->prev == NULL) {
+		calendar->events = e->next;
+		if (e->next != NULL)
+			e->next->prev = NULL;
+	} else {
+		e->prev->next = e->next;
+		if (e->next != NULL)
+			e->next->prev = e->prev;
 	}
 
-	return 0;
+	free_timed_event(e);
 }
 
 
@@ -1629,6 +1600,11 @@ create_event(enum timed_event_types event_type,
 	te->event_ptr = event_ptr;
 	te->event_func = event_func;
 	te->event_func_arg = event_func_arg;
+
+	if (event_type & TIMED_RUN_EVENT)
+		((resource_resv *)event_ptr)->run_event = te;
+	if (event_type & TIMED_END_EVENT)
+		((resource_resv *)event_ptr)->end_event = te;
 
 	if (determine_event_name(te) == 0) {
 		free_timed_event(te);

--- a/src/scheduler/simulate.h
+++ b/src/scheduler/simulate.h
@@ -320,7 +320,7 @@ int add_event(event_list *calendar, timed_event *te);
 /*
  *	delete_event - delete a timed event from an event list
  */
-int delete_event(server_info *sinfo, timed_event *e, unsigned int flags);
+void delete_event(server_info *sinfo, timed_event *e);
 
 /*
  *      create_event - create a timed_event with the passed in arguemtns


### PR DESCRIPTION
#### Describe Bug or Feature
A recent change went in to have a job/reservation know its run/end event.  It was possible for these pointers to be left dangling if the event is deleted.

Also, the timed_event doubly linked list was broken.  The prev pointers wouldn't properly be updated.

#### Describe Your Change
I've changed the code so the run/end_event pointers are set in create_event() and NULL'd in free_timed_event().  This will ensure the pointers will never dangle, and are set properly.
I changed all timed_event functions to use create_event() and free_timed_event(), so we only have to set/NULL the run/end_event pointers in one place
I fixed add_event(), dup_timed_event_list(), and delete_event() to properly add and delete events using the doubly linked list.  The prev pointer code has been fixed to properly set them.

#### Attach Test and Valgrind Logs/Output
SInce this is a refactor project, no new PTL test was written.  The travis SmokeTest run should be fine to show testing.