### PR TITLE
Fixed race condition in test_wait_to_queued of TestqstatStateCount

### DIFF
--- a/test/tests/functional/pbs_qstat_count.py
+++ b/test/tests/functional/pbs_qstat_count.py
@@ -80,10 +80,10 @@ class TestqstatStateCount(TestFunctional):
         counts['all_state_count'] = all_state_count
         counts['total_jobs'] = int(qstat[0]['total_jobs'])
         # Find queued count from output of qstat
-        counts['expected_queued_count'] = (counts['total_jobs']
-                                           - counts['Held']
-                                           - counts['Waiting']
-                                           - counts['Running'])
+        counts['expected_queued_count'] = (counts['total_jobs'] -
+                                           counts['Held'] -
+                                           counts['Waiting'] -
+                                           counts['Running'])
         return counts
 
     def verify_count(self):
@@ -248,12 +248,14 @@ class TestqstatStateCount(TestFunctional):
         self.server.expect(JOB, {'job_state': 'W'}, id=jid,
                            offset=30, interval=2)
 
-        jid = self.submit_waiting_job(3)
+        jid = self.submit_waiting_job(7)
         j = Job(TEST_USER)
-        self.server.submit(j)
+        jid1 = self.server.submit(j)
         j = Job(TEST_USER)
-        self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid, offset=3)
+        jid2 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid, offset=7)
         self.server.restart()
         self.verify_count()
 

--- a/test/tests/functional/pbs_qstat_count.py
+++ b/test/tests/functional/pbs_qstat_count.py
@@ -248,7 +248,7 @@ class TestqstatStateCount(TestFunctional):
         self.server.expect(JOB, {'job_state': 'W'}, id=jid,
                            offset=30, interval=2)
 
-        jid1 = self.submit_waiting_job(7)
+        jid1 = self.submit_waiting_job(10)
         j = Job(TEST_USER)
         jid2 = self.server.submit(j)
         j = Job(TEST_USER)

--- a/test/tests/functional/pbs_qstat_count.py
+++ b/test/tests/functional/pbs_qstat_count.py
@@ -248,14 +248,14 @@ class TestqstatStateCount(TestFunctional):
         self.server.expect(JOB, {'job_state': 'W'}, id=jid,
                            offset=30, interval=2)
 
-        jid = self.submit_waiting_job(7)
-        j = Job(TEST_USER)
-        jid1 = self.server.submit(j)
+        jid1 = self.submit_waiting_job(7)
         j = Job(TEST_USER)
         jid2 = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        j = Job(TEST_USER)
+        jid3 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
-        self.server.expect(JOB, {'job_state': 'Q'}, id=jid, offset=7)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid1, offset=10)
         self.server.restart()
         self.verify_count()
 


### PR DESCRIPTION

#### Describe Bug or Feature
Test  test_wait_to_queued  failed sometime due to a race condition.

**Problem : -** 
test_wait_to_queued of TestqstatStateCount failed some time while verifying job_state=Q 
at below step
self.server.expect(JOB, {'job_state': 'Q'}, id=jid, offset=3)
Rarely hit this issue where test expect job to be in Q but got as got: job_state = R , even after 60th attempt
**Reason : -** 
In test we are submitting 4 jobs (say J1, J2 ,J3 and J4 )  test will fail in case where 
all three jobs J2 , J3 and J4  enqued at workq at same time and if  by that time start time of job J2 also meet and  as we have only two ncpus on node, job J2  can run instead of job J4. While as per test J4 should be running (R) state and J2 should move  to Q from W  state because ncpus is not available .

**Solution : -** 
Increased 'timedelta'  from 3 to 7 in 
jid = self.submit_waiting_job(3)
so that even if all three jobs enqued at same time at workq only jobs J3 and J4  will get resources and run , and job J2  will be in Q from W .
and also look for job J3 and J4 is in R state after submission to confirm that 2  ncpus actually consumed and no resources available to run the job J2   .


#### Describe Your Change
Increased 'timedelta'  from 3 to 7 in 
jid = self.submit_waiting_job(3)
so that even if all three jobs enqued at same time at workq only jobs J3 and J4  will get resources and run , and job J2  will be in Q from W .
and also look for job J3 and J4 is in R state after submission to confirm that 2  ncpus actually consumed and no resources available to run the job J2   .

Note : - More detail is given in internal ticket .

#### Attach Test and Valgrind Logs/Output
[after_fix_test_logs_x37.txt](https://github.com/PBSPro/pbspro/files/3579438/after_fix_test_logs_x37.txt)
[after_fix_test_wait_to_queued_logs_x37.txt](https://github.com/PBSPro/pbspro/files/3579439/after_fix_test_wait_to_queued_logs_x37.txt)

