### PR TITLE
[WIP] TestMomDynRes suite fails if mom is on remote host

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13832,10 +13832,8 @@ class MoM(PBSService):
         else:
             if dirname is None:
                 dirname = self.pbs_conf['PBS_HOME']
-            local_host = socket.gethostname()
             tmp_file = self.du.create_temp_file(prefix=prefix, suffix=suffix,
-                                                body=script_body,
-                                                hostname=local_host)
+                                                body=script_body)
             res_file = os.path.join(dirname, tmp_file.split(os.path.sep)[-1])
             self.du.run_copy(host, tmp_file, res_file, sudo=True,
                              preserve_permission=False)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2397,10 +2397,6 @@ class BatchUtils(object):
             if isinstance(v, list):
                 v = ','.join(v)
 
-            if isinstance(v, str):
-                if " " in v:
-                    v = "'" + v + "'"
-
             # when issuing remote commands, escape spaces in attribute values
             if (((hostname is not None) and
                  (not self.du.is_localhost(hostname))) or
@@ -6037,6 +6033,13 @@ class Server(PBSService):
                     del obj.custom_attrs[ATTR_queue]
 
             _conf = self.default_client_pbs_conf
+            user_host = PbsUser.get_user(obj.username).host
+            if (not self._is_local) or \
+                    (not self.du.is_localhost(user_host)):
+                for k, v in obj.custom_attrs.items():
+                    if isinstance(v, str) and (" " in v):
+                        v = "'" + v + "'"
+                        obj.custom_attrs[k] = v
             cmd = self.utils.convert_to_cli(obj.custom_attrs, IFL_SUBMIT,
                                             self.hostname, dflt_conf=_conf,
                                             exclude_attrs=exclude_attrs)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13832,10 +13832,10 @@ class MoM(PBSService):
         else:
             if dirname is None:
                 dirname = self.pbs_conf['PBS_HOME']
+            local_host = socket.gethostname()
             tmp_file = self.du.create_temp_file(prefix=prefix, suffix=suffix,
                                                 body=script_body,
-                                                hostname=host)
-
+                                                hostname=local_host)
             res_file = os.path.join(dirname, tmp_file.split(os.path.sep)[-1])
             self.du.run_copy(host, tmp_file, res_file, sudo=True,
                              preserve_permission=False)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6037,8 +6037,14 @@ class Server(PBSService):
             if (not self._is_local) or \
                     (not self.du.is_localhost(user_host)):
                 for k, v in obj.custom_attrs.items():
-                    if isinstance(v, str) and (" " in v):
-                        v = "'" + v + "'"
+                    if isinstance(v, str):
+                        if " " in v:
+                            v = "'%s'" % v
+                        if any((c in v) for c in set(',\'"')):
+                            if '"' in v:
+                                v = "\\'%s\\'" % v
+                            else:
+                                v = '\\"%s\\"' % v
                         obj.custom_attrs[k] = v
             cmd = self.utils.convert_to_cli(obj.custom_attrs, IFL_SUBMIT,
                                             self.hostname, dflt_conf=_conf,

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2403,7 +2403,12 @@ class BatchUtils(object):
                     (not dflt_conf)):
                 if ' ' in str(v):
                     v = '"' + v + '"'
-
+                if isinstance(v, str):
+                    if any((c in v) for c in set(',\'"')):
+                        if '"' in v:
+                            v = "\\'%s\\'" % v
+                        else:
+                            v = '\\"%s\\"' % v
             if '.' in a:
                 (attribute, resource) = a.split('.')
                 ret.append('-' + api_to_cli[attribute])
@@ -6034,6 +6039,10 @@ class Server(PBSService):
 
             _conf = self.default_client_pbs_conf
             user_host = PbsUser.get_user(obj.username).host
+            if user_host:
+                hostname = user_host
+            else:
+                hostname = self.hostname
             if (not self._is_local) or \
                     (not self.du.is_localhost(user_host)):
                 for k, v in obj.custom_attrs.items():
@@ -6047,7 +6056,7 @@ class Server(PBSService):
                                 v = '\\"%s\\"' % v
                         obj.custom_attrs[k] = v
             cmd = self.utils.convert_to_cli(obj.custom_attrs, IFL_SUBMIT,
-                                            self.hostname, dflt_conf=_conf,
+                                            hostname=hostname, dflt_conf=_conf,
                                             exclude_attrs=exclude_attrs)
 
             if cmd is None:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2397,6 +2397,10 @@ class BatchUtils(object):
             if isinstance(v, list):
                 v = ','.join(v)
 
+            if isinstance(v, str):
+                if " " in v:
+                    v = "'" + v + "'"
+
             # when issuing remote commands, escape spaces in attribute values
             if (((hostname is not None) and
                  (not self.du.is_localhost(hostname))) or

--- a/test/tests/functional/pbs_mom_dynamic_resource.py
+++ b/test/tests/functional/pbs_mom_dynamic_resource.py
@@ -164,7 +164,7 @@ class TestMomDynRes(TestFunctional):
                            id=jid, attrop=PTL_AND)
 
         # Submit a job that requests mom dynamic resource
-        attr = {"Resource_List." + resc_name[0]: '\'\"This is a test\"\''}
+        attr = {"Resource_List." + resc_name[0]: '"This is a test"'}
         j = Job(TEST_USER, attrs=attr)
         jid = self.server.submit(j)
 

--- a/test/tests/functional/pbs_mom_dynamic_resource.py
+++ b/test/tests/functional/pbs_mom_dynamic_resource.py
@@ -441,7 +441,7 @@ class TestMomDynRes(TestFunctional):
             self.du.rm(path=self.dirnames, sudo=True, force=True,
                        recursive=True)
             self.dirnames[:] = []
-        if len(self.resc_files) != 0:
+        if self.resc_files:
             self.du.rm(path=self.resc_files, sudo=True, force=True,
                        hostname=self.mom.shortname)
 


### PR DESCRIPTION
#### Describe Bug or Feature
TestMomDynRes test suite fails to run if mom is on remote host.
TestMomDynRes test suite creates a mom_dyn_resource file on local host and adds path of this file inside mom_priv/config file. If moms are on remote hosts, this file will not be present and resource value will be null.

#### Describe Your Change
Copy resource file to remote host and delete when done with it.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->

#### Attach Test Logs
[TestMomDynRes_logs.txt](https://github.com/PBSPro/pbspro/files/3749676/TestMomDynRes_logs.txt)