### PR TITLE
fix travis showing passed despite build fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - '[ "${OS_TYPE}" == "opensuse/leap:15" ] && export DOCKER_EXTRA_ARG="-e LC_ALL=C.utf8" || true'
   - docker run -it -d -h testdev.pbspro.org --name testdev -v $(pwd):$(pwd) --privileged -w $(pwd) ${DOCKER_EXTRA_ARG} ${OS_TYPE} /bin/bash
   - docker ps -a
-  - export DOCKER_EXEC="docker exec -it ${DOCKER_EXTRA_ARG} --privileged testdev"
+  - export DOCKER_EXEC="docker exec -it ${DOCKER_EXTRA_ARG} -e BUILD_MODE="${BUILD_MODE}" --privileged testdev"
 install:
   - '${DOCKER_EXEC} .travis/do_sanitize_mode.sh'
   - '${DOCKER_EXEC} .travis/do.sh'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ before_install:
   - docker ps -a
   - export DOCKER_EXEC="docker exec -it ${DOCKER_EXTRA_ARG} --privileged testdev"
 install:
-  - '[ "x${BUILD_MODE}" == "xsanitize" ] && ${DOCKER_EXEC} .travis/do_sanitize_mode.sh || true'
-  - '[ "x${BUILD_MODE}" != "xsanitize" ] && ${DOCKER_EXEC} .travis/do.sh || true'
+  - '${DOCKER_EXEC} .travis/do_sanitize_mode.sh'
+  - '${DOCKER_EXEC} .travis/do.sh'
 script: true

--- a/.travis/do.sh
+++ b/.travis/do.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -xe
 
+if [ "x${BUILD_MODE}" == "xsanitize" ]; then
+   exit 0
+fi
 . /etc/os-release
 if [ "x${ID}" == "xcentos" ]; then
     yum -y install python3
@@ -13,3 +16,7 @@ fi
 
 PBS_DIR=$(dirname $(readlink -f $(basename $0)))
 ${PBS_DIR}/ci/ci --local
+if [ $? -ne 0 ];then
+    exit 1
+fi
+

--- a/.travis/do_sanitize_mode.sh
+++ b/.travis/do_sanitize_mode.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -xe
 
+if [ "x${BUILD_MODE}" != "xsanitize" ]; then
+   exit 0
+fi
 . /etc/os-release
 if [ "x${ID}" == "xcentos" ]; then
     yum -y install python3
@@ -13,4 +16,7 @@ fi
 
 PBS_DIR=$(dirname $(readlink -f $(basename $0)))
 ${PBS_DIR}/ci/ci --local="sanitize"
+if [ $? -ne 0 ];then
+    exit 1
+fi
 

--- a/ci/ci
+++ b/ci/ci
@@ -371,9 +371,11 @@ if __name__ == "__main__":
             os.chdir(pbs_dirname)
             # using subprocess.run instead of run_cmd function so we dont supress stdout and stderr
             if args.local == 'called':
-                subprocess.run("./do.sh")
+                exit_code = subprocess.run("./do.sh")
+                sys.exit(exit_code.returncode)
             if args.local == 'sanitize':
-                subprocess.run("./do_sanitize_mode.sh")
+                exit_code = subprocess.run("./do_sanitize_mode.sh")
+                sys.exit(exit_code.returncode)
         else:
             sys.exit(0)
     except Exception as e:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The ci wrapper python script for do.sh was not returning the exit code. Since the test part is also in the same script '|| true' part of earlier code was suppressing errors.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Handled error code in ci script
* In travis config passing scripts without '|| true' and taking care of sanitize conditions in the script itself as BUILD_MODE env variable.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[Failed test scenario](https://travis-ci.org/sandisamp/pbspro/builds/614379367?utm_medium=notification&utm_source=github_status)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
