### PR TITLE
while deleting sub-job, the server can get stuck in an infinite loop

### DIFF
--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -552,8 +552,11 @@ req_deletejob(struct batch_request *preq)
 			}
 
 			sjst = get_subjob_state(parent, i);
-			if ((sjst == JOB_STATE_EXITING) && !forcedel)
+			if ((sjst == JOB_STATE_EXITING) && !forcedel) {
+				x += z; /* ignore it */
 				continue;
+			}
+
 			if ((pjob = parent->ji_ajtrk->tkm_tbl[i].trk_psubjob)) {
 				if (delhist)
 					pjob->ji_deletehistory = 1;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
I observed that the server can get stuck in an infinite loop. If the sub-job state is JOB_STATE_EXITING and the server tries to delete it, then the sub-job is meant to be skipped but the array index is not increased, which leads to infinite loop.


#### Describe Your Change
Increase the sub-job index, please see the context of the change. It is obvious. It is a similar case to the case for 'no such index' a few lines above.


#### Link to Design Doc
None


#### Attach Test and Valgrind Logs/Output
None. The PTL test is not suitable because it is not easy to reproduce this bug.



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
