### PR TITLE
Correct modulefile MANPATH from $PBS_EXEC/man to $PBS_EXEC/share/man

### DIFF
--- a/src/cmds/scripts/modulefile.in
+++ b/src/cmds/scripts/modulefile.in
@@ -14,5 +14,5 @@ puts stderr ""
 set _module_name [module-info name]
 set is_module_rm [module-info mode remove]
 set package_root @prefix@
-prepend-path MANPATH [file join ${package_root} man]
+prepend-path MANPATH [file join ${package_root} share/man]
 prepend-path PATH [file join ${package_root} bin]


### PR DESCRIPTION
The modulefile sets an incorrect MANPATH.  The end result should be $PBS_EXEC/share/man, not $PBS_EXEC/man.

