### PR TITLE
degrading reservations if the scheduled node went down when a scheduling

### DIFF
--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -358,7 +358,7 @@ extern	int  act_resv_add_owner(attribute*, void*, int);
 extern	void svr_mailownerResv(resc_resv*, int, int, char*);
 extern	void resv_free(resc_resv*);
 extern	void set_old_subUniverse(resc_resv *);
-extern	int  assign_resv_resc(resc_resv *, char *);
+extern	int  assign_resv_resc(resc_resv *, char *, int);
 extern	void  resv_exclusive_handler(resc_resv *);
 #ifdef	__cplusplus
 }

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -2493,7 +2493,7 @@ stat_update(int stream)
 				/* or resources_used was modified         */
 
 				pjob->ji_wattr[(int)JOB_ATR_session_id].at_flags &= ~ATR_VFLAG_MODIFY;
-				for (i=0; i<JOB_ATR_LAST; ++i) {
+				for (i = 0; i < JOB_ATR_LAST; ++i) {
 					if (pjob->ji_wattr[i].at_flags & ATR_VFLAG_MODIFY) {
 						job_save(pjob, SAVEJOB_FULL);
 						break;
@@ -2767,7 +2767,7 @@ discard_job(job *pjob, char *txt, int noack)
 		/* had better be the "natural" vnode with only the one parent */
 		if (pnode != NULL) {
 
-			for (i=0; i < nmom; ++i) {
+			for (i = 0; i < nmom; ++i) {
 				if ((pdsc+i)->jdcd_mom == pnode->nd_moms[0])
 					break;		/* already have this Mom */
 			}
@@ -3343,7 +3343,7 @@ ping_nodes(struct work_task *ptask)
 				return;
 			}
 
-			for (i=0; i<mominfo_array_size; i++) {
+			for (i = 0; i < mominfo_array_size; i++) {
 				if (mominfo_array[i]) {
 					ping_a_mom_mcast(mominfo_array[i], 0,
 						mtfd_ishello, mtfd_isnull,
@@ -3425,7 +3425,7 @@ setup_pnames(char *namestr)
 
 		/* is the resource name already in the pnames attribute? */
 		if (pparst) {
-			for (i=0; i<pparst->as_usedptr; ++i) {
+			for (i = 0; i < pparst->as_usedptr; ++i) {
 				if (strcasecmp(ps, pparst->as_string[i]) == 0)
 					break;
 			}
@@ -3521,7 +3521,7 @@ cross_link_mom_vnode(struct pbsnode *pnode, mominfo_t *pmom)
 
 	/* see if the node already has this Mom listed,if not add her */
 
-	for (i=0; i<pnode->nd_nummoms; ++i) {
+	for (i = 0; i < pnode->nd_nummoms; ++i) {
 		if (pnode->nd_moms[i] == pmom)
 			break;
 	}
@@ -3563,7 +3563,7 @@ cross_link_mom_vnode(struct pbsnode *pnode, mominfo_t *pmom)
 	/* Now set reverse linkage Mom -> node */
 
 	prmomsvr = pmom->mi_data;
-	for (i=0; i<prmomsvr->msr_numvnds; ++i) {
+	for (i = 0; i < prmomsvr->msr_numvnds; ++i) {
 		if (prmomsvr->msr_children[i] == pnode)
 			break;
 	}
@@ -3664,7 +3664,7 @@ update2_to_vnode(vnal_t *pvnal, int new, mominfo_t *pmom, int *madenew, int from
 
 		int have_topology   = 0;
 		int is_compute_node = 0;
-		for (i=0; i < pvnal->vnal_used; i++) {
+		for (i = 0; i < pvnal->vnal_used; i++) {
 			psrp = VNAL_NODENUM(pvnal, i);
 			if (strcasecmp(psrp->vna_name, ATTR_NODE_TopologyInfo) == 0)
 				have_topology = 1;
@@ -3785,7 +3785,7 @@ update2_to_vnode(vnal_t *pvnal, int new, mominfo_t *pmom, int *madenew, int from
 	 */
 
 	if (!from_hook) {
-		for (i=0; i < ND_ATR_LAST; ++i) {
+		for (i = 0; i < ND_ATR_LAST; ++i) {
 			/* if this vnode has been updated earlier in this update2 */
 			/* then don't free anything but topology */
 			if ((i != ND_ATR_TopologyInfo) && (pnode->nd_modified & NODE_UPDATE_VNL))
@@ -3821,7 +3821,7 @@ update2_to_vnode(vnal_t *pvnal, int new, mominfo_t *pmom, int *madenew, int from
 
 	pRA = &pnode->nd_attr[(int)ND_ATR_ResourceAvail];
 
-	for (i=0; i < pvnal->vnal_used; i++) {
+	for (i = 0; i < pvnal->vnal_used; i++) {
 		psrp = VNAL_NODENUM(pvnal, i);
 		strncpy(buf, psrp->vna_name, sizeof(buf)-1);
 		buf[sizeof(buf)-1] = '\0';
@@ -4244,7 +4244,7 @@ check_and_set_multivnode(struct pbsnode *pnode)
 		host_str1 = prc->rs_value.at_val.at_str;
 	}
 
-	for (i=0; i < svr_totnodes; i++) {
+	for (i = 0; i < svr_totnodes; i++) {
 		if (pnode != pbsndlist[i]) {
 			char *host_str2 = NULL;
 
@@ -4975,7 +4975,7 @@ found:
 					}
 					/* clear the NODE_UPDATE_VNL on all vnodes for this Mom */
 					/* It was set in update2_to_vnode() */
-					for (i=0; i<psvrmom->msr_numvnds; ++i)
+					for (i = 0; i < psvrmom->msr_numvnds; ++i)
 						(psvrmom->msr_children[i])->nd_modified &= ~NODE_UPDATE_VNL;
 
 					/* if multiple vnodes indicated (above) and
@@ -4987,7 +4987,7 @@ found:
 						(psvrmom->msr_numvnds > 1)) {
 						if (psvrmom->msr_children[1]->nd_nummoms > 1) {
 							j = psvrmom->msr_children[1]->nd_nummoms;
-							for (i=0; i<j; ++i) {
+							for (i = 0; i<j; ++i) {
 								psvrmom->msr_children[1]->nd_moms[i]->mi_modtime = vnlp->vnl_modtime;
 							}
 						}
@@ -5847,7 +5847,7 @@ write_node_state()
 	 **	The only state that carries forward is if the
 	 **	node has been marked offline.
 	 */
-	for (i=0; i<svr_totnodes; i++) {
+	for (i = 0; i < svr_totnodes; i++) {
 		np = pbsndlist[i];
 
 		if (np->nd_state & INUSE_DELETED)
@@ -6425,7 +6425,7 @@ cvt_nodespec_to_select(char *str, char **cvt_bp, size_t *cvt_lenp, attribute *pa
 		/* 4. now need to see if any property matches a node name */
 
 		for (walkprop = prop; walkprop; walkprop = walkprop->next) {
-			for (i=0; i<svr_totnodes; i++) {
+			for (i = 0; i < svr_totnodes; i++) {
 				if (pbsndlist[i]->nd_state & INUSE_DELETED)
 					continue;
 				if (strcasecmp(pbsndlist[i]->nd_name, walkprop->name) == 0) {
@@ -6604,7 +6604,7 @@ add_job_index_to_mom(struct pbsnode *pnode, job *pjob)
 
 	/* see if there is an empty slot in the array */
 
-	for (i=0; i<psm->msr_jbinxsz; i++) {
+	for (i = 0; i < psm->msr_jbinxsz; i++) {
 		if (psm->msr_jobindx[i] == NULL) {
 			psm->msr_jobindx[i] = pjob;
 			return i;
@@ -6622,7 +6622,7 @@ add_job_index_to_mom(struct pbsnode *pnode, job *pjob)
 			"could not realloc memory for adding job index");
 		return -1;
 	}
-	for (i=oldn; i<newn; i++)
+	for (i = oldn; i<newn; i++)
 		pnew[i] = NULL;
 	psm->msr_jobindx = pnew;
 	psm->msr_jbinxsz = newn;
@@ -6828,7 +6828,7 @@ build_execvnode(job *pjob, char *nds)
 	*(outbuf+strlen(outbuf)-1) = '\0';	/* remove trailing '+' */
 done:
 	/* it is safe to freeing <ndarray> upto <nnodes> as it was memset'd */
-	for (i=0; i<nnodes; ++i)
+	for (i = 0; i < nnodes; ++i)
 		free(*(ndarray+i));
 	free(ndarray);
 	ndarray = NULL;
@@ -6864,7 +6864,7 @@ which_parent_mom(pbsnode *pnode, mominfo_t *pcur_mom)
 	 */
 
 	if (pcur_mom != NULL) {
-		for (i=0; i<pnode->nd_nummoms; ++i) {
+		for (i = 0; i < pnode->nd_nummoms; ++i) {
 			if (pcur_mom == pnode->nd_moms[i])
 				return (pcur_mom);	/* use same as before */
 		}
@@ -7130,7 +7130,7 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				return (PBSE_UNKNODE);
 			}
 
-			if ((pnode->nd_state & (INUSE_DOWN | INUSE_STALE | INUSE_OFFLINE)) && (svr_init == FALSE))
+			if ((pnode->nd_state & VNODE_UNAVAILABLE) && (svr_init == FALSE))
 				if ((objtype == RESC_RESV_OBJECT) && (presv->ri_qs.ri_resvID[0] != PBS_MNTNC_RESV_ID_CHAR) /*&& (presv->ri_qs.ri_state == RESV_UNCONFIRMED)*/)
 					set_resv_for_degrade(pnode, presv);
 
@@ -7235,8 +7235,8 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				setck = 1;	/* end of multi-vnode chunk,start new */
 
 
-			for (i=0; i<nelem; i++) {
-				if (strcasecmp("ncpus", (pkvp+i)->kv_keyw) == 0)
+			for (i = 0; i < nelem; i++) {
+				if (strcasecmp("ncpus", (pkvp + i)->kv_keyw) == 0)
 					(phowl+ndindex)->hw_ncpus = atoi((pkvp+i)->kv_val);
 				else {
 					if ((find_resc_def(svr_resc_def, (pkvp+i)->kv_keyw, svr_resc_size) == NULL) && (svr_init == FALSE)) {
@@ -7248,7 +7248,7 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				}
 			}
 
-			hostcpus += (phowl+ndindex)->hw_ncpus;
+			hostcpus += (phowl + ndindex)->hw_ncpus;
 
 			if (setck == 1) {
 				(phowl+ndindex)->hw_htcpu = hostcpus;
@@ -7284,10 +7284,10 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 		ehlen = 0;
 		ehlen2 = 0;
 
-		for (i=1; i<ndindex; ++i) {
-			if ((phowl+i)->hw_chunk) {
-				ehlen  += strlen((phowl+i)->hw_natvn->nd_name) + 16;
-				ehlen2 += strlen((phowl+i)->hw_mom->mi_host) + 6 + 16;
+		for (i = 1; i < ndindex; ++i) {
+			if ((phowl + i)->hw_chunk) {
+				ehlen  += strlen((phowl + i)->hw_natvn->nd_name) + 16;
+				ehlen2 += strlen((phowl + i)->hw_mom->mi_host) + 6 + 16;
 			}
 		}
 
@@ -7518,9 +7518,9 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 			pc = ehbuf;
 			*ehbuf2 = '\0';
 			pc2 = ehbuf2;
-			for (i=0; i<ndindex; ++i) {
-				if ((phowl+i)->hw_chunk) {
-					sprintf(pc, "%s/%d", (phowl+i)->hw_natvn->nd_name,
+			for (i = 0; i < ndindex; ++i) {
+				if ((phowl + i)->hw_chunk) {
+					sprintf(pc, "%s/%d", (phowl + i)->hw_natvn->nd_name,
 						(phowl+i)->hw_index);
 
 					sprintf(pc2, "%s:%d/%d", (phowl+i)->hw_mom->mi_host,
@@ -7553,7 +7553,7 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 		/* FOR RESERVATIONS */
 
 		/* now for each node, create a resvinfo structure */
-		for (i=0; i<ndindex; ++i) {
+		for (i = 0; i < ndindex; ++i) {
 
 			struct resvinfo *rp;
 			/* Create a list of pointers to each vnode associated to the reservation */
@@ -7628,7 +7628,7 @@ free_nodes(job *pjob)
 
 	/* Now loop through the Moms and remove the jobindx entry */
 	/* and remove this jobs's jobinfo entry from each vnode   */
-	for (i=0; i<mominfo_array_size; i++) {
+	for (i = 0; i < mominfo_array_size; i++) {
 		if (mominfo_array[i] == NULL)
 			continue;
 		psvrmom = (mom_svrinfo_t *)(mominfo_array[i]->mi_data);
@@ -7749,7 +7749,7 @@ free_resvNodes(resc_resv *presv)
 	pbsnode_list_t *pnl_next;
 
 	DBPRT(("%s: entered\n", __func__))
-	for (i=0; i<svr_totnodes; i++) {
+	for (i = 0; i < svr_totnodes; i++) {
 		pnode = pbsndlist[i];
 
 		for (prev=NULL, rinfp = pnode->nd_resvp;
@@ -8509,7 +8509,7 @@ degrade_downed_nodes_reservations(void)
 	struct pbsnode *pn;
 
 	DBPRT(("%s: entered\n", __func__))
-	for (i=0; i<svr_totnodes; i++) {
+	for (i = 0; i < svr_totnodes; i++) {
 		pn = pbsndlist[i];
 		/* checking for nodes that are down, including stale state,
 		 * but excluding those that are offlined as those were checked
@@ -8779,6 +8779,17 @@ update_node_rassn(attribute *pexech, enum batch_op op)
 {
 	update_job_node_rassn(NULL, pexech, op);
 }
+
+/**
+ * @brief - Degrade a reservation.
+ *
+ * This function is different from vnode_unavailable, as here we know the
+ * reservation that needs to be degraded
+ *
+ * @param[in] - pnode - pbsnode which has gone down.
+ * @param[in] - presv - reservation that needs to be degraded.
+ *
+ */
 
 static void
 set_resv_for_degrade(struct pbsnode *pnode, resc_resv *presv)

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -8817,18 +8817,19 @@ set_resv_for_degrade(struct pbsnode *pnode, resc_resv *presv)
 	if (presv->ri_vnodes_down > presv->ri_vnodect) {
 		attribute *rsv_attr = presv->ri_wattr;
 		/* If a standing reservation we print the execvnodes sequence
-		 * string for debugging purposes */
+		 * string for debugging purposes
+		 */
 		if (rsv_attr[RESV_ATR_resv_standing].at_val.at_long) {
 			snprintf(log_buffer, sizeof(log_buffer), " execvnodes sequence %s",
 				rsv_attr[RESV_ATR_resv_execvnodes].at_val.at_str);
-			log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+			log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
 				presv->ri_qs.ri_resvID, log_buffer);
 
 		}
 		snprintf(log_buffer, sizeof(log_buffer), "vnodes in occurrence: %d; "
 			" unavailable vnodes in reservation: %d",
 			presv->ri_vnodect, presv->ri_vnodes_down);
-		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_DEBUG,
+		log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_RESV, LOG_DEBUG,
 			presv->ri_qs.ri_resvID, log_buffer);
 	}
 	presv->ri_vnodes_down++;

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -429,13 +429,14 @@ degrade_overlapping_resv(resc_resv *presv) {
  *
  * @parm[in,out]	presv	-	reservation structure
  * @parm[in]	vnodes	-	original vnode list from scheduler/operator
+ * @parm[in]	svr_init	- the server is recovering jobs and reservations
  *
  * @return	int
  * @return	0 : no problems detected in the process
  * @retval	non-zero	: error code if problem occurs
  */
 int
-assign_resv_resc(resc_resv *presv, char *vnodes)
+assign_resv_resc(resc_resv *presv, char *vnodes, int svr_init)
 {
 	int		  ret;
 	char     *node_str = NULL;
@@ -445,7 +446,7 @@ assign_resv_resc(resc_resv *presv, char *vnodes)
 		return (PBSE_BADNODESPEC);
 
 	ret = set_nodes((void *)presv, presv->ri_qs.ri_type, vnodes,
-		&node_str, &host_str, &host_str2, 0, FALSE);
+		&node_str, &host_str, &host_str2, 0, svr_init);
 
 	if (ret == PBSE_NONE) {
 		/*update resc_resv object's RESV_ATR_resv_nodes attribute*/
@@ -486,25 +487,25 @@ assign_resv_resc(resc_resv *presv, char *vnodes)
 void
 req_confirmresv(struct batch_request *preq)
 {
-	char		buf[PBS_MAXQRESVNAME+PBS_MAXHOSTNAME+256] = {0}; /* FQDN resvID+text */
-	time_t		newstart = 0;
-	attribute	*petime = NULL;
-	resc_resv	*presv = NULL;
-	int		rc = 0;
-	int		state = 0;
-	int		sub = 0;
-	int		resv_count = 0;
-	int		is_degraded = 0;
-	long		next_retry_time = 0;
-	char		*execvnodes = NULL;
-	char		*next_execvnode = NULL;
-	char		**short_xc = NULL;
-	char		**tofree = NULL;
-	char		*str_time = NULL;
-	extern char	server_host[];
-	int		is_being_altered = 0;
-	char		*tmp_buf = NULL;
-	size_t		tmp_buf_size = 0;
+	time_t newstart = 0;
+	attribute *petime = NULL;
+	resc_resv *presv = NULL;
+	int rc = 0;
+	int state = 0;
+	int sub = 0;
+	int resv_count = 0;
+	int is_degraded = 0;
+	long next_retry_time = 0;
+	char *execvnodes = NULL;
+	char *next_execvnode = NULL;
+	char **short_xc = NULL;
+	char **tofree = NULL;
+	char *str_time = NULL;
+	extern char server_host[];
+	int is_being_altered = 0;
+	char *tmp_buf = NULL;
+	size_t tmp_buf_size = 0;
+	char buf[PBS_MAXQRESVNAME+PBS_MAXHOSTNAME+256] = {0}; /* FQDN resvID+text */
 
 	if ((preq->rq_perm & (ATR_DFLAG_MGWR | ATR_DFLAG_OPWR)) == 0) {
 		req_reject(PBSE_PERM, 0, preq);
@@ -547,23 +548,20 @@ req_confirmresv(struct batch_request *preq)
 					(void)snprintf(log_buffer, sizeof(log_buffer), "Next attempt to reconfirm reservation will be made on %s", str_time);
 					log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_RESV, LOG_NOTICE, presv->ri_qs.ri_resvID, log_buffer);
 				}
-			}
-			else {
+			} else {
 				/* reached a retry attempt that falls within the cutoff
 				 * When processing an advance reservation, unset retry attribute
 				 */
 				if (presv->ri_wattr[RESV_ATR_resv_standing].at_val.at_long == 0) {
 					unset_resv_retry(presv);
-				}
-				else {
+				} else {
 					/* When processing a standing reservation, set a retry time
 					 * past the end time of the soonest occurrence.
 					 */
 					set_resv_retry(presv, presv->ri_wattr[RESV_ATR_end].at_val.at_long + RESV_RETRY_DELAY);
 				}
 			}
-		}
-		else {
+		} else {
 			if (!is_being_altered)
 				log_event(PBS_EVENTCLASS_RESV, PBS_EVENTCLASS_RESV,
 					LOG_INFO, presv->ri_qs.ri_resvID,
@@ -735,8 +733,7 @@ req_confirmresv(struct batch_request *preq)
 					preq->rq_ind.rq_run.rq_destin);
 			}
 		}
-	}
-	else { /* Advance reservation */
+	} else { /* Advance reservation */
 		next_execvnode = strdup(preq->rq_ind.rq_run.rq_destin);
 		if (next_execvnode == NULL) {
 			req_reject(PBSE_SYSTEM, 0, preq);
@@ -776,7 +773,7 @@ req_confirmresv(struct batch_request *preq)
 	 */
 	if (is_being_altered)
 		free_resvNodes(presv);
-	rc = assign_resv_resc(presv, next_execvnode);
+	rc = assign_resv_resc(presv, next_execvnode, FALSE);
 
 	if (rc != PBSE_NONE) {
 		free(next_execvnode);


### PR DESCRIPTION
cycle was in progress

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
If a reservation is confirmed on a down or stale vnode, it will go into the RESV_CONFIRMED state.  It will not be degraded unless there is some other event that will cause it to go degraded.
The same can happen for jobs as well, but we need not handle that case - for the below reasons -
1) If we reject the runjob request - the scheduler will not be looking for other nodes to run the job on.
2) It does not add value as the node can go down just after the check, so the best place to check is when we send the job for running and that check is already present.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
In set_nodes(), we check for the node to be down, offline or stale and degrade the reservation. Set the retry time and degraded time.

#### Attach Test and Valgrind Logs/Output
No new PTL tests are written as it is not possible to time the offline-ing of a node during a scheduling cycle. Smoke test for degraded reservation has passed.
[ptl_test_degrade_resv_smoke.txt](https://github.com/PBSPro/pbspro/files/3637492/ptl_test_degrade_resv_smoke.txt)
Manual testing logs are attached
[Standing reservations - manual testing.txt](https://github.com/PBSPro/pbspro/files/3637607/Standing.reservations.-.manual.testing.txt)
[Advance reservations - manual testing.txt](https://github.com/PBSPro/pbspro/files/3637608/Advance.reservations.-.manual.testing.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
