### PR TITLE
TestJobRouting.test_t2 failing due to race condition

### DIFF
--- a/test/tests/functional/pbs_job_routing.py
+++ b/test/tests/functional/pbs_job_routing.py
@@ -45,17 +45,9 @@ class TestJobRouting(TestFunctional):
 
     def setUp(self):
         TestFunctional.setUp(self)
-        self.momA = self.moms.values()[0]
-        self.momA.delete_vnode_defs()
-
-        self.hostA = self.momA.shortname
-
-        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
-
-        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
 
         a = {'resources_available.ncpus': 3}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'})
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test 'test_t2' from test suite 'TestJobRouting' failing due to race condition. 
In test scheduling is set to False and submit array job of 3 sub-jobs. After scheduling is set to True and expecting all sub-jobs should be in R state, but jobs remains in 'Q' state with comment 'Not Running: Not enough free nodes available' .
Race condition occurred due to in setUp(), PTL delete and create default node and when scheduling is set to True, but till that point Node is not in free state and jobs remains in 'Q' state. 

#### Describe Your Change
No need of delete and create default node in setUp(). remove the code for the same and after that test passed. 

#### Attach Test and Valgrind Logs/Output
[res_TestJobRouting_after_fix.txt](https://github.com/PBSPro/pbspro/files/3530288/res_TestJobRouting_after_fix.txt)
[res_TestJobRouting_test_t2_after_fix.txt](https://github.com/PBSPro/pbspro/files/3530289/res_TestJobRouting_test_t2_after_fix.txt)
[res_TestJobRouting_test_t2_before_fix.txt](https://github.com/PBSPro/pbspro/files/3530290/res_TestJobRouting_test_t2_before_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
