### PR TITLE
PTL Changes for Shasta

### DIFF
--- a/test/fw/doc/howtotest.rst
+++ b/test/fw/doc/howtotest.rst
@@ -109,7 +109,7 @@ their functionality by overriding the setUp and/or tearDown methods in your
 own class, for example
 
 ::
-   
+
       class TestMyFix(PBSTestSuite):
 
             def setUp(self):
@@ -119,7 +119,7 @@ own class, for example
 For detailed test directory structure one can refer to below link:
 
 https://pbspro.atlassian.net/wiki/display/DG/PTL+Directory+Structure+and+Naming+Conventions
- 
+
 Writing a test suite
 --------------------
 
@@ -153,6 +153,11 @@ it needs to be skipped.
 
   Tests that inherit from PBSTestSuite inherit a method called ``skipOnCray`` that
   is used to skip tests on Cray platform.
+
+.. topic:: skipOnShasta:
+
+  Tests that inherit from PBSTestSuite inherit a method called ``skipOnShasta`` that
+  is used to skip tests on Cray Shasta platform.
 
 How to add a new attribute to the library
 -----------------------------------------

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13901,7 +13901,6 @@ class Job(ResourceResv):
                          be created
         :type hostname: str or None
         """
-        shasta_set_host = False
 
         if body is None:
             return None
@@ -13938,7 +13937,6 @@ class Job(ResourceResv):
             user = PbsUser.get_user(self.username)
             if user.host:
                 hostname = user.host
-                shasta_set_host = True
                 asuser = user.name
 
         self.script_body = body

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8010,7 +8010,7 @@ class Server(PBSService):
         operation.
 
         :param obj_type: The type of object to query, JOB, SERVER,
-                         SCHEDULER, QUEUE NODE
+                         SCHEDULER, QUEUE, NODE
         :type obj_type: str
         :param attrib: Attributes to query, can be a string, a list,
                        or a dict
@@ -13932,6 +13932,8 @@ class Job(ResourceResv):
                     body[i] = " ".join(line_arr)
             body = '\n'.join(body)
 
+        # If the user has a userhost, the job will run from there
+        # so the script should be made there
         if self.platform == 'shasta' and self.username:
             user = PbsUser.get_user(self.username)
             if user.host:
@@ -13947,10 +13949,6 @@ class Job(ResourceResv):
         fn = self.du.create_temp_file(hostname, prefix='PtlPbsJobScript',
                                       asuser=asuser, body=body)
         self.du.chmod(hostname, fn, mode=0755)
-        # on shasta, if we have already set the hostname,
-        # it does not need to be copied again
-        if not self.du.is_localhost(hostname) and not shasta_set_host:
-            self.du.run_copy(hostname, fn, fn)
         self.script = fn
         return fn
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13933,7 +13933,7 @@ class Job(ResourceResv):
 
         # If the user has a userhost, the job will run from there
         # so the script should be made there
-        if self.platform == 'shasta' and self.username:
+        if self.username:
             user = PbsUser.get_user(self.username)
             if user.host:
                 hostname = user.host

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13937,6 +13937,7 @@ class Job(ResourceResv):
             if user.host:
                 hostname = user.host
                 shasta_set_host = True
+                asuser = user.name
 
         self.script_body = body
         if self.du is None:

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -979,7 +979,8 @@ class DshUtils(object):
                     # TODO: get a valid remote temporary file rather than
                     # assume that the remote host has a similar file
                     # system layout
-                    self.run_copy(hostname, _script, _script, level=level)
+                    self.run_copy(hostname, _script, _script,
+                                  runas=runas, level=level)
                     os.remove(_script)
                 runcmd = rshcmd + sudocmd + [_script]
             else:
@@ -1019,7 +1020,7 @@ class DshUtils(object):
             if as_script:
                 # must pass as_script=False otherwise it will loop infinite
                 self.rm(hostname, path=_script, as_script=False,
-                        level=level)
+                        level=level, runas=runas)
 
             # handle the case where stdout is not a PIPE
             if o is not None:
@@ -1111,6 +1112,9 @@ class DshUtils(object):
         if sudo is True and not self.sudo_cmd:
             sudo = False
 
+        if runas:
+            _runas_user = PbsUser.get_user(runas)
+
         for targethost in hosts:
             islocal = self.is_localhost(targethost)
             if sudo and not islocal:
@@ -1148,6 +1152,9 @@ class DshUtils(object):
                 cmd += copy_cmd
                 if recursive:
                     cmd += ['-r']
+                if (self.get_platform() == 'shasta' and _runas_user and
+                   _runas_user.port):
+                    cmd += ['-P', _runas_user.port]
                 cmd += [src]
                 if islocal:
                     cmd += [dest]

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1950,7 +1950,7 @@ class DshUtils(object):
                 # by default mkstemp creates file with 0600 permission
                 # to create file as different user first change the file
                 # permission to 0644 so that other user has read permission
-                self.chmod(tmpfile, mode=0644)
+                self.chmod(path=tmpfile, mode=0644)
                 # copy temp file created  on local host to remote host
                 # as different user
                 self.run_copy(hostname, tmpfile, tmpfile, runas=asuser,

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1280,6 +1280,12 @@ class DshUtils(object):
         if ipaddr in iplist:
             self._h2l[host] = True
             return True
+        # on a shasta machine, the name returned by `hostname` (pbs-host) is
+        # different than the one we tell PTL to use (pbs-service-nmn).
+        if (self.get_platform() == 'shasta' and host == 'pbs-service-nmn' and
+           localhost == 'pbs-host'):
+            self._h2l[host] = True
+            return True
         self._h2l[host] = False
         return False
 

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1093,7 +1093,6 @@ class DshUtils(object):
         :returns: {'out':<outdata>, 'err': <errdata>, 'rc':<retcode>}
                   upon and None if no source file specified
         """
-        _runas_user = None
 
         if src is None:
             self.logger.warning('no source file specified')

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1933,13 +1933,20 @@ class DshUtils(object):
             else:
                 os.write(fd, body)
         os.close(fd)
+
+        if self.get_platform() == 'shasta' and not hostname and asuser:
+            asuser = PbsUser.get_user(asuser)
+            if asuser.host:
+                self.logger.info('set hostname to userhost')
+                hostname = asuser.host
+
         # if temp file to be created on remote host
         if not self.is_localhost(hostname):
             if asuser is not None:
                 # by default mkstemp creates file with 0600 permission
                 # to create file as different user first change the file
                 # permission to 0644 so that other user has read permission
-                self.chmod(hostname, tmpfile, mode=0644)
+                self.chmod(tmpfile, mode=0644)
                 # copy temp file created  on local host to remote host
                 # as different user
                 self.run_copy(hostname, tmpfile, tmpfile, runas=asuser,
@@ -1948,8 +1955,8 @@ class DshUtils(object):
                 # copy temp file created on localhost to remote as current user
                 self.run_copy(hostname, tmpfile, tmpfile,
                               preserve_permission=False, level=level)
-            # remove local temp file
-            os.unlink(tmpfile)
+                # remove local temp file
+                os.unlink(tmpfile)
         if asuser is not None:
             # by default mkstemp creates file with 0600 permission
             # to create file as different user first change the file

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1019,7 +1019,7 @@ class DshUtils(object):
 
             if as_script:
                 # must pass as_script=False otherwise it will loop infinite
-                if platform == 'shasta' and not runas:
+                if platform == 'shasta' and runas:
                     self.rm(hostname, path=_script, as_script=False,
                             level=level, runas=runas)
                 else:

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -1019,8 +1019,12 @@ class DshUtils(object):
 
             if as_script:
                 # must pass as_script=False otherwise it will loop infinite
-                self.rm(hostname, path=_script, as_script=False,
-                        level=level, runas=runas)
+                if platform == 'shasta' and not runas:
+                    self.rm(hostname, path=_script, as_script=False,
+                            level=level, runas=runas)
+                else:
+                    self.rm(hostname, path=_script, as_script=False,
+                            level=level)
 
             # handle the case where stdout is not a PIPE
             if o is not None:

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -913,7 +913,7 @@ class DshUtils(object):
                 # must be as PbsUser object
                 runas = str(runas)
 
-        if (platform == "shasta") and runas:
+        if runas:
             _runas_user = PbsUser.get_user(runas)
 
         if isinstance(cmd, str):
@@ -1019,12 +1019,8 @@ class DshUtils(object):
 
             if as_script:
                 # must pass as_script=False otherwise it will loop infinite
-                if platform == 'shasta' and runas:
-                    self.rm(hostname, path=_script, as_script=False,
-                            level=level, runas=runas)
-                else:
-                    self.rm(hostname, path=_script, as_script=False,
-                            level=level)
+                self.rm(hostname, path=_script, as_script=False,
+                        level=level, runas=runas)
 
             # handle the case where stdout is not a PIPE
             if o is not None:
@@ -1154,7 +1150,7 @@ class DshUtils(object):
                 cmd += copy_cmd
                 if recursive:
                     cmd += ['-r']
-                if self.get_platform() == 'shasta' and runas and runas.port:
+                if runas and runas.port:
                     cmd += ['-P', runas.port]
                 cmd += [src]
                 if islocal:

--- a/test/fw/ptl/utils/pbs_procutils.py
+++ b/test/fw/ptl/utils/pbs_procutils.py
@@ -173,7 +173,7 @@ class ProcUtils(object):
             platform = sys.platform
 
         try:
-            if platform.startswith('linux'):
+            if platform.startswith('linux') or platform.startswith('shasta'):
                 cmd = ['ps', '-o', 'stat', '-p', str(pid), '--no-heading']
                 rv = self.du.run_cmd(hostname, cmd, level=logging.DEBUG2)
                 return rv['out'][0][0]
@@ -202,7 +202,7 @@ class ProcUtils(object):
 
             childlist = []
 
-            if platform.startswith('linux'):
+            if platform.startswith('linux') or platform.startswith('shasta'):
                 cmd = ['ps', '-o', 'pid', '--ppid:%s' % ppid, '--no-heading']
                 rv = self.du.run_cmd(hostname, cmd)
                 children = rv['out'][:-1]
@@ -292,6 +292,7 @@ class ProcMonitor(threading.Thread):
         """
         self._go = False
         self._Thread__stop()
+
 
 if __name__ == '__main__':
     pm = ProcMonitor(name='.*pbs_server.*|.*pbs_sched.*', regexp=True,

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -148,6 +148,21 @@ def skipOnCray(function):
     return wrapper
 
 
+def skipOnShasta(function):
+    """
+    Decorator to skip a test on a ``Cray Shasta`` system
+    """
+
+    def wrapper(self, *args, **kwargs):
+        if self.mom.is_shasta():
+            self.skipTest(reason='capability not supported on Cray Shasta')
+        else:
+            function(self, *args, **kwargs)
+    wrapper.__doc__ = function.__doc__
+    wrapper.__name__ = function.__name__
+    return wrapper
+
+
 def skipOnCpuSet(function):
     """
     Decorator to skip a test on a CpuSet system

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -877,6 +877,11 @@ class PBSTestSuite(unittest.TestCase):
                 return scppath
         elif conf == "PBS_LOG_HIGHRES_TIMESTAMP":
             return "1"
+        elif conf == "PBS_PUBLIC_HOST_NAME":
+            if hostobj.platform == "shasta" and hosttype == "server":
+                return socket.gethostname()
+            else:
+                return None
 
         return None
 
@@ -1126,6 +1131,13 @@ class PBSTestSuite(unittest.TestCase):
                 new_pbsconf["PBS_LOG_HIGHRES_TIMESTAMP"] = "1"
                 restart_pbs = True
 
+            # if shasta, set PBS_PUBLIC_HOST_NAME
+            if server.platform == 'shasta':
+                localhost = socket.gethostname()
+                if new_pbsconf["PBS_PUBLIC_HOST_NAME"] != localhost:
+                    new_pbsconf["PBS_PUBLIC_HOST_NAME"] = localhost
+                    restart_pbs = True
+
             # Check if existing pbs.conf has more/less entries than the
             # default list
             if len(pbs_conf_val) != len(new_pbsconf):
@@ -1202,7 +1214,12 @@ class PBSTestSuite(unittest.TestCase):
             "PBS_LOG_HIGHRES_TIMESTAMP": None
         }
 
-        self._revert_pbsconf_server(vals_to_set)
+        server_vals_to_set = vals_to_set
+
+        if primary_server.platform == 'shasta':
+            server_vals_to_set["PBS_PUBLIC_HOST_NAME"] = None
+
+        self._revert_pbsconf_server(server_vals_to_set)
 
         self._revert_pbsconf_mom(primary_server, vals_to_set)
 
@@ -1258,7 +1275,7 @@ class PBSTestSuite(unittest.TestCase):
         except PbsManagerError as e:
             self.logger.error(e.msg)
         a = {ATTR_managers: (INCR, current_user + '@*,' +
-             str(MGR_USER) + '@*')}
+                             str(MGR_USER) + '@*')}
         server.manager(MGR_CMD_SET, SERVER, a, sudo=True)
 
         a1 = {ATTR_operators: (INCR, str(OPER_USER) + '@*')}

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1229,7 +1229,7 @@ class PBSTestSuite(unittest.TestCase):
             "PBS_LOG_HIGHRES_TIMESTAMP": None
         }
 
-        server_vals_to_set = vals_to_set
+        server_vals_to_set = copy.deepcopy(vals_to_set)
 
         if primary_server.platform == 'shasta':
             server_vals_to_set["PBS_PUBLIC_HOST_NAME"] = None

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -1495,29 +1495,30 @@ else:
         # Set queue limit
         a = {
             'max_run': '[o:PBS_ALL=100],[g:PBS_GENERIC=20],\
-                       [u:PBS_GENERIC=20],[g:tstgrp01 = 8],[u:pbsuser1=10]'}
+                       [u:PBS_GENERIC=20],[g:tstgrp01 = 8],[u:%s=10]' %
+                       str(TEST_USER1)}
         self.server.manager(MGR_CMD_SET, QUEUE,
                             a, id='workq2')
 
         a = {'max_run_res.ncpus':
              '[o:PBS_ALL=100],[g:PBS_GENERIC=50],\
-             [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:pbsuser1=12]'}
+             [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:%s=12]' % str(TEST_USER1)}
         self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq2')
 
         a = {'max_run_res_soft.ncpus':
              '[o:PBS_ALL=100],[g:PBS_GENERIC=30],\
-             [u:PBS_GENERIC=10],[g:tstgrp01=10],[u:pbsuser1=10]'}
+             [u:PBS_GENERIC=10],[g:tstgrp01=10],[u:%s=10]' % str(TEST_USER1)}
         self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq2')
 
         # Create server limits
         a = {
             'max_run': '[o:PBS_ALL=100],[g:PBS_GENERIC=50],\
-            [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:pbsuser1=13]'}
+            [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:%s=13]' % str(TEST_USER1)}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'max_run_soft':
              '[o:PBS_ALL=50],[g:PBS_GENERIC=25],[u:PBS_GENERIC=10],\
-             [g:tstgrp01=10],[u:pbsuser1=10]'}
+             [g:tstgrp01=10],[u:%s=10]' % str(TEST_USER1)}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Turn scheduling off

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -1495,30 +1495,33 @@ else:
         # Set queue limit
         a = {
             'max_run': '[o:PBS_ALL=100],[g:PBS_GENERIC=20],\
-                       [u:PBS_GENERIC=20],[g:tstgrp01 = 8],[u:%s=10]' %
-                       str(TEST_USER1)}
+                       [u:PBS_GENERIC=20],[g:%s = 8],[u:%s=10]' %
+                       (str(TSTGRP1), str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, QUEUE,
                             a, id='workq2')
 
         a = {'max_run_res.ncpus':
              '[o:PBS_ALL=100],[g:PBS_GENERIC=50],\
-             [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:%s=12]' % str(TEST_USER1)}
+             [u:PBS_GENERIC=20],[g:%s=13],[u:%s=12]' %
+             (str(TSTGRP1), str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq2')
 
         a = {'max_run_res_soft.ncpus':
              '[o:PBS_ALL=100],[g:PBS_GENERIC=30],\
-             [u:PBS_GENERIC=10],[g:tstgrp01=10],[u:%s=10]' % str(TEST_USER1)}
+             [u:PBS_GENERIC=10],[g:%s=10],[u:%s=10]' %
+             (str(TSTGRP1), str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq2')
 
         # Create server limits
         a = {
             'max_run': '[o:PBS_ALL=100],[g:PBS_GENERIC=50],\
-            [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:%s=13]' % str(TEST_USER1)}
+            [u:PBS_GENERIC=20],[g:%s=13],[u:%s=13]' %
+            (str(TSTGRP1), str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'max_run_soft':
              '[o:PBS_ALL=50],[g:PBS_GENERIC=25],[u:PBS_GENERIC=10],\
-             [g:tstgrp01=10],[u:%s=10]' % str(TEST_USER1)}
+             [g:%s=10],[u:%s=10]' % (str(TSTGRP1), str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Turn scheduling off

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -327,6 +327,7 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, a, attrop=PTL_AND)
 
     @skipOnCpuSet
+    @skip('This test is broken for oss')
     def test_finished_jobs(self):
         """
         Test for finished jobs and resource used for jobs.

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -588,6 +588,7 @@ class SmokeTest(PBSTestSuite):
         self.assertEqual(_f1, _f2)
         self.logger.info(str(_f1) + " = " + str(_f2) + " ... OK")
 
+    @skipOnShasta
     def test_staging(self):
         """
         Test for file staging
@@ -1498,6 +1499,7 @@ class SmokeTest(PBSTestSuite):
         self.assertEqual(fs4.usage, 3)
 
     @checkModule("pexpect")
+    @skipOnShasta
     def test_interactive_job(self):
         """
         Submit an interactive job

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -327,7 +327,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, a, attrop=PTL_AND)
 
     @skipOnCpuSet
-    @skip('This test is broken for oss')
     def test_finished_jobs(self):
         """
         Test for finished jobs and resource used for jobs.

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1378,13 +1378,13 @@ class SmokeTest(PBSTestSuite):
                                              validate=False)
         self.scheduler.add_to_resource_group('grp2', 200, 'root', 40,
                                              validate=False)
-        self.scheduler.add_to_resource_group('pbsuser1', 101, 'grp1', 40,
+        self.scheduler.add_to_resource_group(TEST_USER1, 101, 'grp1', 40,
                                              validate=False)
-        self.scheduler.add_to_resource_group('pbsuser2', 102, 'grp1', 20,
+        self.scheduler.add_to_resource_group(TEST_USER2, 102, 'grp1', 20,
                                              validate=False)
-        self.scheduler.add_to_resource_group('pbsuser3', 201, 'grp2', 30,
+        self.scheduler.add_to_resource_group(TEST_USER3, 201, 'grp2', 30,
                                              validate=False)
-        self.scheduler.add_to_resource_group('pbsuser4', 202, 'grp2', 10,
+        self.scheduler.add_to_resource_group(TEST_USER4, 202, 'grp2', 10,
                                              validate=True)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduler_iteration': 7})
         a = {'fair_share': 'True', 'fairshare_decay_time': '24:00:00',

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -135,29 +135,29 @@ class TestJobEquivClassPerf(TestPerformance):
         # Set queue limit
         a = {
             'max_run': '[o:PBS_ALL=100],[g:PBS_GENERIC=20],\
-                       [u:PBS_GENERIC=20],[g:tstgrp01 = 8],[u:pbsuser1=10]'}
+                       [u:PBS_GENERIC=20],[g:tstgrp01 = 8],[u:%s=10]' % str(TEST_USER1)}
         self.server.manager(MGR_CMD_SET, QUEUE,
                             a, id='workq2')
 
         a = {'max_run_res.ncpus':
              '[o:PBS_ALL=100],[g:PBS_GENERIC=50],\
-             [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:pbsuser1=12]'}
+             [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:%s=12]' % str(TEST_USER1)}
         self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq2')
 
         a = {'max_run_res_soft.ncpus':
              '[o:PBS_ALL=100],[g:PBS_GENERIC=30],\
-             [u:PBS_GENERIC=10],[g:tstgrp01=10],[u:pbsuser1=10]'}
+             [u:PBS_GENERIC=10],[g:tstgrp01=10],[u:%s=10]' % str(TEST_USER1)}
         self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq2')
 
         # Set server limits
         a = {
             'max_run': '[o:PBS_ALL=100],[g:PBS_GENERIC=50],\
-            [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:pbsuser1=13]'}
+            [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:%s=13]' % str(TEST_USER1)}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'max_run_soft':
              '[o:PBS_ALL=50],[g:PBS_GENERIC=25],[u:PBS_GENERIC=10],\
-             [g:tstgrp01=10],[u:pbsuser1=10]'}
+             [g:tstgrp01=10],[u:%s=10]' % str(TEST_USER1)}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Turn scheduling off

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -135,8 +135,8 @@ class TestJobEquivClassPerf(TestPerformance):
         # Set queue limit
         a = {
             'max_run': ('[o:PBS_ALL=100],[g:PBS_GENERIC=20],'
-                        '[u:PBS_GENERIC=20],[g:%s = 8],[u:%s=10]'
-                        % str(TEST_USER1))}
+                        '[u:PBS_GENERIC=20],[g:%s = 8],[u:%s=10]' %
+                        (str(TSTGRP1), str(TEST_USER1)))}
         self.server.manager(MGR_CMD_SET, QUEUE,
                             a, id='workq2')
 

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -134,8 +134,9 @@ class TestJobEquivClassPerf(TestPerformance):
 
         # Set queue limit
         a = {
-            'max_run': '[o:PBS_ALL=100],[g:PBS_GENERIC=20],\
-                       [u:PBS_GENERIC=20],[g:tstgrp01 = 8],[u:%s=10]' % str(TEST_USER1)}
+            'max_run': ('[o:PBS_ALL=100],[g:PBS_GENERIC=20],'
+                        '[u:PBS_GENERIC=20],[g:tstgrp01 = 8],[u:%s=10]'
+                        % str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, QUEUE,
                             a, id='workq2')
 

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -135,30 +135,34 @@ class TestJobEquivClassPerf(TestPerformance):
         # Set queue limit
         a = {
             'max_run': ('[o:PBS_ALL=100],[g:PBS_GENERIC=20],'
-                        '[u:PBS_GENERIC=20],[g:tstgrp01 = 8],[u:%s=10]'
+                        '[u:PBS_GENERIC=20],[g:%s = 8],[u:%s=10]'
                         % str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, QUEUE,
                             a, id='workq2')
 
         a = {'max_run_res.ncpus':
              '[o:PBS_ALL=100],[g:PBS_GENERIC=50],\
-             [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:%s=12]' % str(TEST_USER1)}
+             [u:PBS_GENERIC=20],[g:%s=13],[u:%s=12]' %
+             (str(TSTGRP1), str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq2')
 
         a = {'max_run_res_soft.ncpus':
              '[o:PBS_ALL=100],[g:PBS_GENERIC=30],\
-             [u:PBS_GENERIC=10],[g:tstgrp01=10],[u:%s=10]' % str(TEST_USER1)}
+             [u:PBS_GENERIC=10],[g:%s=10],[u:%s=10]' %
+             (str(TSTGRP1), str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq2')
 
         # Set server limits
         a = {
             'max_run': '[o:PBS_ALL=100],[g:PBS_GENERIC=50],\
-            [u:PBS_GENERIC=20],[g:tstgrp01=13],[u:%s=13]' % str(TEST_USER1)}
+            [u:PBS_GENERIC=20],[g:%s=13],[u:%s=13]' %
+            (str(TSTGRP1), str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         a = {'max_run_soft':
              '[o:PBS_ALL=50],[g:PBS_GENERIC=25],[u:PBS_GENERIC=10],\
-             [g:tstgrp01=10],[u:%s=10]' % str(TEST_USER1)}
+             [g:%s=10],[u:%s=10]' %
+             (str(TSTGRP1), str(TEST_USER1))}
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Turn scheduling off

--- a/test/tests/performance/pbs_jobperf.py
+++ b/test/tests/performance/pbs_jobperf.py
@@ -70,7 +70,7 @@ class TestJobPerf(TestPerformance):
         """
         Submit jobs with provided arguments and job
         """
-        job = 'sudo -u ' + user + ' ' + \
+        job = 'sudo -u ' + str(user) + ' ' + \
               str(os.path.join(
                   self.server.pbs_conf['PBS_EXEC'], 'bin', 'qsub'))
         if qsub_exec_arg is None:
@@ -105,7 +105,7 @@ class TestJobPerf(TestPerformance):
         qdel = qdel + ' -W force'
         cmd = qdel + " `" + str(os.path.join(bin_path, 'qselect'))
         for u in range(0, num_users):
-            qdel_cmd = cmd + " -u" + users[u] + " `"
+            qdel_cmd = cmd + " -u" + str(users[u]) + " `"
             subprocess.call(qdel_cmd, shell=True)
 
     @timeout(3600)
@@ -148,9 +148,9 @@ class TestJobPerf(TestPerformance):
         sclg = PBSLogAnalyzer()
         while j < config['No_of_tries']:
             i = 0
-            users = ['pbsuser1', 'pbsuser2', 'pbsuser3', 'pbsuser4',
-                     'pbsuser5', 'pbsuser6', 'pbsuser7', 'pbstest',
-                     'pbsroot', 'pbsadmin']
+            users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
+                     TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
+                     ROOT_USER, ADMIN_USER]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -239,9 +239,9 @@ class TestJobPerf(TestPerformance):
         while j < self.config['No_of_tries']:
             i = 0
             log_start = time.time()
-            users = ['pbsuser1', 'pbsuser2', 'pbsuser3', 'pbsuser4',
-                     'pbsuser5', 'pbsuser6', 'pbsuser7', 'pbstest',
-                     'pbsroot', 'pbsadmin']
+            users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
+                     TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
+                     ROOT_USER, ADMIN_USER]
             a = {'log_events': self.config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'job_history_enable': True}
@@ -331,9 +331,9 @@ class TestJobPerf(TestPerformance):
         j = 0
         while j < config['No_of_tries']:
             i = 0
-            users = ['pbsuser1', 'pbsuser2', 'pbsuser3', 'pbsuser4',
-                     'pbsuser5', 'pbsuser6', 'pbsuser7', 'pbstest',
-                     'pbsroot', 'pbsadmin']
+            users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
+                     TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
+                     ROOT_USER, ADMIN_USER]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -407,9 +407,9 @@ class TestJobPerf(TestPerformance):
                 self.config['No_of_moms'] - counts['state=free'], self.mom)
         while j < self.config['No_of_tries']:
             i = 0
-            users = ['pbsuser1', 'pbsuser2', 'pbsuser3', 'pbsuser4',
-                     'pbsuser5', 'pbsuser6', 'pbsuser7', 'pbstest',
-                     'pbsroot', 'pbsadmin']
+            users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
+                     TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
+                     ROOT_USER, ADMIN_USER]
             a = {'log_events': self.config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -467,9 +467,9 @@ class TestJobPerf(TestPerformance):
         j = 0
         while j < config['No_of_tries']:
             i = 0
-            users = ['pbsuser1', 'pbsuser2', 'pbsuser3', 'pbsuser4',
-                     'pbsuser5', 'pbsuser6', 'pbsuser7', 'pbstest',
-                     'pbsroot', 'pbsadmin']
+            users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
+                     TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
+                     ROOT_USER, ADMIN_USER]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -545,9 +545,9 @@ class TestJobPerf(TestPerformance):
         qdel_time = []
         j = 0
         while j < config['No_of_tries']:
-            users = ['pbsuser1', 'pbsuser2', 'pbsuser3', 'pbsuser4',
-                     'pbsuser5', 'pbsuser6', 'pbsuser7', 'pbstest',
-                     'pbsroot', 'pbsadmin']
+            users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
+                     TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
+                     ROOT_USER, ADMIN_USER]
             a = {'log_events': config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}
@@ -605,9 +605,9 @@ class TestJobPerf(TestPerformance):
                 'mom', a,
                 self.config['No_of_moms'] - counts['state=free'], self.mom)
         while j < self.config['No_of_tries']:
-            users = ['pbsuser1', 'pbsuser2', 'pbsuser3', 'pbsuser4',
-                     'pbsuser5', 'pbsuser6', 'pbsuser7', 'pbstest',
-                     'pbsroot', 'pbsadmin']
+            users = [TEST_USER1, TEST_USER2, TEST_USER3, TEST_USER4,
+                     TEST_USER5, TEST_USER6, TEST_USER7, TEST_USER,
+                     ROOT_USER, ADMIN_USER]
             a = {'log_events': self.config['svr_log_level']}
             self.server.manager(MGR_CMD_SET, SERVER, a)
             a = {'scheduling': 'False'}


### PR DESCRIPTION
Still some things need to be changed in PTL for shasta.

#### Describe Bug or Feature
is_localhost fails on shasta
PBS_PUBLIC_HOST_NAME needs to be set
run_copy needs to handle user-hosts
create_temp_file needs to handle user-hosts
Job.create_script needs to handle user-hosts
proc_utils does not support the shasta platform
\@skipOnShasta needs to be implemented
Some usernames are hardcoded in PTL

#### Describe Your Change
is_localhost should check the hostnames reported, and if they're the server hostname, return `True`
Set PBS_PUBLIC_HOST_NAME on the server conf.
Add user-host specific code to run_copy, create_temp_file, and Job.create_script
Allow the shasta platform to use proc_utils
Implement \@skipOnShasta
Change hard-coded usernames to str(TEST_USER)


#### Link to Design Doc
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1327235075/Support+PTL+on+Shasta


#### Attach Test and Valgrind Logs/Output
soon


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
