### PR TITLE
Fix windows build version

### DIFF
--- a/win_configure/msi/wix/create_msi.bat
+++ b/win_configure/msi/wix/create_msi.bat
@@ -32,7 +32,7 @@ REM
 REM Use of Altair’s trademarks, including but not limited to "PBS™",
 REM "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 REM trademark licensing policies.
-setlocal
+setlocal enabledelayedexpansion
 @echo on
 
 cd "%~dp0..\..\..\..\"
@@ -69,7 +69,11 @@ for /F "tokens=3 USEBACKQ" %%F IN (`findstr /l /c:" pbs_version " %PBS_SPEC_FILE
     set PBS_VERSION=%%F
 )
 for /F "tokens=1-3 delims=." %%F IN ("%PBS_VERSION%") DO (
-    set PBS_SHORT_VERSION=%%F.%%G.%%H
+    set MAJOR_V=%%F
+    if "!MAJOR_V:~0,2!"=="20" (
+        set MAJOR_V=!MAJOR_V:~2,4!
+    )
+    set PBS_SHORT_VERSION=!MAJOR_V!.%%G.%%H
 )
 
 set PBS_PRODUCT_NAME=%PBS_PRODUCT_NAME% %PBS_VERSION%


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* The windows build was failing after changing the version to 2020 as wix toolset checks for the product version.
* The major and minor version of product version can have maximum value of 255. Check this [link](https://docs.microsoft.com/en-us/windows/win32/msi/productversion?redirectedfrom=MSDN) for microsoft's official page regarding this.


#### Describe Your Change
* While creating msi in windows, we are removing first two characters of major version in product version if it starts with "2020" and keeping the last two characters.



#### Attach Test and Valgrind Logs/Output
* Test Logs: [Logs_windows_build_Version.txt](https://github.com/PBSPro/pbspro/files/3872804/Logs_windows_build_Version.txt)






<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
