### PR TITLE
Apply requirements decorator to test which require mom to be installed on host other than server host

### DIFF
--- a/test/tests/functional/pbs_power_provisioning_sgi.py
+++ b/test/tests/functional/pbs_power_provisioning_sgi.py
@@ -38,6 +38,7 @@
 from tests.functional import *
 
 
+@requirements(no_mom_on_server=True)
 class Test_power_provisioning_sgi(TestFunctional):
 
     """


### PR DESCRIPTION
#### Describe Bug or Feature
Apply requirements decorator to tests which require mom to be installed on  host other than server host

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
