### PR TITLE
Few of the tests of TestMomHookSync are failing while verifying the msg count

### DIFF
--- a/test/tests/functional/pbs_mom_hook_sync.py
+++ b/test/tests/functional/pbs_mom_hook_sync.py
@@ -175,10 +175,10 @@ class TestMomHookSync(TestFunctional):
             'to %s.*' % self.momB.hostname,
             starttime=now, max_attempts=10, regexp=True)
 
-        # the higher the number, the earlier the line appears in the log
-        self.assertTrue(match_delete[0] > match_sent1[0])
-        self.assertTrue(match_delete[0] > match_sent2[0])
-        self.assertTrue(match_delete[0] > match_sent3[0])
+        # Lower the linecount, earlier the line appears in log
+        self.assertTrue(match_delete[0] < match_sent1[0])
+        self.assertTrue(match_delete[0] < match_sent2[0])
+        self.assertTrue(match_delete[0] < match_sent3[0])
 
     def test_momhook_to_momhook_with_resume(self):
         """
@@ -226,8 +226,8 @@ class TestMomHookSync(TestFunctional):
             'to %s.*' % self.momB.hostname,
             starttime=now, max_attempts=10, regexp=True)
 
-        # the higher the number, the earlier the line appears in the log
-        self.assertTrue(match_sent[0] > match_delete[0])
+        # Lower the linecount, earlier the line appears in log
+        self.assertTrue(match_sent[0] < match_delete[0])
 
         self.server.log_match(
             'successfully sent hook file .*cpufreq.CF ' +
@@ -299,10 +299,10 @@ class TestMomHookSync(TestFunctional):
             'to %s.*' % self.momB.hostname,
             starttime=now, max_attempts=10, regexp=True)
 
-        # the higher the number, the earlier the line appears in the log
-        self.assertTrue(match_delete[0] > match_sent1[0])
-        self.assertTrue(match_delete[0] > match_sent2[0])
-        self.assertTrue(match_delete[0] > match_sent3[0])
+        # Lower the linecount, earlier the line appears in log
+        self.assertTrue(match_delete[0] < match_sent1[0])
+        self.assertTrue(match_delete[0] < match_sent2[0])
+        self.assertTrue(match_delete[0] < match_sent3[0])
 
     def test_momhook_to_momhook_with_restart(self):
         """


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Few of the tests of TestMomHookSync are failing while verifying the msg count

#### Describe Your Change

- The test failed while verifying that the following msg "successfully sent hook file .*cpufreq.HK" is appearing in the server_logs before the log msg "successfully deleted hook file cpufreq.HK". This is acheived in the test by comparing the linecount return by log_match function for both the msgs.

- With the changes made to the "log_lines" function as part of [PR:1268](https://github.com/PBSPro/pbspro/pull/1268/) the line count is reported in the ascending order of the log msgs i.e the lower the number of linecount, earlier the line appears in logs 

- Need to update the tests to look that the linecount of the following msg "successfully sent hook file .*cpufreq.HK" is less than the linecount of msg "successfully deleted hook file cpufreq.HK"

#### Attach Test and Valgrind Logs/Output

- [Execution_logs_TestMomHookSync_aftr_fix.txt](https://github.com/PBSPro/pbspro/files/3715862/Execution_logs_TestMomHookSync_aftr_fix.txt)

- [Execution_logs_TestMomHookSync_bfr_fix.txt](https://github.com/PBSPro/pbspro/files/3715863/Execution_logs_TestMomHookSync_bfr_fix.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
