### PR TITLE
PTL tests wrongly expect that all daemons are on the same node

### DIFF
--- a/test/tests/functional/pbs_job_sort_formula.py
+++ b/test/tests/functional/pbs_job_sort_formula.py
@@ -49,7 +49,7 @@ class TestJobSortFormula(TestFunctional):
         job_sort_formula sort properly
         """
         a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, self.server.shortname)
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         self.server.manager(MGR_CMD_CREATE, RSC, {'type': 'float'}, id='foo')
 
         a = {'job_sort_formula': 'foo', 'scheduling': 'False'}

--- a/test/tests/functional/pbs_pbsnodes.py
+++ b/test/tests/functional/pbs_pbsnodes.py
@@ -69,11 +69,11 @@ class TestPbsnodes(TestFunctional):
         return expected values of attributes on a newly created node
         """
         expect_dict = {}
-        expect_dict[ATTR_NODE_Mom] = self.server.hostname
+        expect_dict[ATTR_NODE_Mom] = self.mom.hostname
         expect_dict[ATTR_NODE_ntype] = 'PBS'
         expect_dict[ATTR_NODE_state] = 'free'
-        expect_dict[ATTR_rescavail + '.vnode'] = self.server.shortname
-        expect_dict[ATTR_rescavail + '.host'] = self.server.shortname
+        expect_dict[ATTR_rescavail + '.vnode'] = self.mom.shortname
+        expect_dict[ATTR_rescavail + '.host'] = self.mom.shortname
         expect_dict[ATTR_NODE_resv_enable] = 'True'
 
         if user == 'root':


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Below test suites were failing if mom is on remote host.

#### Cause / Analysis
Most of the test cases were using self.server.shortname while creating nodes and for other mom related APIs. It is not mandatory for mom to be on same node as server

#### Describe Your Change
We need to use self.mom.shortname instead of using server hostname.

#### Attach Test Logs/Output
[TestJobSortFormula.txt](https://github.com/PBSPro/pbspro/files/3755108/TestJobSortFormula.txt)
[TestPbsnodes.txt](https://github.com/PBSPro/pbspro/files/3755109/TestPbsnodes.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
