### PR TITLE
Default Job()/Reservation() user to TEST_USER

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -59,7 +59,7 @@ from ptl.lib.pbs_api_to_cli import api_to_cli
 from ptl.utils.pbs_cliutils import CliUtils
 from ptl.utils.pbs_dshutils import DshUtils, PtlUtilError
 from ptl.utils.pbs_procutils import ProcUtils
-from ptl.utils.pbs_testusers import PbsUser
+from ptl.utils.pbs_testusers import PbsUser, TEST_USER
 
 try:
     import psycopg2
@@ -13726,7 +13726,7 @@ class Job(ResourceResv):
     runtime = 100
     du = DshUtils()
 
-    def __init__(self, username=None, attrs={}, jobname=None):
+    def __init__(self, username=TEST_USER, attrs={}, jobname=None):
         self.platform = self.du.get_platform()
         self.server = {}
         self.script = None
@@ -13971,7 +13971,7 @@ class Reservation(ResourceResv):
 
     dflt_attributes = {}
 
-    def __init__(self, username=None, attrs=None, hosts=None):
+    def __init__(self, username=TEST_USER, attrs=None, hosts=None):
         self.server = {}
         self.script = None
 


### PR DESCRIPTION
#### Describe Bug or Feature
When submitting jobs or reservations, we submit them as the user TEST_USER.  This should be the default so we don't need to always type it.

#### Describe Your Change
I imported TEST_USER from pbs_testusers and then set the default value of the username parameter of Reservation() and Job() to TEST_USER

#### Attach Test and Valgrind Logs/Output
I ran a full weekend regression on the branch and from what I can tell nothing failed because of this change.