### PR TITLE
Add scp path for client installation in windows

### DIFF
--- a/src/cmds/scripts/win_postinstall.py
+++ b/src/cmds/scripts/win_postinstall.py
@@ -105,7 +105,7 @@ def install_vcredist():
     if ret > 0:
         if ret == 1638:
             msg = 'Newer version of Visual C++ redistributable is already'
-            msg += 'installed, ignoring this installation'
+            msg += ' installed, ignoring this installation'
             __log_info(msg)
         else:
             __log_err('Failed to install Visual C++ redistributable')
@@ -133,7 +133,8 @@ def create_pbs_conf():
                                                   pbs_start_server=0,
                                                   pbs_start_comm=0,
                                                   pbs_start_sched=0,
-                                                  pbs_start_mom=0)
+                                                  pbs_start_mom=0,
+                                                  pbs_scp=scp_path)
         fp.write(pbs_conf_data.lstrip())
     __log_info('Successfully created PBSPro configuration')
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* The scp path was not being added in pbs.conf for installation of pbs client in windows.

#### Describe Your Change
* Adding the scp path while running win_postinstall.py for client installation in windows. It is similar to what is done for MoM installation.


#### Attach Test and Valgrind Logs/Output
* [client_installation_logs.txt](https://github.com/PBSPro/pbspro/files/3823627/client_installation_logs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
