### PR TITLE
Automate:Resv test suite to check the excl of node

### DIFF
--- a/test/tests/functional/pbs_cray_check_node_exclusivity.py
+++ b/test/tests/functional/pbs_cray_check_node_exclusivity.py
@@ -1,0 +1,408 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+@tags('cray', 'reservation')
+class TestCheckNodeExclusivity(TestFunctional):
+
+    """
+    Test suite for reservation. This test Suite checks
+    the exclusivity of node when a reservation asks for it.
+    Adapted for Cray Configuration
+    """
+
+    def setUp(self):
+        if not self.du.get_platform().startswith('cray'):
+            self.skipTest("Test suite only meant to run on a Cray")
+        self.script = []
+        self.script += ['echo Hello World\n']
+        self.script += ['aprun -b -B /bin/sleep 10']
+
+        TestFunctional.setUp(self)
+
+    ncpus = None
+    vnode = None
+
+    def get_vnode_ncpus_value(self):
+        all_nodes = self.server.status(NODE)
+        for n in all_nodes:
+            if n['resources_available.vntype'] == 'cray_compute':
+                self.ncpus = n['resources_available.ncpus']
+                self.vnode = n['resources_available.vnode']
+
+    def test_node_state_with_adavance_resv(self):
+        """
+        Test node state will change when reservation
+        asks for exclusivity.
+        """
+        # Submit a resrvation with place=excl
+        now = int(time.time())
+        a = {'Resource_List.select': '1:ncpus=1:vntype=cray_compute',
+             'Resource_List.place': 'excl', 'reserve_start': now + 30,
+             'reserve_end': now + 60}
+        r = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(r)
+        rid_q = rid.split('.')[0]
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+        node = self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node = self.server.reservations[rid].get_vnodes()[0]
+        self.server.expect(NODE, {'state': 'free'},
+                           id=resv_node)
+        self.server.qterm(runas=ROOT_USER)
+        self.server.start()
+        self.server.expect(NODE, {'state': 'free'},
+                           id=resv_node)
+
+        self.logger.info('Waiting 20s for reservation to start')
+        a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
+        self.server.expect(RESV, a, id=rid, offset=20)
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node)
+        # Wait for reservation to delete from server
+        msg = "Que;" + rid_q + ";deleted at request of pbs_server@"
+        self.server.log_match(msg, starttime=now, interval=10)
+        self.server.expect(NODE, {'state': 'free'},
+                           id=resv_node)
+
+    def test_node_state_with_standing_resv(self):
+        """
+        Test node state will change when reservation
+        asks for exclusivity.
+        """
+        if 'PBS_TZID' in self.conf:
+            tzone = self.conf['PBS_TZID']
+        elif 'PBS_TZID' in os.environ:
+            tzone = os.environ['PBS_TZID']
+        else:
+            self.logger.info('Missing timezone, using America/Los_Angeles')
+            tzone = 'America/Los_Angeles'
+        # Submit a standing reservation to occur every other minute for a
+        # total count of 2
+        start = int(time.time()) + 20
+        end = start + 20
+        a = {'Resource_List.select': '1:ncpus=1:vntype=cray_compute',
+             'Resource_List.place': 'excl',
+             ATTR_resv_rrule: 'FREQ=MINUTELY;COUNT=2',
+             ATTR_resv_timezone: tzone,
+             'reserve_start': start,
+             'reserve_end': end,
+             }
+        r = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(r)
+        rid_q = rid.split(".")[0]
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2'),
+             'reserve_index': 1}
+        self.server.expect(RESV, a, id=rid)
+        node = self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node = self.server.reservations[rid].get_vnodes()[0]
+        self.server.expect(NODE, {'state': 'free'},
+                           id=resv_node)
+        self.logger.info('Waiting 10s for reservation to start')
+        a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5"),
+             'reserve_index': 1}
+        self.server.expect(RESV, a, id=rid, offset=10)
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node)
+        # Wait for standing reservation first instance to finished
+        exp_attr = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2"),
+                    'reserve_index': 2}
+        self.server.expect(RESV, exp_attr, id=rid, offset=20)
+        # Node state of the nodes in resv_nodes should be free
+        self.server.expect(NODE, {'state': 'free'},
+                           id=resv_node)
+        # Wait for standing reservation second instance to start
+        self.logger.info(
+            'Waiting 40 sec for second  instance of reservation to start')
+        exp_attr = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5"),
+                    'reserve_index': 2}
+        self.server.expect(RESV, exp_attr, id=rid, offset=40, interval=1)
+        # check the node state of the nodes in resv_nodes
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node)
+        # Wait for reservations to be finished
+        msg = "Que;" + rid_q + ";deleted at request of pbs_server@"
+        self.server.log_match(msg, starttime=end, interval=2)
+        self.server.expect(NODE, {'state': 'free'},
+                           id=resv_node)
+
+    def test_job_outside_resv_not_allowed(self):
+        """
+        Test Job outside the reservation will not be allowed
+        to run if reservation has place=excl.
+        """
+        # Submit a resrvation with place=excl
+        now = int(time.time())
+        a = {'Resource_List.select': '1:ncpus=1:vntype=cray_compute',
+             'Resource_List.place': 'excl', 'reserve_start': now + 20,
+             'reserve_end': now + 30}
+        r = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(r)
+        rid_q = rid.split('.')[0]
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+        node = self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node = self.server.reservations[rid].get_vnodes()[0]
+        self.server.expect(NODE, {'state': 'free'},
+                           id=resv_node)
+        self.logger.info('Waiting 20s for reservation to start')
+        a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
+        self.server.expect(RESV, a, id=rid, offset=20)
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node)
+        # Submit a job outside the reservation requesting  resv_nodes
+        submit_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        a = {ATTR_q: 'workq', ATTR_l + '.select': '1:vnode=%s' % resv_node}
+        j1 = Job(TEST_USER, attrs=a)
+        j1.create_script(self.script)
+        jid1 = self.server.submit(j1, submit_dir=submit_dir)
+        comment = 'Not Running: Insufficient amount of resource: vnode'
+        self.server.expect(
+            JOB, {'job_state': 'Q', 'comment': comment}, id=jid1)
+        # Wait for reservation to end and verify node state
+        # changed as job-exclusive
+        msg = "Que;" + rid_q + ";deleted at request of pbs_server@"
+        self.server.log_match(msg, starttime=now, interval=2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        self.server.expect(NODE, {'state': 'job-exclusive'},
+                           id=resv_node)
+
+    def test_conflict_reservation_on_resv_exclusive_node(self):
+        """
+        Test no other reservation will get confirmed (in the duration)
+        when a node has a exclusive reservation confirmed on it.
+        Reservation2 is inside the duration of confirmed reservation
+        requesting the same vnode in Reservation1.
+        """
+        # Submit a resrvation with place=excl
+        now = int(time.time())
+        a = {'Resource_List.select': '1:ncpus=1:vntype=cray_compute',
+             'Resource_List.place': 'excl', 'reserve_start': now + 20,
+             'reserve_end': now + 60}
+        r = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+        node = self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node = self.server.reservations[rid].get_vnodes()[0]
+        self.logger.info('Waiting 20s for reservation to start')
+        a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
+        self.server.expect(RESV, a, id=rid, offset=20)
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node)
+        # Submit another reservation requesting on vnode in resv_node
+        a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % resv_node,
+             'reserve_start': now + 25,
+             'reserve_end': now + 30}
+        r = Reservation(TEST_USER, attrs=a)
+        rid2 = self.server.submit(r)
+        msg = "Resv;" + rid2 + ";Reservation denied"
+        self.server.log_match(msg, starttime=now, interval=2)
+        msg2 = "Resv;" + rid2 + ";reservation deleted"
+        self.server.log_match(msg2, starttime=now, interval=2)
+        msg3 = "Resv;" + rid2 + ";PBS Failed to confirm resv: Insufficient "
+        msg3 += "amount of resource: vnode"
+        self.scheduler.log_match(msg3, starttime=now, interval=2)
+
+    def test_node_exclusivity_with_multinode_reservation(self):
+        """
+        Test Jobs run correctly in multinode reservation
+        and accordingly update node exclusivity.
+        """
+        self.get_vnode_ncpus_value()
+        # Submit a resrvation with place=excl
+        now = int(time.time())
+        a = {ATTR_l + '.select': '2:ncpus=%d' % (int(self.ncpus)),
+             'Resource_List.place': 'excl', 'reserve_start': now + 10,
+             'reserve_end': now + 1600}
+        r = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(r)
+        rid_q = rid.split(".")[0]
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+        node = self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node = self.server.reservations[rid].get_vnodes()
+        self.logger.info('Waiting 10s for reservation to start')
+        a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
+        self.server.expect(RESV, a, id=rid, offset=10)
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node[0])
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node[1])
+        # Submit a job inside the reservation
+        submit_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        a = {ATTR_q: rid_q, ATTR_l + '.select': '1:ncpus=1',
+             'Resource_List.place': 'shared'}
+        j1 = Job(TEST_USER, attrs=a)
+        j1.create_script(self.script)
+        jid1 = self.server.submit(j1, submit_dir=submit_dir)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        self.server.expect(NODE, {'state': 'job-exclusive,resv-exclusive'},
+                           id=resv_node[0])
+        # Below steps are blocked due to PP-1213
+        # Submit aother job inside the reservation
+        submit_dir = self.du.create_temp_dir(asuser=TEST_USER)
+        a = {ATTR_q: rid_q, ATTR_l + '.select': '2:ncpus=1',
+             'Resource_List.place': 'shared'}
+        j2 = Job(TEST_USER, attrs=a)
+        j2.create_script(self.script)
+        jid2 = self.server.submit(j2, submit_dir=submit_dir)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(NODE, {'state': 'job-exclusive,resv-exclusive'},
+                           id=resv_node[0])
+
+    def test_multiple_reservation_request_exclusive_placement(self):
+        """
+        Test Multiple reservations requesting exclusive placement
+        are confirmed when not overlapping in time.
+        """
+        self.get_vnode_ncpus_value()
+        # Submit a resrvation with place=excl
+        now = int(time.time())
+        a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % self.vnode,
+             'Resource_List.place': 'excl', 'reserve_start': now + 10,
+             'reserve_duration': 3600, ATTR_inter: 5}
+        r = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+        node = self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node = self.server.reservations[rid].get_vnodes()[0]
+        # Submit a non-overlapping reservation requesting place=excl
+        a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % resv_node,
+             'Resource_List.place': 'excl',
+             'reserve_start': now + 7200,
+             'reserve_duration': 3600, ATTR_inter: 5}
+        r = Reservation(TEST_USER, attrs=a)
+        rid2 = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid2)
+
+    def test_delete_future_resv_not_effect_node_state(self):
+        """
+        Test (Advance Reservation)Multiple reservations requesting exclusive
+        placement are confirmed when not overlapping.
+        Deleting the latter reservation after earlier one starts running
+        leaves node in state resv-exclusive.
+        """
+        self.get_vnode_ncpus_value()
+        # Submit a resrvation with place=excl
+        now = int(time.time())
+        a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % self.vnode,
+             'Resource_List.place': 'excl', 'reserve_start': now + 10,
+             'reserve_duration': 3600, ATTR_inter: 5}
+        r = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+        node = self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node = self.server.reservations[rid].get_vnodes()[0]
+        # Submit a non-overlapping reservation requesting place=excli
+        # on vnode in resv_node
+        a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % resv_node,
+             'Resource_List.place': 'excl',
+             'reserve_start': now + 7200,
+             'reserve_duration': 3600, ATTR_inter: 5}
+        r = Reservation(TEST_USER, attrs=a)
+        rid2 = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid2)
+        self.logger.info('Waiting 10s for reservation to start')
+        a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
+        self.server.expect(RESV, a, id=rid, offset=10)
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node)
+        # Delete future reservation rid2 and verify that resv node
+        # is still in state resv-exclusive
+        self.server.delete(rid2)
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node)
+
+    def test_delete_future_standing_resv_not_effect_node_state(self):
+        """
+        Test (Standing Reservation)Multiple reservations requesting exclusive
+        placement are confirmed when not overlapping.
+        Deleting the latter reservation after earlier one starts running
+        leaves node in state resv-exclusive.
+        """
+        self.get_vnode_ncpus_value()
+
+        if 'PBS_TZID' in self.conf:
+            tzone = self.conf['PBS_TZID']
+        elif 'PBS_TZID' in os.environ:
+            tzone = os.environ['PBS_TZID']
+        else:
+            self.logger.info('Missing timezone, using America/Los_Angeles')
+            tzone = 'America/Los_Angeles'
+        # Submit a standing reservation with place=excl
+        now = int(time.time())
+        a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % self.vnode,
+             'Resource_List.place': 'excl',
+             ATTR_resv_rrule: 'FREQ=HOURLY;COUNT=2',
+             ATTR_resv_timezone: tzone,
+             'reserve_start': now + 10,
+             'reserve_end': now + 3100, ATTR_inter: 5}
+        r = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+        node = self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node = self.server.reservations[rid].get_vnodes()[0]
+        # Submit a non-overlapping reservation requesting place=excli
+        # on vnode in resv_node
+        a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % resv_node,
+             'Resource_List.place': 'excl',
+             ATTR_resv_rrule: 'FREQ=HOURLY;COUNT=2',
+             ATTR_resv_timezone: tzone,
+             'reserve_start': now + 7200,
+             'reserve_end': now + 10800, ATTR_inter: 5}
+        r = Reservation(TEST_USER, attrs=a)
+        rid2 = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid2)
+        self.logger.info('Waiting 10s for reservation to start')
+        a = {'reserve_state': (MATCH_RE, "RESV_RUNNING|5")}
+        self.server.expect(RESV, a, id=rid, offset=10)
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node)
+        # Delete future reservation rid2 and verify that resv node
+        # is still in state resv-exclusive
+        self.server.delete(rid2)
+        self.server.expect(NODE, {'state': 'resv-exclusive'},
+                           id=resv_node)

--- a/test/tests/functional/pbs_cray_check_node_exclusivity.py
+++ b/test/tests/functional/pbs_cray_check_node_exclusivity.py
@@ -300,7 +300,7 @@ class TestCheckNodeExclusivity(TestFunctional):
         now = int(time.time())
         a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % self.vnode,
              'Resource_List.place': 'excl', 'reserve_start': now + 10,
-             'reserve_duration': 3600, ATTR_inter: 5}
+             'reserve_duration': 3600}
         r = Reservation(TEST_USER, attrs=a)
         rid = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
@@ -311,7 +311,7 @@ class TestCheckNodeExclusivity(TestFunctional):
         a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % resv_node,
              'Resource_List.place': 'excl',
              'reserve_start': now + 7200,
-             'reserve_duration': 3600, ATTR_inter: 5}
+             'reserve_duration': 3600}
         r = Reservation(TEST_USER, attrs=a)
         rid2 = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
@@ -329,7 +329,7 @@ class TestCheckNodeExclusivity(TestFunctional):
         now = int(time.time())
         a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % self.vnode,
              'Resource_List.place': 'excl', 'reserve_start': now + 10,
-             'reserve_duration': 3600, ATTR_inter: 5}
+             'reserve_duration': 3600}
         r = Reservation(TEST_USER, attrs=a)
         rid = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
@@ -341,7 +341,7 @@ class TestCheckNodeExclusivity(TestFunctional):
         a = {ATTR_l + '.select': '1:ncpus=1:vnode=%s' % resv_node,
              'Resource_List.place': 'excl',
              'reserve_start': now + 7200,
-             'reserve_duration': 3600, ATTR_inter: 5}
+             'reserve_duration': 3600}
         r = Reservation(TEST_USER, attrs=a)
         rid2 = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
@@ -380,7 +380,7 @@ class TestCheckNodeExclusivity(TestFunctional):
              ATTR_resv_rrule: 'FREQ=HOURLY;COUNT=2',
              ATTR_resv_timezone: tzone,
              'reserve_start': now + 10,
-             'reserve_end': now + 3100, ATTR_inter: 5}
+             'reserve_end': now + 3100}
         r = Reservation(TEST_USER, attrs=a)
         rid = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
@@ -394,7 +394,7 @@ class TestCheckNodeExclusivity(TestFunctional):
              ATTR_resv_rrule: 'FREQ=HOURLY;COUNT=2',
              ATTR_resv_timezone: tzone,
              'reserve_start': now + 7200,
-             'reserve_end': now + 10800, ATTR_inter: 5}
+             'reserve_end': now + 10800}
         r = Reservation(TEST_USER, attrs=a)
         rid2 = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}

--- a/test/tests/functional/pbs_cray_check_node_exclusivity.py
+++ b/test/tests/functional/pbs_cray_check_node_exclusivity.py
@@ -86,7 +86,6 @@ class TestCheckNodeExclusivity(TestFunctional):
         resv_node = self.server.reservations[rid].get_vnodes()[0]
         self.server.expect(NODE, {'state': 'free'},
                            id=resv_node)
-        self.server.qterm(runas=ROOT_USER)
         self.server.restart()
         self.server.expect(NODE, {'state': 'free'},
                            id=resv_node)


### PR DESCRIPTION

#### Describe Bug or Feature
Automate: Resv test suite to check the excl of node_Cray_XT
Adapted to Cray.


#### Describe Your Change
Added test script to cover above test suite


#### Attach Test and Valgrind Logs/Output
[Test_execution_logs_withpep_newly_added_test.txt](https://github.com/PBSPro/pbspro/files/3632654/Test_execution_logs_withpep_newly_added_test.txt)
[Test_execution_logs_newly_added_test_non_cray.txt](https://github.com/PBSPro/pbspro/files/3634366/Test_execution_logs_newly_added_test_non_cray.txt)
[test_logs_TestCheckNodeExclusivity_on_cray.txt](https://github.com/PBSPro/pbspro/files/3635109/test_logs_TestCheckNodeExclusivity_on_cray.txt)
[test_logs_TestCheckNodeExclusivity_with_skip_on_cray.txt](https://github.com/PBSPro/pbspro/files/3635110/test_logs_TestCheckNodeExclusivity_with_skip_on_cray.txt)

