### PR TITLE
Fix two test case bugs

### DIFF
--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -2089,4 +2089,3 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id='sc2')
         self.server.log_match("processing priority socket", starttime=t)
-

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -45,6 +45,10 @@ class TestMultipleSchedulers(TestFunctional):
     """
     Test suite to test different scheduler interfaces
     """
+    rlimit_flag = 0
+
+    open_files_soft_limit = ''
+    open_files_hard_limit = ''
 
     def setup_sc1(self):
         a = {'partition': 'P1,P4',
@@ -1835,12 +1839,14 @@ class TestMultipleSchedulers(TestFunctional):
 
         try:
             # get the number of open files per process
-            (open_files_soft_limit, open_files_hard_limit) =\
+            (TestMultipleSchedulers.open_files_soft_limit,
+             TestMultipleSchedulers.open_files_hard_limit) = \
                 resource.getrlimit(resource.RLIMIT_NOFILE)
 
             # set the soft limit of number of open files per process to 10
-            resource.setrlimit(resource.RLIMIT_NOFILE,
-                               (10, open_files_hard_limit))
+            resource.setrlimit(resource.RLIMIT_NOFILE,(10,
+                                TestMultipleSchedulers.open_files_hard_limit))
+            TestMultipleSchedulers.rlimit_flag = 1
         except (ValueError, resource.error):
             self.assertFalse(True, "Error in accessing system RLIMIT_ "
                                    "variables, test fails.")
@@ -1852,8 +1858,8 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id="sc3")
 
-        self.logger.info('The sleep is 15 seconds which will trigger required '
-                         'number of scheduling cycles that are needed to '
+        self.logger.info('The sleep is 15 seconds which will trigger required'
+                         ' number of scheduling cycles that are needed to '
                          'exhaust open files per process which is 10 in our '
                          'case')
         time.sleep(15)
@@ -1861,13 +1867,6 @@ class TestMultipleSchedulers(TestFunctional):
         # are exhausted.
         self.server.expect(SCHED, {'scheduling': 'True'},
                            id='sc3', max_attempts=10)
-
-        try:
-            resource.setrlimit(resource.RLIMIT_NOFILE, (open_files_soft_limit,
-                                                        open_files_hard_limit))
-        except (ValueError, resource.error):
-            self.assertFalse(True, "Error in accessing system RLIMIT_ "
-                                   "variables, test fails.")
 
     def test_set_msched_attr_sched_log_with_sched_off(self):
         """
@@ -2084,3 +2083,16 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id='sc2')
         self.server.log_match("processing priority socket", starttime=t)
+
+    def tearDown(self):
+        if TestMultipleSchedulers.rlimit_flag == 1:
+            try:
+                resource.setrlimit(resource.RLIMIT_NOFILE,
+                                (TestMultipleSchedulers.open_files_soft_limit,
+                                TestMultipleSchedulers.open_files_hard_limit))
+                TestMultipleSchedulers.rlimit_flag = 0
+            except (ValueError, resource.error):
+                self.assertFalse(True, "Error in accessing system RLIMIT_ "
+                                       "variables, test fails.")
+        TestFunctional.tearDown(self)
+

--- a/test/tests/functional/pbs_test_entity_limits.py
+++ b/test/tests/functional/pbs_test_entity_limits.py
@@ -67,16 +67,16 @@ class TestEntityLimits(TestFunctional):
             self.server.manager(MGR_CMD_SET, SERVER, entstr)
 
         if queued:
-            j = Job(TST_USR, job_attr)
+            j = Job(TEST_USER, job_attr)
             jid = self.server.submit(j)
             self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
         for _ in range(self.limit):
-            j = Job(TST_USR, job_attr)
+            j = Job(TEST_USER, job_attr)
             self.server.submit(j)
 
         try:
-            j = Job(TST_USR, job_attr)
+            j = Job(TEST_USER, job_attr)
             self.server.submit(j)
         except PbsSubmitError as e:
             if e.msg[0] != exp_err:
@@ -90,7 +90,7 @@ class TestEntityLimits(TestFunctional):
         try:
             jval = "1-" + str(self.limit + 1)
             job_attr[ATTR_J] = jval
-            j = Job(TST_USR, job_attr)
+            j = Job(TEST_USER, job_attr)
             jid = self.server.submit(j)
         except PbsSubmitError as e:
             if e.msg[0] != exp_err:
@@ -102,18 +102,18 @@ class TestEntityLimits(TestFunctional):
         jval = "1-" + str(self.limit)
         job_attr[ATTR_J] = jval
 
-        j = Job(TST_USR, job_attr)
+        j = Job(TEST_USER, job_attr)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'B'}, id=jid)
 
         del job_attr[ATTR_J]
 
         if queued:
-            j = Job(TST_USR, job_attr)
+            j = Job(TEST_USER, job_attr)
             self.server.submit(j)
 
         try:
-            j = Job(TST_USR, job_attr)
+            j = Job(TEST_USER, job_attr)
             self.server.submit(j)
         except PbsSubmitError as e:
             if e.msg[0] != exp_err:
@@ -145,12 +145,12 @@ class TestEntityLimits(TestFunctional):
 
     def test_server_user_limits_queued(self):
         """
-        Test queued_jobs_threshold for user TST_USR at the server level.
+        Test queued_jobs_threshold for user TEST_USER at the server level.
         """
         a = {"queued_jobs_threshold":
-             "[u:" + str(TST_USR) + "=" + str(self.limit) + "]"}
+             "[u:" + str(TEST_USER) + "=" + str(self.limit) + "]"}
         errmsg = "qsub: Maximum number of jobs in 'Q' state for user " + \
-            str(TST_USR) + ' already in complex'
+            str(TEST_USER) + ' already in complex'
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
     def test_server_project_limits_queued(self):
@@ -216,10 +216,10 @@ class TestEntityLimits(TestFunctional):
         Test queued_jobs_threshold for user pbsuser1 for the default queue.
         """
         a = {"queued_jobs_threshold":
-             "[u:" + str(TST_USR) + "=" + str(self.limit) + "]"}
+             "[u:" + str(TEST_USER) + "=" + str(self.limit) + "]"}
         attrs = {ATTR_queue: self.server.default_queue}
         errmsg = "qsub: Maximum number of jobs in 'Q' state for user " + \
-            str(TST_USR) + ' already in queue ' + self.server.default_queue
+            str(TEST_USER) + ' already in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
     def test_queue_group_limits_queued(self):
@@ -291,9 +291,9 @@ class TestEntityLimits(TestFunctional):
         Test queued_jobs_threshold_res for user pbsuser1 at the server level.
         """
         a = {"queued_jobs_threshold_res.ncpus":
-             "[u:" + str(TST_USR) + "=" + str(self.limit) + "]"}
+             "[u:" + str(TEST_USER) + "=" + str(self.limit) + "]"}
         attrs = {'Resource_List.select': '1:ncpus=1'}
-        errmsg = 'qsub: would exceed user ' + str(TST_USR) + \
+        errmsg = 'qsub: would exceed user ' + str(TEST_USER) + \
             "'s limit on resource ncpus in complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
@@ -369,10 +369,10 @@ class TestEntityLimits(TestFunctional):
         Test queued_jobs_threshold_res for user pbsuser1 for the default queue.
         """
         a = {"queued_jobs_threshold_res.ncpus":
-             "[u:" + str(TST_USR) + "=" + str(self.limit) + "]"}
+             "[u:" + str(TEST_USER) + "=" + str(self.limit) + "]"}
         attrs = {ATTR_queue: self.server.default_queue,
                  'Resource_List.select': '1:ncpus=1'}
-        errmsg = 'qsub: would exceed user ' + str(TST_USR) + \
+        errmsg = 'qsub: would exceed user ' + str(TEST_USER) + \
             "'s limit on resource ncpus in queue " + \
             self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
@@ -452,8 +452,8 @@ class TestEntityLimits(TestFunctional):
         Test max_queued for user pbsuser1 at the server level.
         """
         a = {"max_queued":
-             "[u:" + str(TST_USR) + "=" + str(self.limit) + "]"}
-        errmsg = 'qsub: Maximum number of jobs for user ' + str(TST_USR) + \
+             "[u:" + str(TEST_USER) + "=" + str(self.limit) + "]"}
+        errmsg = 'qsub: Maximum number of jobs for user ' + str(TEST_USER) + \
             ' already in complex'
         self.common_limit_test(True, a, exp_err=errmsg)
 
@@ -517,9 +517,9 @@ class TestEntityLimits(TestFunctional):
         Test max_queued for user pbsuser1 for the default queue.
         """
         a = {"max_queued":
-             "[u:" + str(TST_USR) + "=" + str(self.limit) + "]"}
+             "[u:" + str(TEST_USER) + "=" + str(self.limit) + "]"}
         attrs = {ATTR_queue: self.server.default_queue}
-        errmsg = 'qsub: Maximum number of jobs for user ' + str(TST_USR) + \
+        errmsg = 'qsub: Maximum number of jobs for user ' + str(TEST_USER) + \
             ' already in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
@@ -591,9 +591,9 @@ class TestEntityLimits(TestFunctional):
         Test max_queued_res for user pbsuser1 at the server level.
         """
         a = {"max_queued_res.ncpus":
-             "[u:" + str(TST_USR) + "=" + str(self.limit) + "]"}
+             "[u:" + str(TEST_USER) + "=" + str(self.limit) + "]"}
         attrs = {'Resource_List.select': '1:ncpus=1'}
-        errmsg = 'qsub: would exceed user ' + str(TST_USR) + \
+        errmsg = 'qsub: would exceed user ' + str(TEST_USER) + \
             "'s limit on resource ncpus in complex"
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
@@ -666,10 +666,10 @@ class TestEntityLimits(TestFunctional):
         Test max_queued_res for user pbsuser1 for the default queue.
         """
         a = {"max_queued_res.ncpus":
-             "[u:" + str(TST_USR) + "=" + str(self.limit) + "]"}
+             "[u:" + str(TEST_USER) + "=" + str(self.limit) + "]"}
         attrs = {ATTR_queue: self.server.default_queue,
                  'Resource_List.select': '1:ncpus=1'}
-        errmsg = 'qsub: would exceed user ' + str(TST_USR) + \
+        errmsg = 'qsub: would exceed user ' + str(TEST_USER) + \
             "'s limit on resource ncpus in queue " + \
             self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
@@ -750,12 +750,12 @@ class TestEntityLimits(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {ATTR_scheduling: 'False'})
 
         attrs = {ATTR_queue: qname, 'Resource_List.' + res_name: 9}
-        j_1 = Job(TST_USR, attrs)
+        j_1 = Job(TEST_USER, attrs)
         J_1_id = self.server.submit(j_1)
 
         try:
             attrs = {ATTR_queue: qname, 'Resource_List.' + res_name: 2}
-            j_2 = Job(TST_USR, attrs)
+            j_2 = Job(TEST_USER, attrs)
             self.server.submit(j_2)
         except PbsSubmitError as e:
             exp_err = 'qsub: would exceed limit on resource ' + res_name + \
@@ -772,7 +772,7 @@ class TestEntityLimits(TestFunctional):
 
         try:
             attrs = {ATTR_queue: qname, 'Resource_List.' + res_name: 1}
-            j_3 = Job(TST_USR, attrs)
+            j_3 = Job(TEST_USER, attrs)
             self.server.submit(j_3)
         except PbsSubmitError as e:
             exp_err = 'qsub: would exceed limit on resource ' + res_name + \
@@ -796,14 +796,14 @@ class TestEntityLimits(TestFunctional):
         a = {"queued_jobs_threshold":
              "[u:PBS_GENERIC=5]"}
         self.server.manager(MGR_CMD_SET, QUEUE, a, defqname)
-        jd = Job(TST_USR, {ATTR_queue: defqname})
-        j2 = Job(TST_USR, {ATTR_queue: q2name})
+        jd = Job(TEST_USER, {ATTR_queue: defqname})
+        j2 = Job(TEST_USER, {ATTR_queue: q2name})
 
         jid = self.server.submit(jd)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
         for _ in range(5):
-            jd = Job(TST_USR, {ATTR_queue: defqname})
+            jd = Job(TEST_USER, {ATTR_queue: defqname})
             self.server.submit(jd)
 
         try:


### PR DESCRIPTION
#### Describe Bug or Feature
* Most of the test cases in Testsuite pbs_test_entity_limits.py uses TST_USR. 
* TestMultipleSchedulers.test_auto_sched_off_due_to_fds_limit sets the limit of open files to 10, then reverts it to its original at the end of the test. However, if the test fails between them, it does not revert the limit of open files and all the future tests fail.

#### Describe Your Change
1. Modifed the test user TST_USR to TEST_USER in pbs_test_entity_limits.py to make it generic.
2. Added teardown to the TestMultipleSchedulers to reset the rlimit even if the test fails. 

#### Attach Test and Valgrind Logs/Output
[sched_test_case_logs.txt](https://github.com/PBSPro/pbspro/files/3739831/sched_test_case_logs.txt)
[TestEntityLimits_test_logs.txt](https://github.com/PBSPro/pbspro/files/3739836/TestEntityLimits_test_logs.txt)


