### PR TITLE
adjustments on newer OS versions that have shell functions in environ…

### DIFF
--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -141,8 +141,7 @@ sleep 5
         Check if unescaped variable is in job output
         """
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=1)
-        cmd = ['cat', job_outfile]
-        ret = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        ret = self.du.cat(filename=job_outfile)
         job_out = '\n'.join(ret['out'])
         self.logger.info('job output from %s:\n%s' % (job_outfile, job_out))
         job_output = ""

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -89,11 +89,6 @@ unset -f foo
 exit 0
 """
         self.script = """#PBS -V
-for e in $(env | grep -v BASH_FUNC_foo | grep BASH_FUNC_ | \
-sed 's/BASH_FUNC_//' | sed 's/[%(].*//')
-do
-    unset -f $e
-done
 env | grep -A2 foo
 foo
 sleep 5
@@ -146,6 +141,10 @@ sleep 5
         Check if unescaped variable is in job output
         """
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=1)
+        cmd = ['cat', job_outfile]
+        ret = self.du.run_cmd(self.server.hostname, cmd=cmd)
+        job_out = '\n'.join(ret['out'])
+        self.logger.info('job output from %s:\n%s' % (job_outfile, job_out))
         job_output = ""
         with open(job_outfile, 'r') as f:
             job_output = f.read().strip()

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -88,6 +88,16 @@ env | grep foo
 unset -f foo
 exit 0
 """
+        self.script = """#PBS -V
+for e in $(env | grep -v BASH_FUNC_foo | grep BASH_FUNC_ | \
+sed 's/BASH_FUNC_//' | sed 's/[%(].*//')
+do
+    unset -f $e
+done
+env | grep -A2 foo
+foo
+sleep 5
+"""
         fn = self.du.create_temp_file(body=foo_scr)
         self.du.chmod(path=fn, mode=0755)
         foo_msg = 'Failed to run foo_scr'
@@ -296,11 +306,7 @@ exit 0
                 chk_var = self.n + '=() { a=%s; echo XX${a}YY}; }' % ch
             out = self.n + \
                 '=() {  a=%s;\n echo XX${a}YY}\n}\nXX%sYY}' % (ch, ch)
-            script = ['#PBS -V']
-            script += ['env | grep -A 3 foo\n']
-            script += ['foo\n']
-            script += ['sleep 5']
-            jid = self.create_and_submit_job(content=script)
+            jid = self.create_and_submit_job(content=self.script)
             # Check if qstat -f output contains the escaped character
             self.check_qstatout(chk_var, jid)
             # Check if job output contains the character
@@ -411,11 +417,7 @@ exit 0
             self.bold_esc, self.red_esc)
         out = self.n + '=() {  a=$(%s; %s);\n echo XX${a}YY\n}\nXXYY' % (
             self.bold, self.red)
-        script = ['#PBS -V']
-        script += ['env | grep -A 3 foo\n']
-        script += ['foo\n']
-        script += ['sleep 5']
-        jid = self.create_and_submit_job(content=script)
+        jid = self.create_and_submit_job(content=self.script)
         # Check if qstat -f output contains the escaped character
         self.check_qstatout(chk_var, jid)
         # Check if job output contains the character


### PR DESCRIPTION
…ment

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Newer OS versions like SLES15, RHEL8, RHEL7, and Ubuntu 18 might have shell functions in the user environment, for example,

1) on SLES 15:
BASH_FUNC_module%%=() { eval $($LMOD_CMD bash "$@") && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
}
BASH_FUNC_ml%%=()
{ eval $($LMOD_DIR/ml_cmd "$@") }

2) on RHEL7:
BASH_FUNC_module()=() {  eval $($LMOD_CMD bash "$@") && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
}
BASH_FUNC_ml()=() {  eval $($LMOD_DIR/ml_cmd "$@")
}

that will cause the TestNonprintingCharacters tests test_nonprint_shell_function, test_terminal_control_shell_function to fail.

#### Describe Your Change
Changed the grep in the job script.


#### Attach Test Logs/Output
[test_shell_func_s15_before.txt](https://github.com/PBSPro/pbspro/files/3611976/test_shell_func_s15_before.txt)
[shell_function_s15_after.txt](https://github.com/PBSPro/pbspro/files/3618685/shell_function_s15_after.txt)
[shell_function_r6_after.txt](https://github.com/PBSPro/pbspro/files/3618686/shell_function_r6_after.txt)

[shell_function_s15_after1.txt](https://github.com/PBSPro/pbspro/files/3622291/shell_function_s15_after1.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
