### PR TITLE
add Kerberos build into Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - OS_TYPE=ubuntu:18.04
   - OS_TYPE=debian:9
   - OS_TYPE=centos:7 BUILD_MODE=sanitize
+  - OS_TYPE=centos:7 BUILD_MODE=kerberos
 before_install:
   - .github/runchecks
   - docker pull ${OS_TYPE}

--- a/ci/do.sh
+++ b/ci/do.sh
@@ -114,9 +114,6 @@ if [ "x${ONLY_REBUILD}" != "x1" -a "x${ONLY_INSTALL}" != "x1" -a "x${ONLY_TEST}"
     else 
       configure_opt='--prefix=/opt/pbs --enable-ptl'
     fi
-    if [ "x${BUILD_MODE}" == "xkerberos" ]; then
-      configure_opt="${configure_opt} --with-krbauth PATH_KRB5_CONFIG=/usr/bin/krb5-config"
-    fi
     ../configure CFLAGS="${_cflags}" ${configure_opt}
     if [ "x${ONLY_CONFIGURE}" == "x1" ];then
       exit 0

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -867,6 +867,9 @@ fi
 [ -z "${PBS_START_SCHED}" ] && PBS_START_SCHED=0
 [ -z "${PBS_START_COMM}" ] && PBS_START_COMM=0
 
+# For Kerberos enabled server
+[ ! -z "${PBS_START_SERVER}" ] && export PBSPRO_IGNORE_KERBEROS=1
+
 UNIX95=1
 export UNIX95
 PBS_MOM_HOME=${PBS_MOM_HOME:-$PBS_HOME}

--- a/src/lib/Libutil/krb5_util.c
+++ b/src/lib/Libutil/krb5_util.c
@@ -69,7 +69,7 @@
 int
 init_pbs_client_ccache_from_keytab(char *err_buf, int err_buf_size)
 {
-	krb5_error_code ret;
+	krb5_error_code ret = KRB5KRB_ERR_GENERIC;
 	krb5_context context = NULL;
 	krb5_principal pbs_service = NULL;
 	krb5_keytab keytab = NULL;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
New PBS Pro build for Travis CI with enabled Kerberos. The build runs on epel7 and uses MIT Kerberos. This is the first phase of adding automated tests for testing Kerberos.

Discussion [here](http://community.pbspro.org/t/kerberos-support/48/80).

#### Describe Your Change
Adding a new build with enabled Kerberos.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
See travis log.



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
