### PR TITLE
release_19_1_branch: Make mom accept only privileged requests

### DIFF
--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -472,6 +472,12 @@ process_request(int sfds)
 		return;
 	}
 
+	if ((conn->cn_authen & PBS_NET_CONN_FROM_PRIVIL) == 0) {
+		req_reject(PBSE_BADCRED, 0, request);
+		close_client(sfds);
+		return;
+	}
+
 	request->rq_fromsvr = 1;
 	request->rq_perm = ATR_DFLAG_USRD | ATR_DFLAG_USWR |
 			   ATR_DFLAG_OPRD | ATR_DFLAG_OPWR |


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* An attacker can sniff the network (e.g. using tcpdump) and as a regular user modify the execution user attribute of a job.

* The cause is that pbs_mom just blindly accepts any request, trusting that it is coming from a pbs_server process (daemon process) running on a privilege port.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* The privileged port origin check is missing in pbs_mom (it's there on the pbs_server side) the job can execute as an unauthorized user, including root.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [fix_19_1_test.txt](https://github.com/PBSPro/pbspro/files/3699058/fix_19_1_test.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->