### PR TITLE
test_maintenance_reconfirm_reservation_and_run of TestMaintenanceReservations failed with unauthorized request

### DIFF
--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -425,7 +425,7 @@ class TestMaintenanceReservations(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'managers': '%s@*' % TEST_USER})
         self.server.manager(MGR_CMD_SET, SERVER,
-                            {'scheduler_iteration': 3})
+                            {'scheduler_iteration': 3}, runas=TEST_USER)
 
         self.momA = self.moms.values()[0]
         self.momB = self.moms.values()[1]

--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -423,9 +423,9 @@ class TestMaintenanceReservations(TestFunctional):
         now = int(time.time())
 
         self.server.manager(MGR_CMD_SET, SERVER,
-                            {'managers': '%s@*' % TEST_USER})
+                            {'managers': (INCR, '%s@*' % TEST_USER)})
         self.server.manager(MGR_CMD_SET, SERVER,
-                            {'scheduler_iteration': 3}, runas=TEST_USER)
+                            {'scheduler_iteration': 3})
 
         self.momA = self.moms.values()[0]
         self.momB = self.moms.values()[1]


### PR DESCRIPTION

#### Describe Bug or Feature
test_maintenance_reconfirm_reservation_and_run of TestMaintenanceReservations failed  on all platform with error with unauthorized request

#### Describe Your Change
 When test is trying to run this  self.server.manager(MGR_CMD_SET, SERVER,
{'scheduler_iteration': 3}) it throwing error as

PbsManagerError: rc=159, rv=False, msg=['qmgr obj= svr=default: Unauthorized Request ', 'qmgr: Error (15007) returned from server']

Because in test manger Value set as pbsuser
self.server.manager(MGR_CMD_SET, SERVER, {'managers': '%s@*' % TEST_USER})

But by default PTL framework is running this /opt/pbs/bin/qmgr -c set server scheduler_iteration=3 operation as pbsroot only which cause the above error.

Solution:- Test is running /opt/pbs/bin/qmgr -c set server scheduler_iteration=3 command as user pbsroot instead of test user TEST_USER (pbsuser) , need to run this command as as TEST_USER (pbsuser) in script.
Done changes as below:-
Before fix : -  self.server.manager(MGR_CMD_SET, SERVER,  {'scheduler_iteration': 3})

After fix : - self.server.manager(MGR_CMD_SET, SERVER,  {'scheduler_iteration': 3}, runas=TEST_USER)


#### Attach Test and Valgrind Logs/Output
[test_maintenance_reconfirm_reservation_and_run_after_fix.txt](https://github.com/PBSPro/pbspro/files/3634511/test_maintenance_reconfirm_reservation_and_run_after_fix.txt)
[test_maintenance_reconfirm_reservation_and_run_before_fix.txt](https://github.com/PBSPro/pbspro/files/3634520/test_maintenance_reconfirm_reservation_and_run_before_fix.txt)





