### PR TITLE
test_runjob_hook can't find the specific server in the log message

### DIFF
--- a/test/tests/functional/pbs_hooksmoketest.py
+++ b/test/tests/functional/pbs_hooksmoketest.py
@@ -432,19 +432,21 @@ print_attribs(j)"""
         ev = ret[0]['exec_vnode']
         # Verify server logs
         self.logger.info("Verifying logs in server")
-        msg_1 = "Server@%s;Hook;%s;started" % \
-                (self.server.shortname, self.hook_name)
-        msg_2 = "Hook;Server@%s;requestor = Scheduler" % \
-                self.server.shortname
-        msg_3 = "Hook;Server@%s;hook_name = %s" % \
-                (self.server.shortname, self.hook_name)
-        msg_4 = "Hook;Server@%s;exec_vnode = %s" % \
-                (self.server.shortname, ev)
-        msg_5 = "Server@%s;Hook;%s;finished" % \
-                (self.server.shortname, self.hook_name)
+        msg_1 = "Server@.*;Hook;%s;started" % \
+                (self.hook_name)
+        msg_2 = "Hook;Server@.*;requestor = Scheduler"
+        msg_3 = "Hook;Server@.*;hook_name = %s" % \
+                (self.hook_name)
+        msg_4 = "Hook;Server@.*;exec_vnode = %s" % \
+                (ev)
+        # Character escaping '()' as the log_match is regexp
+        msg_4 = msg_4.replace("(", "\(")
+        msg_4 = msg_4.replace(")", "\)")
+        msg_5 = "Server@.*;Hook;%s;finished" % \
+                (self.hook_name)
         msg = [msg_1, msg_2, msg_3, msg_4, msg_5]
         for i in msg:
-            self.server.log_match(i, starttime=now)
+            self.server.log_match(i, starttime=now, regexp=True)
             self.logger.info("Got expected logs in server as %s", i)
 
     def tearDown(self):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature


When running TestHookSmokeTest.test_runjob_hook where server and clients are on different hosts, the test fails when trying to do a log match.

The PTL test is looking for:
"Server@pbs-service-nmn;Hook;test_hook;started"

The server logs have this:
Server@pbs-host;Hook;test_hook;started





#### Describe Your Change
Using regular expressions to avoid matching server name.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[test_runjob_hook_LOGS.txt](https://github.com/PBSPro/pbspro/files/3862768/test_runjob_hook_LOGS.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
