### PR TITLE
Fixed test_finished_jobs test when mom is on different node

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14225,8 +14225,8 @@ class Job(ResourceResv):
         """
         script_dir = os.path.dirname(os.path.dirname(__file__))
         script_path = os.path.join(script_dir, 'utils', 'jobs', 'eatcpu.py')
-        d = os.path.join(os.path.sep, 'home', self.username)
         if mom:
+            d = pwd.getpwnam(self.username).pw_dir
             DshUtils().run_copy(hosts=mom, src=script_path, dest=d)
             script_path = os.path.join(d, "eatcpu.py")
         DshUtils().chmod(path=script_path, mode=0o755)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14223,18 +14223,20 @@ class Job(ResourceResv):
         Create a job that eats cpu indefinitely or for the given
         duration of time
         """
+        if self.du is None:
+            self.du = DshUtils()
         script_dir = os.path.dirname(os.path.dirname(__file__))
         script_path = os.path.join(script_dir, 'utils', 'jobs', 'eatcpu.py')
-        if not DshUtils().is_localhost(mom):
-            pbs_conf = DshUtils().parse_pbs_config(mom)
-            shell_path = os.path.join(pbs_conf['PBS_EXEC'],
-                                      'bin', 'pbs_python')
-            a = {ATTR_S: shell_path}
-            self.set_attributes(a)
+        pbs_conf = self.du.parse_pbs_config(mom)
+        shell_path = os.path.join(pbs_conf['PBS_EXEC'],
+                                  'bin', 'pbs_python')
+        a = {ATTR_S: shell_path}
+        self.set_attributes(a)
+        if not self.du.is_localhost(mom):
             d = pwd.getpwnam(self.username).pw_dir
-            DshUtils().run_copy(hosts=mom, src=script_path, dest=d)
+            self.du.run_copy(hosts=mom, src=script_path, dest=d)
             script_path = os.path.join(d, "eatcpu.py")
-        DshUtils().chmod(path=script_path, mode=0o755)
+        self.du.chmod(path=script_path, mode=0o755)
         self.set_execargs(script_path, duration)
 
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14231,8 +14231,8 @@ class Job(ResourceResv):
             d = pwd.getpwnam(self.username).pw_dir
             ret = self.du.run_copy(hosts=mom, src=script_path, dest=d)
             if ret is None or ret['rc'] != 0:
-                raise AssertionError("Failed to copy file %s"
-                                     % (script_path))
+                raise AssertionError("Failed to copy file %s to %s"
+                                     % (script_path, mom))
             script_path = os.path.join(d, "eatcpu.py")
         pbs_conf = self.du.parse_pbs_config(mom)
         shell_path = os.path.join(pbs_conf['PBS_EXEC'],

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14218,13 +14218,17 @@ class Job(ResourceResv):
         return job_array_id[:idx + 1] + str(subjob_index) + \
             job_array_id[idx + 1:]
 
-    def create_eatcpu_job(self, duration=None):
+    def create_eatcpu_job(self, duration=None, mom=None):
         """
         Create a job that eats cpu indefinitely or for the given
         duration of time
         """
         script_dir = os.path.dirname(os.path.dirname(__file__))
         script_path = os.path.join(script_dir, 'utils', 'jobs', 'eatcpu.py')
+        d = os.path.join(os.path.sep, 'home', self.username)
+        if mom:
+            DshUtils().run_copy(hosts=mom, src=script_path, dest=d)
+            script_path = os.path.join(d, "eatcpu.py")
         DshUtils().chmod(path=script_path, mode=0o755)
         self.set_execargs(script_path, duration)
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -14225,7 +14225,12 @@ class Job(ResourceResv):
         """
         script_dir = os.path.dirname(os.path.dirname(__file__))
         script_path = os.path.join(script_dir, 'utils', 'jobs', 'eatcpu.py')
-        if mom:
+        if not DshUtils().is_localhost(mom):
+            pbs_conf = DshUtils().parse_pbs_config(mom)
+            shell_path = os.path.join(pbs_conf['PBS_EXEC'],
+                                      'bin', 'pbs_python')
+            a = {ATTR_S: shell_path}
+            self.set_attributes(a)
             d = pwd.getpwnam(self.username).pw_dir
             DshUtils().run_copy(hosts=mom, src=script_path, dest=d)
             script_path = os.path.join(d, "eatcpu.py")

--- a/test/fw/ptl/utils/jobs/eatcpu.py
+++ b/test/fw/ptl/utils/jobs/eatcpu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import signal
 import sys
 

--- a/test/fw/ptl/utils/jobs/eatcpu.py
+++ b/test/fw/ptl/utils/jobs/eatcpu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 import signal
 import sys
 

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -335,15 +335,10 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         a = {'job_history_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
-        shell_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
-                                  "bin", "pbs_python")
-        a = {'Resource_List.ncpus': 2, ATTR_S: shell_path}
+        a = {'Resource_List.ncpus': 2}
         j = Job(TEST_USER, a)
         j.set_sleep_time(15)
         mom = self.moms.values()[0].shortname
-        server = self.server.shortname
-        if server == mom:
-            mom = None
         j.create_eatcpu_job(15, mom)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'F'}, extend='x', offset=15,

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -335,10 +335,16 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
         a = {'job_history_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
-        a = {'Resource_List.ncpus': 2}
+        shell_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                  "bin", "pbs_python")
+        a = {'Resource_List.ncpus': 2, ATTR_S: shell_path}
         j = Job(TEST_USER, a)
         j.set_sleep_time(15)
-        j.create_eatcpu_job(15)
+        mom = self.moms.values()[0].shortname
+        server = self.server.shortname
+        if server == mom:
+            mom = None
+        j.create_eatcpu_job(15, mom)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'F'}, extend='x', offset=15,
                            interval=1, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When mom node is different from server node, test_finished_jobs fails as it expects eatcpu.py file on mom.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
1. When job pbs_benchpress is run by providing moms as -p option, then eatcpu script is copied to all test user home directory.
2. Job is submitted as : -S PBS_EXEC/bin/pbs_python shell path.
3. Changed shebang of eatcpu script to "#!/usr/bin/env python3".
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
NA

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl_fix_logs.txt](https://github.com/PBSPro/pbspro/files/3771056/ptl_fix_logs.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
