### PR TITLE
long_resource_end fails because it expects MAIL to be set

### DIFF
--- a/test/tests/functional/pbs_acct_log.py
+++ b/test/tests/functional/pbs_acct_log.py
@@ -53,6 +53,21 @@ class TestAcctLog(TestFunctional):
         Test to see if a very long string resource is neither truncated
         in the job's resources_used attr or the accounting log at job end
         """
+
+        # Make sure emails are not truncated
+        try:
+            mailfile = os.environ['MAIL']
+        except KeyError:
+            self.skip_test(
+                "mail is not setup. " +
+                "Hence this step would be skipped. " +
+                "Please setup the mail.")
+        if not os.path.isfile(mailfile):
+            self.skip_test(
+                "Mail file does not exist. " +
+                "Hence this step would be skipped. " +
+                "Please check manually.")
+
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'job_history_enable': 'True'})
 
@@ -89,19 +104,6 @@ class TestAcctLog(TestFunctional):
         log_match = 'resources_used.foo_str=' + hstr
         self.server.log_match("%s;.*%s.*" % (jid, log_match), regexp=True)
 
-        # Make sure emails are not truncated
-        try:
-            mailfile = os.environ['MAIL']
-        except KeyError:
-            self.skip_test(
-                "mail is not setup. " +
-                "Hence this step would be skipped. " +
-                "Please setup the mail.")
-        if not os.path.isfile(mailfile):
-            self.skip_test(
-                "Mail file does not exist. " +
-                "Hence this step would be skipped. " +
-                "Please check manually.")
         mailpass = 0
         for x in range(1, 5):
             fo = open(mailfile, 'r')

--- a/test/tests/functional/pbs_acct_log.py
+++ b/test/tests/functional/pbs_acct_log.py
@@ -90,11 +90,18 @@ class TestAcctLog(TestFunctional):
         self.server.log_match("%s;.*%s.*" % (jid, log_match), regexp=True)
 
         # Make sure emails are not truncated
-        mailfile = os.environ['MAIL']
+        try:
+            mailfile = os.environ['MAIL']
+        except KeyError:
+            self.skip_test(
+                "mail is not setup. " +
+                "Hence this step would be skipped. " +
+                "Please setup the mail.")
         if not os.path.isfile(mailfile):
-            self.logger.info("Mail file does not exist or mail is not setup.\
-                     Hence this step would be skipped. Please check manually.")
-            return 1
+            self.skip_test(
+                "Mail file does not exist. " +
+                "Hence this step would be skipped. " +
+                "Please check manually.")
         mailpass = 0
         for x in range(1, 5):
             fo = open(mailfile, 'r')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
long_resource_end fails because we get KeyError message, when mail is not setup.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Skip the test if mail is not setup or mail file doesn't exist.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_long_resource_end.txt](https://github.com/PBSPro/pbspro/files/3895425/test_long_resource_end.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
