### PR TITLE
Fix test failures of pbs_cray_reliable_job_startup testsuite

### DIFF
--- a/test/tests/functional/pbs_cray_reliable_job_startup.py
+++ b/test/tests/functional/pbs_cray_reliable_job_startup.py
@@ -124,7 +124,7 @@ if e.job.in_ms_mom():
                 break
         self.assertTrue(input_file is not None)
         with PBSLogUtils().open_log(input_file, sudo=True) as f:
-            self.assertTrue(search_str in f.read())
+            self.assertTrue(search_str in f.read().decode())
             self.logger.info("Found \"%s\" in %s" % (search_str, input_file))
 
     @tags('cray')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
We get a " TypeError: a bytes-like object is required, not 'str'" error while running tests from pbs_cray_reliable_job_startup.py. In def match_str_in_input_file(), we are reading data from a file as bytes and searching a string in the read data. So we need to decode the read data before doing a search.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Used decode() on data read from the file in def match_str_in_input_file()

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
NA

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
