### PR TITLE
Server failing to recover queue on restart and having panic shutdown

### DIFF
--- a/src/server/attr_recov_db.c
+++ b/src/server/attr_recov_db.c
@@ -423,6 +423,15 @@ decode_attr_db(
 							snprintf(log_buffer,LOG_BUF_SIZE, "Action function failed for %s attr, errn %d",
 									(padef+index)->at_name, act_rc);
 							log_err(act_rc, __func__, log_buffer);
+							for ( index++; index <= limit; index++) {
+								while (pal) {
+									tmp_pal = pal->al_sister;
+									free(pal);
+									pal = tmp_pal;
+								}
+								if (index < limit)
+									pal = palarray[index];
+							}
 							free(palarray);
 							/* bailing out from this function */
 							/* any previously allocated attrs will be */

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -545,14 +545,18 @@ job_recov_db(char *jid)
 
 	pj = job_recov_db_spl(&dbjob);
 	if (!pj)
-		goto db_err;
+		goto db_err_reset;
 
 	if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0)
-		goto db_err;
+		goto db_err_reset;
 
 	pbs_db_reset_obj(&obj);
 
 	return (pj);
+
+db_err_reset:
+	pbs_db_reset_obj(&obj);
+
 db_err:
 	if (pj)
 		job_free(pj);
@@ -690,7 +694,7 @@ resv_recov_db(char *resvid)
 		goto db_err;
 
 	if (db_to_svr_resv(presv, &dbresv) != 0)
-		goto db_err;
+		goto db_err_reset;
 
 	pbs_db_reset_obj(&obj);
 
@@ -698,6 +702,9 @@ resv_recov_db(char *resvid)
 		goto db_err;
 
 	return (presv);
+
+db_err_reset:
+	pbs_db_reset_obj(&obj);
 db_err:
 	if (presv)
 		resv_free(presv);

--- a/src/server/queue_recov_db.c
+++ b/src/server/queue_recov_db.c
@@ -224,20 +224,23 @@ que_recov_db(char *qname)
 		return NULL;
 	}
 
-	/* load server_qs */
+	/* load queue name */
 	snprintf(dbque.qu_name, sizeof(dbque.qu_name), "%s", qname);
 
-	/* read in job fixed sub-structure */
+	/* read in queue fixed sub-structure */
 	if (pbs_db_load_obj(conn, &obj) != 0)
 		goto db_err;
 
 	if (db_to_svr_que(pq, &dbque) != 0)
-		goto db_err;
+		goto db_err_reset;
 
 	pbs_db_reset_obj(&obj);
 
 	/* all done recovering the queue */
 	return (pq);
+
+db_err_reset:
+	pbs_db_reset_obj(&obj);
 
 db_err:
 	snprintf(log_buffer, LOG_BUF_SIZE, "Failed to recover queue %s", qname);

--- a/src/server/resc_attr.c
+++ b/src/server/resc_attr.c
@@ -414,7 +414,7 @@ preempt_targets_action(resource *presc, attribute *pattr, void *pobject, int typ
 	resource_def *resdef = NULL;
 	char ch;
 
-	if (actmode == ATR_ACTION_FREE)
+	if ((actmode == ATR_ACTION_FREE) || (actmode == ATR_ACTION_RECOV))
 		return PBSE_NONE;
 
 	if ((pattr->at_flags & ATR_VFLAG_SET) == 0)

--- a/src/server/svr_recov_db.c
+++ b/src/server/svr_recov_db.c
@@ -283,6 +283,7 @@ svr_recov_db(void)
 		goto db_err;
 
 	if (db_to_svr_svr(&server, &dbsvr) != 0) {
+		pbs_db_reset_obj(&obj);
 		log_err(-1, "svr_recov", "Failed to recover server");
 		goto db_err;
 	}
@@ -411,12 +412,15 @@ sched_recov_db(char *sname)
 		goto db_err;
 
 	if (db_to_svr_sched(ps, &dbsched) != 0)
-		goto db_err;
+		goto db_err_reset;
 
 	pbs_db_reset_obj(&obj);
 
 	/* all done recovering the sched */
 	return (ps);
+
+db_err_reset:
+	pbs_db_reset_obj(&obj);
 
 db_err:
 	sprintf(log_buffer, "Failed to recover sched %s", sname);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
1. #1383 
2. two memory leaks found after #1308 when server encounters db recovery failures

1:
Server is unable to recover a queue having preempt_targets set as a queue and has a panic shutdown when we try to create this un-recovered queue.

Steps to reproduce:

Create workq2 and workq3
On workq2 set preempt_targets as a queu
set queue workq2 resources_default.preempt_targets=queue=workq3
Restart PBS
/etc/init.d/pbs restart
PBS fails to recover workq2!
Try to create workq2
create queue workq2 queue_type=e,enabled=t,started=t
The server has a panic shutdown!

2:
The two memory leak signatures when a queue db recovery fails during server init
363 bytes in 3 blocks are definitely lost in loss record 848 of 1,130
   at 0x4C271B2: malloc (vg_replace_malloc.c:298)
   by 0x460CC7: make_attr (attr_recov_db.c:109)
   by 0x460FAB: decode_attr_db (attr_recov_db.c:300)
   by 0x4943EA: db_to_svr_que (queue_recov_db.c:141)
   by 0x4943EA: que_recov_db (queue_recov_db.c:234)
   by 0x48C96F: pbsd_init (pbsd_init.c:889)
   by 0x490B6D: main (pbsd_main.c:1691)

&

1,169 (1,064 direct, 105 indirect) bytes in 1 blocks are definitely lost in loss record 964 of 1,130
   at 0x4C271B2: malloc (vg_replace_malloc.c:298)
   by 0x53EC56: convert_array_to_db_attr_list (db_postgres_attr.c:115)
   by 0x53D71F: pg_db_load_que (db_postgres_que.c:237)
   by 0x494390: que_recov_db (queue_recov_db.c:231)
   by 0x48C96F: pbsd_init (pbsd_init.c:889)
   by 0x490B6D: main (pbsd_main.c:1691)


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
1. Made the action function `preempt_targets_action()`  return `PBSE_NONE` when the `(actmode == ATR_ACTION_RECOV)`
2. Freed few malloc's when there is db recovery failure



#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[Before_test_preempt_queue_restart.zip](https://github.com/PBSPro/pbspro/files/3825237/Before_test_preempt_queue_restart.zip)
[After_test_preempt_queue_restart.zip](https://github.com/PBSPro/pbspro/files/3825241/After_test_preempt_queue_restart.zip)
[SmokeTest.zip](https://github.com/PBSPro/pbspro/files/3825238/SmokeTest.zip)
[valgrind_before.log](https://github.com/PBSPro/pbspro/files/3825240/valgrind_before.log)
[valgrind_after.log](https://github.com/PBSPro/pbspro/files/3825239/valgrind_after.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
