### PR TITLE
Fix for sched crash with entity limits

### DIFF
--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1341,10 +1341,9 @@ find_counts_elm(counts *cts_list, char *name, resdef *rdef, counts **cnt, resour
 			*cnt = cts;
 		if (rdef == NULL)
 			return cts->running;
-		else {
-			if ((res_lim = find_resource_count(cts->rescts, rdef)) != NULL)
-				if (rcount != NULL)
-					*rcount = res_lim;
+		else if ((res_lim = find_resource_count(cts->rescts, rdef)) != NULL) {
+			if (rcount != NULL)
+				*rcount = res_lim;
 			return res_lim->amount;
 		}
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Scheduler crashes when it is trying to check limits for an entity that has no other registered running job requesting the limit resource.


#### Describe Your Change
Change is simple, an 'if' condition was wrongly scoped. It ended up dereferencing uninitialized stack variables.


#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
I ended up extending an existing limits smoketest.
[test_before.txt](https://github.com/PBSPro/pbspro/files/3790263/test_before.txt)
[test_after.txt](https://github.com/PBSPro/pbspro/files/3790264/test_after.txt)
