### PR TITLE
In PTL, the check for arch is not happening in is_cpuset_mom() as the variable is being overwritten

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13108,13 +13108,13 @@ class MoM(PBSService):
         """
         if self._is_cpuset_mom is not None:
             return self._is_cpuset_mom
-        raa = ATTR_rescavail + '.arch'
-        a = {raa: None}
+        a = {'state': 'free'}
         try:
-            a = {'state': 'free'}
             self.server.expect(NODE, a, id=self.shortname, interval=1)
         except PtlExpectError:
             return False
+        raa = ATTR_rescavail + '.arch'
+        a = {raa: None}
         try:
             rv = self.server.status(NODE, a, id=self.shortname)
         except PbsStatusError:


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In is_cpuset_mom(), we are overwriting the variable which will be used to check arch of the node after the node is free. Hence we end up checking if the node is free twice and do not check the arch of the node. Found through code walkthrough.

#### Describe Your Change
Rearranged the code to ensure check for arch happens

#### Attach Test and Valgrind Logs/Output
[test_log_is_cpuset_mom.txt](https://github.com/PBSPro/pbspro/files/3656201/test_log_is_cpuset_mom.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
