### PR TITLE
Fix remote manager commands in PTL

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6548,7 +6548,9 @@ class Server(PBSService):
             else:
                 as_script = False
 
-            if not self._is_local or as_script:
+            if (not self._is_local or as_script or
+                (runas and
+                 not self.du.is_localhost(PbsUser.get_user(runas).host))):
                 execcmd = '\'' + " ".join(execcmd) + '\''
             else:
                 execcmd = " ".join(execcmd)


### PR DESCRIPTION
#### Describe Bug or Feature
When users with userhosts try to use manager, and the userhost is a remote host, then manager needs to quote the command.


#### Describe Your Change
Check `runas` is defined and the host is remote, if so then quote the command. 


#### Attach Test and Valgrind Logs/Output
[after-fix.txt](https://github.com/PBSPro/pbspro/files/3688230/after-fix.txt)
[before-fix.txt](https://github.com/PBSPro/pbspro/files/3688231/before-fix.txt)
