### PR TITLE
PTL fails in setUp when PBS is stopped

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -714,6 +714,13 @@ class PBSTestSuite(unittest.TestCase):
                                          func=init_server_func)
         if cls.servers:
             cls.server = cls.servers.values()[0]
+            for _server in cls.servers.values():
+                rv = _server.isUp()
+                if not rv:
+                    cls.logger.error('server ' + _server.hostname + ' is down')
+                    _server.pi.restart(_server.hostname)
+                    msg = 'Failed to restart server ' + _server.hostname
+                    cls.assertTrue(_server.isUp(), msg)
 
     @classmethod
     def init_comms(cls, init_comm_func=None, skip=None):


### PR DESCRIPTION
#### Describe Bug or Feature
When PBS is stopped on the machine and if you run PTL/pbs_benchpress then it fails with below error, which it shouldn't. Means it should start PBS daemons before reverting them to default.

Error:
File "/opt/ptl/lib/python2.7/site-packages/ptl/utils/pbs_testsuite.py", line 770, in init_schedulers
cls.scheduler = cls.scheds['default']
KeyError: 'default'

#### Describe Your Change
After initializing servers, check if server is up and running. If not then restart PBS.

#### Attach Test Logs/Output
[test_logs_after_fix.txt](https://github.com/PBSPro/pbspro/files/3675599/test_logs_after_fix.txt)
[test_logs_before_fix.txt](https://github.com/PBSPro/pbspro/files/3675600/test_logs_before_fix.txt)
