### PR TITLE
TestNonprintingCharacters: python3 adjustments to open()

### DIFF
--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -145,7 +145,7 @@ sleep 5
         job_out = '\n'.join(ret['out'])
         self.logger.info('job output from %s:\n%s' % (job_outfile, job_out))
         job_output = ""
-        with open(job_outfile, 'r') as f:
+        with open(job_outfile, 'r', newline="") as f:
             job_output = f.read().strip()
         self.assertEqual(job_output, chk_var)
         self.logger.info('job output has: %s' % chk_var)
@@ -741,7 +741,7 @@ sleep 5
             # Once all commands sent and matched, job exits
             self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=1)
             # Check for the non-printable character in the output file
-            with open(self.job_out1_tempfile) as fd:
+            with open(self.job_out1_tempfile, newline="") as fd:
                 pkey = ""
                 penv = {}
                 for line in fd:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Non printing character \r is getting converted to \n when using open() on the output file. 


#### Describe Your Change
Use newline="" in open().


#### Attach Test Logs/Output
[TestNonprintingCharacters_a01.txt](https://github.com/PBSPro/pbspro/files/3714006/TestNonprintingCharacters_a01.txt)

![image](https://user-images.githubusercontent.com/17935097/66605995-fff54880-eb65-11e9-8b9e-bd3e374ed614.png)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
