### PR TITLE
Include missing file in PTL Makefile.am

### DIFF
--- a/test/fw/Makefile.am
+++ b/test/fw/Makefile.am
@@ -100,6 +100,7 @@ dist_ptlmoduleutils_PYTHON = \
 	ptl/utils/pbs_testsuite.py \
 	ptl/utils/pbs_anonutils.py \
 	ptl/utils/pbs_snaputils.py \
+	ptl/utils/pbs_testusers.py \
 	ptl/utils/__init__.py
 
 ptlmoduleutilspluginsdir = $(ptlmoduleutilsdir)/plugins


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
After moving PBS users from ptl.lib.pbs_testlib.py to ptl.utils.pbs_testusers.py (#1246), most of the PTL commands(pbs_snapshot, pbs_config, etc) started failing:
Traceback (most recent call last):
  File "/opt/pbs/unsupported/fw/bin/pbs_snapshot.py", line 51, in <module>
    from ptl.lib.pbs_testlib import PtlConfig
  File "/opt/pbs/unsupported/fw/ptl/lib/pbs_testlib.py", line 60, in <module>
    from ptl.utils.pbs_dshutils import DshUtils, PtlUtilError
  File "/opt/pbs/unsupported/fw/ptl/utils/pbs_dshutils.py", line 51, in <module>
    from ptl.utils.pbs_testusers import PBS_ALL_USERS, PbsUser
ImportError: No module named pbs_testusers

#### Describe Your Change
Include pbs_testusers in Makefile.am.