### PR TITLE
Build fails in opensuse leap-15 due to third party issues

### DIFF
--- a/.travis/do.sh
+++ b/.travis/do.sh
@@ -37,8 +37,8 @@ if [ "x${ONLY_REBUILD}" != "x1" ]; then
     zypper -n update
     zypper -n install rpmdevtools python3-pip sudo which net-tools man time.x86_64
     rpmdev-setuptree
-    zypper -n install --force-resolution $(rpmspec --buildrequires -q ${SPEC_FILE} | awk '{print $1}'| sort -u | grep -vE '^(/bin/)?(ba)?sh$')
-    zypper -n install --force-resolution $(rpmspec --requires -q ${SPEC_FILE} | awk '{print $1}'| sort -u | grep -vE '^(/bin/)?(ba)?sh$')
+    zypper -n install --force-resolution $(rpmspec --buildrequires -q ${SPEC_FILE} | sort -u | grep -vE '^(/bin/)?(ba)?sh$')
+    zypper -n install --force-resolution $(rpmspec --requires -q ${SPEC_FILE} | sort -u | grep -vE '^(/bin/)?(ba)?sh$')
     pip3 install -r ${REQ_FILE}
   elif [ "x${ID}" == "xdebian" ]; then
     if [ "x${DEBIAN_FRONTEND}" == "x" ]; then

--- a/pbspro.spec
+++ b/pbspro.spec
@@ -100,7 +100,7 @@ BuildRequires: rpm-build
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool
-BuildRequires: hwloc-devel
+BuildRequires: hwloc-devel < 2.0
 BuildRequires: libX11-devel
 BuildRequires: libXt-devel
 BuildRequires: libedit-devel

--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -100,7 +100,7 @@ BuildRequires: rpm-build
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool
-BuildRequires: hwloc-devel
+BuildRequires: hwloc-devel < 2.0
 BuildRequires: libX11-devel
 BuildRequires: libXt-devel
 BuildRequires: libedit-devel


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Travis builds are failing in OpenSuse Leap 15 as it fetches the latest version of hwloc available in its repo (hwloc 2.0) which does not work with PBSPro resulting in compilation failure


#### Describe Your Change
* hwloc version should be lesser than 2.0 (updating rpm spec file)
* Travis build scripts should make use of version specified in the rpm spec file


#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
Travis Build Fix - Infra changes.



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->

CC: @arungrover 