### PR TITLE
test test_advance_resv_with_multinode_job_array from TestReservationsfailed due to race condition.

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -1064,9 +1064,9 @@ class TestReservations(TestFunctional):
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
 
         self.server.sigjob(subjid[0], 'resume')
-        self.logger.info("Wait 180s for all the subjobs to complete")
+        self.logger.info("Wait 120s for all the subjobs to complete")
         self.server.expect(JOB, {'job_state': 'F', 'exit_status': '0'},
-                           id=jid, extend='x', offset=180)
+                           id=jid, extend='x', interval=10, offset=120)
 
         self.server.expect(JOB, {'job_state': 'B'}, id=jid2)
         self.server.expect(JOB, {'job_state=R': 2}, count=True,
@@ -1086,9 +1086,9 @@ class TestReservations(TestFunctional):
         self.server.sigjob(subjid2[1], 'resume')
         self.server.expect(JOB, {'job_state=R': 2}, count=True,
                            extend='t', id=jid2)
-        self.logger.info("Wait 180s for all the subjobs to complete")
+        self.logger.info("Wait 120s for all the subjobs to complete")
         self.server.expect(JOB, {'job_state': 'F'},
-                           id=jid2, extend='x', offset=180)
+                           id=jid2, extend='x', interval=10, offset=120)
 
     def test_reservations_with_expired_subjobs(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
in test advanced reservation with 2 chunk of 2 ncpus is submitted in scatter way. The 5 subjobs of array job submitted in reservation and expecting 2 subjob is in R state and 3 subjobs are in Q state. After suspending 1st running job, test expect 1 queue job should come in R state.

Again 5 subjobs of array job is submitted and expecting it should be in Q state. After waiting for 180 sec. test expect all subjobs from first array job should be completed and 2 subjobs should be in R state and 3 subjobs should be in Q state from second array job. race condition occurred such that, while waiting for 180 sec. all subjobs from first array job completed and from second array job 2 subjobs are completed,  2 subjobs are in R state and 1 job is in Q state and test got failed. 

#### Describe Your Change
job is of 60 sec and 2 jobs are in R state at a time, we can wait 120 sec Instead of 180 sec, and check first job array is completed or not after every 10 sec. of interval. if first job array completed early so we can easily get 2 subjobs are in R state and 3 subjobs are in Q state from second job array.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[before fix.txt](https://github.com/PBSPro/pbspro/files/3670963/before.fix.txt)
[1_after_fix.txt](https://github.com/PBSPro/pbspro/files/3670964/1_after_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
