### PR TITLE
Support PTL to import and export hook config file

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -9732,7 +9732,8 @@ class Server(PBSService):
         else:
             hook_t = PBS_HOOK
 
-        fn = self.du.create_temp_file(body=json.dumps(hook_conf))
+        hook_body = json.dumps(hook_conf, indent=4)
+        fn = self.du.create_temp_file(body=hook_body)
 
         if not self._is_local:
             tmpdir = self.du.get_tempdir(self.hostname)
@@ -9752,7 +9753,7 @@ class Server(PBSService):
             self.du.rm(self.hostname, rfile)
         self.logger.log(level, 'server ' + self.shortname +
                         ': imported hook config\n---\n' +
-                        str(hook_conf) + '---')
+                        str(hook_body) + '\n---\n')
         return True
 
     def export_hook_config(self, hook_name, hook_type):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -9765,7 +9765,7 @@ class Server(PBSService):
         The hook must have been created prior to calling this
         function.
 
-        :param hook_name: The name of the hook to import body to
+        :param hook_name: The name of the hook to export config from
         :type name: str
         :param hook_type: The hook type "site" or "pbshook"
         :type hook_type: str

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -9718,7 +9718,7 @@ class Server(PBSService):
         The hook must have been created prior to calling this
         function.
 
-        :param hook_name: The name of the hook to import body to
+        :param hook_name: The name of the hook to import hook config
         :type name: str
         :param hook_conf: The body of the hook config as a dict.
         :type hook_conf: dict
@@ -9732,13 +9732,16 @@ class Server(PBSService):
         else:
             hook_t = PBS_HOOK
 
-        hook_body = json.dumps(hook_conf, indent=4)
-        fn = self.du.create_temp_file(body=hook_body)
+        hook_config_data = json.dumps(hook_conf, indent=4)
+        fn = self.du.create_temp_file(body=hook_config_data)
 
         if not self._is_local:
             tmpdir = self.du.get_tempdir(self.hostname)
             rfile = os.path.join(tmpdir, os.path.basename(fn))
-            self.du.run_copy(self.hostname, fn, rfile)
+            rc = self.du.run_copy(self.hostname, fn, rfile)
+            if rc != 0
+                raise AssertionError("Failed to copy file %s"
+                                     % (rfile))
         else:
             rfile = fn
 
@@ -9753,7 +9756,7 @@ class Server(PBSService):
             self.du.rm(self.hostname, rfile)
         self.logger.log(level, 'server ' + self.shortname +
                         ': imported hook config\n---\n' +
-                        str(hook_body) + '\n---\n')
+                        str(hook_config_data) + '\n---\n')
         return True
 
     def export_hook_config(self, hook_name, hook_type):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -9720,8 +9720,8 @@ class Server(PBSService):
 
         :param hook_name: The name of the hook to import body to
         :type name: str
-        :param hook_conf: The body of the hook config as a string.
-        :type hook_conf: str
+        :param hook_conf: The body of the hook config as a dict.
+        :type hook_conf: dict
         :param hook_type: The hook type "site" or "pbshook"
         :type hook_type: str
         :returns: True on success.
@@ -9732,7 +9732,7 @@ class Server(PBSService):
         else:
             hook_t = PBS_HOOK
 
-        fn = self.du.create_temp_file(body=hook_conf)
+        fn = self.du.create_temp_file(body=json.dumps(hook_conf))
 
         if not self._is_local:
             tmpdir = self.du.get_tempdir(self.hostname)
@@ -9752,7 +9752,7 @@ class Server(PBSService):
             self.du.rm(self.hostname, rfile)
         self.logger.log(level, 'server ' + self.shortname +
                         ': imported hook config\n---\n' +
-                        hook_conf + '---')
+                        str(hook_conf) + '---')
         return True
 
     def export_hook_config(self, hook_name, hook_type):
@@ -9782,7 +9782,8 @@ class Server(PBSService):
             config_dict = json.loads(config_out)
             return config_dict
         else:
-            self.fail("Failed to export hook config, %s", ret['err'])
+            raise AssertionError("Failed to export hook config, %s"
+                                 % (ret['err']))
 
     def evaluate_formula(self, jobid=None, formula=None, full=True,
                          include_running_jobs=False, exclude_subjobs=True):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -9739,7 +9739,7 @@ class Server(PBSService):
             tmpdir = self.du.get_tempdir(self.hostname)
             rfile = os.path.join(tmpdir, os.path.basename(fn))
             rc = self.du.run_copy(self.hostname, fn, rfile)
-            if rc != 0
+            if rc != 0:
                 raise AssertionError("Failed to copy file %s"
                                      % (rfile))
         else:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Support PTL to import and export hook config files.

#### Describe Your Change
Added import_hook_config and export_hook_config in pbs_testlib.py to support import and export hook config files respectively.
