### PR TITLE
Fixed call to find_node_by_indrank()

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -3211,14 +3211,14 @@ eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 							ns->end_of_chunk = 1;
 						}
 
-						if (ns != NULL) {
-							/* replace the dup'd node with the real one */
+						/* Replace the dup'd node with the real one, but only if we dup'd the nodes */
+						if (ns != NULL && pninfo_arr != ninfo_arr) {
 #ifdef NAS /* localmod 049 */
 							if (ns->ninfo->rank == resresv->server->nodes_by_NASrank[ns->ninfo->NASrank]->rank)
 								ns->ninfo = resresv->server->nodes_by_NASrank[ns->ninfo->NASrank];
 							else
-#endif /* localmod 049 */
-								ns->ninfo = find_node_by_indrank(pninfo_arr, ns->ninfo->node_ind, ns->ninfo->rank);
+#endif /* localmod 049 */					/* Need to call find_node_by_rank() over indrank since eval_placement might dup the nodes */
+								ns->ninfo = find_node_by_rank(pninfo_arr, ns->ninfo->rank);
 						}
 						if (!ninfo_arr[i]->lic_lock) {
 							ncpusreq = find_resource_req(specreq_cons, getallres(RES_NCPUS));


### PR DESCRIPTION
## Describe Bug or Feature
A recent change to the normal node codepath changed several calls of find_node_by_rank() to find_node_by_indrank().  I was a little overzealous on this and changed too many.  The two calls in eval_complex_selspec() and eval_placement() are correct.  The call in eval_simple_selspec() is not.  The reason the call in eval_simple_selspec() is wrong is the fact that eval_placement() dups the nodes for free placement.  We need the exec_vnode structures to hold pointers to the dup'd nodes, so we can modify the nodes.  When you call find_node_by_indrank(), you get pointers back to the real nodes.  This means that when eval_placement() is trying to modify the dup'd nodes, it would modify the real node and perturb future attempts to run jobs.

#### Describe Your Change
Revert the call to find_node_by_indrank() in eval_selspec() to find_node_by_rank()

#### Attach Test and Valgrind Logs/Output
This was a refactoring project that went a little far.  No extra testing should be required.
