### PR TITLE
Skip test suites that need to pass environment variables to remote hosts

### DIFF
--- a/test/tests/functional/pbs_hook_set_jobenv.py
+++ b/test/tests/functional/pbs_hook_set_jobenv.py
@@ -39,6 +39,7 @@ from tests.functional import *
 from ptl.utils.pbs_logutils import PBSLogUtils
 
 
+@skipOnShasta
 class TestPbsHookSetJobEnv(TestFunctional):
     """
     This test suite to make sure hooks properly

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -39,7 +39,7 @@ from tests.functional import *
 import json
 import os
 
-
+@skipOnShasta
 class TestNonprintingCharacters(TestFunctional):
     """
     Test to check passing non-printable environment variables

--- a/test/tests/functional/pbs_nonprint_characters.py
+++ b/test/tests/functional/pbs_nonprint_characters.py
@@ -39,6 +39,7 @@ from tests.functional import *
 import json
 import os
 
+
 @skipOnShasta
 class TestNonprintingCharacters(TestFunctional):
     """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The TestNonprintingCharacters suite and the TestPbsHookSetJobEnv suite need to be updated to pass the environment variable to remote hosts.  

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Skipping both suites for now.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Test output is not applicable since the suites would be skipped.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->