### PR TITLE
Convert log_filter -> log_events for scheduler

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -571,6 +571,7 @@ extern int check_for_bgl_nodes(attribute *patr,  void *pobject,  int actmode);
 extern int action_sched_iteration(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_priv(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_log(attribute *pattr, void *pobj, int actmode);
+extern int action_sched_log_events(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_user(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_port(attribute *pattr, void *pobj, int actmode);
 extern int action_sched_host(attribute *pattr, void *pobj, int actmode);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -127,37 +127,39 @@ extern int  setup_env(char *filename);
 
 /* Event types */
 
-#define PBSEVENT_ERROR		0x0001		/* internal errors	      */
-#define PBSEVENT_SYSTEM		0x0002		/* system (server) events     */
-#define PBSEVENT_ADMIN		0x0004		/* admin events		      */
-#define PBSEVENT_JOB		0x0008		/* job related events	      */
-#define PBSEVENT_JOB_USAGE	0x0010		/* End of Job accounting      */
-#define PBSEVENT_SECURITY	0x0020		/* security violation events  */
-#define PBSEVENT_SCHED		0x0040		/* scheduler events	      */
-#define PBSEVENT_DEBUG		0x0080		/* common debug messages      */
+#define PBSEVENT_ERROR		0x0001		/* internal errors */
+#define PBSEVENT_SYSTEM		0x0002		/* system (server) events */
+#define PBSEVENT_ADMIN		0x0004		/* admin events */
+#define PBSEVENT_JOB		0x0008		/* job related events */
+#define PBSEVENT_JOB_USAGE	0x0010		/* End of Job accounting */
+#define PBSEVENT_SECURITY	0x0020		/* security violation events */
+#define PBSEVENT_SCHED		0x0040		/* scheduler events */
+#define PBSEVENT_DEBUG		0x0080		/* common debug messages */
 #define PBSEVENT_DEBUG2		0x0100		/* less needed debug messages */
-#define PBSEVENT_RESV		0x0200		/* reservation related msgs   */
+#define PBSEVENT_RESV		0x0200		/* reservation related msgs */
 #define PBSEVENT_DEBUG3		0x0400		/* less needed debug messages */
-#define PBSEVENT_DEBUG4		0x0800		/* rarely needed debugging    */
-#define PBSEVENT_FORCE		0x8000		/* set to force a messag      */
+#define PBSEVENT_DEBUG4		0x0800		/* rarely needed debugging */
+#define PBSEVENT_FORCE		0x8000		/* set to force a message */
 #define SVR_LOG_DFLT		PBSEVENT_ERROR | PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_JOB \
 				| PBSEVENT_JOB_USAGE | PBSEVENT_SECURITY | PBSEVENT_SCHED \
 				| PBSEVENT_DEBUG | PBSEVENT_DEBUG2
+#define SCHED_LOG_DFLT		PBSEVENT_ERROR | PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_JOB | PBSEVENT_JOB_USAGE \
+				| PBSEVENT_SECURITY | PBSEVENT_SCHED | PBSEVENT_DEBUG | PBSEVENT_RESV
 
-/* Event Object Classes, see array class_names[] in ../lib/Liblog/pbs_log.c   */
+/* Event Object Classes, see array class_names[] in ../lib/Liblog/pbs_log.c */
 
-#define PBS_EVENTCLASS_SERVER	1	/* The server itself	*/
-#define PBS_EVENTCLASS_QUEUE	2	/* Queues		*/
-#define PBS_EVENTCLASS_JOB	3	/* Jobs			*/
-#define PBS_EVENTCLASS_REQUEST	4	/* Batch Requests	*/
-#define PBS_EVENTCLASS_FILE	5	/* A Job related File	*/
-#define PBS_EVENTCLASS_ACCT	6	/* Accounting info	*/
-#define PBS_EVENTCLASS_NODE	7	/* Nodes		*/
-#define PBS_EVENTCLASS_RESV	8	/* Reservations		*/
-#define PBS_EVENTCLASS_SCHED	9	/* Scheduler		*/
-#define PBS_EVENTCLASS_HOOK	10	/* Hook			*/
-#define PBS_EVENTCLASS_RESC	11	/* Resource		*/
-#define PBS_EVENTCLASS_TPP 	12	/* TPP                  */
+#define PBS_EVENTCLASS_SERVER	1	/* The server itself */
+#define PBS_EVENTCLASS_QUEUE	2	/* Queues */
+#define PBS_EVENTCLASS_JOB	3	/* Jobs	 */
+#define PBS_EVENTCLASS_REQUEST	4	/* Batch Requests */
+#define PBS_EVENTCLASS_FILE	5	/* A Job related File */
+#define PBS_EVENTCLASS_ACCT	6	/* Accounting info */
+#define PBS_EVENTCLASS_NODE	7	/* Nodes */
+#define PBS_EVENTCLASS_RESV	8	/* Reservations */
+#define PBS_EVENTCLASS_SCHED	9	/* Scheduler */
+#define PBS_EVENTCLASS_HOOK	10	/* Hook	 */
+#define PBS_EVENTCLASS_RESC	11	/* Resource */
+#define PBS_EVENTCLASS_TPP 	12	/* TPP */
 
 /* Logging Masks */
 

--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -91,6 +91,7 @@ enum sched_atr {
 	SCHED_ATR_preempt_prio,
 	SCHED_ATR_preempt_order,
 	SCHED_ATR_preempt_sort,
+	SCHED_ATR_log_events,
 #include "site_sched_attr_enum.h"
 	/* This must be last */
 	SCHED_ATR_LAST

--- a/src/lib/Libattr/master_sched_attr_def.xml
+++ b/src/lib/Libattr/master_sched_attr_def.xml
@@ -459,6 +459,24 @@
 	<ECL>verify_value_preempt_sort</ECL>
 	</member_verify_function>
    </attributes>
+   <attributes>
+   /* SCHED_ATR_log_events */
+        <member_name><both>ATTR_logevents</both></member_name>          <!-- "log_events" -->
+        <member_at_decode>decode_l</member_at_decode>
+        <member_at_encode>encode_l</member_at_encode>
+        <member_at_set>set_l</member_at_set>
+        <member_at_comp>comp_l</member_at_comp>
+        <member_at_free>free_null</member_at_free>
+        <member_at_action>action_sched_log_events</member_at_action>
+        <member_at_flags><both>NO_USER_SET</both></member_at_flags>
+        <member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
+        <member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
+        <member_verify_function>
+        <ECL>verify_datatype_long</ECL>
+        <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+        </member_verify_function>
+   </attributes>
+
     <tail>
      <SVR>
          #include "site_sched_attr_def.h"

--- a/src/lib/Libattr/master_sched_attr_def.xml
+++ b/src/lib/Libattr/master_sched_attr_def.xml
@@ -473,7 +473,7 @@
         <member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
         <member_verify_function>
         <ECL>verify_datatype_long</ECL>
-        <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+        <ECL>verify_value_zero_or_positive</ECL>
         </member_verify_function>
    </attributes>
 

--- a/src/lib/Libattr/master_svr_attr_def.xml
+++ b/src/lib/Libattr/master_svr_attr_def.xml
@@ -717,7 +717,7 @@
 	<member_at_parent>PARENT_TYPE_SERVER</member_at_parent>
 	<member_verify_function>
 	<ECL>verify_datatype_long</ECL>
-	<ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+	<ECL>verify_value_zero_or_positive</ECL>
 	</member_verify_function>
    </attributes>
    <attributes>	

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -1084,7 +1084,6 @@ struct config
 	int num_holidays;			/* number of actual holidays */
 	struct timegap ded_time[MAX_DEDTIME_SIZE];/* dedicated times */
 	int unknown_shares;			/* unknown group shares */
-	int log_filter;				/* what events to filter out */
 	int preempt_queue_prio;			/* Queue prio that defines an express queue */
 	int max_preempt_attempts;		/* max num of preempt attempts per cyc*/
 	int max_jobs_to_check;			/* max number of jobs to check in cyc*/

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2459,6 +2459,13 @@ sched_settings_frm_svr(struct batch_status *status)
 			} else if (!strcmp(attr->name, ATTR_comment)) {
 				if ((tmp_comment = string_dup(attr->value)) == NULL)
 					goto cleanup;
+			} else if (!strcmp(attr->name, ATTR_logevents)) {
+				char *endp;
+				long mask;
+				mask = strtol(attr->value, &endp, 10);
+				if (*endp != '\0')
+					goto cleanup;
+				*log_event_mask = mask;
 			}
 		}
 		attr = attr->next;

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2450,13 +2450,13 @@ sched_settings_frm_svr(struct batch_status *status)
 	while (attr != NULL) {
 
 		if (attr->name != NULL && attr->value != NULL) {
-			if (!strcmp(attr->name, ATTR_sched_priv)) {
+			if (!strcmp(attr->name, ATTR_sched_priv) && !dflt_sched) {
 				if ((tmp_priv_dir = string_dup(attr->value)) == NULL)
 					goto cleanup;
-			} else if (!strcmp(attr->name, ATTR_sched_log)) {
+			} else if (!strcmp(attr->name, ATTR_sched_log) && !dflt_sched) {
 				if ((tmp_log_dir = string_dup(attr->value)) == NULL)
 					goto cleanup;
-			} else if (!strcmp(attr->name, ATTR_comment)) {
+			} else if (!strcmp(attr->name, ATTR_comment) && !dflt_sched) {
 				if ((tmp_comment = string_dup(attr->value)) == NULL)
 					goto cleanup;
 			} else if (!strcmp(attr->name, ATTR_logevents)) {
@@ -2470,9 +2470,6 @@ sched_settings_frm_svr(struct batch_status *status)
 		}
 		attr = attr->next;
 	}
-
-	if (tmp_priv_dir == NULL || tmp_log_dir == NULL)
-		goto cleanup;
 
 	if (!dflt_sched) {
 		int err;
@@ -2745,9 +2742,9 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	patt->next = NULL;
 
 	err = pbs_manager(connector,
-		MGR_CMD_SET, MGR_OBJ_SCHED,
-		sc_name, attribs, NULL);
-	if (err == 0 && svr_knows_me == 0)
+			  MGR_CMD_SET, MGR_OBJ_SCHED,
+			  sc_name, attribs, NULL);
+	if (err == 0)
 		svr_knows_me = 1;
 
 	free(attribs);

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -401,8 +401,8 @@ void
 schdlog(int event, int class, int sev, const char *name, const char *text)
 {
 	struct tm *ptm;
-	if (!(conf.log_filter & event) && text[0] != '\0') {
-		log_record(event, class, sev, name, text);
+	if (text[0] != '\0') {
+		log_event(event, class, sev, name, text);
 		if (conf.logstderr) {
 			time_t logtime;
 
@@ -411,7 +411,7 @@ schdlog(int event, int class, int sev, const char *name, const char *text)
 			ptm = localtime(&logtime);
 			if (ptm != NULL) {
 				fprintf(stderr, "%02d/%02d/%04d %02d:%02d:%02d;%s;%s\n",
-					ptm->tm_mon+1, ptm->tm_mday, ptm->tm_year+1900,
+					ptm->tm_mon + 1, ptm->tm_mday, ptm->tm_year + 1900,
 					ptm->tm_hour, ptm->tm_min, ptm->tm_sec,
 					name, text);
 			}
@@ -444,7 +444,7 @@ schdlogerr(int event, int class, int sev, char *name, char *text,
 	if (err == NULL)
 		return;
 
-	if (!(conf.log_filter & event)) {
+	if (will_log_event(event)) {
 		translate_fail_code(err, NULL, logbuf);
 		if (text == NULL)
 			schdlog(event, class, sev, name, logbuf);

--- a/src/scheduler/parse.c
+++ b/src/scheduler/parse.c
@@ -367,8 +367,10 @@ parse_config(char *fname)
 					obsolete[0] = PARSE_NODE_GROUP_KEY;
 					obsolete[1] = "nothing - set via qmgr";
 				}
-				else if (!strcmp(config_name, PARSE_LOG_FILTER))
-					conf.log_filter = num;
+				else if (!strcmp(config_name, PARSE_LOG_FILTER)) {
+					obsolete[0] = PARSE_LOG_FILTER;
+					obsolete[1] = "nothing - set log_events via qmgr";
+				}
 				else if (!strcmp(config_name, PARSE_PREEMPT_QUEUE_PRIO)) {
 					obsolete[0] = PARSE_PREEMPT_QUEUE_PRIO;
 					obsolete[1] = "nothing - set via qmgr";

--- a/src/scheduler/pbs_sched_config
+++ b/src/scheduler/pbs_sched_config
@@ -478,18 +478,3 @@ preemptive_sched: true	ALL
 #	NO PRIME OPTION
 dedicated_prefix: ded
 
-#### MISC OPTIONS
-
-#
-# log_filter
-#
-#	Bit field of log levels to have the scheduler NOT write to its log file.
-#
-# 	256 are DEBUG2 messages 
-#	1024 are DEBUG3 messages (the most prolific messages)
-#	1280 is the combination of these two
-#
-#	NO PRIME OPTION
-
-log_filter: 3328
-

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1827,7 +1827,7 @@ mgr_sched_unset(struct batch_request *preq)
 	for (tmp_plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr); tmp_plist; tmp_plist = (struct svrattrl *)GET_NEXT(tmp_plist->al_link)) {
 		if (strcasecmp(tmp_plist->al_name, ATTR_sched_log) == 0 ||
 			strcasecmp(tmp_plist->al_name, ATTR_sched_priv) == 0 ||
-			strcasecmp(tmp_plist->al_name, ATTR_logevents)) {
+			strcasecmp(tmp_plist->al_name, ATTR_logevents) == 0) {
 			set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
 		} else if (strcasecmp(tmp_plist->al_name, ATTR_schediteration) == 0) {
 			if (dflt_scheduler) {

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1826,7 +1826,8 @@ mgr_sched_unset(struct batch_request *preq)
 
 	for (tmp_plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr); tmp_plist; tmp_plist = (struct svrattrl *)GET_NEXT(tmp_plist->al_link)) {
 		if (strcasecmp(tmp_plist->al_name, ATTR_sched_log) == 0 ||
-			strcasecmp(tmp_plist->al_name, ATTR_sched_priv) == 0) {
+			strcasecmp(tmp_plist->al_name, ATTR_sched_priv) == 0 ||
+			strcasecmp(tmp_plist->al_name, ATTR_logevents)) {
 			set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
 		} else if (strcasecmp(tmp_plist->al_name, ATTR_schediteration) == 0) {
 			if (dflt_scheduler) {

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -608,7 +608,7 @@ set_scheduler_flag(int flag, pbs_sched *psched)
 		 * Note: A) usually SCH_QUIT is sent directly and not via here
 		 *       B) if we ever add a 3rd high prio command, we can lose them
 		 */
-		if (flag == SCH_CONFIGURE || flag == SCH_QUIT) {
+		if (flag == SCH_CONFIGURE || flag == SCH_ATTRS_CONFIGURE || flag == SCH_QUIT) {
 			if (psched->svr_do_sched_high == SCH_QUIT)
 				return; /* keep only SCH_QUIT */
 

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -341,9 +341,9 @@ action_sched_log_events(attribute *pattr, void *pobj, int actmode)
 	psched = (pbs_sched *) pobj;
 
 	if (actmode != ATR_ACTION_RECOV)
-		(void)contact_sched(SCH_ATTRS_CONFIGURE, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port);
-	
-	return PBSE_NONE;
+		set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
+
+		    return PBSE_NONE;
 }
 
 /**

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -326,6 +326,27 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 }
 
 /**
+ * @brief action function for 'log_events' sched attribute
+ * 
+ * @param[in]	pattr		attribute being set
+ * @param[in]	pobj		Object on which the attribute is being set
+ * @param[in]	actmode		the mode of setting
+ * 
+ * @return error code
+ */
+int
+action_sched_log_events(attribute *pattr, void *pobj, int actmode)
+{
+	pbs_sched *psched;
+	psched = (pbs_sched *) pobj;
+
+	if (actmode != ATR_ACTION_RECOV)
+		(void)contact_sched(SCH_ATTRS_CONFIGURE, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port);
+	
+	return PBSE_NONE;
+}
+
+/**
  * @brief
  * 		action routine for the sched's "sched_iteration" attribute
  *
@@ -586,6 +607,12 @@ set_sched_default(pbs_sched *psched, int unset_flag, int from_scheduler)
 			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_log]), &sched_attr_def[(int) SCHED_ATR_sched_log],
 				dir_path);
 	}
+	if ((psched->sch_attr[(int)SCHED_ATR_log_events].at_flags & ATR_VFLAG_SET) == 0) {
+		psched->sch_attr[SCHED_ATR_log_events].at_val.at_long = SCHED_LOG_DFLT;
+		psched->sch_attr[SCHED_ATR_log_events].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_DEFLT;
+		flag = 1;
+	}
+
 	if (!(psched->sch_attr[SCHED_ATR_preempt_queue_prio].at_flags & ATR_VFLAG_SET)) {
 		psched->sch_attr[SCHED_ATR_preempt_queue_prio].at_val.at_long = PBS_PREEMPT_QUEUE_PRIO_DEFAULT;
 		psched->sch_attr[SCHED_ATR_preempt_queue_prio].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_DEFLT;

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -329,6 +329,11 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 {
 	return 0;
 }
+int
+action_sched_log_events(attribute *pattr, void *pobj, int actmode)
+{
+	return 0;
+}
 
 int
 action_sched_iteration(attribute *pattr, void *pobj, int actmode)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5452,14 +5452,13 @@ class Server(PBSService):
             if self.schedulers[self.dflt_sched_name] is None:
                 self.schedulers[self.dflt_sched_name] = Scheduler(
                     self.hostname)
-            if 'log_filter' in self.schedulers[
-                    self.dflt_sched_name].sched_config:
-                _prev_filter = self.schedulers[
-                    self.dflt_sched_name].sched_config[
-                    'log_filter']
-                if int(_prev_filter) & 2048:
-                    self.schedulers[self.dflt_sched_name].set_sched_config(
-                        {'log_filter': 2048})
+            _prev_events = self.status(SCHED, 'log_events',
+                                       id=self.dflt_schd_name)[0]['log_events']
+
+            # Job sort formula events are logged at DEBUG2 (256)
+            if not int(_prev_events) & 256:
+                self.manager(MGR_CMD_SET, SCHED, {'log_events': 2047},
+                             id=self.dflt_schd_name)
             self.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
             if id is None:
                 _formulas = self.schedulers[self.dflt_sched_name].job_formula()
@@ -5469,10 +5468,9 @@ class Server(PBSService):
                         self.dflt_sched_name].job_formula(
                         jobid=id)
                 }
-            if not int(_prev_filter) & 2048:
-                self.schedulers[self.dflt_sched_name].set_sched_config(
-                    {'log_filter': int(_prev_filter)})
-
+            if not int(_prev_filter) & 256:
+                self.manager(MGR_CMD_SET, SCHED, {'log_events': _prev_events}, 
+                             id=self.dflt_schd_name)
             if len(bsl) == 0:
                 bsl = [{'id': id}]
             for _b in bsl:
@@ -10520,8 +10518,6 @@ class Scheduler(PBSService):
         "by_queue": "True                ALL",
         "preemptive_sched": "true        ALL",
         "resources": "\"ncpus, mem, arch, host, vnode, aoe\"",
-        "log_filter": "3328 ",
-
     }
 
     sched_config_options = ["node_group_key",
@@ -10531,7 +10527,6 @@ class Scheduler(PBSService):
                             "resource_unset_infinite",
                             "sync_time",
                             "unknown_shares",
-                            "log_filter",
                             "dedicated_prefix",
                             "load_balancing",
                             "help_starving_jobs",

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5469,7 +5469,7 @@ class Server(PBSService):
                         jobid=id)
                 }
             if not int(_prev_filter) & 256:
-                self.manager(MGR_CMD_SET, SCHED, {'log_events': _prev_events}, 
+                self.manager(MGR_CMD_SET, SCHED, {'log_events': _prev_events},
                              id=self.dflt_schd_name)
             if len(bsl) == 0:
                 bsl = [{'id': id}]

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -48,7 +48,7 @@ class TestEquivClass(TestFunctional):
         TestFunctional.setUp(self)
         a = {'resources_available.ncpus': 8}
         self.server.create_vnodes('vnode', a, 1, self.mom, usenatvnode=True)
-        self.scheduler.set_sched_config({'log_filter': 2048})
+        self.server.managers(MGR_CMD_SET, SCHED, {'log_events': 2047})
         # capture the start time of the test for log matching
         self.t = int(time.time())
 

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -48,7 +48,7 @@ class TestEquivClass(TestFunctional):
         TestFunctional.setUp(self)
         a = {'resources_available.ncpus': 8}
         self.server.create_vnodes('vnode', a, 1, self.mom, usenatvnode=True)
-        self.server.managers(MGR_CMD_SET, SCHED, {'log_events': 2047})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
         # capture the start time of the test for log matching
         self.t = int(time.time())
 

--- a/test/tests/functional/pbs_fairshare.py
+++ b/test/tests/functional/pbs_fairshare.py
@@ -93,7 +93,7 @@ class TestFairshare(TestFunctional):
         """
 
         self.set_up_resource_group()
-        self.scheduler.set_sched_config({'log_filter': 2048})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         self.server.manager(MGR_CMD_SET, SERVER,
@@ -120,7 +120,7 @@ class TestFairshare(TestFunctional):
         """
 
         self.set_up_resource_group()
-        self.scheduler.set_sched_config({'log_filter': 2048})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         self.server.manager(MGR_CMD_SET, SERVER,
@@ -149,7 +149,7 @@ class TestFairshare(TestFunctional):
         """
 
         self.set_up_resource_group()
-        self.scheduler.set_sched_config({'log_filter': 2048})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
         formula = 'pow(2,-(fairshare_tree_usage/fairshare_perc))'
 
@@ -185,7 +185,7 @@ class TestFairshare(TestFunctional):
         """
 
         self.set_up_resource_group()
-        self.scheduler.set_sched_config({'log_filter': 2048})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
         formula = 'fairshare_factor'
 
@@ -222,7 +222,8 @@ class TestFairshare(TestFunctional):
         """
 
         self.set_up_resource_group()
-        a = {'log_filter': 2048, 'fair_share': "True ALL"}
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
+        a = {'fair_share': "True ALL"}
         self.scheduler.set_sched_config(a)
 
         formula = 'fairshare_factor'
@@ -261,7 +262,7 @@ class TestFairshare(TestFunctional):
         """
 
         self.set_up_resource_group()
-        self.scheduler.set_sched_config({'log_filter': 2048})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
         formula = 'fairshare_factor + (walltime/ncpus)'
 
@@ -355,7 +356,7 @@ class TestFairshare(TestFunctional):
         Test that fairshare decay doesn't reduce the usage below 1
         """
         self.scheduler.set_sched_config({'fair_share': 'True'})
-        self.scheduler.set_sched_config({'log_filter': 0})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 4095})
         self.scheduler.add_to_resource_group(TEST_USER, 10, 'root', 50)
         self.scheduler.set_fairshare_usage(TEST_USER, 1)
         self.scheduler.set_sched_config({"fairshare_decay_time": "00:00:02"})

--- a/test/tests/functional/pbs_holidays.py
+++ b/test/tests/functional/pbs_holidays.py
@@ -62,7 +62,7 @@ class TestHolidays(TestFunctional):
         TestFunctional.setUp(self)
 
         # Enable DEBUG2 sched log messages
-        self.scheduler.set_sched_config({'log_filter': 3072})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 1023})
 
     def test_missing_days(self):
         """
@@ -298,8 +298,8 @@ class TestHolidays(TestFunctional):
         Test that for a commented out holidays file, scheduler doesn't
         add policy change events to the calendar
         """
-        self.scheduler.set_sched_config({'log_filter': 2048,
-                                         'strict_ordering': "true    all"})
+        self.scheduler.set_sched_config({'strict_ordering': "true    all"})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
         self.scheduler.holidays_delete_entry('a')
 

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -56,7 +56,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].start()
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id="sc1")
-        self.scheds['sc1'].set_sched_config({'log_filter': 2048})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047}, id='sc1')
 
     def setup_sc2(self):
         dir_path = os.path.join(os.sep, 'var', 'spool', 'pbs', 'sched_dir')
@@ -1059,7 +1059,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.setup_sc1()
         self.setup_sc2()
         self.setup_queues_nodes()
-        self.scheds['sc2'].set_sched_config({'log_filter': 2048})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047}, id='sc2')
         t = int(time.time())
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'False'}, id="sc1")
@@ -1875,7 +1875,8 @@ class TestMultipleSchedulers(TestFunctional):
         and check whether they are actually be effective
         """
         self.setup_sc3()
-        self.scheds['sc3'].set_sched_config({'log_filter': 2048})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047}, id='sc3')
+
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'False'}, id="sc3")
 
@@ -1905,9 +1906,8 @@ class TestMultipleSchedulers(TestFunctional):
         and check whether they are actually be effective
         """
         self.setup_sc3()
-        self.scheds['sc3'].set_sched_config({'log_filter': 2048})
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'False'}, id="sc3")
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'False',
+                            'log_events': 2047}, id="sc3")
 
         # create and set-up a new priv directory for sc3
         new_sched_priv = os.path.join(self.server.pbs_conf['PBS_HOME'],

--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -396,7 +396,7 @@ class TestNodeBuckets(TestFunctional):
 
         self.scheduler.revert_to_defaults()
         self.scheduler.add_resource('color')
-        self.scheduler.set_sched_config(schd_attr)
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
         # the bucket codepath requires excl
         self.logger.info('Test different place specs')

--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -78,7 +78,7 @@ class TestNodeBuckets(TestFunctional):
 
         self.scheduler.add_resource('color')
 
-        self.scheduler.set_sched_config({'log_filter': '2048'})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
     def cust_attr_func(self, name, totalnodes, numnode, attribs):
         """
@@ -370,14 +370,14 @@ class TestNodeBuckets(TestFunctional):
         # Running a 10010 cpu job through the normal code path spams the log.
         # We don't care about it, so there is no reason to increase
         # the log size by so much.
-        self.scheduler.set_sched_config({'log_filter': '3328'})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 767})
         # Run a job on all nodes leaving 1 cpus available on each node
         j = Job(TEST_USER, {'Resource_List.select': '10010:ncpus=1',
                             'Resource_List.place': 'scatter'})
         j.set_sleep_time(600)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.scheduler.set_sched_config({'log_filter': '2048'})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
         # Node sorting via unused resources uses the standard code path
         self.logger.info('Test node_sort_key with unused resources')
@@ -386,8 +386,7 @@ class TestNodeBuckets(TestFunctional):
         self.check_normal_path()
 
         self.scheduler.revert_to_defaults()
-        schd_attr = {'log_filter': '2048'}
-        self.scheduler.set_sched_config(schd_attr)
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
         # provisioning_policy: avoid_provisioning uses the standard code path
         self.logger.info('Test avoid_provision')

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -93,8 +93,6 @@ class TestPBSSnapshot(TestFunctional):
         :type sched_priv: str
         :param sched_log: 'sched_log' (full path) for the scheduler
         :type sched_log: str
-        :param log_filter: log filter value for the scheduler
-        :type log_filter: int
         """
         a = {'partition': partition,
              'sched_host': self.server.hostname,

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1389,7 +1389,6 @@ class SmokeTest(PBSTestSuite):
         self.scheduler.set_sched_config(a)
         self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 4095})
 
-
     @skipOnCpuSet
     def test_fairshare_enhanced(self):
         """

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -395,8 +395,7 @@ class SmokeTest(PBSTestSuite):
         """
         Test for preemption
         """
-        a = {'log_filter': 2048}
-        self.scheduler.set_sched_config(a)
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
         a = {'resources_available.ncpus': '1'}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         self.server.status(QUEUE)
@@ -573,7 +572,7 @@ class SmokeTest(PBSTestSuite):
         """
         a = {'resources_available.ncpus': 8}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
-        self.scheduler.set_sched_config({'log_filter': '2048'})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
         a = {'job_sort_formula': 'ncpus'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
         # purposely submitting a job that is highly unlikely to run so
@@ -943,7 +942,7 @@ class SmokeTest(PBSTestSuite):
         """
         Test job_sort_formula_threshold basic behavior
         """
-        self.scheduler.set_sched_config({'log_filter': '2048'})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
         a = {'resources_available.ncpus': 1}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         a = {'job_sort_formula':
@@ -1386,9 +1385,10 @@ class SmokeTest(PBSTestSuite):
                                              validate=True)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduler_iteration': 7})
         a = {'fair_share': 'True', 'fairshare_decay_time': '24:00:00',
-             'fairshare_decay_factor': 0.5, 'fairshare_usage_res': formula,
-             'log_filter': '0'}
+             'fairshare_decay_factor': 0.5, 'fairshare_usage_res': formula}
         self.scheduler.set_sched_config(a)
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 4095})
+
 
     @skipOnCpuSet
     def test_fairshare_enhanced(self):

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -54,7 +54,7 @@ class TestJobEquivClassPerf(TestPerformance):
         a = {'resources_available.ncpus': 1, 'resources_available.mem': '8gb'}
         self.server.create_vnodes('vnode', a, 10000, self.mom, expect=False,
                                   sharednode=False)
-	self.server.expect(NODE, {'state=free': 10001})
+        self.server.expect(NODE, {'state=free': 10001})
 
     def run_n_get_cycle_time(self):
         """

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -52,8 +52,9 @@ class TestJobEquivClassPerf(TestPerformance):
 
         # Create vnodes
         a = {'resources_available.ncpus': 1, 'resources_available.mem': '8gb'}
-        self.server.create_vnodes('vnode', a, 10000, self.mom,
+        self.server.create_vnodes('vnode', a, 10000, self.mom, expect=False,
                                   sharednode=False)
+	self.server.expect(NODE, {'state=free': 10001})
 
     def run_n_get_cycle_time(self):
         """

--- a/test/tests/performance/pbs_equiv_classes_perf.py
+++ b/test/tests/performance/pbs_equiv_classes_perf.py
@@ -48,7 +48,7 @@ class TestJobEquivClassPerf(TestPerformance):
 
     def setUp(self):
         TestPerformance.setUp(self)
-        self.scheduler.set_sched_config({'log_filter': 2048})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
 
         # Create vnodes
         a = {'resources_available.ncpus': 1, 'resources_available.mem': '8gb'}

--- a/test/tests/selftest/pbs_cycles_test.py
+++ b/test/tests/selftest/pbs_cycles_test.py
@@ -72,7 +72,7 @@ class PBSTestCycle(TestSelf):
         self.scheds['sc'].start()
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id="sc")
-        self.scheds['sc'].set_sched_config({'log_filter': 2048})
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047}, id='sc')
 
         # Turn off scheduling for all the scheds.
         for name in self.scheds:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The server uses log_events where you turn on the levels you want to log.  The scheduler uses log_filter where you start with everything on and turn off levels you don't want to log.  This RFE makes the scheduler more like the server with a log_events attribute for itself.

#### Describe Your Change
The scheduler will use a sched object attribute called log_events which will work like the scheduler.  This RFE just converts log_filter -> log_events.  The rest of the functionality in the design document is still to come.

#### Link to Design Doc
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1351319574/Scheduler+s+log+events

#### Attach Test and Valgrind Logs/Output
The smoke tests run by travis should be sufficient.  They match logs which should still be emitted by the scheduler.