### PR TITLE
cached credentials not used with kerberos

### DIFF
--- a/src/server/req_cred.c
+++ b/src/server/req_cred.c
@@ -184,7 +184,7 @@ get_cached_cred(job  *pjob)
 	}
 
 	strncpy(cred->credid, pjob->ji_wattr[(int)JOB_ATR_cred_id].at_val.at_str,
-		strlen(pjob->ji_wattr[(int)JOB_ATR_cred_id].at_val.at_str));
+		strlen(pjob->ji_wattr[(int)JOB_ATR_cred_id].at_val.at_str) + 1); /* +1 for '\0' */
 	cred->type = cred_type;
 	cred->validity = validity;
 	cred->size = strlen(buf);

--- a/src/server/req_cred.c
+++ b/src/server/req_cred.c
@@ -102,7 +102,6 @@ get_cached_cred(job  *pjob)
 	long validity = 0;
 	int cred_type = CRED_NONE;
 	int ret = 0;
-	int credid_len;
 
 	/* try the cache first */
 	cred = (cred_cache *)GET_NEXT(svr_creds_cache);
@@ -184,9 +183,8 @@ get_cached_cred(job  *pjob)
 		return NULL;
 	}
 
-	credid_len = strlen(pjob->ji_wattr[(int)JOB_ATR_cred_id].at_val.at_str);
-	strncpy(cred->credid, pjob->ji_wattr[(int)JOB_ATR_cred_id].at_val.at_str, credid_len);
-	cred->credid[credid_len] = '\0';
+	strncpy(cred->credid, pjob->ji_wattr[(int)JOB_ATR_cred_id].at_val.at_str, PBS_MAXUSER);
+	cred->credid[PBS_MAXUSER] = '\0';
 	cred->type = cred_type;
 	cred->validity = validity;
 	cred->size = strlen(buf);

--- a/src/server/req_cred.c
+++ b/src/server/req_cred.c
@@ -102,6 +102,7 @@ get_cached_cred(job  *pjob)
 	long validity = 0;
 	int cred_type = CRED_NONE;
 	int ret = 0;
+	int credid_len;
 
 	/* try the cache first */
 	cred = (cred_cache *)GET_NEXT(svr_creds_cache);
@@ -183,8 +184,9 @@ get_cached_cred(job  *pjob)
 		return NULL;
 	}
 
-	strncpy(cred->credid, pjob->ji_wattr[(int)JOB_ATR_cred_id].at_val.at_str,
-		strlen(pjob->ji_wattr[(int)JOB_ATR_cred_id].at_val.at_str) + 1); /* +1 for '\0' */
+	credid_len = strlen(pjob->ji_wattr[(int)JOB_ATR_cred_id].at_val.at_str);
+	strncpy(cred->credid, pjob->ji_wattr[(int)JOB_ATR_cred_id].at_val.at_str, credid_len);
+	cred->credid[credid_len] = '\0';
 	cred->type = cred_type;
 	cred->validity = validity;
 	cred->size = strlen(buf);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This bug was introduced during the review process #1281. I changed strcpy to strncpy but I forgot that strncpy will not implicitly copy null termination of the string. This means the cred->credid was not terminated. cred->credid is used for finding credentials in the cache. Since cred->credid was not terminated, the cached credentials were never found and new credentials were always created.


#### Describe Your Change
Include  '\0' in strncpy while caching credentials.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Manual test:
* First run of a job for a particular user logs acquiring credentials: 
 11/13/2019 07:43:58;0080;Server@torque1;Svr;Server@torque1;using cred_renew_tool '/usr/bin/krb525_renew' to acquire credentials for user: vchlum@META
* another job of the same user uses the credential without acquiring a new one



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
