### PR TITLE
Fixing segfault in sched MT code for single core systems

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1037,7 +1037,7 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 	resresv_arr[num_prev_jobs] = NULL;
 
 	tid = *((int *) pthread_getspecific(th_id_key));
-	if (tid != 0 || num_threads == 1) {
+	if (tid != 0 || num_threads <= 1) {
 		/* don't use multi-threading if I am a worker thread or num_threads is 1 */
 		tdata = alloc_tdata_jquery(policy, pbs_sd, jobs, qinfo, 0, num_new_jobs - 1);
 		if (tdata == NULL) {

--- a/src/scheduler/multi_threading.c
+++ b/src/scheduler/multi_threading.c
@@ -174,14 +174,14 @@ init_multi_threading(int nthreads)
 	pthread_mutex_init(&result_lock, &attr);
 	pthread_mutex_init(&general_lock, &attr);
 
-	if (nthreads < 1) {
+	num_cores = sysconf(_SC_NPROCESSORS_ONLN);
+	if (nthreads < 1 && num_cores > 2)
 		/* Create as many threads as half the number of cores */
-		num_cores = sysconf(_SC_NPROCESSORS_ONLN);
 		num_threads = num_cores / 2;
-	} else
+	else
 		num_threads = nthreads;
 
-	if (num_threads == 1)
+	if (num_threads <= 1)
 		return 1; /* main thread will act as the only worker thread */
 
 	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,

--- a/src/scheduler/multi_threading.c
+++ b/src/scheduler/multi_threading.c
@@ -181,8 +181,10 @@ init_multi_threading(int nthreads)
 	else
 		num_threads = nthreads;
 
-	if (num_threads <= 1)
+	if (num_threads <= 1) {
+		num_threads = 1;
 		return 1; /* main thread will act as the only worker thread */
+	}
 
 	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,
 			"", "Launching worker threads");

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -355,7 +355,7 @@ query_nodes(int pbs_sd, server_info *sinfo)
 #endif /* localmod 049 */
 
 	tid = *((int *) pthread_getspecific(th_id_key));
-	if (tid != 0 || num_threads == 1) {
+	if (tid != 0 || num_threads <= 1) {
 		/* don't use multi-threading if I am a worker thread or num_threads is 1 */
 		tdata = alloc_tdata_nd_query(nodes, sinfo, 0, num_nodes - 1);
 		if (tdata == NULL) {
@@ -864,7 +864,7 @@ free_nodes(node_info **ninfo_arr)
 	num_nodes = count_array((void **) ninfo_arr);
 
 	tid = *((int *) pthread_getspecific(th_id_key));
-	if (tid != 0 || num_threads == 1) {
+	if (tid != 0 || num_threads <= 1) {
 		/* don't use multi-threading if I am a worker thread or num_threads is 1 */
 		tdata = alloc_tdata_free_nodes(ninfo_arr, 0, num_nodes - 1);
 		if (tdata == NULL)
@@ -1559,7 +1559,7 @@ dup_nodes(node_info **onodes, server_info *nsinfo,
 #endif /* localmod 049 */
 
 	tid = *((int *) pthread_getspecific(th_id_key));
-	if (tid != 0 || num_threads == 1) {
+	if (tid != 0 || num_threads <= 1) {
 		/* don't use multi-threading if I am a worker thread or num_threads is 1 */
 		tdata = alloc_tdata_dup_nodes(flags, nsinfo, onodes, nnodes, 0, num_nodes - 1);
 		if (tdata == NULL) {
@@ -6313,7 +6313,7 @@ check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, plac
 		num_nodes = count_array((void **) ninfo_arr);
 
 	tid = *((int *) pthread_getspecific(th_id_key));
-	if (tid != 0 || num_threads == 1) {
+	if (tid != 0 || num_threads <= 1) {
 		/* don't use multi-threading if I am a worker thread or num_threads is 1 */
 		tdata = alloc_tdata_nd_eligible(pl, resresv, ninfo_arr, 0, num_nodes - 1);
 		if (tdata == NULL)

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -276,7 +276,7 @@ free_resource_resv_array(resource_resv **resresv_arr)
 	num_jobs = count_array((void **) resresv_arr);
 
 	tid = *((int *) pthread_getspecific(th_id_key));
-	if (tid != 0 || num_threads == 1) {
+	if (tid != 0 || num_threads <= 1) {
 		/* don't use multi-threading if I am a worker thread or num_threads is 1 */
 		tdata = alloc_tdata_free_rr_arr(resresv_arr, 0, num_jobs - 1);
 		if (tdata == NULL)
@@ -516,7 +516,7 @@ dup_resource_resv_array(resource_resv **oresresv_arr,
 	nresresv_arr[0] = NULL;
 
 	tid = *((int *) pthread_getspecific(th_id_key));
-	if (tid != 0 || num_threads == 1) {
+	if (tid != 0 || num_threads <= 1) {
 		/* don't use multi-threading if I am a worker thread or num_threads is 1 */
 		tdata = alloc_tdata_dup_nodes(oresresv_arr, nresresv_arr, nsinfo, nqinfo, 0, num_resresv - 1);
 		if (tdata == NULL)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
For single core systems, scheduler was segfaulting because of divide by 0 error. This happens because we create num_cores/2 number of threads by default. So for single core systems this becomes 0 and we end up dividing by num threads later and segfault.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fixed the code to account for single core systems

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
