### PR TITLE
Node wrongly assigned to suspended job after server restart

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -7385,6 +7385,13 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 					}
 				}
 			}
+			else if ((svr_init == TRUE) &&
+				((pjob->ji_qs.ji_substate == JOB_SUBSTATE_SUSPEND ||
+				  pjob->ji_qs.ji_substate == JOB_SUBSTATE_SCHSUSP)) &&
+				(pjob->ji_wattr[(int)JOB_ATR_resc_released].at_flags & ATR_VFLAG_SET))
+				/* No need to add suspended job to jobinfo structure and assign CPU slots to it*/
+				break;
+
 			snp = pnode->nd_psn;
 			if ((phowl+i)->hw_ncpus == 0) {
 				/* setup jobinfo struture */

--- a/test/tests/functional/pbs_release_limited_res_suspend.py
+++ b/test/tests/functional/pbs_release_limited_res_suspend.py
@@ -949,7 +949,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'preempt_order': preempt_method}, runas=ROOT_USER)
 
-        # Set 1gb mem available on the node
+        # Set 2 ncpus available on the node
         a = {ATTR_rescavail + '.ncpus': "2"}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
 
@@ -997,3 +997,42 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.mom.add_config(c)
 
         self.helper_test_preempt_release_all("C")
+
+    def test_server_restart_with_suspened_job(self):
+        """
+        Test that when a job releases limited resources on a node and then
+        PBS server is restarted, the job is able to resume back on the same
+        node.
+        """
+        # Set ncpus in restrict_res_to_release_on_suspend server attribute
+        a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        # Set 2 ncpus available on the node
+        self.server.manager(MGR_CMD_DELETE, NODE, id="@default")
+        self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom.shortname)
+        a = {ATTR_rescavail + '.ncpus': "2"}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        # Submit a job which takes up all of the ncpus
+        j1 = Job(TEST_USER)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=2'})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        # make sure that job id is part of node's jobs attribute
+        node = self.server.status(NODE, id=self.mom.shortname)
+        self.assertTrue(jid1 in node[0]['jobs'])
+
+        # suspend job
+        self.server.sigjob(jobid=jid1, signal="suspend")
+
+        self.server.restart()
+
+        self.assertTrue(self.server.isUp())
+        self.server.expect(NODE, {'state': 'free'}, id=self.mom.shortname)
+        self.server.expect(NODE, 'jobs', op=UNSET, id=self.mom.shortname)
+
+        # resume job
+        self.server.sigjob(jobid=jid1, signal="resume")
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)

--- a/test/tests/functional/pbs_release_limited_res_suspend.py
+++ b/test/tests/functional/pbs_release_limited_res_suspend.py
@@ -1009,8 +1009,6 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
 
         # Set 2 ncpus available on the node
-        self.server.manager(MGR_CMD_DELETE, NODE, id="@default")
-        self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom.shortname)
         a = {ATTR_rescavail + '.ncpus': "2"}
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
 
@@ -1022,7 +1020,7 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
 
         # make sure that job id is part of node's jobs attribute
         node = self.server.status(NODE, id=self.mom.shortname)
-        self.assertTrue(jid1 in node[0]['jobs'])
+        self.assertIn(jid1, node[0]['jobs'])
 
         # suspend job
         self.server.sigjob(jobid=jid1, signal="suspend")
@@ -1036,3 +1034,4 @@ class TestReleaseLimitedResOnSuspend(TestFunctional):
         # resume job
         self.server.sigjob(jobid=jid1, signal="resume")
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+        self.server.expect(NODE, 'jobs', op=SET, id=self.mom.shortname)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If a running job is suspended and then server is restarted, the node gets assigned back again to the job. This only happens when restrict_res_to_release_on_suspend attribute is set in PBS server.
The cause of the problem is that when "restrict_res_to_release_on_suspend" is set on server, PBS server on a restart calls "reassign_resc()" on suspended jobs with released resources. This function internally calls set_nodes which sets the node's "jobs" attribute and assigns virtual cpu slots to this job.

#### Describe Your Change
Added a check in set_nodes to check if the job that is suspended and set_nodes is called on a restart for the first time, do not allow set_nodes to modify node's "jobs" attribute or state.

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
[test_before.txt](https://github.com/PBSPro/pbspro/files/3700018/test_before.txt)
[test_after.txt](https://github.com/PBSPro/pbspro/files/3700019/test_after.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
