### PR TITLE
PTL tests are failing in setUp() when run on cpuset mom

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1410,7 +1410,7 @@ class PBSTestSuite(unittest.TestCase):
         if not mom.isUp():
             self.logger.error('mom ' + mom.shortname + ' is down after revert')
         self.server.manager(MGR_CMD_CREATE, NODE, None, mom.shortname)
-        a = {'state': 'free', 'resources_available.ncpus': (GE, 1)}
+        a = {'state': 'free'}
         self.server.expect(NODE, a, id=mom.shortname, interval=1)
         return mom
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PTL Tests are failing in setUp(), when run on cpuset mom

#### Describe Your Change

- When setUp() is called at the beginning of the test case, setUp() calls revert_mom(). revert_mom() deletes and recreates the node and expects the node state to be free and resources_available.ncpus to be >= 1. But on cpuset mom, the value of resources_available.ncpus will be zero on base node and hence test fails.

- We should update revert_mom() function to check that total available ncpus should be greater than 1 in the cluster.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_with_fix.txt](https://github.com/PBSPro/pbspro/files/3977910/Execution_logs_with_fix.txt)

- [Execution_logs_without_fix.txt](https://github.com/PBSPro/pbspro/files/3977911/Execution_logs_without_fix.txt)