### PR TITLE
PTL failed with ValueError('No JSON object could be decoded') exception if skip-setup or skip-teardown parameter passed.

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_report_json.py
+++ b/test/fw/ptl/utils/plugins/ptl_report_json.py
@@ -88,7 +88,8 @@ class PTLJsonData(object):
             if data['testparam']:
                 for param in data['testparam'].split(','):
                     par = param.split('=', 1)
-                    data_json['test_conf'][par[0]] = par[1]
+                    if '=' in par:
+                        data_json['test_conf'][par[0]] = par[1]
         else:
             data_json = prev_data
         tsname = data['suite']

--- a/test/fw/ptl/utils/plugins/ptl_report_json.py
+++ b/test/fw/ptl/utils/plugins/ptl_report_json.py
@@ -87,9 +87,11 @@ class PTLJsonData(object):
             }
             if data['testparam']:
                 for param in data['testparam'].split(','):
-                    par = param.split('=', 1)
-                    if '=' in par:
+                    if '=' in param:
+                        par = param.split('=', 1)
                         data_json['test_conf'][par[0]] = par[1]
+                    else:
+                        data_json['test_conf'][param] = True
         else:
             data_json = prev_data
         tsname = data['suite']


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PTL failed with ValueError('No JSON object could be decoded') exception if skip-setup or  
skip-teardown test parameter passed.
while creating JSON report, code checks for '=' sign in test parameter (in -p). In skip-setup,
skip-teardown don't have '=' sign and JSON failed in creating report  with error ValueError('No JSON object could be decoded') .    

#### Describe Your Change
check that '=' sign in test parameter while creating JSON data.

#### Attach Test and Valgrind Logs/Output
[after_fix.txt](https://github.com/PBSPro/pbspro/files/3606059/after_fix.txt)
[after_fix_without_setup.txt](https://github.com/PBSPro/pbspro/files/3606060/after_fix_without_setup.txt)
[after_fix_without_tear_down.txt](https://github.com/PBSPro/pbspro/files/3606061/after_fix_without_tear_down.txt)
[before_fix.txt](https://github.com/PBSPro/pbspro/files/3606062/before_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
