### PR TITLE
remove useless cput check immediately after job submission

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1261,12 +1261,10 @@ if %s e.job.in_ms_mom():
         o = j.attributes[ATTR_o]
         self.tempfile.append(o)
         # Scouring the logs for initial values takes too long
-        resc_list = ['resources_used.cput', 'resources_used.mem']
+        resc_list = ['resources_used.mem']
         if self.swapctl == 'true':
             resc_list.append('resources_used.vmem')
         qstat = self.server.status(JOB, resc_list, id=jid)
-        cput = qstat[0]['resources_used.cput']
-        self.assertEqual(cput, '00:00:00')
         mem = qstat[0]['resources_used.mem']
         match = re.match(r'(\d+)kb', mem)
         self.assertFalse(match is None)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The value of resources_used.cput is checked immediately after submitting job even though we know that the CPU time started at zero, and it will always be greater than or equal to zero.


#### Describe Your Change
Removed reference to resources_used.cput and the assertion that checks its value.


#### Attach Test Logs/Output
[test_cgroup_periodic_update_check_values_a01_19.4_before.txt](https://github.com/PBSPro/pbspro/files/3571945/test_cgroup_periodic_update_check_values_a01_19.4_before.txt)
[test_cgroup_periodic_update_check_values_a01_19.4_after.txt](https://github.com/PBSPro/pbspro/files/3571946/test_cgroup_periodic_update_check_values_a01_19.4_after.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
