### PR TITLE
Fix in Server.expect for missing attr in status returned dict and DshUtils.create_temp_dir for create dir as user

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -41,8 +41,8 @@ import datetime
 import grp
 import logging
 import os
-import pwd
 import pickle
+import pwd
 import random
 import re
 import socket
@@ -8229,8 +8229,13 @@ class Server(PBSService):
                         ks.lower(): [ks, vs] for ks, vs in stat.items()}
                     k_lower = k.lower()
                     if k_lower not in attrs_lower:
-                        self.logger.error("Attribute %s not found" % k)
-                        return False
+                        time.sleep(interval)
+                        _tsc = trigger_sched_cycle
+                        return self.expect(obj_type, attrib, id, op, attrop,
+                                           attempt + 1, max_attempts,
+                                           interval, count, extend,
+                                           level=level, msg=" ".join(msg),
+                                           trigger_sched_cycle=_tsc)
                     stat_v = attrs_lower[k_lower][1]
                     stat_k = attrs_lower[k_lower][0]
                 else:

--- a/test/fw/ptl/utils/pbs_dshutils.py
+++ b/test/fw/ptl/utils/pbs_dshutils.py
@@ -35,19 +35,20 @@
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
 
-from subprocess import PIPE, Popen
-import os
-import sys
-import re
-import stat
-import socket
-import logging
-import traceback
 import copy
-import tempfile
-import pwd
 import grp
+import logging
+import os
 import platform
+import pwd
+import re
+import socket
+import stat
+import sys
+import tempfile
+import traceback
+from subprocess import PIPE, Popen
+
 from ptl.utils.pbs_testusers import PBS_ALL_USERS, PbsUser
 
 DFLT_RSYNC_CMD = ['rsync', '-e', 'ssh', '--progress', '--partial', '-ravz']
@@ -1310,7 +1311,7 @@ class DshUtils(object):
         # different than the one we tell PTL to use (pbs-service-nmn). This
         # causes a name mismatch, so we should just set it to be True
         if (self.get_platform() == 'shasta' and host == 'pbs-service-nmn' and
-           localhost == 'pbs-host'):
+                localhost == 'pbs-host'):
             self._h2l[host] = True
             return True
         self._h2l[host] = False
@@ -2037,6 +2038,7 @@ class DshUtils(object):
         if dirname is not None:
             dirname = str(dirname)
             self.run_copy(hostname, tmpdir, dirname, runas=asuser,
+                          recursive=True,
                           preserve_permission=False, level=level)
             tmpdir = dirname + tmpdir[4:]
 
@@ -2050,6 +2052,7 @@ class DshUtils(object):
                 # copy temp dir created on local host to remote host
                 # as different user
                 self.run_copy(hostname, tmpdir, tmpdir, runas=asuser,
+                              recursive=True,
                               preserve_permission=False, level=level)
             else:
                 # copy temp dir created on localhost to remote as current user
@@ -2065,8 +2068,10 @@ class DshUtils(object):
             # since we need to create as differnt user than current user
             # create a temp dir just to get temp dir name with absolute path
             tmpdir2 = tempfile.mkdtemp(suffix, prefix, dirname)
+            os.rmdir(tmpdir2)
             # copy the orginal temp as new temp dir
             self.run_copy(hostname, tmpdir, tmpdir2, runas=asuser,
+                          recursive=True,
                           preserve_permission=False, level=level)
             # remove original temp dir
             os.rmdir(tmpdir)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* In very last of PBSTestSuite.rever_mom we HUP/restart mom, create a node and immediately calls Server.expect() with `a = {'state': 'free', 'resources_available.ncpus': (GE, 1)}` but since the node is just created and HUPed/restarted, it is still coming online so it doesn't have `resources_available.ncpus` set on it and state is `state-unknown,down`. Now in Server.expect() at [here](https://github.com/PBSPro/pbspro/blob/master/test/fw/ptl/lib/pbs_testlib.py#L8233) we return False if we don't find given attribute name in status returned dict but returning False is wrong here, we should not return from here unless we hit max attempts.
* In DshUtils.create_temp_dir calls `self.run_copy` for dir without `recursive=True` so `cp` command fails as it needs `-r` arg for directory.
* Also in the same method at [here](https://github.com/PBSPro/pbspro/blob/master/test/fw/ptl/utils/pbs_dshutils.py#L2067) it creates tempdir just to get tempdir name but it doesn't delete dir after getting name, which leads `cp` to fails as newly created dir doesn't have proper permission


#### Describe Your Change
* In Server.expect() replace `return False` with a call to itself
* In DshUtils.create_temp_dir, pass `recursive=True` while calling `self.run_copy` and delete newly created tempdir after we get tempdir name


#### Link to Design Doc
None


#### Attach Test and Valgrind Logs/Output
* For Server.expect() - Travis will be sufficient
* For DshUtils.create_temp_dir():
  * [TestQsub_remove_files_before_fix.txt](https://github.com/PBSPro/pbspro/files/3660878/TestQsub_remove_files_before_fix.txt)
  * [TestQsub_remove_files_after_fix.txt](https://github.com/PBSPro/pbspro/files/3660879/TestQsub_remove_files_after_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->