### PR TITLE
miscellaneous maintenance fixes

### DIFF
--- a/src/cmds/pbs_rsub.c
+++ b/src/cmds/pbs_rsub.c
@@ -806,7 +806,7 @@ main(int argc, char *argv[], char *envp[])
 				if (ncpus_str != NULL)
 					ncpus = strtol(ncpus_str, &endp, 0);
 				
-				if (*endp != '\0' || ncpus_str == NULL) {
+				if (*endp != '\0') {
 					fprintf(stderr, "pbs_rsub: Attribute value error\n");
 					CS_close_app();
 					exit(2);

--- a/src/cmds/pbs_rsub.c
+++ b/src/cmds/pbs_rsub.c
@@ -95,6 +95,7 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 	char dur_buf[800];
 	char badw[] = "pbs_rsub: illegal -W value\n";
 	int opt_re_flg = FALSE;
+	int opt_res_req_flg = FALSE;
 #ifdef WIN32
 	struct attrl *ap = NULL;
 	short nSizeofHostName = 0;
@@ -143,6 +144,7 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 				break;
 
 			case 'l':
+				opt_res_req_flg = TRUE;
 				if ((i = set_resources(&attrib, optarg, 0, &erp)) != 0) {
 					if (i > 1) {
 						pbs_prt_parse_err("pbs_rsub: illegal -l value\n", optarg,
@@ -274,6 +276,11 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 
 	if (opt_re_flg == TRUE && qmoveflg ==TRUE) {
 		fprintf(stderr, "pbs_rsub: -Wqmove is not compatible with -R or -E option\n");
+		errflg++;
+	}
+
+	if (opt_res_req_flg && is_maintenance_resv) {
+		fprintf(stderr, "pbs_rsub: can't use -l with --hosts\n");
 		errflg++;
 	}
 

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -550,6 +550,11 @@ chk_rescResv_request(char *resvID, struct batch_request *preq)
 		return NULL;
 	}
 
+	if (resvID[0] == PBS_MNTNC_RESV_ID_CHAR && ! (preq->rq_perm & (ATR_DFLAG_OPWR | ATR_DFLAG_MGWR))) {
+		req_reject(PBSE_PERM, 0, preq);
+		return NULL;
+	}
+
 	if (svr_authorize_resvReq(preq, presv) == -1) {
 		(void)sprintf(log_buffer, msg_permlog, preq->rq_type,
 			"RESCRESV", presv->ri_qs.ri_resvID,

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6393,7 +6393,7 @@ class Server(PBSService):
 
         obj_type = {}
         for j in id:
-            if j[0] in ('R', 'S'):
+            if j[0] in ('R', 'S', 'M'):
                 obj_type[j] = RESV
                 try:
                     rc = self.delresv(j, extend, runas, logerr=logerr)

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -90,7 +90,7 @@ class TestMaintenanceReservations(TestFunctional):
         except PbsSubmitError as err:
             msg = err.msg[0].strip()
 
-        self.assertEqual("pbs_rsub: can't use -l select with --hosts", msg)
+        self.assertEqual("pbs_rsub: can't use -l with --hosts", msg)
 
         a = {'Resource_List.place': 'scatter',
              'reserve_start': now + 3600,
@@ -105,7 +105,7 @@ class TestMaintenanceReservations(TestFunctional):
         except PbsSubmitError as err:
             msg = err.msg[0].strip()
 
-        self.assertEqual("pbs_rsub: can't use -l place with --hosts", msg)
+        self.assertEqual("pbs_rsub: can't use -l with --hosts", msg)
 
     def test_maintenance_missing_hosts(self):
         """

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -68,9 +68,9 @@ class TestMaintenanceReservations(TestFunctional):
 
         self.assertEqual("pbs_rsub: Unauthorized Request", msg)
 
-    def test_maintenance_forbidden_parameters(self):
+    def test_maintenance_conflicting_parameters(self):
         """
-        Test if forbidden parameters are refused
+        Test if conflicting parameters are refused
         """
         now = int(time.time())
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* The First bug is regarding creating maintenance while node(s) without ncpus is in PBS. This situation is not usual but it is not a bug to have a node without ncpus. For example, If we add a node that is not up/online, no ncpus is set automatically and the creation of maintenance is denied with error "pbs_rsub: Attribute value error" for any host. This is not correct behavior. IMHO, it is better to simply ignore such a node while creating maintenance.

* The second bug: The maintenance can be created only by a manager or operator but it is possible to delete or alter the maintenance by a regular user.


#### Describe Your Change
* With the first bug, we can simply ignore nodes without ncpus by not throwing an error.

* The second bug needs to test the first char in maintenance id and for such maintenance check the correct permissions. This is done in chk_rescResv_request().


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Manual test for first bug:
```
(JESSIE)vchlum@torque3:~$ pbsnodes -v torque4
torque4
     Mom = torque4.ics.muni.cz
     Port = 15002
     pbs_version = unavailable
     ntype = PBS
     state = state-unknown,down
     resources_available.host = torque4
     resources_available.vnode = torque4
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 0
     resources_assigned.vmem = 0kb
     comment = node down: communication closed
     resv_enable = True
     sharing = default_shared
     last_state_change_time = Wed Sep 18 09:12:44 2019

(JESSIE)vchlum@torque3:~$ pbs_rsub -R 1200 -D 3600 --hosts torque4
pbs_rsub: missing host(s)
usage: pbs_rsub [-I seconds] [-m mail_points] [-M mail_list]
                [-N reservation_name] [-u user_list] [-g group_list]
                [-U auth_user_list] [-G auth_group_list] [-H auth_host_list]
                [-R start_time] [-E end_time] [-D duration] [-q destination]
                [-r rrule_expression] [-W otherattributes=value...]
                -l resource_list | --hosts host1 [... hostn]
       pbs_rsub --version
(JESSIE)vchlum@torque3:~$ 
```

PTL maintenance test:
[ptl_maintenance_output.txt](https://github.com/PBSPro/pbspro/files/3625847/ptl_maintenance_output.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
