### PR TITLE
PTL's server.expect does not reset operator

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8341,7 +8341,7 @@ class Server(PBSService):
             return self.expect(obj_type, attrib, id, op, attrop, attempt + 1,
                                max_attempts, interval, count, extend,
                                runas=runas, level=level, msg=" ".join(msg))
-
+        inp_op = op
         for k, v in attrib.items():
             varargs = None
             if isinstance(v, tuple):
@@ -8349,6 +8349,8 @@ class Server(PBSService):
                 if len(v) > 2:
                     varargs = v[2:]
                 v = v[1]
+            else:
+                op = inp_op
 
             for stat in statlist:
                 if k not in stat:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When more than one attribute is given to PTL's server.expect call to match and one of the attribute has an operator set on it, expect() retains the value of operator and try to use the same operator for all other attributes.
For instance `self.server.expect(JOB, {'job_state': (NE, 'running'), 'comment': 'Job not running'}, id=jid)` will make server's expect method to set operator to NE for the first attribute (job_state in this case) and then it will retain this operator and try to check that comment is also "Not-Equal" to "Job not running". 


#### Describe Your Change
Store the value of the input operator and use that for comparing attributes when an explicit operator is not specified for each attribute.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Test "test_maintenance_confirm" fails because of this issue - 
[test_before.txt](https://github.com/PBSPro/pbspro/files/3719086/test_before.txt)
[test_after.txt](https://github.com/PBSPro/pbspro/files/3719087/test_after.txt)
