### PR TITLE
Fix for PTL test case TestPbsExecjobAbort.test_execjob_abort_exit_job_launch_reject

### DIFF
--- a/test/tests/functional/pbs_hook_execjob_abort.py
+++ b/test/tests/functional/pbs_hook_execjob_abort.py
@@ -113,7 +113,7 @@ time.sleep(2)
 """
         # job used in the tests
         a = {ATTR_l + '.select': '3:ncpus=1', ATTR_l + '.place': 'scatter'}
-        self.j = Job(self.du.get_current_user(), attrs=a)
+        self.j = Job(TEST_USER, attrs=a)
 
     def test_execjob_abort_ms_prologue(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestPbsExecjobAbort.test_execjob_abort_exit_job_launch_reject test case submit job as root user but for some platform root user don't have permission to copy out job's output and error files.
This test case check for job's exit status after a hook rejection (for 60 attempt) but due to the error in copy out file (which takes longer time), test case fails. 


#### Describe Your Change
Submit job as TEST_USER


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[before_fix.txt](https://github.com/PBSPro/pbspro/files/3812722/before_fix.txt)
[after_fix.txt](https://github.com/PBSPro/pbspro/files/3812739/after_fix.txt)

[Full_testsuite_log.txt](https://github.com/PBSPro/pbspro/files/3812844/Full_testsuite_log.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
