### PR TITLE
pbs.get_local_nodename() data inconsistencies for nodes added by IP address

### DIFF
--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -125,6 +125,7 @@
 #include	"mom_mach.h"
 #endif	/* MOM_CSA or MOM_ALPS */
 #include	"pbs_reliable.h"
+#include	<arpa/inet.h>
 
 #define STATE_UPDATE_TIME 10
 #ifndef	PRIO_MAX
@@ -8212,6 +8213,8 @@ main(int argc, char *argv[])
 	char				path_hooks_rescdef[MAXPATHLEN+1];
 	int					sock_bind_rm;
 	int					sock_bind_mom;
+	struct				sockaddr_in check_ip;
+	int				is_mom_host_ip;
 #ifdef	WIN32
 	/* Win32 only */
 	struct arg_param	*p = (struct arg_param *)pv;
@@ -8873,9 +8876,10 @@ main(int argc, char *argv[])
 	}
 	(void)strncpy(mom_short_name, mom_host, (sizeof(mom_short_name) - 1));
 	mom_short_name[(sizeof(mom_short_name) - 1)] = '\0';
-	if ((ptr = strchr(mom_short_name, (int)'.')) != NULL)
-		*ptr = '\0';  /* terminate shortname at first dot */
-
+	is_mom_host_ip = inet_pton(AF_INET, mom_host, &(check_ip.sin_addr));
+	if (!(is_mom_host_ip > 0))
+		if ((ptr = strchr(mom_short_name, (int)'.')) != NULL)
+			*ptr = '\0';  /* terminate shortname at first dot */
 	/*
 	 * Now get mom_host, which determines resources_available.host
 	 * and also the interface used to register to pbs_comm if

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -3800,10 +3800,9 @@ struct batch_request *preq;
 		}
 	}
 	is_node_ip = inet_pton(AF_INET, preq->rq_ind.rq_manager.rq_objname, &(check_ip.sin_addr));
-	if(is_node_ip > 0) {
+	if (is_node_ip > 0) {
 		log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE, LOG_INFO, preq->rq_ind.rq_manager.rq_objname,
-			"Add PBS_MOM_NODE_NAME='IP address' in /etc/pbs.conf in Mom host and restart MOM to avoid node inconsistencies.");
-
+			"Node added using IPv4 address\nVerify that PBS_MOM_NODE_NAME is configured on the respective host");
 	}
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 	rc = create_pbs_node(preq->rq_ind.rq_manager.rq_objname,

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -120,6 +120,7 @@
 #include "pbs_sched.h"
 #include "pbs_share.h"
 #include "pbs_license.h"
+#include <arpa/inet.h>
 
 
 #define PERM_MANAGER (ATR_DFLAG_MGWR | ATR_DFLAG_MGRD)
@@ -3772,6 +3773,8 @@ struct batch_request *preq;
 	long		 vn_pool;
 	struct pbsnode	*pnode;
 	mominfo_t	*mymom;
+	struct		sockaddr_in check_ip;
+	int		is_node_ip;
 
 	/*
 	 * Before creating the (v)node, validate the (v)node name using
@@ -3795,6 +3798,12 @@ struct batch_request *preq;
 			req_reject(PBSE_NODENBIG, 0, preq);
 			return;
 		}
+	}
+	is_node_ip = inet_pton(AF_INET, preq->rq_ind.rq_manager.rq_objname, &(check_ip.sin_addr));
+	if(is_node_ip > 0) {
+		log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE, LOG_INFO, preq->rq_ind.rq_manager.rq_objname,
+			"Add PBS_MOM_NODE_NAME='IP address' in /etc/pbs.conf in Mom host and restart MOM to avoid node inconsistencies.");
+
 	}
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 	rc = create_pbs_node(preq->rq_ind.rq_manager.rq_objname,


### PR DESCRIPTION
#### Describe Bug or Feature
* When a node is created using IP address, the hook API pbs.get_local_nodename() returns the host name of the machine. In cgroups hook, the pbs.get_local_nodename() returning hostname is matched with the exec_vnode of the job which is set to the IP address. There is a mismatch of these two, the job does not run successfully.
* When a node is created using IP address and the PBS_MOM_NODE_NAME variable is set in /etc/pbs.conf, pbs.get_local_nodename() returns a part of the IP address since the mom name is split by a dot i.e. Ex- If the IP adrdess is 172.0.0.1 then the above api returns just "172". In cgroups hooks, this is matched with exec_vnode of the job which is the full IP address and there is a mismatch.

#### Describe Your Change
For a case, where the nodes are created using IP address, we will make it mandatory for the users to set the variable PBS_MOM_NODE_NAME in /etc/pbs.conf and check if it's an IP address then don't split it by the dot.

#### Attach Test and Valgrind Logs/Output
I have ran all automated tests and none failed. 

[verification_logs.txt](https://github.com/PBSPro/pbspro/files/3675519/verification_logs.txt)
[cgroups_hook_logs.txt](https://github.com/PBSPro/pbspro/files/3675520/cgroups_hook_logs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
