### PR TITLE
Fixed sched crash due to freeing in wrong order

### DIFF
--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1172,8 +1172,6 @@ free_server_info(server_info *sinfo)
 	if (sinfo->nodes_by_NASrank != NULL)
 		free(sinfo->nodes_by_NASrank);
 #endif
-
-	free(sinfo);
 }
 
 /**
@@ -1700,6 +1698,8 @@ free_server(server_info *sinfo)
 	if (sinfo == NULL)
 		return;
 
+	free_server_info(sinfo);
+
 	free_queues(sinfo->queues);
 	free_nodes(sinfo->nodes);
 	free_resource_resv_array(sinfo->resvs);
@@ -1707,7 +1707,7 @@ free_server(server_info *sinfo)
 #ifdef NAS /* localmod 053 */
 	site_restore_users();
 #endif /* localmod 053 */
-	free_server_info(sinfo);
+	free(sinfo);
 }
 
 /**

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1697,7 +1697,10 @@ free_server(server_info *sinfo)
 {
 	if (sinfo == NULL)
 		return;
-
+	/* We need to free the sinfo first to free the calendar. 
+	 * When the calendar is freed, the job events modify the jobs.  We can't
+	 * free the jobs before then.
+	 */
 	free_server_info(sinfo);
 
 	free_queues(sinfo->queues);


### PR DESCRIPTION
## Describe Bug or Feature
A recent change in the scheduler has the job/resv objects keep track of their run/end events.  When the event is freed, the run/end event on the job/resv is NULL'd.  These objects were freed out of order.  The jobs were freed dangling pointers in the events.  When the events were freed, they'd try and NULL pointers on the already freed job/resv objects and crash

#### Describe Your Change
Free the calendar first before the jobs/resvs.

#### Attach Test and Valgrind Logs/Output
[valgrind-before.log](https://github.com/PBSPro/pbspro/files/3571589/valgrind-before.log)
[valgrind-after.log](https://github.com/PBSPro/pbspro/files/3571588/valgrind-after.log)
grep for free_timed_event