### PR TITLE
scheduler may oversubscribe node with exiting subjob

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -692,7 +692,7 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 		}
 
 		/* Make sure scheduler does not process a subjob in undesirable state*/
-		if (resresv->job->is_subjob && !resresv->job->is_running &&
+		if (resresv->job->is_subjob && !resresv->job->is_running && !resresv->job->is_exiting &&
 			!resresv->job->is_suspended && !resresv->job->is_provisioning) {
 			log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_RESV, LOG_DEBUG,
 				resresv->name, "Subjob found in undesirable state, ignoring this job");

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -490,6 +490,7 @@ select_job(job *pjob, struct select_list *psel, int dosubjobs, int dohistjobs)
 	}
 
 	if ((dosubjobs == 2) && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) &&
+		(pjob->ji_qs.ji_state != JOB_STATE_EXITING) &&
 		(pjob->ji_qs.ji_state != JOB_STATE_RUNNING)) /* select only running subjobs */
 		return 0;
 

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -491,7 +491,7 @@ select_job(job *pjob, struct select_list *psel, int dosubjobs, int dohistjobs)
 
 	if ((dosubjobs == 2) && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) &&
 		(pjob->ji_qs.ji_state != JOB_STATE_EXITING) &&
-		(pjob->ji_qs.ji_state != JOB_STATE_RUNNING)) /* select only running subjobs */
+		(pjob->ji_qs.ji_state != JOB_STATE_RUNNING)) /* select only exiting or running subjobs */
 		return 0;
 
 	if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_ArrayJob) == 0)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The scheduler can oversubscribe the node with exiting sub-job on it. As described in #1317, the sub-jobs in the exiting state are not processed by the scheduler and if such a sub-job occupies the node, the resources are miscounted.

Submitting 'sleep 1" | qsub -J 1-1000', the bug randomly appears and it looks like this:
```
(JESSIE)vchlum@torque1:~$ pbsnodes -v torque2 | grep -E "cpus|jobs"
     pcpus = 2
     jobs = 1145[719].torque1.ics.muni.cz/0, 1145[723].torque1.ics.muni.cz/1, 1145[722].torque1.ics.muni.cz/1, 1145[720].torque1.ics.muni.cz/1
     resources_available.ncpus = 2
     resources_assigned.ncpus = 4
```


#### Describe Your Change
The scheduler should process all states that occupy a node, which includes the exiting state.  Let the scheduler process JOB_STATE_EXITING too.


#### Link to Design Doc
None


#### Attach Test and Valgrind Logs/Output

PTL test is not suitable for this fix because the problem can not be reliably reproduced, but a manual test with the fix confirmed correctness - With the fix, I wasn't able to reproduce the bug at all.



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
