### PR TITLE
PTL fails with list index out of range error with ONLY remote moms

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -673,17 +673,17 @@ class PBSTestSuite(unittest.TestCase):
             server_param = cls.conf['servers']
             if 'comms' not in cls.conf and 'comm' not in cls.conf:
                 cls.conf['comms'] = server_param
-            if 'schedulers' not in cls.conf and 'scheduler' not in cls.conf:
-                cls.conf['schedulers'] = server_param
+            if 'sched' not in cls.conf and 'scheds' not in cls.conf:
+                cls.conf['scheds'] = server_param
             if 'moms' not in cls.conf and 'mom' not in cls.conf:
                 cls.conf['moms'] = server_param
         if 'server' in cls.conf:
             server_param = cls.conf['server']
-            if 'comms' not in cls.conf and 'comm' not in cls.conf:
+            if 'comm' not in cls.conf:
                 cls.conf['comm'] = server_param
-            if 'schedulers' not in cls.conf and 'scheduler' not in cls.conf:
-                cls.conf['scheduler'] = server_param
-            if 'moms' not in cls.conf and 'mom' not in cls.conf:
+            if 'sched' not in cls.conf:
+                cls.conf['sched'] = server_param
+            if 'mom' not in cls.conf:
                 cls.conf['mom'] = server_param
         cls.servers = cls.init_from_conf(conf=cls.conf, single='server',
                                          multiple='servers', skip=skip,
@@ -714,8 +714,8 @@ class PBSTestSuite(unittest.TestCase):
         if init_sched_func is None:
             init_sched_func = cls.init_scheduler
         cls.scheds = cls.init_from_conf(conf=cls.conf,
-                                        single='scheduler',
-                                        multiple='schedulers', skip=skip,
+                                        single='sched',
+                                        multiple='scheds', skip=skip,
                                         func=init_sched_func)
 
         for sched in cls.scheds.values():

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -670,18 +670,18 @@ class PBSTestSuite(unittest.TestCase):
         if init_server_func is None:
             init_server_func = cls.init_server
         if 'servers' in cls.conf:
-            if 'comms' not in cls.conf:
+            if 'comms' not in cls.conf and 'comm' not in cls.conf:
                 cls.conf['comms'] = cls.conf['servers']
-            if 'schedulers' not in cls.conf:
+            if 'schedulers' not in cls.conf and 'scheduler' not in cls.conf:
                 cls.conf['schedulers'] = cls.conf['servers']
-            if 'moms' not in cls.conf:
+            if 'moms' not in cls.conf and 'mom' not in cls.conf:
                 cls.conf['moms'] = cls.conf['servers']
         if 'server' in cls.conf:
-            if 'comm' not in cls.conf:
+            if 'comms' not in cls.conf and 'comm' not in cls.conf:
                 cls.conf['comm'] = cls.conf['server']
-            if 'scheduler' not in cls.conf:
+            if 'schedulers' not in cls.conf and 'scheduler' not in cls.conf:
                 cls.conf['scheduler'] = cls.conf['server']
-            if 'mom' not in cls.conf:
+            if 'moms' not in cls.conf and 'mom' not in cls.conf:
                 cls.conf['mom'] = cls.conf['server']
         cls.servers = cls.init_from_conf(conf=cls.conf, single='server',
                                          multiple='servers', skip=skip,

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -670,19 +670,21 @@ class PBSTestSuite(unittest.TestCase):
         if init_server_func is None:
             init_server_func = cls.init_server
         if 'servers' in cls.conf:
+            server_param = cls.conf['servers']
             if 'comms' not in cls.conf and 'comm' not in cls.conf:
-                cls.conf['comms'] = cls.conf['servers']
+                cls.conf['comms'] = server_param
             if 'schedulers' not in cls.conf and 'scheduler' not in cls.conf:
-                cls.conf['schedulers'] = cls.conf['servers']
+                cls.conf['schedulers'] = server_param
             if 'moms' not in cls.conf and 'mom' not in cls.conf:
-                cls.conf['moms'] = cls.conf['servers']
+                cls.conf['moms'] = server_param
         if 'server' in cls.conf:
+            server_param = cls.conf['server']
             if 'comms' not in cls.conf and 'comm' not in cls.conf:
-                cls.conf['comm'] = cls.conf['server']
+                cls.conf['comm'] = server_param
             if 'schedulers' not in cls.conf and 'scheduler' not in cls.conf:
-                cls.conf['scheduler'] = cls.conf['server']
+                cls.conf['scheduler'] = server_param
             if 'moms' not in cls.conf and 'mom' not in cls.conf:
-                cls.conf['mom'] = cls.conf['server']
+                cls.conf['mom'] = server_param
         cls.servers = cls.init_from_conf(conf=cls.conf, single='server',
                                          multiple='servers', skip=skip,
                                          func=init_server_func)

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -673,16 +673,16 @@ class PBSTestSuite(unittest.TestCase):
             server_param = cls.conf['servers']
             if 'comms' not in cls.conf and 'comm' not in cls.conf:
                 cls.conf['comms'] = server_param
-            if 'sched' not in cls.conf and 'scheds' not in cls.conf:
-                cls.conf['scheds'] = server_param
+            if 'scheduler' not in cls.conf and 'schedulers' not in cls.conf:
+                cls.conf['schedulers'] = server_param
             if 'moms' not in cls.conf and 'mom' not in cls.conf:
                 cls.conf['moms'] = server_param
         if 'server' in cls.conf:
             server_param = cls.conf['server']
             if 'comm' not in cls.conf:
                 cls.conf['comm'] = server_param
-            if 'sched' not in cls.conf:
-                cls.conf['sched'] = server_param
+            if 'scheduler' not in cls.conf:
+                cls.conf['scheduler'] = server_param
             if 'mom' not in cls.conf:
                 cls.conf['mom'] = server_param
         cls.servers = cls.init_from_conf(conf=cls.conf, single='server',
@@ -714,8 +714,8 @@ class PBSTestSuite(unittest.TestCase):
         if init_sched_func is None:
             init_sched_func = cls.init_scheduler
         cls.scheds = cls.init_from_conf(conf=cls.conf,
-                                        single='sched',
-                                        multiple='scheds', skip=skip,
+                                        single='scheduler',
+                                        multiple='schedulers', skip=skip,
                                         func=init_sched_func)
 
         for sched in cls.scheds.values():


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PTL throws error in setUp as "list index out of range" if we use below combination in pbs_benchpress command
pbs_benchpress Testsuite -p servers=server1,nomom=server1,mom=mom1

Reason is, in init_servers, we are assigning cls.conf['moms'] = servers if 'moms' is not in cls.conf where cls.conf has param list which is passed in "pbs_benchpress -p" option. But eventually we are passing mom value with 'mom' key in -p option. While initializing moms in init_moms(), it is reading cls.conf['moms'] value which "server's hostname" and assuming it is passed through -p option. Since cls.conf['moms'] is updated with server hostname and 'nomom' is also passed in -p option, in "init_from_conf" method cls.conf['moms'] gets emptied as server hostname is in it and nomom is also set to server hostname.

#### Describe Your Change
Check for both "mom" and "moms" values in -p param list and update accordingly.

#### Test Logs
[test_logs_after_fix_with_different_param_ccombn.txt](https://github.com/PBSPro/pbspro/files/3631172/test_logs_after_fix_with_different_param_ccombn.txt)
[test_logs_before_fix.txt](https://github.com/PBSPro/pbspro/files/3631173/test_logs_before_fix.txt)


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
