### PR TITLE
test_prologue_hook_does_not_execute_twice_on_pbsdsh fails due to out of range error

### DIFF
--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -261,12 +261,9 @@ class TestPbsExecutePrologue(TestFunctional):
         ret = self.du.cat(hostname=host, filename=opath, runas=TEST_USER)
         _msg = "cat command failed with error: %s" % ret['err']
         self.assertEqual(ret['rc'], 0, _msg)
-        if len(ret['out']) == 4:
-            mom1 = ret['out'][2].split(".")[0]
-            mom2 = ret['out'][3].split(".")[0]
-        else:
-            mom1 = ret['out'][0].split(".")[0]
-            mom2 = ret['out'][1].split(".")[0]
+        ret['out']=ret['out'][2:]
+        mom1 = ret['out'][0].split(".")[0]
+        mom2 = ret['out'][1].split(".")[0]
         self.exec_mom1 = self.moms[mom1]
         self.exec_mom2 = self.moms[mom2]
         self.exec_mom1.log_match("Job;%s;executed prologue hook" % jid)

--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -46,6 +46,7 @@ class TestPbsExecutePrologue(TestFunctional):
 
     PRE: Have a cluster of PBS with 3 mom hosts.
     """
+
     def setUp(self):
         if len(self.moms) != 3:
             self.skip_test(reason="need 3 mom hosts: -p moms=<m1>:<m2>:<m3>")
@@ -261,7 +262,7 @@ class TestPbsExecutePrologue(TestFunctional):
         ret = self.du.cat(hostname=host, filename=opath, runas=TEST_USER)
         _msg = "cat command failed with error: %s" % ret['err']
         self.assertEqual(ret['rc'], 0, _msg)
-        ret['out']=ret['out'][-2:]
+        ret['out'] = ret['out'][-2:]
         mom1 = ret['out'][0].split(".")[0]
         mom2 = ret['out'][1].split(".")[0]
         self.exec_mom1 = self.moms[mom1]

--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -261,8 +261,12 @@ class TestPbsExecutePrologue(TestFunctional):
         ret = self.du.cat(hostname=host, filename=opath, runas=TEST_USER)
         _msg = "cat command failed with error: %s" % ret['err']
         self.assertEqual(ret['rc'], 0, _msg)
-        mom1 = ret['out'][2].split(".")[0]
-        mom2 = ret['out'][3].split(".")[0]
+        if len(ret['out']) == 4:
+            mom1 = ret['out'][2].split(".")[0]
+            mom2 = ret['out'][3].split(".")[0]
+        else:
+            mom1 = ret['out'][0].split(".")[0]
+            mom2 = ret['out'][1].split(".")[0]
         self.exec_mom1 = self.moms[mom1]
         self.exec_mom2 = self.moms[mom2]
         self.exec_mom1.log_match("Job;%s;executed prologue hook" % jid)

--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -261,7 +261,7 @@ class TestPbsExecutePrologue(TestFunctional):
         ret = self.du.cat(hostname=host, filename=opath, runas=TEST_USER)
         _msg = "cat command failed with error: %s" % ret['err']
         self.assertEqual(ret['rc'], 0, _msg)
-        ret['out']=ret['out'][2:]
+        ret['out']=ret['out'][-2:]
         mom1 = ret['out'][0].split(".")[0]
         mom2 = ret['out'][1].split(".")[0]
         self.exec_mom1 = self.moms[mom1]


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The test failed with out of range error.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Sometimes the machines returned warning messages along with the mom names. An example is given below
`{'out': ['Warning: no access to tty (Bad file descriptor).', 'Thus no job control in this shell.', 'x52-rhel7.pbspro.com', 'x58-r7.pbspro.com'], 'err': [], 'rc': 0}`

> This is an innocuous warning that simply means you are running a script (rather than a binary) under a job that has no access to the TTY. In otherwords, you cannot interrupt it (^C), suspend it (^Z) or use other interactive commands because there is no screen or keyboard to interact with it. It can be safely ignored.

Fix now always takes the last  2 elements from the dictionary key ['out']

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[test_prologue_hook_does_not_execute_twice_on_pbsdsh](https://github.com/PBSPro/pbspro/files/3885068/prologue_log.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
