### PR TITLE
pbs_ralter passes even with conflicting reservations

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -3921,7 +3921,7 @@ check_resources_for_node(resource_req *resreq, node_info *ninfo,
 	 * need to check for timed conflicts if the current object is a job inside a
 	 * reservation.
 	 */
-	if (min_chunks > 0 && exists_run_event_on_node(ninfo, end_time)
+	if (min_chunks > 0 && exists_run_event(calendar, end_time)
 		&& !(resresv->job != NULL && resresv->job->resv != NULL)) {
 		/* Check for possible conflicts with timed events by walking the sorted
 		 * event list that was created in eval_selspec. This runs a simulation


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
pbs_ralter passes when there are conflicting reservations in the system


#### Describe Your Change
The problem was that in node search code, scheduler was trying to find out the next run event which now gets stored on the node in the node_event variable. But in case of free placement we duplicate the node in eval_placement() and work on the duplicated node. This duplicated node does not have node_event set on it because it is only set when we duplicate the whole universe (not just the node).
Now, normally one would think that why don't we just duplicate the node_event too while duplicating the node. The reason is that node_event is set in dup_server_info() function because of the event pointer this variable points to comes from a duplicated calendar. Since we do no duplicate the calendar in eval_placement, setting the node_event there would mean that we will end up setting it to an event from the actual universe on a duplicated node. 

This change just reverts the call to find the run event on the node to find the run event in the calendar.  

#### Link to Design Doc
None


#### Attach Test and Valgrind Logs/Output
There is already an existing test that fails because of this problem - TestPbsResvAlter.test_conflict_two_advance_resvs in pbs_ralter.py
[test.txt](https://github.com/PBSPro/pbspro/files/3598046/test.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
