### PR TITLE
Fix log_match dst failure

### DIFF
--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -210,9 +210,6 @@ PARSER_OK_STOP = 1
 PARSER_ERROR_CONTINUE = 2
 PARSER_ERROR_STOP = 3
 
-epoch_datetime = datetime.fromtimestamp(0)
-
-
 class PBSLogUtils(object):
 
     """
@@ -240,12 +237,6 @@ class PBSLogUtils(object):
         if dt is None:
             return None
 
-        stdoffset = timedelta(seconds=-time.timezone)
-        if time.daylight:
-            dstoffset = timedelta(seconds=-time.altzone)
-        else:
-            dstoffset = stdoffset
-        offsetdiff = dstoffset - stdoffset
         micro = False
         if fmt is None:
             if '.' in dt:
@@ -257,10 +248,8 @@ class PBSLogUtils(object):
         try:
             # Get datetime object
             t = datetime.strptime(dt, fmt)
-            # Get timedelta object of epoch time
-            t -= epoch_datetime
-            # get epoch time from timedelta object
-            tm = t.total_seconds() - offsetdiff.total_seconds()
+            # Get epoch-timestamp assuming local timezone
+            tm = t.timestamp()
         except ValueError:
             cls.logger.debug("could not convert date time: " + str(dt))
             return None

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -359,6 +359,8 @@ class PBSLogUtils(object):
                 dt_str = l.split(';', 1)[0]
                 if starttime is not None:
                     tm = self.convert_date_time(dt_str)
+                    self.logger.info(f'tm is {tm} | starttime is {starttime}'
+                                     f' | diff is {tm - starttime}')
                     if tm is None or tm < starttime:
                         continue
                 if endtime is not None:

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -210,6 +210,7 @@ PARSER_OK_STOP = 1
 PARSER_ERROR_CONTINUE = 2
 PARSER_ERROR_STOP = 3
 
+
 class PBSLogUtils(object):
 
     """

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -359,8 +359,6 @@ class PBSLogUtils(object):
                 dt_str = l.split(';', 1)[0]
                 if starttime is not None:
                     tm = self.convert_date_time(dt_str)
-                    self.logger.info(f'tm is {tm} | starttime is {starttime}'
-                                     f' | diff is {tm - starttime}')
                     if tm is None or tm < starttime:
                         continue
                 if endtime is not None:


### PR DESCRIPTION
#### Describe Bug or Feature
On some machines, all log_matches are failing, even though the message appears.

#### Describe Your Change
For some reason, `time.daylight` is returning 1, even though daylight savings time has ended.
Instead of doing all the math the code does now, we can use things introduced in python3.
Datetime objects now have a `.timestamp()` method that returns the epoch timestamp, while assuming the datetime is in the local timezone. It's exactly what we need!


#### Attach Test and Valgrind Logs/Output
[afterfix.txt](https://github.com/PBSPro/pbspro/files/3811006/afterfix.txt)
[beforefix.txt](https://github.com/PBSPro/pbspro/files/3811007/beforefix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
