### PR TITLE
jobscript_max_size not working properly

### DIFF
--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -1444,7 +1444,7 @@ req_jobscript(struct batch_request *preq)
 #else /* server - server - server - server */
 	/* add the script to the job */
 	size = get_bytes_from_attr(&attr_jobscript_max_size);
-	if (pj->ji_qs.ji_un.ji_newt.ji_scriptsz > size){
+	if (preq->rq_ind.rq_jobfile.rq_size > size){
 		req_reject(PBSE_JOBSCRIPTMAXSIZE, 0, preq);
 		return;
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
BUG (#1159)
Server does not honor jobscript_max_size setting properly


#### Describe Your Change
The server was using the wrong parameter while comparing the job's script size with jobscript_max_size attribute value. Changed the code to use the right parameter.

#### Link to Design Doc
None

#### Attach Test and Valgrind Logs/Output
I couldn't find a better place to write this test than the smoketest suite. I'm open to suggestions.
[before_change.txt](https://github.com/PBSPro/pbspro/files/3592758/before_change.txt)
[after_change.txt](https://github.com/PBSPro/pbspro/files/3592759/after_change.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
