### PR TITLE
Fixed server crash with alter record

### DIFF
--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -62,7 +62,7 @@ extern "C" {
 #define ATTR_a "Execution_Time"
 #define ATTR_c "Checkpoint"
 #define ATTR_e "Error_Path"
-#define ATTR_g	"group_list"
+#define ATTR_g "group_list"
 #define ATTR_h "Hold_Types"
 #define ATTR_j "Join_Path"
 #define ATTR_J "array_indices_submitted"

--- a/src/server/accounting.c
+++ b/src/server/accounting.c
@@ -2236,7 +2236,6 @@ writeit:
  * @returns void 
  */
 void log_alter_records_for_attrs(job *pjob, svrattrl *plist) {
-	svrattrl *svrattrl_list;
 	svrattrl *cur_svr;
 	pbs_list_head phead;
 	svrattrl *cur_plist;
@@ -2257,6 +2256,7 @@ void log_alter_records_for_attrs(job *pjob, svrattrl *plist) {
 	CLEAR_HEAD(phead);
 	for (i = 0; i < JOB_ATR_LAST; i++) {
 		if (pjob->ji_wattr[i].at_flags & ATR_VFLAG_MODIFY) {
+			svrattrl *svrattrl_list = {0};
 			job_attr_def[i].at_encode(&pjob->ji_wattr[i], &phead, job_attr_def[i].at_name, NULL, ATR_ENCODE_CLIENT, &svrattrl_list);
 			for (cur_plist = plist; cur_plist != NULL; cur_plist = (svrattrl *)GET_NEXT(cur_plist->al_link)) {
 				if (strcmp(cur_plist->al_name, job_attr_def[i].at_name) != 0)

--- a/src/server/accounting.c
+++ b/src/server/accounting.c
@@ -2256,7 +2256,7 @@ void log_alter_records_for_attrs(job *pjob, svrattrl *plist) {
 	CLEAR_HEAD(phead);
 	for (i = 0; i < JOB_ATR_LAST; i++) {
 		if (pjob->ji_wattr[i].at_flags & ATR_VFLAG_MODIFY) {
-			svrattrl *svrattrl_list = {0};
+			svrattrl *svrattrl_list = NULL;
 			job_attr_def[i].at_encode(&pjob->ji_wattr[i], &phead, job_attr_def[i].at_name, NULL, ATR_ENCODE_CLIENT, &svrattrl_list);
 			for (cur_plist = plist; cur_plist != NULL; cur_plist = (svrattrl *)GET_NEXT(cur_plist->al_link)) {
 				if (strcmp(cur_plist->al_name, job_attr_def[i].at_name) != 0)

--- a/test/tests/functional/pbs_acct_log.py
+++ b/test/tests/functional/pbs_acct_log.py
@@ -221,7 +221,7 @@ pbs.event().accept()
         """
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
 
-        j1 = Job()
+        j1 = Job(TEST_USER1)
         jid1 = self.server.submit(j1)
 
         # Basic test for existance of record for Resource_List
@@ -247,6 +247,10 @@ pbs.event().accept()
         # Check for non-resource attribute
         self.server.alterjob(jid1, {ATTR_p: 150})
         self.server.accounting_match(';a;' + jid1 + ';Priority=150')
+
+        self.server.alterjob(jid1, {ATTR_g: str(TSTGRP1)})
+        self.server.accounting_match(';a;' + jid1 +
+                                     ';group_list=' + str(TSTGRP1))
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
A recent PR introduced a new accounting log record ('a').  A structure which is used to encode the attribute to print was not cleared between uses.  This would cause a double free.

#### Describe Your Change
I moved the variable to the block it was being used, so it leaves scope and is reintroduced between uses in the loop.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[alter.log](https://github.com/PBSPro/pbspro/files/3795997/alter.log)
[valgrind.log](https://github.com/PBSPro/pbspro/files/3796004/valgrind.log)
