### PR TITLE
Updating last running job id in cleanup_jobs

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8471,7 +8471,7 @@ class Server(PBSService):
             select_xt = 'x'
         jobs = self.status(JOB, extend=select_xt)
         job_ids = sorted(list(set([x['id'] for x in jobs])))
-        running_jobs = [j['id'] for j in jobs if j['job_state'] == 'R']
+        running_jobs = sorted([j['id'] for j in jobs if j['job_state'] == 'R'])
         host_pid_map = {}
         for job in jobs:
             exec_host = job.get('exec_host', None)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8471,9 +8471,9 @@ class Server(PBSService):
             select_xt = 'x'
         jobs = self.status(JOB, extend=select_xt)
         job_ids = sorted(list(set([x['id'] for x in jobs])))
-        running_jobs = self.filter(JOB, {'job_state': 'R'})
-        if running_jobs.values():
-            last_running_job = list(running_jobs.values())[0][-1]
+        running_jobs = [j['id'] for j in jobs if j['job_state'] == 'R']
+        if running_jobs:
+            last_running_job = running_jobs[-1]
         host_pid_map = {}
         for job in jobs:
             exec_host = job.get('exec_host', None)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8471,6 +8471,9 @@ class Server(PBSService):
             select_xt = 'x'
         jobs = self.status(JOB, extend=select_xt)
         job_ids = sorted(list(set([x['id'] for x in jobs])))
+        running_jobs = self.filter(JOB, {'job_state': 'R'})
+        if running_jobs.values():
+            last_running_job = list(running_jobs.values())[0][-1]
         host_pid_map = {}
         for job in jobs:
             exec_host = job.get('exec_host', None)
@@ -8510,7 +8513,7 @@ class Server(PBSService):
                     self.du.run_cmd(host, ['kill', '-9'] + chunk,
                                     runas=ROOT_USER, logerr=False)
             if running_job is True:
-                _msg = job_ids[-1] + ';'
+                _msg = last_running_job + ';'
                 _msg += 'Job Obit notice received has error 15001'
                 try:
                     self.log_match(_msg, starttime=st, interval=10,

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -8472,8 +8472,6 @@ class Server(PBSService):
         jobs = self.status(JOB, extend=select_xt)
         job_ids = sorted(list(set([x['id'] for x in jobs])))
         running_jobs = [j['id'] for j in jobs if j['job_state'] == 'R']
-        if running_jobs:
-            last_running_job = running_jobs[-1]
         host_pid_map = {}
         for job in jobs:
             exec_host = job.get('exec_host', None)
@@ -8503,16 +8501,14 @@ class Server(PBSService):
         except PbsDeljobError:
             pass
         st = int(time.time())
-        running_job = False
         if len(job_ids) > 100:
             for host, pids in host_pid_map.items():
                 chunks = [pids[i:i + 5000] for i in range(0, len(pids), 5000)]
-                if chunks:
-                    running_job = True
                 for chunk in chunks:
                     self.du.run_cmd(host, ['kill', '-9'] + chunk,
                                     runas=ROOT_USER, logerr=False)
-            if running_job is True:
+            if running_jobs:
+                last_running_job = running_jobs[-1]
                 _msg = last_running_job + ';'
                 _msg += 'Job Obit notice received has error 15001'
                 try:

--- a/test/tests/selftest/pbs_job_cleanup.py
+++ b/test/tests/selftest/pbs_job_cleanup.py
@@ -74,3 +74,28 @@ class TestJobCleanup(TestSelf):
         t2 = time.time()
 
         self.logger.info("Time taken for job cleanup " + str(t2 - t1))
+
+    def test_del_large_num_jobs(self):
+        """
+        Test that the delete jobs functionality works correctly with large
+        number of jobs
+        """
+        num_jobs = 1000
+        a = {'resources_available.ncpus': 1,
+             'resources_available.mem': '2gb'}
+        self.server.create_vnodes('vnode', a, num_jobs, self.mom,
+                                  sharednode=False, expect=False)
+        self.server.expect(NODE, {'state=free': (GE, num_jobs)})
+
+        self.server.manager(MGR_CMD_SET, MGR_OBJ_SERVER,
+                            {'scheduling': 'False'})
+
+        for i in range(num_jobs):
+            j = Job(TEST_USER)
+            self.server.submit(j)
+
+        self.scheduler.run_scheduling_cycle()
+        self.server.expect(JOB, {'job_state=R': num_jobs}, max_attempts=120)
+
+        self.server.cleanup_jobs()
+        self.server.expect(SERVER, {'total_jobs': 0})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In cleanup_jobs in PTL we wait for the last running job to get finished. Currently PTL expects all jobs to be running. This change will filter out only the running jobs and then wait for the last running job in the list to get finished. 

Logs:
[deletion_jobs.txt](https://github.com/PBSPro/pbspro/files/3877251/deletion_jobs.txt)
[deletion_queued_jobs.txt](https://github.com/PBSPro/pbspro/files/3877252/deletion_queued_jobs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
