### PR TITLE
Fix dependencies for Docker build

### DIFF
--- a/docker/centos7/Dockerfile.base
+++ b/docker/centos7/Dockerfile.base
@@ -17,8 +17,10 @@ RUN yum install -y \
     ncurses-devel \
     openssl-devel \
     perl \
+    postgresql-contrib \
     postgresql-devel \
-    python-devel \
+    python3 \
+    python3-devel \
     rpm-build \
     swig \
     tcl-devel \

--- a/docker/centos7/Dockerfile.base
+++ b/docker/centos7/Dockerfile.base
@@ -1,7 +1,25 @@
 # base image for building pbspro
 FROM centos:7
 # install dependencies for building
-RUN yum install -y gcc make rpm-build libtool hwloc-devel libX11-devel \
-	libXt-devel libedit-devel libical-devel ncurses-devel perl \
-	postgresql-devel python-devel tcl-devel  tk-devel swig expat-devel \
-	openssl-devel libXext libXft git
+RUN yum install -y \
+    expat-devel \
+    gcc \
+    git \
+    hwloc-devel \
+    libedit-devel \
+    libical-devel \
+    libtool \
+    libX11-devel \
+    libXext \
+    libXft \
+    libXt-devel \
+    make \
+    ncurses-devel \
+    openssl-devel \
+    perl \
+    postgresql-devel \
+    python-devel \
+    rpm-build \
+    swig \
+    tcl-devel \
+    tk-devel


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

<!--- Describe the problem, ideally from the customer's viewpoint  -->

Previous to this PR, the following command

```sh
docker build -t pbs -f docker/centos7/Dockerfile.build .
```

failed during `./configure` with

```text
checking for a Python interpreter with version >= 3.5... none
configure: error: no suitable Python interpreter found
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add `python3` and `postgresql-contrib` dependencies.  Replace `python-devel` dependency with `python3-devel`.  

#### Test

This PR was tested with the following patch and commands.

##### Patch

Obtain source from local repository instead of GitHub repository.

```diff
diff --git a/docker/centos7/Dockerfile.build b/docker/centos7/Dockerfile.build
index 717da5d4..a6f125c4 100644
--- a/docker/centos7/Dockerfile.build
+++ b/docker/centos7/Dockerfile.build
@@ -3,8 +3,8 @@
 # build script will be triggered
 FROM pbspro/pbsbase:centos7 AS builder
 # get latest PBS Pro source code
-RUN git clone https://github.com/pbspro/pbspro.git /src/pbspro && \
-    bash /src/pbspro/docker/centos7/build.sh
+COPY . /src/pbspro
+RUN bash /src/pbspro/docker/centos7/build.sh

 # base image
 FROM centos:7
```

##### Commands

```sh
docker build -t pbspro/pbsbase:centos7 -f docker/centos7/Dockerfile.base .
docker build -t pbs -f docker/centos7/Dockerfile.build .
```


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
