### PR TITLE
Fix potential memory corruption in hook alarm signal handler

### DIFF
--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -95,10 +95,6 @@ static pthread_once_t log_once_ctl = PTHREAD_ONCE_INIT;
 static pthread_key_t pbs_log_tls_key;
 static pthread_mutex_t log_mutex;
 
-struct pbs_log_lock {
-	int locked;
-};
-
 char *msg_daemonname;
 
 /* Local Data */
@@ -275,15 +271,15 @@ log_get_tls_data(void)
 int
 log_mutex_lock()
 {
-	long log_lock;
-	if ((log_lock = (long)pthread_getspecific(pbs_log_tls_key)) != 0)
+	void *log_lock;
+	if ((log_lock = pthread_getspecific(pbs_log_tls_key)) != 0)
 		return -1;
 
 	if (pthread_mutex_lock(&log_mutex) != 0)
 		return -1;
 	
 	log_lock = 1;
-	pthread_setspecific(pbs_log_tls_key, (void*)log_lock);
+	pthread_setspecific(pbs_log_tls_key, log_lock);
 
 	return 0;
 }
@@ -305,15 +301,15 @@ log_mutex_lock()
 int
 log_mutex_unlock()
 {
-	long log_lock;
-	if ((log_lock = (long)pthread_getspecific(pbs_log_tls_key)) == 0)
+	void *log_lock;
+	if ((log_lock = pthread_getspecific(pbs_log_tls_key)) == 0)
 		return -1;
 	
 	if (pthread_mutex_unlock(&log_mutex) != 0)
 		return -1;
 
 	log_lock = 0;
-	pthread_setspecific(pbs_log_tls_key, (void*)log_lock);
+	pthread_setspecific(pbs_log_tls_key, log_lock);
 	
 	return 0;
 }

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -272,13 +272,14 @@ int
 log_mutex_lock()
 {
 	void *log_lock;
-	if ((log_lock = pthread_getspecific(pbs_log_tls_key)) != 0)
+	if ((log_lock = pthread_getspecific(pbs_log_tls_key)) != NULL)
 		return -1;
 
 	if (pthread_mutex_lock(&log_mutex) != 0)
 		return -1;
 	
-	log_lock = 1;
+	/* use &log_lock for non-null value */
+	log_lock = &log_lock;
 	pthread_setspecific(pbs_log_tls_key, log_lock);
 
 	return 0;
@@ -302,13 +303,13 @@ int
 log_mutex_unlock()
 {
 	void *log_lock;
-	if ((log_lock = pthread_getspecific(pbs_log_tls_key)) == 0)
+	if ((log_lock = pthread_getspecific(pbs_log_tls_key)) == NULL)
 		return -1;
 	
 	if (pthread_mutex_unlock(&log_mutex) != 0)
 		return -1;
 
-	log_lock = 0;
+	log_lock = NULL;
 	pthread_setspecific(pbs_log_tls_key, log_lock);
 	
 	return 0;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Hook alarm signal handler could potentially cause memory corruption. It calls `log_event()`, which has a `calloc()` and `calloc()` is not safe to call from within a signal handler. 

#### Describe Your Change
Use stack memory for `log_lock` to instead allocating heap memory.

#### Link to Design Doc
N/A

#### Attach Test and Valgrind Logs/Output
[SmokeTest.txt](https://github.com/PBSPro/pbspro/files/3735742/SmokeTest.txt)
[TestHookSmokeTest.txt](https://github.com/PBSPro/pbspro/files/3735743/TestHookSmokeTest.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->