### PR TITLE
fixing few test bugs

### DIFF
--- a/test/tests/performance/pbs_jobperf.py
+++ b/test/tests/performance/pbs_jobperf.py
@@ -295,7 +295,7 @@ class TestJobPerf(TestPerformance):
 
     def qstat_jobs(self, user, num_stats, qstat_arg=None):
         for _ in range(num_stats):
-            qstat = 'sudo -u ' + user + ' ' + \
+            qstat = 'sudo -u ' + str(user) + ' ' + \
                 str(os.path.join(
                     self.server.pbs_conf['PBS_EXEC'], 'bin', 'qstat'))
             if qstat_arg:
@@ -398,6 +398,7 @@ class TestJobPerf(TestPerformance):
 
         avg_stat_time = []
         stat_time = []
+        num_ncpus = self.config['No_of_ncpus_per_node']
         j = 0
         counts = self.server.counter(NODE, {'state': 'free'})
         if counts['state=free'] < self.config['No_of_moms']:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Varibale num_ncpus was not defined and user must be string for string concatenation. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
fixed the error.
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl_output.txt](https://github.com/PBSPro/pbspro/files/3754962/ptl_output.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->