### PR TITLE
Checking userhome and update core file report

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -831,11 +831,11 @@ class PTLTestRunner(Plugin):
                 user_home_files = du.listdir(hostname=hostname, path=u.home,
                                              sudo=True, fullpath=False,
                                              runas=u.name)
-                if user_home_files is not None:
-                    if fnmatch.filter(user_home_files, "core*"):
-                        _msg = hostname + ": user-" + str(u)
-                        _msg += ": core files found in "
-                        self.logger.warning(_msg + u.home)
+                if user_home_files and fnmatch.filter(
+                        user_home_files, "core*"):
+                    _msg = hostname + ": user-" + str(u)
+                    _msg += ": core files found in "
+                    self.logger.warning(_msg + u.home)
 
     def startTest(self, test):
         """

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -829,11 +829,13 @@ class PTLTestRunner(Plugin):
                     self.logger.warning(_msg)
             for u in PBS_ALL_USERS:
                 user_home_files = du.listdir(hostname=hostname, path=u.home,
-                                             sudo=True, fullpath=False)
-                if fnmatch.filter(user_home_files, "core*"):
-                    _msg = hostname + ": user-" + str(u)
-                    _msg += ": core files found in "
-                    self.logger.warning(_msg + u.home)
+                                             sudo=True, fullpath=False,
+                                             runas=u.name)
+                if user_home_files is not None:
+                    if fnmatch.filter(user_home_files, "core*"):
+                        _msg = hostname + ": user-" + str(u)
+                        _msg += ": core files found in "
+                        self.logger.warning(_msg + u.home)
 
     def startTest(self, test):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
 Ptl checks the core files in home directory of all the users on every host. It's not valid on all systems. The users don't exist on the server node.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
check the core files if userhome directory is exist. 



#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[no_core_files_when_no_use.txt](https://github.com/PBSPro/pbspro/files/3742503/no_core_files_when_no_use.txt)
[core_file_found_in_user_home (2).txt](https://github.com/PBSPro/pbspro/files/3742505/core_file_found_in_user_home.2.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
