### PR TITLE
Skipping few test cases for a specific platform

### DIFF
--- a/test/tests/functional/pbs_test_entity_limits.py
+++ b/test/tests/functional/pbs_test_entity_limits.py
@@ -134,7 +134,6 @@ class TestEntityLimits(TestFunctional):
             self.assertFalse(True, "Job violating limits got submitted after "
                              "server restart.")
 
-    @skipOnShasta
     def test_server_generic_user_limits_queued(self):
         """
         Test queued_jobs_threshold for any user at the server level.
@@ -144,7 +143,6 @@ class TestEntityLimits(TestFunctional):
         m = "qsub: would exceed complex's per-user limit of jobs in 'Q' state"
         self.common_limit_test(True, a, queued=True, exp_err=m)
 
-    @skipOnShasta
     def test_server_user_limits_queued(self):
         """
         Test queued_jobs_threshold for user TEST_USER at the server level.
@@ -204,7 +202,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: Maximum number of jobs in 'Q' state already in complex"
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
-    @skipOnShasta
     def test_queue_generic_user_limits_queued(self):
         """
         Test queued_jobs_threshold for any user for the default queue.
@@ -216,7 +213,6 @@ class TestEntityLimits(TestFunctional):
             + "jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnShasta
     def test_queue_user_limits_queued(self):
         """
         Test queued_jobs_threshold for user pbsuser1 for the default queue.
@@ -283,7 +279,6 @@ class TestEntityLimits(TestFunctional):
             + self.server.default_queue
         self.common_limit_test(False, a, attrs, queued=True, exp_err=emsg)
 
-    @skipOnShasta
     def test_server_generic_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any user at the server level.
@@ -295,7 +290,6 @@ class TestEntityLimits(TestFunctional):
             + "complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnShasta
     def test_server_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for user pbsuser1 at the server level.
@@ -364,7 +358,6 @@ class TestEntityLimits(TestFunctional):
             + "jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnShasta
     def test_queue_generic_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for all users for the default queue.
@@ -377,7 +370,6 @@ class TestEntityLimits(TestFunctional):
             + self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=emsg)
 
-    @skipOnShasta
     def test_queue_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for user pbsuser1 for the default queue.
@@ -454,7 +446,6 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
-    @skipOnShasta
     def test_server_generic_user_limits_max(self):
         """
         Test max_queued for any user at the server level.
@@ -464,7 +455,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed complex's per-user limit"
         self.common_limit_test(True, a, exp_err=errmsg)
 
-    @skipOnShasta
     def test_server_user_limits_max(self):
         """
         Test max_queued for user pbsuser1 at the server level.
@@ -522,7 +512,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = 'qsub: Maximum number of jobs already in complex'
         self.common_limit_test(True, a, exp_err=errmsg)
 
-    @skipOnShasta
     def test_queue_generic_user_limits_max(self):
         """
         Test max_queued for any user for the default queue.
@@ -533,7 +522,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed queue generic's per-user limit"
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnShasta
     def test_queue_user_limits_max(self):
         """
         Test max_queued for user pbsuser1 for the default queue.
@@ -600,7 +588,6 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnShasta
     def test_server_generic_user_limits_res_max(self):
         """
         Test max_queued_res for any user at the server level.
@@ -611,7 +598,6 @@ class TestEntityLimits(TestFunctional):
         emsg = 'qsub: would exceed per-user limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=emsg)
 
-    @skipOnShasta
     def test_server_user_limits_res_max(self):
         """
         Test max_queued_res for user pbsuser1 at the server level.
@@ -677,7 +663,6 @@ class TestEntityLimits(TestFunctional):
         errmsg = 'qsub: would exceed limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
-    @skipOnShasta
     def test_queue_generic_user_limits_res_max(self):
         """
         Test max_queued_res for all users for the default queue.
@@ -690,7 +675,6 @@ class TestEntityLimits(TestFunctional):
             + ' queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
-    @skipOnShasta
     def test_queue_user_limits_res_max(self):
         """
         Test max_queued_res for user pbsuser1 for the default queue.
@@ -813,7 +797,6 @@ class TestEntityLimits(TestFunctional):
                 raise self.failureException("rcvd unexpected err message: " +
                                             e.msg[0])
 
-    @skipOnShasta
     def test_multiple_queued_limits(self):
         defqname = self.server.default_queue
         q2name = 'q2'

--- a/test/tests/functional/pbs_test_entity_limits.py
+++ b/test/tests/functional/pbs_test_entity_limits.py
@@ -134,6 +134,7 @@ class TestEntityLimits(TestFunctional):
             self.assertFalse(True, "Job violating limits got submitted after "
                              "server restart.")
 
+    @skipOnShasta
     def test_server_generic_user_limits_queued(self):
         """
         Test queued_jobs_threshold for any user at the server level.
@@ -143,6 +144,7 @@ class TestEntityLimits(TestFunctional):
         m = "qsub: would exceed complex's per-user limit of jobs in 'Q' state"
         self.common_limit_test(True, a, queued=True, exp_err=m)
 
+    @skipOnShasta
     def test_server_user_limits_queued(self):
         """
         Test queued_jobs_threshold for user TEST_USER at the server level.
@@ -173,6 +175,7 @@ class TestEntityLimits(TestFunctional):
             + "'Q' state"
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_group_limits_queued(self):
         """
         Test queued_jobs_threshold for group TSTGRP0 at the server level.
@@ -183,6 +186,7 @@ class TestEntityLimits(TestFunctional):
             str(TSTGRP0) + ' already in complex'
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_generic_group_limits_queued(self):
         """
         Test queued_jobs_threshold for any group at the server level.
@@ -200,6 +204,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: Maximum number of jobs in 'Q' state already in complex"
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_generic_user_limits_queued(self):
         """
         Test queued_jobs_threshold for any user for the default queue.
@@ -211,6 +216,7 @@ class TestEntityLimits(TestFunctional):
             + "jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_user_limits_queued(self):
         """
         Test queued_jobs_threshold for user pbsuser1 for the default queue.
@@ -222,6 +228,7 @@ class TestEntityLimits(TestFunctional):
             str(TEST_USER) + ' already in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_group_limits_queued(self):
         """
         Test queued_jobs_threshold for group TSTGRP0 for the default queue.
@@ -254,6 +261,7 @@ class TestEntityLimits(TestFunctional):
             "'s per-project limit of jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_generic_group_limits_queued(self):
         """
         Test queued_jobs_threshold for any group for the default queue.
@@ -275,6 +283,7 @@ class TestEntityLimits(TestFunctional):
             + self.server.default_queue
         self.common_limit_test(False, a, attrs, queued=True, exp_err=emsg)
 
+    @skipOnShasta
     def test_server_generic_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any user at the server level.
@@ -286,6 +295,7 @@ class TestEntityLimits(TestFunctional):
             + "complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for user pbsuser1 at the server level.
@@ -297,6 +307,7 @@ class TestEntityLimits(TestFunctional):
             "'s limit on resource ncpus in complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_generic_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any group at the server level.
@@ -330,6 +341,7 @@ class TestEntityLimits(TestFunctional):
             + "complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for group pbsuser1 at the server level.
@@ -352,6 +364,7 @@ class TestEntityLimits(TestFunctional):
             + "jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_generic_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for all users for the default queue.
@@ -364,6 +377,7 @@ class TestEntityLimits(TestFunctional):
             + self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=emsg)
 
+    @skipOnShasta
     def test_queue_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for user pbsuser1 for the default queue.
@@ -377,6 +391,7 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for group pbsuser1 for the default queue
@@ -390,6 +405,7 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_generic_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any group for the default queue.
@@ -438,6 +454,7 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_generic_user_limits_max(self):
         """
         Test max_queued for any user at the server level.
@@ -447,6 +464,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed complex's per-user limit"
         self.common_limit_test(True, a, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_user_limits_max(self):
         """
         Test max_queued for user pbsuser1 at the server level.
@@ -475,9 +493,10 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed complex's per-project limit"
         self.common_limit_test(True, a, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_group_limits_max(self):
         """
-        Test max_queued for group pbsuser1 at the server level.
+        Test max_queued for group TSTGRP0 at the server level.
         """
         a = {"max_queued":
              "[g:" + str(TSTGRP0) + "=" + str(self.limit) + "]"}
@@ -485,6 +504,7 @@ class TestEntityLimits(TestFunctional):
             ' already in complex'
         self.common_limit_test(True, a, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_generic_group_limits_max(self):
         """
         Test max_queued for any group at the server level.
@@ -502,6 +522,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = 'qsub: Maximum number of jobs already in complex'
         self.common_limit_test(True, a, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_generic_user_limits_max(self):
         """
         Test max_queued for any user for the default queue.
@@ -512,6 +533,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed queue generic's per-user limit"
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_user_limits_max(self):
         """
         Test max_queued for user pbsuser1 for the default queue.
@@ -523,6 +545,7 @@ class TestEntityLimits(TestFunctional):
             ' already in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_group_limits_max(self):
         """
         Test max_queued for group pbsuser1 for the default queue.
@@ -555,6 +578,7 @@ class TestEntityLimits(TestFunctional):
             "'s per-project limit"
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_generic_group_limits_max(self):
         """
         Test max_queued for any group for the default queue.
@@ -576,6 +600,7 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_generic_user_limits_res_max(self):
         """
         Test max_queued_res for any user at the server level.
@@ -586,6 +611,7 @@ class TestEntityLimits(TestFunctional):
         emsg = 'qsub: would exceed per-user limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=emsg)
 
+    @skipOnShasta
     def test_server_user_limits_res_max(self):
         """
         Test max_queued_res for user pbsuser1 at the server level.
@@ -597,6 +623,7 @@ class TestEntityLimits(TestFunctional):
             "'s limit on resource ncpus in complex"
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
+    @skipOnShasta
     def test_server_generic_group_limits_res_max(self):
         """
         Test max_queued_res for any group at the server level.
@@ -628,6 +655,7 @@ class TestEntityLimits(TestFunctional):
         m = 'qsub: would exceed per-project limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=m)
 
+    @skipOnShasta
     def test_server_group_limits_res_max(self):
         """
         Test max_queued_res for group pbsuser1 at the server level.
@@ -649,6 +677,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = 'qsub: would exceed limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_generic_user_limits_res_max(self):
         """
         Test max_queued_res for all users for the default queue.
@@ -661,6 +690,7 @@ class TestEntityLimits(TestFunctional):
             + ' queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_user_limits_res_max(self):
         """
         Test max_queued_res for user pbsuser1 for the default queue.
@@ -674,6 +704,7 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_group_limits_res_max(self):
         """
         Test max_queued_res for group pbsuser1 for the default queue
@@ -686,6 +717,7 @@ class TestEntityLimits(TestFunctional):
             "'s limit on resource ncpus in queue " + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnShasta
     def test_queue_generic_group_limits_res_max(self):
         """
         Test max_queued_res for any group for the default queue.
@@ -781,6 +813,7 @@ class TestEntityLimits(TestFunctional):
                 raise self.failureException("rcvd unexpected err message: " +
                                             e.msg[0])
 
+    @skipOnShasta
     def test_multiple_queued_limits(self):
         defqname = self.server.default_queue
         q2name = 'q2'


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Few of the test cases from pbs_test_entity_limits does not work when linux users or groups are not present at the server.

#### Describe Your Change
Skipping them for a specific platform where the linux users or groups will not be present at the server. 

#### Attach Test Logs/Output
[skipped_test_logs.txt](https://github.com/PBSPro/pbspro/files/3812995/skipped_test_logs.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
