### PR TITLE
Removing double free of provisioning info structure

### DIFF
--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -6566,7 +6566,6 @@ check_and_enqueue_provisioning(job *pjob, int *need_prov)
 		if ((prov_vnode_info->pvnfo_aoe_req = strdup(aoe_req)) == NULL) {
 			free(prov_vnode_list);
 			free_pvnfo(prov_vnode_info);
-			free(prov_vnode_info);
 			if (aoe_req)
 				free(aoe_req);
 			return PBSE_SYSTEM;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
It was found in code inspection that we free up a provisioning info structure twice if a strdup fails (rarely a case)

#### Describe Your Change
removed double free

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
No test results

