### PR TITLE
Wrong value represented for custom resource of type float in multi-chunk requests

### DIFF
--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -2184,6 +2184,8 @@ set_chunk_sum(attribute  *pselectattr, attribute *pattr)
 							return PBSE_BADATVAL;	/* illegal null value */
 						if (svr_resc_sum[i].rs_def->rs_type == ATR_TYPE_SIZE)
 							tmpatr.at_val.at_size.atsv_num *= nchk;
+						else if (svr_resc_sum[i].rs_def->rs_type == ATR_TYPE_FLOAT)
+							tmpatr.at_val.at_float *= nchk;
 						else
 							tmpatr.at_val.at_long *= nchk;
 

--- a/test/tests/functional/pbs_resource_multichunk.py
+++ b/test/tests/functional/pbs_resource_multichunk.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestResourceMultiChunk(TestFunctional):
+
+    """
+    Test suite to test value of custom resource
+    in a multi chunk job request
+    """
+    def setUp(self):
+        TestFunctional.setUp(self)
+        attr = {}
+        attr['type'] = 'float'
+        attr['flag'] = 'nh'
+        r = 'foo_float'
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id=r)
+        self.scheduler.add_resource('foo_float')
+        a = {'resources_available.foo_float': 4.2,
+             'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+    def test_resource_float_type(self):
+        """
+        Test to check the value of custom resource
+        in Resource_List.<custom resc> matches the value
+        requested by the multi-chunk job
+        """
+        a = {'Resource_List.select': '2:ncpus=1:foo_float=0.8',
+             'Resource_List.place': 'shared'}
+        j = Job(TEST_USER, attrs=a)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.expect(JOB, {'Resource_List.foo_float': 1.6}, id=jid)


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When you create a float custom resource and use it in a multi-chunk job request, the custom resource amounts are not updated correctly


#### Describe Your Change
While calculating the total amount of resource for a multi-chunk request, we were not checking if the type was float (ATR_TYPE_FLOAT). The resource was being treated a long(ATR_TYPE_LONG) and hence incorrect value was being computed. To fix this, in set_chunk_sum(),  we added a condition to handle float type of resource.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[TestResourceMultiChunk_oss.txt](https://github.com/PBSPro/pbspro/files/3738541/TestResourceMultiChunk_oss.txt)
[TestResourceMultiChunk_oss_bf.txt](https://github.com/PBSPro/pbspro/files/3738542/TestResourceMultiChunk_oss_bf.txt)
[oss_test_log.txt](https://github.com/PBSPro/pbspro/files/3738553/oss_test_log.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->