### PR TITLE
changed default ram 1 gb to run ptl test

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -82,9 +82,9 @@ default_requirements = {
     'num_moms': 1,
     'num_comms': 1,
     'num_clients': 1,
-    'min_mom_ram': .128,
+    'min_mom_ram': 1,
     'min_mom_disk': 1,
-    'min_server_ram': .128,
+    'min_server_ram': 1,
     'min_server_disk': 1,
     'no_mom_on_server': False,
     'no_comm_on_server': False,
@@ -822,7 +822,7 @@ class PBSTestSuite(unittest.TestCase):
         """
         try:
             server = cls.servers[server]
-        except:
+        except BaseException:
             server = None
         return Comm(hostname, pbsconf_file=pbsconf_file, server=server)
 
@@ -842,7 +842,7 @@ class PBSTestSuite(unittest.TestCase):
         """
         try:
             server = cls.servers[server]
-        except:
+        except BaseException:
             server = None
         return Scheduler(hostname=hostname, server=server,
                          pbsconf_file=pbsconf_file)
@@ -862,7 +862,7 @@ class PBSTestSuite(unittest.TestCase):
         """
         try:
             server = cls.servers[server]
-        except:
+        except BaseException:
             server = None
         return MoM(hostname, pbsconf_file=pbsconf_file, server=server)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The default ram requirement to run ptl test is 0.128GB. Even pbs_benchpress needs ~200MB to run. With 0.128  GB , We can't run simple job on mom also. Requirement of ram to run ptl test should be more than 1 GB.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Changed default ram requirement to 1 GB


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[CHANGED_RAM_SIZE.txt](https://github.com/PBSPro/pbspro/files/3754333/CHANGED_RAM_SIZE.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
