### PR TITLE
qsub fails with long select PBS directive

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -3160,7 +3160,7 @@ get_script(FILE *file, char *script, char *prefix)
 	char tmp_name[MAXPATHLEN + 1];
 	FILE *TMP_FILE;
 	char *in;
-	char *s_in;
+	char *s_in = NULL;
 	int s_len = 0;
 #ifndef WIN32
 	int fds;

--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -2979,7 +2979,6 @@ make_argv(int *argc, char *argv[], char *line)
 	char *l, *b, *c;
 	char static_buffer[MAX_LINE_LEN + 1];
 	char *buffer;
-	int buf_allocated = 0;
 	int line_len = 0;
 	int len;
 	char quote;
@@ -2995,7 +2994,6 @@ make_argv(int *argc, char *argv[], char *line)
 			fprintf(stderr, "qsub: out of memory\n");
 			exit_qsub(2);
 		}
-		buf_allocated = 1;
 	}
 	else
 		buffer = static_buffer;
@@ -3052,7 +3050,7 @@ make_argv(int *argc, char *argv[], char *line)
 		free(argv[i]);
 		argv[i++] = NULL;
 	}
-	if (buf_allocated)
+	if (buffer != static_buffer)
 		free(buffer);
 }
 

--- a/test/tests/functional/pbs_job_script.py
+++ b/test/tests/functional/pbs_job_script.py
@@ -62,7 +62,7 @@ class TestPbsJobScript(TestFunctional):
         jid = self.server.submit(j)
         return jid
 
-    def test_long_select_spec_without_newline(self):
+    def test_long_select_spec(self):
         """
         Test that PBS is able to accept jobs scripts with very long select
         specification with no newline in it.
@@ -75,7 +75,7 @@ class TestPbsJobScript(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R', 'exec_vnode': execvnode},
                            id=jid)
 
-    def test_long_select_spec_with_newline(self):
+    def test_long_select_spec_extend(self):
         """
         Test that PBS is able to accept jobs scripts with very long select
         specification with newline in it.

--- a/test/tests/functional/pbs_job_script.py
+++ b/test/tests/functional/pbs_job_script.py
@@ -1,0 +1,66 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+from tests.functional import *
+
+
+class TestPbsJobScript(TestFunctional):
+    """
+    Test suite for testing PBS's job script functionality
+    """
+
+    def test_long_select_spec(self):
+        """
+        Test that PBS is able to accept jobs scripts with very long select
+        specification.
+        """
+
+        a = {'resources_available.ncpus': 2}
+        self.server.create_vnodes('Verylongvnodename', a, 500, self.mom)
+
+        selstr = "#PBS -l select=1"
+        for node in range(0, 500):
+            selstr += ":ncpus=1:vnode=Verylongvnodename[" + str(node) + "]+1"
+        selstr = selstr[0:-2]
+
+        scr = []
+        scr += [selstr + '\n']
+        scr += ['/bin/sleep 100\n']
+
+        j = Job()
+        j.create_script(scr)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
qsub command fails when select specification given in a job script file exceeds 4096 characters in length.

#### Describe Your Change
We were expecting all directives to be no more than 4K characters long which is why qsub was failing.
I've changed the code to make it dynamic.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_before.txt](https://github.com/PBSPro/pbspro/files/3806289/test_before.txt)
[test_after.txt](https://github.com/PBSPro/pbspro/files/3806290/test_after.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
