### PR TITLE
Use find_node_by_indrank() when possible

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1371,7 +1371,7 @@ dup_node_info(node_info *onode, server_info *nsinfo,
 	nnode->last_used_time = onode->last_used_time;
 
 	if (onode->svr_node != NULL)
-		nnode->svr_node = find_node_by_rank(nsinfo->nodes, onode->rank);
+		nnode->svr_node = find_node_by_indrank(nsinfo->nodes, onode->node_ind, onode->rank);
 
 	/* Duplicate list of jobs and running reservations.
 	 * If caller is dup_server_info() then nsinfo->resvs/jobs should be NULL,
@@ -2800,8 +2800,7 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 												(*nsa)->ninfo = resresv->server->nodes_by_NASrank[(*nsa)->ninfo->NASrank];
 											else
 #endif /* localmod 049 */
-											(*nsa)->ninfo = find_node_by_rank(nptr,
-												(*nsa)->ninfo->rank);
+											(*nsa)->ninfo = find_node_by_indrank(nptr, (*nsa)->ninfo->node_ind, (*nsa)->ninfo->rank);
 										}
 									}
 									while (*nsa != NULL)
@@ -3003,7 +3002,7 @@ eval_complex_selspec(status *policy, selspec *spec, node_info **ninfo_arr, place
 						(*nsa)->ninfo = resresv->server->nodes_by_NASrank[(*nsa)->ninfo->NASrank];
 					else
 #endif /* localmod 049 */
-					(*nsa)->ninfo = find_node_by_rank(ninfo_arr, (*nsa)->ninfo->rank);
+						(*nsa)->ninfo = find_node_by_indrank(ninfo_arr, (*nsa)->ninfo->node_ind, (*nsa)->ninfo->rank);
 				}
 				nsa++;
 
@@ -3268,7 +3267,7 @@ eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 								ns->ninfo = resresv->server->nodes_by_NASrank[ns->ninfo->NASrank];
 							else
 #endif /* localmod 049 */
-							ns->ninfo = find_node_by_rank(pninfo_arr, ns->ninfo->rank);
+								ns->ninfo = find_node_by_indrank(pninfo_arr, ns->ninfo->node_ind, ns->ninfo->rank);
 						}
 						if (!ninfo_arr[i]->lic_lock) {
 							ncpusreq = find_resource_req(specreq_cons, getallres(RES_NCPUS));

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1797,7 +1797,7 @@ adjust_alter_resv_nodes(resource_resv **all_resvs, node_info **all_nodes)
 			if (all_resvs[j]->resv->resv_substate == RESV_RUNNING) {
 				resv_nodes = all_resvs[j]->ninfo_arr;
 				for (i = 0; resv_nodes[i] != NULL; i++) {
-					ninfo = find_node_by_rank(all_nodes, resv_nodes[i]->rank);
+					ninfo = find_node_by_indrank(all_nodes, resv_nodes[i]->node_ind, resv_nodes[i]->rank);
 					update_node_on_end(ninfo, all_resvs[j], NULL);
 				}
 			}

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -57,9 +57,6 @@ class TestSchedPerf(TestPerformance):
                                   attrfunc=self.cust_attr_func, expect=False)
         self.server.expect(NODE, {'state=free': (GE, 10010)})
         self.scheduler.add_resource('color')
-        a = {'PBS_LOG_HIGHRES_TIMESTAMP': 1}
-        self.du.set_pbs_config(confs=a, append=True)
-        self.scheduler.restart()
 
     def cust_attr_func(self, name, totalnodes, numnode, attribs):
         """

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -250,6 +250,7 @@ class TestSchedPerf(TestPerformance):
         self.perf_test_result(((cycle1_time / cycle2_time) * 100),
                               "optimized_percentage", "percentage")
 
+    @timeout(1200)
     def test_many_chunks(self):
         num_jobs = 1000
         # Submit jobs with a large number of chunks that can't run

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -250,17 +250,18 @@ class TestSchedPerf(TestPerformance):
     @timeout(1200)
     def test_many_chunks(self):
         num_jobs = 1000
+        num_cycles = 3
         # Submit jobs with a large number of chunks that can't run
         a = {'Resource_List.select': '9999:ncpus=1:color=red'}
         jids = self.submit_jobs(a, num_jobs, wt_start=1000)
         m = 'Time taken to consider %d normal jobs' % num_jobs
         times = []
-        for i in range(3):
+        for i in range(num_cycles):
             t = self.run_cycle()
             times.append(t)
 
         self.logger.info('#' * 80)
-        for i in range(3):
+        for i in range(num_cycles):
             m2 = '[%d] %s: %.2f' % (i, m, times[i])
             self.logger.info(m2)
         self.logger.info('#' * 80)

--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -249,3 +249,22 @@ class TestSchedPerf(TestPerformance):
                         'Optimization was not faster')
         self.perf_test_result(((cycle1_time / cycle2_time) * 100),
                               "optimized_percentage", "percentage")
+
+    def test_many_chunks(self):
+        num_jobs = 1000
+        # Submit jobs with a large number of chunks that can't run
+        a = {'Resource_List.select': '9999:ncpus=1:color=red'}
+        jids = self.submit_jobs(a, num_jobs, wt_start=1000)
+        m = 'Time taken to consider %d normal jobs' % num_jobs
+        times = []
+        for i in range(3):
+            t = self.run_cycle()
+            times.append(t)
+
+        self.logger.info('#' * 80)
+        for i in range(3):
+            m2 = '[%d] %s: %.2f' % (i, m, times[i])
+            self.logger.info(m2)
+        self.logger.info('#' * 80)
+
+        self.perf_test_result(times, m, "sec")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When node buckets were introduced, some find node operations changed from O(N) to O(1).  This new method was used with the node bucket algorithm, but the normal node algorithm was not modified to use it.

#### Describe Your Change
Replace find_node_by_rank() to find_node_by_indrank() whenever possible.  

#### Attach Test and Valgrind Logs/Output
[ptl.before.log](https://github.com/PBSPro/pbspro/files/3649421/ptl.before.log)
[ptl.after.log](https://github.com/PBSPro/pbspro/files/3649420/ptl.after.log)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
