### PR TITLE
test_man_pages fails because man is not installed

### DIFF
--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1520,8 +1520,8 @@ class SmokeTest(PBSTestSuite):
         man_cmd = "man"
         man_bin_path = self.du.which(exe=man_cmd)
         if man_bin_path == man_cmd:
-            self.skip_test(reason='man is not available. Please install man '
-                                  'and try again. ')
+            self.skip_test(reason='man command is not available. Please '
+                                  'install man and try again.')
         manpath = os.path.join(pbs_conf['PBS_EXEC'], "share", "man")
         pbs_cmnds = ["pbsnodes", "qsub"]
         os.environ['MANPATH'] = manpath

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1517,6 +1517,11 @@ class SmokeTest(PBSTestSuite):
         Test basic functionality of man pages
         """
         pbs_conf = self.du.parse_pbs_config(self.server.shortname)
+        man_cmd = "man"
+        man_bin_path = self.du.which(exe=man_cmd)
+        if man_bin_path == man_cmd:
+            self.skip_test(reason='man is not available. Please install man '
+                                  'and try again. ')
         manpath = os.path.join(pbs_conf['PBS_EXEC'], "share", "man")
         pbs_cmnds = ["pbsnodes", "qsub"]
         os.environ['MANPATH'] = manpath


### PR DESCRIPTION
#### Describe Bug or Feature
The test_man_pages test case from Smoketest fails when man is not found on the system.

#### Describe Your Change
The test_man_pages test case should check for the existence of man and if it is not there then skip the test rather than failing. 

#### Attach Test 
[test_man_pages_skip.txt](https://github.com/PBSPro/pbspro/files/3730503/test_man_pages_skip.txt)
