### PR TITLE
Fixed empty log

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -3261,7 +3261,7 @@ eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 		else
 			set_schd_error_codes(err, NOT_RUN, NODE_UNLICENSED);
 
-		if (err->error_code) {
+		if (err->error_code != SUCCESS) {
 			schdlogerr(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_DEBUG,
 				ninfo_arr[i]->name, NULL, err);
 			/* Since this node is not eligible, check if it ever eligible


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Under DEBUG3 the scheduler would print an empty log message for a node.
Like:
10/23/2019 16:26:39.764978;0400;pbs_sched;Node;nimitz;

Note no text after the final ';'

#### Describe Your Change
In a recent PR, the scheduler moved from using its own logging function to using PBS's logging functions.  The scheduler's own function checked to see if we were trying to log an empty string and didn't log it.  The PBS log function does not.

Why were we trying to log an empty string?  A 3+ year old bug had us enter an error case when we were successful.  The error case tried to translate the "error" into a string and log it.  When translating the success into a string, it returned an empty string.  The old log function would not log it.

This change will correctly enter the success case and log the success message:
10/23/2019 16:59:09.986870;0400;pbs_sched;Node;nimitz;Node allocated to job

#### Attach Test and Valgrind Logs/Output
This would show up in any test that logs DEBUG3.  The test I found it in is TestFairshare.test_fairshare_formula.  The test doesn't fail with the log message, so I'm not posting test output.  I'm not writing a test because this is a log message printed at a low level.  It really isn't worth the test.
