### PR TITLE
cgroups hook under big cpuset systems not assigning cpuset.cpus,mems correctly

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -1077,7 +1077,7 @@ class JobUtils(object):
             raise CgroupProcessingError('No job information available')
         # Create a list of local vnodes
         vnodes = []
-        vnhost_pattern = r'%s\[[\d+]\]' % hostname
+        vnhost_pattern = r'%s\[[\d]+\]' % hostname
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: vnhost pattern: %s' %
                    (caller_name(), vnhost_pattern))
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Job exec_vnode list: %s' %
@@ -1926,7 +1926,10 @@ class NodeUtils(object):
                 elif key in ['mem', 'vmem', 'hpmem']:
                     # Used for vnodes per NUMA socket
                     if vnodes:
-                        vnode_resc_avail[key] = pbs.size(val)
+                        mem_val = val
+                        if isinstance(val, float):
+                            mem_val = int(val)
+                        vnode_resc_avail[key] = pbs.size(mem_val)
                 elif isinstance(val, list):
                     pass
                 elif isinstance(val, dict):
@@ -3260,9 +3263,13 @@ class CgroupUtils(object):
                     if needed <= 0:
                         break
                     for thread in node.cpuinfo['cpu'][corenum]['threads']:
+                        if thread in assigned['cpuset.cpus']:
+                            # thread core already assigned
+                            continue
                         assigned['cpuset.cpus'].append(thread)
                         needed -= 1
-                        cores.remove(thread)
+                        if thread in cores:
+                            cores.remove(thread)
                         if needed <= 0:
                             break
                     if needed <= 0:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

1. WIth cgroups hook enabled on a big cpuset system with sockets (or vnodes)
   \>= 10, jobs run but the resulting cpuset.cpus and cpuset.mem cgroup files  are incomplete; ids and memory sockets ids that are in the assigned vnodes number 10 and up are missing.
2.  Also, when cgroups exechost_startup hook is invoked to map sockets into vnodes,
   some vnodes fail to be created due to "KeyError". This is traced to a type error exception
    with pbs.size(val) which expects val to be of type int or str, but system has returned a mem, vmem, or hpmem value of type float. 
 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

* For problem 1 above,  in _get_assigned_job_resources() , the pattern used for searching for matching vnodes is just:

   vnhost pattern: **<vnode-name>\[[\d+]\]**


   But this would only match vnode[0...9] so resources from anything above vnode 9, will not be
   written into cpuset.cpus and cpuset.mem files. Fix is to have the '+' in pattern outside of the [] as in: **\[[\d]+\]** so as to match one or more digits, otherwise, it's matching digits or '+' sign.

* For problem 1 also, with pbs_cgroups hook enabled + standard mom, use_hyperthreads = True + vnode_numa_nodes = True, some cpus are not written to the cpuset.cpus file. This is because in function _assign_resources(), 2 lists are consulted: the cores list and the threads list. From these lists, cpus are assigned to populate the cpuset.cpus file. But there are some repeats, for example cores = [90], threads list = [384, 90], and then pbs would select 90, 384, then 90 again in but only 90 and 384 are actually written to cpuset.cpus file. But pbs_cgroups thinks it had already written 3 items. So the fix is to check to make sure to select only cpu ids that have not been actually written in the cpuset.cpus file. 
* For problem 2, if a mem, hpmem, or vmem value is detected to be of type float, just convert it to int.
* Additionally, the pbs_cgroups_hook ptl testsuite has been updated to be able to run on big cpuset systems like the uv300. The updates to the testsuite involve:
   - Allowing pbs_cgroups_hook testsuite to run without memory subsystem configured. On big cpuset systems, memory enforcement can be handled by cpuset instead.
   - Taking into account that on a system with bigger pool of available resources, jobs may not always be assigned cpuIDs=0 or memory socket = 0.




#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
* [ptl.cgroups.r7.txt](https://github.com/PBSPro/pbspro/files/3827477/ptl.cgroups.r7.txt)
* [ptl.cgroups_hook.uv300.txt](https://github.com/PBSPro/pbspro/files/3838548/ptl.cgroups_hook.uv300.txt)
* [ptl.cgroups.s12.txt](https://github.com/PBSPro/pbspro/files/3827479/ptl.cgroups.s12.txt)
* [ptl.test_big_cgroup_cpuset.PASS.txt](https://github.com/PBSPro/pbspro/files/3826779/ptl.test_big_cgroup_cpuset.PASS.txt)
* [ptl.test_big_cgroup_cpuset.FAIL.txt](https://github.com/PBSPro/pbspro/files/3826780/ptl.test_big_cgroup_cpuset.FAIL.txt)

<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
