### PR TITLE
memory leak when maintenance overlaps a reservation

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7561,7 +7561,7 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 			if (rp) {
 				pbsnode_list_t *tmp_pl;
 				rp->next = (phowl + i)->hw_pnd->nd_resvp;
-				(phowl+i)->hw_pnd->nd_resvp = rp;
+				(phowl + i)->hw_pnd->nd_resvp = rp;
 				rp->resvp = presv;
 
 				/* create a backlink from the reservation to the vnode */
@@ -7575,7 +7575,7 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 				presv->ri_pbsnode_list = tmp_pl;
 				presv->ri_vnodect++;
 				DBPRT(("%s: Adding %s to %s\n", __func__,
-					(phowl+i)->hw_pnd->nd_name, presv->ri_qs.ri_resvID))
+					(phowl + i)->hw_pnd->nd_name, presv->ri_qs.ri_resvID))
 			}
 		}
 		presv->ri_qs.ri_svrflags |= RESV_SVFLG_HasNodes;
@@ -7752,15 +7752,15 @@ free_resvNodes(resc_resv *presv)
 	for (i = 0; i < svr_totnodes; i++) {
 		pnode = pbsndlist[i];
 
-		for (prev=NULL, rinfp = pnode->nd_resvp;
-			rinfp; prev=rinfp, rinfp = rinfp->next) {
+		for (prev = NULL, rinfp = pnode->nd_resvp;
+			rinfp; prev = rinfp, rinfp = rinfp->next) {
 
 
 			if (rinfp->resvp != presv)
 				continue;
 
 			/* garbage collect the pbsnode_list */
-			for (pnl = presv->ri_pbsnode_list, pnl_next=pnl; pnl_next; pnl = pnl_next) {
+			for (pnl = presv->ri_pbsnode_list, pnl_next = pnl; pnl_next; pnl = pnl_next) {
 				pnl_next = pnl->next;
 				free(pnl);
 			}

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -250,7 +250,7 @@ remove_node_from_resv(resc_resv *presv, struct pbsnode *pnode)
 		return;
 	}
 
-	snprintf(tmp_buf, strlen(pnode->nd_name) + 1,"%s:", pnode->nd_name);
+	snprintf(tmp_buf, strlen(pnode->nd_name) + 1, "%s:", pnode->nd_name);
 
 	/* remove the node '(vn[n]:foo)' from RESV_ATR_resv_nodes attribute */
 	if (presv->ri_wattr[RESV_ATR_resv_nodes].at_flags & ATR_VFLAG_SET) {
@@ -325,7 +325,7 @@ remove_node_from_resv(resc_resv *presv, struct pbsnode *pnode)
 	}
 
 	/* traverse the reservations of the node and remove the reservation if found */
-	for (prev = NULL, rinfp = pnode->nd_resvp; rinfp; prev=rinfp, rinfp = rinfp->next) {
+	for (prev = NULL, rinfp = pnode->nd_resvp; rinfp; prev = rinfp, rinfp = rinfp->next) {
 		if (strcmp(presv->ri_qs.ri_resvID, rinfp->resvp->ri_qs.ri_resvID) == 0) {
 			if (prev == NULL)
 				pnode->nd_resvp = rinfp->next;
@@ -351,9 +351,21 @@ remove_node_from_resv(resc_resv *presv, struct pbsnode *pnode)
 void
 remove_host_from_resv(resc_resv *presv, char *hostname) {
 	pbsnode_list_t *pl = NULL;
-	for (pl = presv->ri_pbsnode_list; pl != NULL; pl = pl->next) {
-		if (strcmp(pl->vnode->nd_hostname, hostname) == 0)
+	pbsnode_list_t *prev = NULL;
+
+	for (prev = NULL, pl = presv->ri_pbsnode_list; pl != NULL;) {
+		if (strcmp(pl->vnode->nd_hostname, hostname) == 0) {
 			remove_node_from_resv(presv, pl->vnode);
+			if (prev == NULL) {
+				presv->ri_pbsnode_list = pl->next;
+				free(pl);
+				pl = presv->ri_pbsnode_list;
+			} else {
+				prev->next = pl->next;
+				free(pl);
+				pl = prev->next;
+			}
+		}
 	}
 }
 
@@ -369,7 +381,8 @@ remove_host_from_resv(resc_resv *presv, char *hostname) {
  *
  */
 void
-degrade_overlapping_resv(resc_resv *presv) {
+degrade_overlapping_resv(resc_resv *presv)
+{
 	pbsnode_list_t *pl = NULL;
 	struct resvinfo *rip;
 	resc_resv *tmp_presv;

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -365,6 +365,9 @@ remove_host_from_resv(resc_resv *presv, char *hostname) {
 				free(pl);
 				pl = prev->next;
 			}
+		} else {
+			prev = pl;
+			pl = pl->next;
 		}
 	}
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
valgrind detected memory leak while running TestMaintenanceReservations with the below stack -
> 64 bytes in 4 blocks are definitely lost in loss record 96 of 734
   at 0x4C271B2: malloc (vg_replace_malloc.c:298)
   by 0x483EDC: set_nodes (node_manager.c:7568)
   by 0x4ABD99: assign_resv_resc (req_rescq.c:448)
   by 0x4AC69B: req_confirmresv (req_rescq.c:776)
   by 0x50C5F6: process_socket (net_server.c:504)
   by 0x50C730: wait_request (net_server.c:585)
   by 0x4911A9: main (pbsd_main.c:2141)

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
When a maintenance overlaps a reservation, we remove the nodes belonging to the maintenance from the resv_nodes of the reservation and the reservation is also removed from all the vnodes belonging to the host(s) on which the maintenance is submitted. Now, when we delete the reservation, we call free_resvNodes(). This function parses all the nodes on the server and free()s the ri_pbsnode_list. However, we had removed the reference of this reservation from the node when we submitted the maintenance, hence ri_pbsnode_list is not free()-ed.

**Solution:** While removing the host from the reservation, delete the vnode(s) of that host from ri_pbsnode_list as well.

#### Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[val_out_before.txt](https://github.com/PBSPro/pbspro/files/3698913/val_out_before.txt)
[val_out_after.txt](https://github.com/PBSPro/pbspro/files/3698914/val_out_after.txt)
