### PR TITLE
Fix qstat crash in windows

### DIFF
--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1848,7 +1848,7 @@ create_query_file(void)
 	LocalFree(win_sid);
 #else
 	snprintf(filename, sizeof(filename), "%s/.pbs_last_query_%d", TMP_DIR, usid);
-#endif // WIN32
+#endif /* WIN32 */
 	f = fopen(filename, "w");
 	if (f != NULL)
 		fclose(f);
@@ -1894,6 +1894,6 @@ delay_query(void)
 			usleep(200000);
 		}
 	}
-#endif //WIN32
+#endif /* WIN32 */
 	atexit(create_query_file);
 }

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1841,9 +1841,7 @@ create_query_file(void)
 #ifdef WIN32
 	LPSTR win_sid = NULL;
 	if (!ConvertSidToStringSid(usid, &win_sid)) {
-		fprintf(stderr, "qstat: failed to convert SID to string.\n \
-						Failed error=%d\n", GetLastError());
-		LocalFree(win_sid);
+		fprintf(stderr, "qstat: failed to convert SID to string.Failed error=%d\n", GetLastError());
 		return;
 	}
 	snprintf(filename, sizeof(filename), "%s\\.pbs_last_query_%s", TMP_DIR, win_sid);
@@ -1879,9 +1877,7 @@ delay_query(void)
 #ifdef WIN32
 	LPSTR win_sid=NULL;
 	if (!ConvertSidToStringSid(usid, &win_sid)) {
-		fprintf(stderr, "qstat: failed to convert SID to string.\n \
-						Failed error=%d\n", GetLastError());
-		LocalFree(win_sid);
+		fprintf(stderr, "qstat: failed to convert SID to string.Failed error=%d\n", GetLastError());
 		return;
 	}
 	snprintf(filename, sizeof(filename), "%s\\.pbs_last_query_%s", TMP_DIR, win_sid);

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1841,7 +1841,7 @@ create_query_file(void)
 #ifdef WIN32
 	LPSTR win_sid = NULL;
 	if (!ConvertSidToStringSid(usid, &win_sid)) {
-		fprintf(stderr, "qstat: failed to convert SID to string.Failed error=%d\n", GetLastError());
+		fprintf(stderr, "qstat: failed to convert SID to string with failed error=%d\n", GetLastError());
 		return;
 	}
 	snprintf(filename, sizeof(filename), "%s\\.pbs_last_query_%s", TMP_DIR, win_sid);
@@ -1877,7 +1877,7 @@ delay_query(void)
 #ifdef WIN32
 	LPSTR win_sid=NULL;
 	if (!ConvertSidToStringSid(usid, &win_sid)) {
-		fprintf(stderr, "qstat: failed to convert SID to string.Failed error=%d\n", GetLastError());
+		fprintf(stderr, "qstat: failed to convert SID to string with failed error=%d\n", GetLastError());
 		return;
 	}
 	snprintf(filename, sizeof(filename), "%s\\.pbs_last_query_%s", TMP_DIR, win_sid);

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1838,8 +1838,6 @@ create_query_file(void)
 	FILE *f;
 	char filename[MAXPATHLEN + 1];
 	uid_t usid = getuid();
-	if (usid == NULL)
-		return;
 #ifdef WIN32
 	LPSTR win_sid = NULL;
 	if (!ConvertSidToStringSid(usid, &win_sid)) {
@@ -1878,8 +1876,6 @@ delay_query(void)
 #endif
 	
 	uid_t usid = getuid();
-	if (usid == NULL)
-		return;
 #ifdef WIN32
 	LPSTR win_sid=NULL;
 	if (!ConvertSidToStringSid(usid, &win_sid)) {

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1841,7 +1841,7 @@ create_query_file(void)
 #ifdef WIN32
 	LPSTR win_sid = NULL;
 	if (!ConvertSidToStringSid(usid, &win_sid)) {
-		fprintf(stderr, "qstat: failed to convert SID to string with failed error=%d\n", GetLastError());
+		fprintf(stderr, "qstat: failed to convert SID to string with error=%d\n", GetLastError());
 		return;
 	}
 	snprintf(filename, sizeof(filename), "%s\\.pbs_last_query_%s", TMP_DIR, win_sid);
@@ -1877,7 +1877,7 @@ delay_query(void)
 #ifdef WIN32
 	LPSTR win_sid=NULL;
 	if (!ConvertSidToStringSid(usid, &win_sid)) {
-		fprintf(stderr, "qstat: failed to convert SID to string with failed error=%d\n", GetLastError());
+		fprintf(stderr, "qstat: failed to convert SID to string with error=%d\n", GetLastError());
 		return;
 	}
 	snprintf(filename, sizeof(filename), "%s\\.pbs_last_query_%s", TMP_DIR, win_sid);

--- a/win_configure/include/pbs_config.h
+++ b/win_configure/include/pbs_config.h
@@ -145,7 +145,7 @@ typedef	int		pid_t;
 #define SIZEOF_UNSIGNED_SHORT 2
 
 /* PBS specific: The pathname of the temporary directory for mom */
-#define TMP_DIR "C:\\WINNT\\TEMP"
+#define TMP_DIR "C:\\Windows\\Temp"
 
 /* Let's define PBS_PASS_CREDENTIALS but make sure openssl AES include and lib  */
 /* files are available in \Program Files\Openssl\{include,lib }		*/


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* qstat command was crashing in windows after changes from #1279 PR checked in.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
There are two reasons why the qstat command didn't work:
1. The temporary directory macro (TMP_DIR) defined is valid for older versions of windows (Version < windowsXP). So changed this directory path in pbs_config.
2. The SID returned in getuid() function was not being correctly converted to string in windows. So I used a windows function called 'ConvertSidToStringSid' to convert SID to string.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
* [logs_before_and_after_change.txt](https://github.com/PBSPro/pbspro/files/3755993/logs_before_and_after_change.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
