### PR TITLE
[WIP] - Update valgrind.supp to suppress memory leak caused by Python 3 source

### DIFF
--- a/valgrind.supp
+++ b/valgrind.supp
@@ -427,6 +427,7 @@
    fun:_PyUnicode_Init
    fun:_Py_InitializeEx_Private
    fun:Py_InitializeEx
+   ...
    fun:main
 }
 {
@@ -3177,6 +3178,7 @@
    fun:_PyLong_Init
    fun:_Py_InitializeEx_Private
    fun:Py_InitializeEx
+   ...
    fun:main
 }
 {

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -397,6 +397,3113 @@
 }
 
 {
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:descr_new
+   fun:PyDescr_NewWrapper
+   fun:add_operators
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicode_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:add_subclass
+   fun:PyType_Ready
+   fun:_PyExc_Init
+   fun:_Py_InitializeEx_Private
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:_PyDict_NewKeysForClass
+   fun:type_new
+   fun:type_call
+   fun:PyObject_Call
+   fun:call_function_tail
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:_PyEval_EvalCodeWithName
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyType_Ready
+   fun:_PyObject_GenericSetAttrWithDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:PyModule_Create2TraceRefs
+   fun:PyInit__io
+   fun:_imp_create_builtin
+   fun:PyCFunction_Call
+   fun:do_call_core
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyLong_New
+   fun:r_PyLong
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:r_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:tuple_subtype_new
+   fun:tuple_new
+   fun:tp_new_wrapper
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyType_Ready
+   fun:PyInit__io
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:_PyEval_EvalFrameDefault
+   fun:PyEval_EvalFrameEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyList_New
+   fun:mro_implementation
+   fun:mro_invoke
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:make_keys_shared
+   fun:_PyObjectDict_SetItem
+   fun:_PyObject_GenericSetAttrWithDict
+   fun:PyObject_GenericSetAttr
+   fun:PyObject_SetAttr
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:make_new_set
+   fun:PyFrozenSet_New
+   fun:r_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyCFunction_NewEx
+   fun:add_methods
+   fun:PyType_Ready
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:_PyDict_NewKeysForClass
+   fun:type_new
+   fun:type_call
+   fun:_PyObject_FastCallDict
+   fun:builtin___build_class__
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:_PyEval_EvalCodeWithName
+   fun:fast_function
+   fun:call_function
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:get_xoptions
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyType_Ready
+   fun:PyModuleDef_Init
+   fun:PyModule_Create2TraceRefs
+   fun:_PyBuiltin_Init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:type_prepare
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyErr_NewException
+   fun:PyInit_zipimport
+   fun:_imp_create_builtin
+   fun:PyCFunction_Call
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyUnicode_InternFromString
+   fun:_PyImport_FixupBuiltin
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:PyType_Ready
+   fun:_Py_ReadyTypes
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:dictresize
+   fun:insertion_resize
+   fun:PyDict_SetDefault
+   fun:PyUnicode_InternInPlace
+   fun:PyDict_SetItemString
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:realloc
+   fun:_PyMem_RawRealloc
+   fun:_PyMem_DebugRawRealloc
+   fun:_PyMem_DebugRealloc
+   fun:PyObject_Realloc
+   fun:resize_compact
+   fun:_PyUnicodeWriter_Finish
+   fun:build_string
+   fun:do_string_format
+   fun:_PyCFunction_FastCallDict
+   fun:_PyCFunction_FastCallKeywords
+   fun:call_function
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicode_FromUCS1
+   fun:PyUnicode_FromKindAndData
+   fun:r_object
+   fun:r_object
+   fun:r_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:PyList_AsTuple
+   fun:PySequence_Tuple
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyLong_New
+   fun:PyLong_FromLong
+   fun:PyLong_FromUnsignedLong
+   fun:PyLong_FromVoidPtr
+   fun:add_subclass
+   fun:PyType_Ready
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:_PyObjectDict_SetItem
+   fun:_PyObject_GenericSetAttrWithDict
+   fun:PyObject_GenericSetAttr
+   fun:PyObject_SetAttr
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyCode_New
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:read_object
+   fun:marshal_loads
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:_PyMem_RawCalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawCalloc
+   fun:_PyMem_DebugCalloc
+   fun:PyMem_Calloc
+   fun:PyList_New
+   fun:_PyEval_EvalFrameDefault
+   fun:PyEval_EvalFrameEx
+   fun:_PyEval_EvalCodeWithName
+   fun:PyEval_EvalCodeEx
+   fun:PyEval_EvalCode
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyType_Ready
+   fun:PyInit__thread
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:make_impl_info
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:PyUnicode_Append
+   fun:unicode_concatenate
+   fun:_PyEval_EvalFrameDefault
+   fun:PyEval_EvalFrameEx
+   fun:_PyEval_EvalCodeWithName
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:PyTuple_Pack
+   fun:PyType_Ready
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyCFunction_NewEx
+   fun:_add_methods_to_object
+   fun:PyModule_AddFunctions
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:add_subclass
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyFunction_NewWithQualName
+   fun:_PyEval_EvalFrameDefault
+   fun:PyEval_EvalFrameEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyUnicode_InternFromString
+   fun:descr_new
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyCode_New
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:PyMarshal_ReadObjectFromString
+   fun:get_frozen_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyUnicode_InternFromString
+   fun:create_filter
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:dictresize
+   fun:insertion_resize
+   fun:insertdict
+   fun:PyDict_SetItem
+   fun:_PyDict_SetItemId
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:PyType_GenericNew
+   fun:type_call
+   fun:_PyObject_FastCallDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:PyCode_New
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:r_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:PyInit__thread
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:PyTuple_Pack
+   fun:type_new
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:_PyWarnings_Init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:PyStructSequence_InitType2
+   fun:_PySys_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyLong_New
+   fun:PyLong_FromLong
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:r_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:new_dict_with_shared_keys
+   fun:_PyObjectDict_SetItem
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyUnicode_InternFromString
+   fun:init_slotdefs
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromStringAndSize
+   fun:PyErr_NewException
+   fun:PyInit_zipimport
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:_PyUnicode_FromId
+   fun:_PyDict_GetItemId
+   fun:PyType_Ready
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyCFunction_NewEx
+   fun:method_get
+   fun:lookup_maybe
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:PyTuple_Pack
+   fun:create_filter
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyModule_NewObject
+   fun:PyModule_New
+   fun:PyModule_Create2TraceRefs
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:normalizestring
+   fun:_PyCodec_Lookup
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:PyUnicode_InternInPlace
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:PyStructSequence_InitType2
+   fun:_PyFloat_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:PyCode_New
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:PyMarshal_ReadObjectFromString
+   fun:get_frozen_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawRealloc
+   fun:_PyMem_DebugRealloc
+   fun:PyMem_Realloc
+   fun:list_resize
+   fun:listextend
+   fun:_PyCFunction_FastCallDict
+   fun:_PyCFunction_FastCallKeywords
+   fun:call_function
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyDict_Copy
+   fun:set_names
+   fun:type_new
+   fun:type_call
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:PyCodec_RegisterError
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:new_dict_with_shared_keys
+   fun:_PyObjectDict_SetItem
+   fun:_PyObject_GenericSetAttrWithDict
+   fun:PyObject_GenericSetAttr
+   fun:PyObject_SetAttr
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:PySequence_Tuple
+   fun:intern_string_constants
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyCFunction_NewEx
+   fun:classmethod_get
+   fun:type_getattro
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:PyType_Ready
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:PyImport_Cleanup
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:_PyBuiltin_Init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyType_Ready
+   fun:_Py_ReadyTypes
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:dictresize
+   fun:dict_merge
+   fun:PyDict_Update
+   fun:PyImport_Cleanup
+   fun:Py_FinalizeEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:tupleconcat
+   fun:PyNumber_Add
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:_PyEval_EvalCodeWithName
+   fun:_PyFunction_FastCallDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyDict_Copy
+   fun:type_new
+   fun:type_call
+   fun:_PyObject_FastCallDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:dictresize
+   fun:insertion_resize
+   fun:insertdict
+   fun:PyDict_SetItem
+   fun:add_subclass
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:PyStructSequence_InitType2
+   fun:PyInit_posix
+   fun:_imp_create_builtin
+   fun:PyCFunction_Call
+   fun:do_call_core
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:_PyStack_AsDict
+   fun:_PyObject_FastCallKeywords
+   fun:call_function
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:descr_new
+   fun:PyDescr_NewMember
+   fun:add_members
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyModule_SetDocString
+   fun:PyModule_Create2TraceRefs
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:_PyExc_Init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:PyStructSequence_InitType2
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:_PySys_Init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:r_object
+   fun:r_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:_PyMem_RawCalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawCalloc
+   fun:_PyMem_DebugCalloc
+   fun:PyMem_Calloc
+   fun:PyList_New
+   fun:init_filters
+   fun:_PyWarnings_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyType_Ready
+   fun:PyStructSequence_InitType2
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:PyInit_posix
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyType_Ready
+   fun:_PyExc_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:PyStructSequence_InitType2
+   fun:PyThread_GetInfo
+   fun:_PySys_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:_imp_extension_suffixes_impl
+   fun:_imp_extension_suffixes
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:PyModule_AddObject
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyUnicode_InternFromString
+   fun:PyImport_ImportFrozenModule
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyLong_New
+   fun:PyLong_FromLong
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:PyMarshal_ReadObjectFromString
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyType_Ready
+   fun:_PyUnicode_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:get_xoptions
+   fun:_PySys_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyType_Ready
+   fun:_Py_ReadyTypes
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:PyMem_RawMalloc
+   fun:calculate_path
+   fun:Py_GetProgramFullPath
+   fun:_PySys_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:_PyMem_RawCalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawCalloc
+   fun:_PyMem_DebugCalloc
+   fun:PyMem_Calloc
+   fun:PyList_New
+   fun:_PyEval_EvalFrameDefault
+   fun:PyEval_EvalFrameEx
+   fun:_PyEval_EvalCodeWithName
+   fun:fast_function
+   fun:call_function
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:add_subclass
+   fun:PyType_Ready
+   fun:PyInit__io
+   fun:_imp_create_builtin
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:PyDict_Copy
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:PyStaticMethod_New
+   fun:type_new
+   fun:type_call
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:PyModule_ExecDef
+   fun:exec_builtin_or_dynamic
+   fun:_imp_exec_builtin_impl
+   fun:_imp_exec_builtin
+   fun:PyCFunction_Call
+   fun:do_call_core
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:dictresize
+   fun:dict_merge
+   fun:PyDict_Merge
+   fun:PyDict_Copy
+   fun:type_new
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyType_Ready
+   fun:PyInit_zipimport
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyFrame_New
+   fun:_PyFunction_FastCall
+   fun:fast_function
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyImport_ImportModule
+   fun:PyImport_ImportModuleNoBlock
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyType_Ready
+   fun:_PyBuiltin_Init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyModule_New
+   fun:PyModule_Create2TraceRefs
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:add_subclass
+   fun:PyType_Ready
+   fun:type_new
+   fun:type_call
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:_PyUnicode_FromId
+   fun:_PyDict_SetItemId
+   fun:module_init_dict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:PyModule_NewObject
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyCFunction_NewEx
+   fun:add_tp_new_wrapper
+   fun:add_operators
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:_PyStack_AsTuple
+   fun:_PyObject_FastCallDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyModule_NewObject
+   fun:PyImport_AddModuleObject
+   fun:module_dict_for_exec
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:list_item
+   fun:PySequence_GetItem
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyCell_New
+   fun:_PyEval_EvalCodeWithName
+   fun:PyEval_EvalCodeEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyList_New
+   fun:do_mklist
+   fun:do_mkvalue
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyInit_posix
+   fun:_imp_create_builtin
+   fun:PyCFunction_Call
+   fun:do_call_core
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:_PyUnicode_FromId
+   fun:_PyDict_SetItemId
+   fun:_PySys_SetObjectId
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:PySys_SetObject
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:_PyDict_NewPresized
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyType_Ready
+   fun:_PyExc_Init
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyFrame_New
+   fun:_PyEval_EvalCodeWithName
+   fun:_PyFunction_FastCallDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyFrame_New
+   fun:_PyEval_EvalCodeWithName
+   fun:PyEval_EvalCodeEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyLong_New
+   fun:PyLong_FromLong
+   fun:PyInit_posix
+   fun:_imp_create_builtin
+   fun:PyCFunction_Call
+   fun:do_call_core
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:_PyWarnings_Init
+   fun:_Py_InitializeEx_Private
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:make_impl_info
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:tupleslice
+   fun:PyTuple_GetSlice
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyType_GenericAlloc
+   fun:object_new
+   fun:type_call
+   fun:_PyObject_FastCallDict
+   fun:_PyObject_FastCallKeywords
+   fun:call_function
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:add_subclass
+   fun:PyType_Ready
+   fun:_Py_ReadyTypes
+   fun:_Py_InitializeEx_Private
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromStringAndSize
+   fun:do_mkvalue
+   fun:do_mktuple
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyBytes_FromSize
+   fun:PyBytes_FromStringAndSize
+   fun:bytes_concat
+   fun:PyNumber_Add
+   fun:_PyEval_EvalFrameDefault
+   fun:PyEval_EvalFrameEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:descr_new
+   fun:PyDescr_NewClassMethod
+   fun:add_methods
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:_PyWarnings_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyFrame_New
+   fun:_PyFunction_FastCall
+   fun:_PyFunction_FastCallDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:type_new
+   fun:type_call
+   fun:_PyObject_FastCallDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:_PyObjectDict_SetItem
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicode_JoinArray
+   fun:PyUnicode_Join
+   fun:unicode_join
+   fun:_PyCFunction_FastCallDict
+   fun:_PyCFunction_FastCallKeywords
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:descr_new
+   fun:PyDescr_NewMethod
+   fun:add_methods
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyUnicode_InternFromString
+   fun:PyObject_SetAttrString
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyType_Ready
+   fun:PyInit__io
+   fun:_imp_create_builtin
+   fun:PyCFunction_Call
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyType_Ready
+   fun:PyInit__thread
+   fun:_imp_create_builtin
+   fun:PyCFunction_Call
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:dictresize
+   fun:insertion_resize
+   fun:insertdict
+   fun:PyDict_SetItem
+   fun:add_operators
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:_PyDict_NewPresized
+   fun:_PyEval_EvalFrameDefault
+   fun:PyEval_EvalFrameEx
+   fun:_PyEval_EvalCodeWithName
+   fun:PyEval_EvalCodeEx
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_AsUnicodeAndSize
+   fun:unicode_aswidechar
+   fun:PyUnicode_AsWideCharString
+   fun:unicode_encode_locale
+   fun:PyUnicode_EncodeFSDefault
+   fun:PyUnicode_FSConverter
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyList_New
+   fun:PyMarshal_ReadObjectFromString
+   fun:PyImport_ImportFrozenModuleObject
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:_PyFunction_FastCallDict
+   fun:_PyObject_FastCallDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:dictresize
+   fun:insertion_resize
+   fun:insertdict
+   fun:PyDict_SetItem
+   fun:PyDict_SetItemString
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:PyTuple_Pack
+   fun:PyErr_NewException
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:_PyEval_EvalCodeWithName
+   fun:fast_function
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:_Py_InitializeEx_Private
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:PyStructSequence_InitType2
+   fun:PyInit__signal
+   fun:_imp_create_builtin
+   fun:PyCFunction_Call
+   fun:do_call_core
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyTuple_New
+   fun:_PyStack_AsTuple
+   fun:_PyCFunction_FastCallDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:object_new
+   fun:type_call
+   fun:_PyObject_FastCallDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyObject_GenericGetDict
+   fun:getset_get
+   fun:_PyObject_GenericGetAttrWithDict
+   fun:PyObject_GenericGetAttr
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:module_dict_for_exec
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromStringAndSize
+   fun:PyErr_NewException
+   fun:PyInit__signal
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:PyType_GenericNew
+   fun:type_call
+   fun:PyObject_Call
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:PyObject_GenericGetDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyType_Ready
+   fun:_PyType_Lookup
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyCFunction_NewEx
+   fun:method_get
+   fun:_PyObject_GenericGetAttrWithDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyBytes_FromSize
+   fun:PyBytes_FromStringAndSize
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:r_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:realloc
+   fun:_PyMem_RawRealloc
+   fun:_PyMem_DebugRawRealloc
+   fun:_PyMem_DebugRealloc
+   fun:PyObject_Realloc
+   fun:_PyObject_GC_Resize
+   fun:PyFrame_New
+   fun:_PyEval_EvalCodeWithName
+   fun:PyEval_EvalCodeEx
+   fun:function_call
+   fun:PyObject_Call
+   fun:PyEval_CallObjectWithKeywords
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_weakref
+   fun:PyWeakref_NewRef
+   fun:add_subclass
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyMem_Malloc
+   fun:PyStructSequence_InitType2
+   fun:_PyLong_Init
+   fun:_Py_InitializeEx_Private
+   fun:Py_InitializeEx
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:_PyStack_AsDict
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:new_dict
+   fun:PyDict_New
+   fun:PyErr_NewException
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyLong_New
+   fun:_PyLong_FromByteArray
+   fun:long_from_bytes
+   fun:_PyCFunction_FastCallDict
+   fun:_PyCFunction_FastCallKeywords
+   fun:call_function
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:get_latin1_char
+   fun:_PyUnicode_FromUCS1
+   fun:PyUnicode_FromKindAndData
+   fun:r_object
+   fun:r_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyCell_New
+   fun:_PyEval_EvalCodeWithName
+   fun:fast_function
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:dictresize
+   fun:insertion_resize
+   fun:insertdict
+   fun:PyDict_SetItem
+   fun:_PyEval_EvalFrameDefault
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:PyDict_New
+   fun:PyDict_Copy
+   fun:type_new
+   fun:type_call
+   fun:PyObject_Call
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:type_new
+   fun:type_call
+   fun:_PyObject_FastCallDict
+   fun:builtin___build_class__
+   fun:_PyCFunction_FastCallDict
+   fun:_PyCFunction_FastCallKeywords
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_New
+   fun:PyList_New
+   fun:PySequence_List
+   fun:mro_implementation
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:get_latin1_char
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyUnicode_InternFromString
+   fun:PyInit__io
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:type_new
+   fun:type_call
+   fun:PyObject_Call
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:PyStaticMethod_New
+   fun:add_methods
+   fun:PyType_Ready
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyCode_New
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:r_object
+   fun:r_object
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:new_keys_object
+   fun:dictresize
+   fun:insertion_resize
+   fun:insertdict
+   fun:PyDict_SetItem
+   fun:_PyObjectDict_SetItem
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyDict_SetItemString
+   fun:add_methods
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:_PyObject_GC_NewVar
+   fun:PyFrame_New
+   fun:_PyEval_EvalCodeWithName
+   fun:fast_function
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:_PyObject_GC_Alloc
+   fun:_PyObject_GC_Malloc
+   fun:PyType_GenericAlloc
+   fun:descr_new
+   fun:PyDescr_NewGetSet
+   fun:add_getset
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_AsUnicodeAndSize
+   fun:unicode_aswidechar
+   fun:PyUnicode_AsWideCharString
+   fun:unicode_encode_locale
+   fun:PyUnicode_EncodeFSDefault
+   fun:_Py_stat
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:_PyMem_RawMalloc
+   fun:_PyMem_DebugRawAlloc
+   fun:_PyMem_DebugRawMalloc
+   fun:_PyMem_DebugMalloc
+   fun:PyObject_Malloc
+   fun:PyUnicode_New
+   fun:_PyUnicodeWriter_PrepareInternal
+   fun:PyUnicode_DecodeUTF8Stateful
+   fun:PyUnicode_FromString
+   fun:PyImport_ImportModule
+   fun:initstdio
+}
+
+{
    From PBSPro (TPP layer) - suppress epoll_pwait() glibc bug
    Memcheck:Param
    epoll_pwait(sigmask)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
We use Py_InitializeEx() in pbs_python_ext_quick_start_interpreter() and pbs_python_ext_start_interpreter(). Py_InitializeEx() has leaks which show up in PBS when run under valgrind

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added those leaks to the suppression file as they originate from the Python 3 source code

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
NA


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
[generated-suppfile-3.5 .txt](https://github.com/PBSPro/pbspro/files/3808014/generated-suppfile-3.5.txt)
[sample-program.txt](https://github.com/PBSPro/pbspro/files/3808023/sample-program.txt)


