### PR TITLE
tcp gss - reallocated read buffer too small

### DIFF
--- a/src/lib/Libifl/tcp_dis_gss.c
+++ b/src/lib/Libifl/tcp_dis_gss.c
@@ -295,7 +295,7 @@ dis_gss_read_buff(int fd, struct gss_disbuf *tp, uint32_t ct)
 	len = tp->tdis_bufsize - tp->tdis_eod;
 
 	if (len < ct) {
-		size_t ru = (ct + tp->tdis_lead) / DIS_GSS_BUF_SIZE;
+		size_t ru = (ct + tp->tdis_lead + tp->tdis_eod) / DIS_GSS_BUF_SIZE;
 		tp->tdis_bufsize = (ru + 1) * DIS_GSS_BUF_SIZE;
 		tmcp = (char *) realloc(tp->tdis_thebuf, sizeof(char) * tp->tdis_bufsize);
 		if (tmcp == NULL) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In the function dis_gss_read_buff(), the read buffer (tp) is reallocated (if it is not large enough for reading a specific amount of bytes (ct)). The new buffer size is miscounted in some cases. If the tp->tdis_eod is not 0, the new buffer size does not consider it.
This is the case:
```
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff7cd5535 in __GI_abort () at abort.c:79
#2  0x00007ffff7d2c508 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7ffff7e3728d "%s\n")
    at ../sysdeps/posix/libc_fatal.c:181
#3  0x00007ffff7d32c1a in malloc_printerr (str=str@entry=0x7ffff7e3556a "realloc(): invalid next size")
    at malloc.c:5341
#4  0x00007ffff7d36da4 in _int_realloc (av=av@entry=0x7ffff7e6ec40 <main_arena>, oldp=oldp@entry=0x5555555b0760, 
    oldsize=oldsize@entry=4112, nb=nb@entry=4112) at malloc.c:4561
#5  0x00007ffff7d37d4f in __GI___libc_realloc (oldmem=0x5555555b0770, bytes=4096) at malloc.c:3213
#6  0x000055555557c801 in dis_gss_read_buff (fd=3, tp=0x5555555b00f0, ct=1024)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/tcp_dis_gss.c:300
#7  0x000055555557c947 in dis_gss_read (fd=3) at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/tcp_dis_gss.c:359
#8  0x000055555557ccf6 in dis_gss_gets (fd=3, str=0x55555561f550 "", ct=12848)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/tcp_dis_gss.c:523
#9  0x000055555558dca5 in disrst (stream=3, retval=0x7fffffffe6ac)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libdis/disrst.c:103
#10 0x00005555555876ed in decode_DIS_attrl (sock=3, ppatt=0x55555561f2c0)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/dec_attrl.c:116
#11 0x0000555555581c17 in decode_DIS_replyCmd (sock=3, reply=0x5555555b01a0)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/dec_rpyc.c:178
#12 0x000055555556ceac in PBSD_rdrpy_sock (sock=3, rc=0x7fffffffe78c)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/int_rdrpy.c:90
#13 0x000055555556cfc7 in PBSD_rdrpy (c=1) at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/int_rdrpy.c:126
#14 0x0000555555583fee in PBSD_status_get (c=1) at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/int_status.c:112
#15 0x0000555555583fc7 in PBSD_status (c=1, function=58, objid=0x55555559343f "", attrib=0x0, extend=0x0)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/int_status.c:89
#16 0x00005555555763ed in __pbs_statvnode (c=1, id=0x55555559343f "", attrib=0x0, extend=0x0)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/pbsD_statnode.c:104
#17 0x0000555555566380 in pbs_statvnode (c=1, id=0x55555559343f "", attrib=0x0, extend=0x0)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/ifl_impl.c:659
#18 0x0000555555575fe2 in __pbs_stathost (con=1, hid=0x55555559101b "", attrib=0x0, extend=0x0)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/pbsD_stathost.c:912
#19 0x000055555556631e in pbs_stathost (con=1, hid=0x55555559101b "", attrib=0x0, extend=0x0)
    at /tmp/pbspro-src/src/lib/Libpbs/../Libifl/ifl_impl.c:620
#20 0x0000555555562718 in main (argc=2, argv=0x7fffffffead8) at /tmp/pbspro-src/src/cmds/pbsnodes.c:1103
(gdb) select-frame 6
(gdb) print ct
$1 = 1024
(gdb) print *tp
$2 = {tdis_lead = 7, tdis_trail = 0, tdis_eod = 4015, tdis_bufsize = 4096, 
  tdis_thebuf = 0x5555555b0770 "5+1284813697646.arien-pro.ics.muni.cz/0, 13697646.arien-pro.ics.muni.cz/1, 13697646.arien-pro.ics.muni.cz/2, 13697646.arien-pro.ics.muni.cz/3, 13697646.arien-pro.ics.muni.cz/4, 13697646.arien-pro.ics."...}
```
ct + tdis_lead = 1031, which means ru = 0 and therefore tp->tdis_bufsize remains 4096. The available length of the buffer is 81 but we want to read 1024. The tdis_eod is ignored.

#### Describe Your Change
We need to count with tdis_eod while we count the 'ru'. This way the buffer will be aligned to DIS_GSS_BUF_SIZE and large enough.
It means  
ru = (ct + tp->tdis_lead + tp->tdis_eod) / DIS_GSS_BUF_SIZE;
ru = (1024 + 7 + 4015) /4096 = 1;
and 
tp->tdis_bufsize = (ru + 1) * 4096;

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
```
Breakpoint 2, dis_gss_read_buff (fd=3, tp=0x5555555b00f0, ct=1024)
    at ../Libifl/tcp_dis_gss.c:298
298			size_t ru = (ct + tp->tdis_lead + tp->tdis_eod) / DIS_GSS_BUF_SIZE;
(gdb) print *tp
$5 = {tdis_lead = 6, tdis_trail = 0, tdis_eod = 3659, tdis_bufsize = 4096, 
  tdis_thebuf = 0x5555555b0790 "<not important data>"...}
(gdb) n
299			tp->tdis_bufsize = (ru + 1) * DIS_GSS_BUF_SIZE;
(gdb) print ru
$6 = 1
...<skipped>...
(gdb) 
315		return ((i == 0) ? -2 : i);
(gdb) print *tp
$10 = {tdis_lead = 6, tdis_trail = 0, tdis_eod = 4683, tdis_bufsize = 8192, 
  tdis_thebuf = 0x55555561df90 "<not important data>"...}
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
