### PR TITLE
Make ALPS inventory hook compatible with python 3

### DIFF
--- a/src/modules/python/pbs_hooks/PBS_alps_inventory_check.PY
+++ b/src/modules/python/pbs_hooks/PBS_alps_inventory_check.PY
@@ -135,12 +135,14 @@ def get_mom_home():
 
     return home
 
+
 def hup_mom():
     PBS_MOM_HOME = get_mom_home()
     pidfile = open(os.path.join(PBS_MOM_HOME, "mom_priv", "mom.lock"))
     pid = int(pidfile.readline())
     pidfile.close()
     os.kill(pid, SIGHUP)
+
 
 def get_apstat_nids(msg):
     """
@@ -169,11 +171,11 @@ def get_apstat_nids(msg):
         __exit_hook(1, msg)
 
     pattern = re.compile(
-        "(?P<nid>.+?)\s+(?P<arch>.+?)\s+(?P<state>.+?)\s+" +
-        "(?P<hw>.+?)\s+(?P<everything>.+)")
+        r"(?P<nid>.+?)\s+(?P<arch>.+?)\s+(?P<state>.+?)\s+" +
+        r"(?P<hw>.+?)\s+(?P<everything>.+)")
 
     for apstat_line in apstat_out.stdout:
-        apstat_line = apstat_line.strip()
+        apstat_line = apstat_line.decode().strip()
 
         apstat_record = re.search(pattern, apstat_line)
 
@@ -207,7 +209,7 @@ def my_addresses():
             continue
 
         test_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        ifreq = struct.pack('256s', ifname[:15])
+        ifreq = struct.pack('256s', bytes(ifname[:15], "utf-8"))
 
         try:
             sockaddr_in = fcntl.ioctl(test_socket.fileno(),


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
ALPS inventory hook errors out while trying to sync PBS and ALPS. Once compute nodes are populated, any state changed happening to nodes won't be updated in PBS.


#### Describe Your Change
The errors in the hook are related to Python 3 changes. As part of this PR, I made the hook python 3 compatible.
- Under function my_addresses() hook makes a call to fcntl.ioctl() and we need to change ifname to bytes.
- Under get_apstat_nids(), once we have apstat output we parse each line looking for the nids. Here each of these lines is retuned as bytes and we try to so string operations on them. We need to decode them before we use.

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
