### PR TITLE
Job executing prologue hook could get stuck in substate=41.

### DIFF
--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -383,7 +383,6 @@ extern int   open_slave(void);
 extern char *rcvttype(int);
 extern int   rcvwinsize(int);
 extern int   remtree(char *);
-extern void  rid_job(char *jobid, char *msg);
 extern void  scan_for_exiting(void);
 extern void  scan_for_terminated(void);
 extern int   setwinsize(int);

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -383,7 +383,7 @@ extern int   open_slave(void);
 extern char *rcvttype(int);
 extern int   rcvwinsize(int);
 extern int   remtree(char *);
-extern void  rid_job(char *jobid);
+extern void  rid_job(char *jobid, char *msg);
 extern void  scan_for_exiting(void);
 extern void  scan_for_terminated(void);
 extern int   setwinsize(int);

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -2730,39 +2730,6 @@ send_sisters_deljob_wait(job *pjob)
 		return 0;
 
 }
-/**
- * @brief
- * 	rid_job - rid mom of a job that the server says no longer exists
- *
- * @param[in] jobid - char pointer holding jobid
- * @param[in] msg - message to log if job has been deleted.
- *
- * @return Void
- *
- */
-void
-rid_job(char *jobid, char *msg)
-{
-	job	*pjob;
-
-	pjob = find_job(jobid);
-	if (pjob && !pjob->ji_hook_running_bg_on && (pjob->ji_qs.ji_substate != JOB_SUBSTATE_PRERUN)) {
-		/* Allowing only to rid a job that has actually started
-		 * (i.e. not in JOB_SUBSTATE_PRERUN), would avoid the race condition
-		 * resulting in a hung job: server force reruns a job which
-		 * is lingering in PRERUN state, and an Obit request for
-		 * the previous instance of the job is received by the server and
-		 * rejected, causing mom to delete the new instance of the
-		 * job.
-		 * If the job has passed the PRERUN stage, then it would have already
-		 * synced up with the server on status, and not end up in this
-		 * race condition.
-		 */
-		if (msg != NULL)
-			log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_NOTICE, jobid, msg);
-		mom_deljob(pjob);
-	}
-}
 
 /**
  * @brief

--- a/src/resmom/mom_server.c
+++ b/src/resmom/mom_server.c
@@ -1029,9 +1029,7 @@ is_request(int stream, int version)
 			if (ret != DIS_SUCCESS)
 				goto err;
 
-			log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_NOTICE,
-				jobid, "Job removed, Server rejected Obit");
-			rid_job(jobid);
+			rid_job(jobid, "Job removed, Server rejected Obit");
 			free(jobid);
 			jobid = NULL;
 			break;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* A job that is in pre-execution stage (i.e. executing a prologue hook, in substate=41/PRERUN), can be interrupted with qrerun -W force. This causes the server to immediately rerun the job without waiting for an acknowledgement from Mom (it's "forced") that she has killed the job. Server would just send a discard message to the mom to delete the previous version of the job.
* A race condition can occur where Server reruns the job, but then immediately receives an Obit request from the mom as she had killed the original job.Now server  rejects the Obit request from 
 Mom since it had already started a new instance of the job. When Mom receives the server's reject obit reply, it proceeds to delete the job that happens to be the newly instantiated job!
* The end result is a hung job: server knows of the newly instantiated job; mom forgets about the job.
* Server_logs snippet shows server rerunning the job, but then immediately receives an Obit request from mom:
10/15/2019 15:00:24.156178;0008;Server@x100-s15;Job;107.x100-s15;Discard running job, Force rerun
...
10/15/2019 15:00:29.553551;0008;Server@x100-s15;Job;107.x100-s15;Job Run at request of Scheduler@x100-s15.pbspro.com on exec_vnode (x100-s15:ncpus=1)
10/15/2019 15:00:29.564214;0080;Server@x100-s15;Job;107.x100-s15;Obit received momhop:1 serverhop:2 state:4 substate:41
10/15/2019 15:00:29.564246;0001;Server@x100-s15;Svr;Server@x100-s15;Success (0) in job_obit, reject_obit(107.x100-s15): run is for an older run version of the job

* Mom_logs show it has received the reject obit reply and proceeds to forget the job:
10/16/2019 09:14:12.046179;0008;pbs_mom;Job;107.x100-s15;Job removed, Server rejected Obit


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* When mom receives the reject obit reply from server, it calls the function rid_job(). Code has been adjusted to only issue a mom_deljob() (i.e. forget the job) if job is actually running (not in PRERUN state like executing the prologue hook) so as to prevent the race condition. When job is in PRERUN state and is forgotten by Mom, job would never progress at all. 


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* Ran: pbs_benchpress -t TestQdel_Wforce_ext.test_qrerun_job_in_prologue_hook 100 times, and on the 55th try, it failed stuck looking for job to advance from substate=41 (PRERUN) to substate=42 (RUNNING):
[ptl.prologue_qrerun.FAIL.txt](https://github.com/PBSPro/pbspro/files/3746287/ptl.prologue_qrerun.FAIL.txt)

* Ran: pbs_benchpress -t TestQdel_Wforce_ext.test_qrerun_job_in_prologue_hook 100 times on the fixed code and it all passed:
[ptl.prologue_qrerun.PASS.txt](https://github.com/PBSPro/pbspro/files/3746288/ptl.prologue_qrerun.PASS.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
