### PR TITLE
Fixed maintenance resv test to set managers correctly

### DIFF
--- a/test/tests/functional/pbs_maintenance_reservations.py
+++ b/test/tests/functional/pbs_maintenance_reservations.py
@@ -244,7 +244,7 @@ class TestMaintenanceReservations(TestFunctional):
         now = int(time.time())
 
         self.server.manager(MGR_CMD_SET, SERVER,
-                            {'managers': '%s@*' % TEST_USER})
+                            {'managers': (INCR, '%s@*' % TEST_USER)})
 
         a = {'reserve_start': now + 3600,
              'reserve_end': now + 7200}
@@ -255,7 +255,8 @@ class TestMaintenanceReservations(TestFunctional):
 
         self.assertTrue(rid.startswith('M'))
 
-        self.server.manager(MGR_CMD_UNSET, SERVER, 'managers')
+        self.server.manager(MGR_CMD_SET, SERVER,
+                            {'managers': (DECR, '%s@*' % TEST_USER)})
 
         msg = ""
 
@@ -267,7 +268,7 @@ class TestMaintenanceReservations(TestFunctional):
         self.assertEqual("pbs_rdel: Unauthorized Request  " + rid, msg)
 
         self.server.manager(MGR_CMD_SET, SERVER,
-                            {'managers': '%s@*' % TEST_USER})
+                            {'managers': (INCR, '%s@*' % TEST_USER)})
 
         self.server.delete(rid, runas=TEST_USER)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test_maintenance_resv test was creating TEST_USER as manager and then unsetting the managers attribute. This was overwriting the existing "managers" attribute on the server object (which by default is the user who is running the test). Because of overwriting managers attribute, unset command used to fail with permission denied error.

#### Describe Your Change
Instead of overwriting the attribute, use INCR/DECR operator to change managers

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test.txt](https://github.com/PBSPro/pbspro/files/3726247/test.txt)
[test_fixed.txt](https://github.com/PBSPro/pbspro/files/3726248/test_fixed.txt)
