### PR TITLE
Tests of TestCgroupsHook are failing in setUp while verifying the node attributes

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2901,6 +2901,7 @@ event.accept()
             self.remove_vntype()
         for mom in self.moms_list:
             mom.delete_vnode_defs()
+            mom.restart()
         events = ['execjob_begin', 'execjob_launch', 'execjob_attach',
                   'execjob_epilogue', 'execjob_end', 'exechost_startup',
                   'exechost_periodic', 'execjob_resize', 'execjob_abort']

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -2899,9 +2899,6 @@ event.accept()
         self.load_default_config()
         if not self.iscray:
             self.remove_vntype()
-        for mom in self.moms_list:
-            mom.delete_vnode_defs()
-            mom.restart()
         events = ['execjob_begin', 'execjob_launch', 'execjob_attach',
                   'execjob_epilogue', 'execjob_end', 'exechost_startup',
                   'exechost_periodic', 'execjob_resize', 'execjob_abort']


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Tests of TestCgroupsHook are failing in setUp while verifying the node attributes
**Expected:** resources_available.ncpus >= 1
**Got:** resources_available.ncpus = 0


#### Describe Your Change

- Test "test_cgroup_assign_resources_mem_only_vnode" is creating vnodes and in tearDown the vnodes are deleted using "mom.delete_vnode_defs()". We are not restarting the mom explictly here as setUp use to restart PBS earlier but after the changes made as part of [PR:1268](https://github.com/PBSPro/pbspro/pull/1268) the test needs to explicilty restart/HUP mom after deleting the vnode file.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution Logs before fix](https://github.com/PBSPro/pbspro/files/3605550/Execution_logs_TestCgroupsHook_bfr_fix.txt)

- [Execution Logs after fix](https://github.com/PBSPro/pbspro/files/3605553/Updated_Execution_logs_TestCgroupsHook.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
