### PR TITLE
some tests from Test_Rrecord_with_resources_used failed in verifying job state.

### DIFF
--- a/test/tests/functional/pbs_Rrecord_resources_used.py
+++ b/test/tests/functional/pbs_Rrecord_resources_used.py
@@ -65,17 +65,9 @@ class Test_Rrecord_with_resources_used(TestFunctional):
         # of hostname and MoM object
         self.momA = self.moms.values()[0]
         self.momB = self.moms.values()[1]
-        self.momA.delete_vnode_defs()
-        self.momB.delete_vnode_defs()
 
         self.hostA = self.momA.shortname
         self.hostB = self.momB.shortname
-
-        self.server.manager(MGR_CMD_DELETE, NODE, None, "")
-
-        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostA)
-
-        self.server.manager(MGR_CMD_CREATE, NODE, id=self.hostB)
 
         a = {'resources_available.ncpus': 4}
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.hostA)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test 'test_Rrecord_job_rerun_forcefully' and 'test_Rrecord_when_mom_restarted_without_r' from test suite 'Test_Rrecord_with_resources_used' failing due to race condition.
- **test_Rrecord_job_rerun_forcefully**
    in this test submit 1 rerunable, 1 non-rerunable and 1 array job and expecting rerunable, non-rerunable and 1 sub job should in R state, getting all jobs are in Q state.

- **test_Rrecord_when_mom_restarted_without_r**
    in this test submit 3 non-rerunable jobs and expecting all jobs in R state, but getting jobs are in Q state.

Race condition occurred in both tests due to in setUp() PTL delete and create default node and immediately submit the jobs, but till that point Node is not in free state and jobs remains in 'Q' state.

#### Describe Your Change
PTL internally delete and create all the node and also check that nodes are in free state.
No need of delete and create default node in setUp(). remove the code for the same and after that tests passed.

#### Attach Test and Valgrind Logs/Output
[res_before_fix.txt](https://github.com/PBSPro/pbspro/files/3656138/res_before_fix.txt)
[res_after_fix.txt](https://github.com/PBSPro/pbspro/files/3656139/res_after_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
