### PR TITLE
Fix PTL setup on Shasta

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5051,6 +5051,20 @@ class Server(PBSService):
                                           'lib', 'python', 'altair',
                                           'pbs_hooks',
                                           'PBS_translate_mpp.HK')
+        self.jacs_hk = os.path.join(self.pbs_conf['PBS_HOME'],
+                                    'server_priv', 'hooks',
+                                    'PBS_cray_jacs.HK')
+        self.dflt_jacs_hk = os.path.join(self.pbs_conf['PBS_EXEC'],
+                                         'lib', 'python', 'altair',
+                                         'pbs_hooks',
+                                         'PBS_cray_jacs.HK')
+        self.jacs_cf = os.path.join(self.pbs_conf['PBS_HOME'],
+                                    'server_priv', 'hooks',
+                                    'PBS_cray_jacs.CF')
+        self.dflt_jacs_cf = os.path.join(self.pbs_conf['PBS_EXEC'],
+                                         'lib', 'python', 'altair',
+                                         'pbs_hooks',
+                                         'PBS_cray_jacs.CF')
         self.unset_svr_attrib()
         for k in self.dflt_attributes.keys():
             if(k not in self.attributes or


### PR DESCRIPTION
#### Describe Bug or Feature
PR #1117 broke ptl setup on shasta by removing the declarations of some hook-path variables.


#### Describe Your Change
Put the declarations back in 


#### Attach Test and Valgrind Logs/Output
[after-fix.txt](https://github.com/PBSPro/pbspro/files/3692506/after-fix.txt)
[before-fix.txt](https://github.com/PBSPro/pbspro/files/3692507/before-fix.txt)
