### PR TITLE
Remove ecl verify value function for log_events

### DIFF
--- a/src/lib/Libattr/master_sched_attr_def.xml
+++ b/src/lib/Libattr/master_sched_attr_def.xml
@@ -473,7 +473,7 @@
         <member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
         <member_verify_function>
         <ECL>verify_datatype_long</ECL>
-        <ECL>verify_value_zero_or_positive</ECL>
+        <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
         </member_verify_function>
    </attributes>
 

--- a/src/lib/Libattr/master_svr_attr_def.xml
+++ b/src/lib/Libattr/master_svr_attr_def.xml
@@ -717,7 +717,7 @@
 	<member_at_parent>PARENT_TYPE_SERVER</member_at_parent>
 	<member_verify_function>
 	<ECL>verify_datatype_long</ECL>
-	<ECL>verify_value_zero_or_positive</ECL>
+	<ECL>NULL_VERIFY_VALUE_FUNC</ECL>
 	</member_verify_function>
    </attributes>
    <attributes>	


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
As part of the recent move from the scheduler's log_filter to log_events, an ECL verify value function was introduced to only allow 0 or positive numbers.  The documentation lists -1 as a valid value.

#### Describe Your Change
Remove ECL verify value function