### PR TITLE
PBS_ALL softlimit affect jobs that are not over limit

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -287,6 +287,7 @@ struct server_info
 	unsigned has_user_limit:1;	/* server has user hard or soft limit */
 	unsigned has_grp_limit:1;	/* server has group hard or soft limit */
 	unsigned has_proj_limit:1;	/* server has project hard or soft limit */
+	unsigned has_all_limit:1;	/* server has PBS_ALL limits set on it */
 	unsigned has_prime_queue:1;	/* server has a primetime queue */
 	unsigned has_ded_queue:1;	/* server has a dedtime queue */
 	unsigned has_nonprime_queue:1;	/* server has a non primetime queue */
@@ -374,7 +375,6 @@ struct server_info
 	resresv_set **equiv_classes;
 	node_bucket **buckets;		/* node bucket array */
 	node_info **unordered_nodes;
-	int soft_limit_preempt_bit;	/* Overall preempt bit to mark server is over max run softlimits */
 #ifdef NAS
 	/* localmod 049 */
 	node_info **nodes_by_NASrank;	/* nodes indexed by NASrank */
@@ -400,6 +400,7 @@ struct queue_info
 	unsigned has_user_limit:1;	/* queue has user hard or soft limit */
 	unsigned has_grp_limit:1;	/* queue has group hard or soft limit */
 	unsigned has_proj_limit:1;	/* queue has project hard or soft limit */
+	unsigned has_all_limit:1;	/* queue has PBS_ALL limits set on it */
 	struct server_info *server;	/* server where queue resides */
 	char *name;			/* queue name */
 	state_count sc;			/* number of jobs in different states */
@@ -442,7 +443,6 @@ struct queue_info
 	int num_topjobs;		/* current number of top jobs in this queue */
 	int backfill_depth;		/* total allowable topjobs in this queue*/
 	char *partition;		/* partition to which queue belongs to */
-	int soft_limit_preempt_bit;	/* Overall preempt bit to mark queue is over max run softlimits */
 };
 
 struct job_info

--- a/src/scheduler/limits.c
+++ b/src/scheduler/limits.c
@@ -2039,20 +2039,16 @@ check_queue_max_run_soft(server_info *si, queue_info *qi, resource_resv *rr)
 	max_running = (int) lim_get(key, LI2RUNCTXSOFT(qi->liminfo));
 	free(key);
 
-	if ((max_running == SCHD_INFINITY) ||
-		(max_running > qi->sc.running)) {
-		qi->alljobcounts->soft_limit_preempt_bit = 0;
-		return (0);
+	/* at this point, we know a limit is set for PBS_ALL*/
+	used = find_counts_elm(qi->alljobcounts, PBS_ALL_ENTITY, NULL, &cnt, NULL);
+	if (max_running != SCHD_INFINITY && used > max_running) {
+		if (cnt != NULL)
+			cnt->soft_limit_preempt_bit = PREEMPT_TO_BIT(PREEMPT_OVER_QUEUE_LIMIT);
+		return (PREEMPT_TO_BIT(PREEMPT_OVER_QUEUE_LIMIT));
 	} else {
-		/* at this point, we know a limit is set  for PBS_ALL*/
-		used = find_counts_elm(qi->alljobcounts, PBS_ALL_ENTITY, NULL, &cnt, NULL);
-		if (used > max_running) {
-			if (cnt != NULL)
-				cnt->soft_limit_preempt_bit = PREEMPT_TO_BIT(PREEMPT_OVER_QUEUE_LIMIT);
-			return (PREEMPT_TO_BIT(PREEMPT_OVER_QUEUE_LIMIT));
-		} else {
-			return (0);
-		}
+		if (cnt != NULL)
+			cnt->soft_limit_preempt_bit = 0;
+		return (0);
 	}
 
 }
@@ -2297,20 +2293,16 @@ check_server_max_run_soft(server_info *si, queue_info *qi, resource_resv *rr)
 	max_running = (int) lim_get(key, LI2RUNCTXSOFT(si->liminfo));
 	free(key);
 
-	if ((max_running == SCHD_INFINITY) ||
-		(max_running > si->sc.running)) {
-		si->alljobcounts->soft_limit_preempt_bit = 0;
-		return (0);
+	/* at this point, we know a limit is set for PBS_ALL*/
+	used = find_counts_elm(si->alljobcounts, PBS_ALL_ENTITY , NULL, &cnt, NULL);
+	if (max_running != SCHD_INFINITY && used > max_running) {
+		if (cnt != NULL)
+			cnt->soft_limit_preempt_bit = PREEMPT_TO_BIT(PREEMPT_OVER_SERVER_LIMIT);
+		return (PREEMPT_TO_BIT(PREEMPT_OVER_SERVER_LIMIT));
 	} else {
-		/* at this point, we know a limit is set  for PBS_ALL*/
-		used = find_counts_elm(si->alljobcounts, PBS_ALL_ENTITY , NULL, &cnt, NULL);
-		if (used > max_running) {
-			if (cnt != NULL)
-				cnt->soft_limit_preempt_bit = PREEMPT_TO_BIT(PREEMPT_OVER_SERVER_LIMIT);
-			return (PREEMPT_TO_BIT(PREEMPT_OVER_SERVER_LIMIT));
-		} else {
-			return (0);
-		}
+		if (cnt != NULL)
+			cnt->soft_limit_preempt_bit = 0;
+		return (0);
 	}
 }
 

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -271,14 +271,13 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 					err = 1;
 
 				if (qinfo->has_soft_limit || qinfo->has_hard_limit) {
+					counts *allcts;
+					allcts = find_alloc_counts(qinfo->alljobcounts,
+						PBS_ALL_ENTITY);
+					if (qinfo->alljobcounts == NULL)
+						qinfo->alljobcounts = allcts;
+
 					if (qinfo->running_jobs != NULL) {
-						counts *allcts;
-
-						allcts = find_alloc_counts(qinfo->alljobcounts,
-							"o:" PBS_ALL_ENTITY);
-						if (qinfo->alljobcounts == NULL)
-							qinfo->alljobcounts = allcts;
-
 						/* set the user and group counts */
 						for (j = 0; qinfo->running_jobs[j] != NULL; j++) {
 							cts = find_alloc_counts(qinfo->user_counts,
@@ -408,6 +407,8 @@ query_queue_info(status *policy, struct batch_status *queue, server_info *sinfo)
 				qinfo->has_grp_limit = 1;
 			if(strstr(attrp->value, "p:") != NULL)
 				qinfo->has_proj_limit = 1;
+			if(strstr(attrp->value, "o:") != NULL)
+				qinfo->has_all_limit = 1;
 		}
 		else if (is_runlimattr(attrp)) {
 			(void) lim_setlimits(attrp, LIM_RUN, qinfo->liminfo);
@@ -417,7 +418,8 @@ query_queue_info(status *policy, struct batch_status *queue, server_info *sinfo)
 				qinfo->has_grp_limit = 1;
 			if(strstr(attrp->value, "p:") != NULL)
 				qinfo->has_proj_limit = 1;
-
+			if(strstr(attrp->value, "o:") != NULL)
+				qinfo->has_all_limit = 1;
 		}
 		else if (is_oldlimattr(attrp)) {
 			char *limname = convert_oldlim_to_new(attrp);
@@ -552,6 +554,7 @@ new_queue_info(int limallocflag)
 	qinfo->has_user_limit = 0;
 	qinfo->has_grp_limit = 0;
 	qinfo->has_proj_limit = 0;
+	qinfo->has_all_limit = 0;
 	init_state_count(&(qinfo->sc));
 	if ((limallocflag != 0))
 		qinfo->liminfo = lim_alloc_liminfo();
@@ -589,7 +592,6 @@ new_queue_info(int limallocflag)
 	qinfo->ignore_nodect_sort	 = 0;
 #endif
 	qinfo->partition = NULL;
-	qinfo->soft_limit_preempt_bit = 0;
 	return qinfo;
 }
 
@@ -706,7 +708,7 @@ update_queue_on_run(queue_info *qinfo, resource_resv *resresv, char *job_state)
 
 			update_counts_on_run(cts, resresv->resreq);
 
-			allcts = find_alloc_counts(qinfo->alljobcounts, "o:" PBS_ALL_ENTITY);
+			allcts = find_alloc_counts(qinfo->alljobcounts, PBS_ALL_ENTITY);
 
 			if (qinfo->alljobcounts == NULL)
 				qinfo->alljobcounts = allcts;
@@ -796,7 +798,7 @@ update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 			if (cts != NULL)
 				update_counts_on_end(cts, resresv->resreq);
 
-			cts = find_alloc_counts(qinfo->alljobcounts, "o:" PBS_ALL_ENTITY);
+			cts = find_alloc_counts(qinfo->alljobcounts, PBS_ALL_ENTITY);
 
 			if (cts != NULL)
 				update_counts_on_end(cts, resresv->resreq);
@@ -933,6 +935,7 @@ dup_queue_info(queue_info *oqinfo, server_info *nsinfo)
 	nqinfo->has_user_limit = oqinfo->has_user_limit;
 	nqinfo->has_grp_limit = oqinfo->has_grp_limit;
 	nqinfo->has_proj_limit = oqinfo->has_proj_limit;
+	nqinfo->has_all_limit = oqinfo->has_all_limit;
 	nqinfo->sc = oqinfo->sc;
 	nqinfo->liminfo = lim_dup_liminfo(oqinfo->liminfo);
 	nqinfo->priority = oqinfo->priority;
@@ -991,7 +994,6 @@ dup_queue_info(queue_info *oqinfo, server_info *nsinfo)
 			return NULL;
 		}
 	}
-	nqinfo->soft_limit_preempt_bit = oqinfo->soft_limit_preempt_bit;
 
 	return nqinfo;
 }

--- a/test/tests/functional/pbs_test_entity_limits.py
+++ b/test/tests/functional/pbs_test_entity_limits.py
@@ -41,8 +41,7 @@ from tests.functional import *
 class TestEntityLimits(TestFunctional):
 
     """
-    This test suite tests working of queued_jobs_threshold, max_queued,
-    queued_jobs_threshold_res and max_queued_res.
+    This test suite tests working of FGC limits
 
     PBS supports entity limits at queue and server level. And these limits
     can be applied for a user, group, project or overall.
@@ -846,3 +845,191 @@ class TestEntityLimits(TestFunctional):
                                             e.msg[0])
         else:
             self.assertFalse(True, "Job violating limits got submitted.")
+
+    def test_pbs_all_soft_limits(self):
+        """
+        Set resource soft limit on server for PBS_ALL and see that the job
+        requesting this resource is susceptible to preemption
+        """
+        # set max_run_res_soft on mem for PBS_ALL
+        a = {'max_run_res_soft.mem': '[o:PBS_ALL=256mb]'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        a = {'resources_available.ncpus': 4,
+             'resources_available.mem': '2gb'}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        # set preempt prio on the scheduler
+        t = "express_queue, normal_jobs, server_softlimits"
+        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_prio': t})
+
+        # submit a job that requests mem and exceeds soft limit
+        attr = {'Resource_List.select': '1:ncpus=2:mem=1gb'}
+        j1 = Job(attrs=attr)
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        # Sleep for a second and submit another job requesting all ncpus left
+        # Sleep is required so that scheduler sorts the most recently started
+        # job to the top of the preemptible candidates when it tries
+        # preemption
+        time.sleep(1)
+        attr = {'Resource_List.select': '1:ncpus=2'}
+        j2 = Job(attrs=attr)
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        # Submit third job (normal priority) that will try to preempt the
+        # job which is running over its softlimits (which is J1 here).
+        j3 = Job(attrs=attr)
+        jid3 = self.server.submit(j3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        # Now that no job is over its soft limits, if we submit another
+        # normal priority job, it should stay queued
+        j4 = Job(attrs=attr)
+        jid4 = self.server.submit(j4)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
+
+    def test_user_soft_limits(self):
+        """
+        Set resource soft limit on server for a user and see that the job
+        requesting this resource submitted by same user are susceptible
+        to preemption
+        """
+        # set max_run_res_soft on mem for TEST_USER
+        a = {'max_run_res_soft.mem': '[u:' + str(TEST_USER) + '=256mb]'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        a = {'resources_available.ncpus': 4,
+             'resources_available.mem': '2gb'}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        # set preempt prio on the scheduler
+        t = "express_queue, normal_jobs, server_softlimits"
+        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_prio': t})
+
+        # submit a job as TEST_USER that requests mem and exceeds soft limit
+        attr = {'Resource_List.select': '1:ncpus=2:mem=1gb'}
+        j1 = Job(TEST_USER, attrs=attr)
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        # Sleep for a second and submit another job requesting all ncpus left
+        # Sleep is required so that scheduler sorts the most recently started
+        # job to the top of the preemptible candidates when it tries
+        # preemption
+        time.sleep(1)
+        attr = {'Resource_List.select': '1:ncpus=2'}
+        j2 = Job(TEST_USER, attrs=attr)
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        # Submit third job (normal priority) that will try to preempt the
+        # job which is running over its softlimits (which is J1 here).
+        j3 = Job(TEST_USER, attrs=attr)
+        jid3 = self.server.submit(j3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        # Now that no job is over its soft limits, if we submit another
+        # normal priority job, it should stay queued
+        j4 = Job(TEST_USER, attrs=attr)
+        jid4 = self.server.submit(j4)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
+
+    def test_group_soft_limits(self):
+        """
+        Set resource soft limit on server for a group and see that the job
+        requesting this resource submitted by same group are susceptible
+        to preemption
+        """
+        # set max_run_res_soft on mem for TSTGRP0
+        a = {'max_run_res_soft.mem': '[g:' + str(TSTGRP0) + '=256mb]'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        a = {'resources_available.ncpus': 4,
+             'resources_available.mem': '2gb'}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        # set preempt prio on the scheduler
+        t = "express_queue, normal_jobs, server_softlimits"
+        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_prio': t})
+
+        # submit a job as TSTGRP0 that requests mem and exceeds soft limit
+        attr = {'Resource_List.select': '1:ncpus=2:mem=1gb',
+                'group_list': TSTGRP0}
+        j1 = Job(TEST_USER, attrs=attr)
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        # Sleep for a second and submit another job requesting all ncpus left
+        # Sleep is required so that scheduler sorts the most recently started
+        # job to the top of the preemptible candidates when it tries
+        # preemption
+        time.sleep(1)
+        attr = {'Resource_List.select': '1:ncpus=2',
+                'group_list': TSTGRP1}
+        j2 = Job(TEST_USER1, attrs=attr)
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        # Submit third job (normal priority) that will try to preempt the
+        # job which is running over its softlimits (which is J1 here).
+        j3 = Job(TEST_USER1, attrs=attr)
+        jid3 = self.server.submit(j3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        # Now that no job is over its soft limits, if we submit another
+        # normal priority job, it should stay queued
+        j4 = Job(TEST_USER1, attrs=attr)
+        jid4 = self.server.submit(j4)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
+
+    def test_project_soft_limits(self):
+        """
+        Set resource soft limit on server for a project and see that the job
+        requesting this resource submitted under same project is susceptible
+        to preemption
+        """
+        # set max_run_res_soft on mem for project P1
+        a = {'max_run_res_soft.mem': '[p:P1=256mb]'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        a = {'resources_available.ncpus': 4,
+             'resources_available.mem': '2gb'}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+        # set preempt prio on the scheduler
+        t = "express_queue, normal_jobs, server_softlimits"
+        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_prio': t})
+
+        # submit a job under P1 project that requests mem and exceeds
+        # soft limit
+        attr = {'Resource_List.select': '1:ncpus=2:mem=1gb',
+                ATTR_project: 'P1'}
+        j1 = Job(TEST_USER, attrs=attr)
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        # Sleep for a second and submit another job requesting all ncpus left
+        # Sleep is required so that scheduler sorts the most recently started
+        # job to the top of the preemptible candidates when it tries
+        # preemption
+        time.sleep(1)
+        attr = {'Resource_List.select': '1:ncpus=2',
+                ATTR_project: 'P2'}
+        j2 = Job(TEST_USER, attrs=attr)
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        # Submit third job (normal priority) that will try to preempt the
+        # job which is running over its softlimits (which is J1 here).
+        j3 = Job(TEST_USER, attrs=attr)
+        jid3 = self.server.submit(j3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        # Now that no job is over its soft limits, if we submit another
+        # normal priority job, it should stay queued
+        j4 = Job(TEST_USER, attrs=attr)
+        jid4 = self.server.submit(j4)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS_ALL softlimit applied to a resource affects the jobs that are not even requesting that resource.


#### Describe Your Change
Earlier any job exceeding PBS_ALL softlimit used to set a preempt_bit on server/queue (depending on where the limit was set) and this resulted into all the jobs in that server/queue to be marked over PBS_ALL softlimit even when these jobs are not requesting the resource to which the limit was applied.
This change removes preempt_bit from server/queue and manages PBS_ALL limit just like it handles user/group/project limit. It now checks if the job in hand has requested the resource to which PBS_ALL limit is applied and then only copy over the preempt_bit from the relevant resource.


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test.txt](https://github.com/PBSPro/pbspro/files/3865268/test.txt)

