### PR TITLE
Fix windows redistributable installation

### DIFF
--- a/src/cmds/scripts/win_postinstall.py
+++ b/src/cmds/scripts/win_postinstall.py
@@ -101,7 +101,7 @@ def install_vcredist():
     cmd += ['/q', '/norestart']
     ret = __run_cmd(cmd)
     if ret > 0:
-        if ret == 5100:
+        if ret == 1638:
             msg = 'Newer version of Visual C++ redistributable is already'
             msg += 'installed, ignoring this installation'
             __log_info(msg)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Installation of Visual C++ 2015-2019 Redistributable is failing if the system already has the higher version of Redistributable installed.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The previous version of Visual C++ 2008 Redistributable had 5100 as the error code if it found that the system already has a newer version of redistributable. The upgraded Visual C++ 2015-2019 Redistributable has 1638 as the error code for the same reason.  So just changing the code from '5100' to '1638'.


#### Attach Test and Valgrind Logs/Output
Test Logs: 
[windows_fix_log.txt](https://github.com/PBSPro/pbspro/files/3706556/windows_fix_log.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
