### PR TITLE
Sched segfaults accessing free'd node partition cache

### DIFF
--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -523,7 +523,7 @@ enum nodepart
 	NP_IGNORE_EXCL = 1,
 	NP_CREATE_REST = 2,
 	NP_NO_ADD_NP_ARR = 4
-	/* next 4, 8, etc */
+	/* next 8, 16, etc */
 };
 
 /* It is used to identify the provisioning policy set on scheduler */

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -522,7 +522,7 @@ enum nodepart
 	NP_LOW = 0,
 	NP_IGNORE_EXCL = 1,
 	NP_CREATE_REST = 2,
-	NP_NO_CACHE_UPDATE = 4
+	NP_NO_ADD_NP_ARR = 4
 	/* next 4, 8, etc */
 };
 

--- a/src/scheduler/constant.h
+++ b/src/scheduler/constant.h
@@ -521,7 +521,8 @@ enum nodepart
 {
 	NP_LOW = 0,
 	NP_IGNORE_EXCL = 1,
-	NP_CREATE_REST = 2
+	NP_CREATE_REST = 2,
+	NP_NO_CACHE_UPDATE = 4
 	/* next 4, 8, etc */
 };
 

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -577,12 +577,14 @@ create_node_partitions(status *policy, node_info **nodes, char **resnames, unsig
 							}
 						}
 					}
-					tmp_arr = add_ptr_to_array(nodes[node_i]->np_arr, np_arr[np_i]);
-					if (tmp_arr == NULL) {
-						free_node_partition_array(np_arr);
-						return NULL;
+					if (!(NP_NO_CACHE_UPDATE & flags)) {
+						tmp_arr = add_ptr_to_array(nodes[node_i]->np_arr, np_arr[np_i]);
+						if (tmp_arr == NULL) {
+							free_node_partition_array(np_arr);
+							return NULL;
+						}
+						nodes[node_i]->np_arr = tmp_arr;
 					}
-					nodes[node_i]->np_arr = tmp_arr;
 
 					np_arr[np_i]->ninfo_arr[i] = nodes[node_i];
 					i++;
@@ -897,10 +899,12 @@ find_alloc_np_cache(status *policy, np_cache ***pnpc_arr,
 	npc = find_np_cache(*pnpc_arr, resnames, ninfo_arr);
 
 	if (npc == NULL) {
+		int flags;
+
+		flags = policy->only_explicit_psets ? NP_NO_CACHE_UPDATE : NP_CREATE_REST | NP_NO_CACHE_UPDATE;
+
 		/* didn't find node partition cache, need to allocate and create */
-		nodepart = create_node_partitions(policy, ninfo_arr, resnames,
-			policy->only_explicit_psets ? NO_FLAGS : NP_CREATE_REST,
-			&num_parts);
+		nodepart = create_node_partitions(policy, ninfo_arr, resnames, flags, &num_parts);
 		if (nodepart != NULL) {
 			if (sort_func != NULL)
 				qsort(nodepart, num_parts, sizeof(node_partition *), sort_func);

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -577,7 +577,7 @@ create_node_partitions(status *policy, node_info **nodes, char **resnames, unsig
 							}
 						}
 					}
-					if (!(NP_NO_CACHE_UPDATE & flags)) {
+					if (!(NP_NO_ADD_NP_ARR & flags)) {
 						tmp_arr = add_ptr_to_array(nodes[node_i]->np_arr, np_arr[np_i]);
 						if (tmp_arr == NULL) {
 							free_node_partition_array(np_arr);
@@ -899,9 +899,10 @@ find_alloc_np_cache(status *policy, np_cache ***pnpc_arr,
 	npc = find_np_cache(*pnpc_arr, resnames, ninfo_arr);
 
 	if (npc == NULL) {
-		int flags;
+		int flags = NP_NO_ADD_NP_ARR;
 
-		flags = policy->only_explicit_psets ? NP_NO_CACHE_UPDATE : NP_CREATE_REST | NP_NO_CACHE_UPDATE;
+		if (policy->only_explicit_psets)
+			flags |= NP_CREATE_REST;
 
 		/* didn't find node partition cache, need to allocate and create */
 		nodepart = create_node_partitions(policy, ninfo_arr, resnames, flags, &num_parts);

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -167,7 +167,8 @@ on_segv(int sig)
 	if (thid != NULL && *thid != 0)
 		pthread_exit(NULL);
 
-	kill_threads();
+	if (num_threads > 1)
+		kill_threads();
 
 	/* we crashed less then 5 minutes ago, lets not restart ourself */
 	if ((segv_last_time - segv_start_time) < 300) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Scheduler's node structure was recently enhanced to have pointers to node partitions. This was done for performance reasons. This cache is created when the universe is first queried, and is not expected to be updated through the course of a sched cycle. But, we were updating it in a corner case during calendaring if the simulation code ends up creating host sets, which can happen in certain situations, one of which is if calendaring a suspended job on a multi-vnoded host, this leads to the creation of host sets, which ends up creating placements sets and attaching a new copy of the cache on the duplicated nodes, which gets free'd, and scheduler seg-faults when the free'd cache is access for the next event in the calendar.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added a new flag to tell create_node_partitions to not update the node partition cache.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
I actually wrote a specialized PTL test for this, but it didn't seem functionally valuable to me. It's only interesting to trigger this segfault, but not otherwise. So, I'm not adding it to the PR. Please let me know if you think that I should add it.
The test i did involved creating 2 vnodes (8 ncpus each) on the same host, an expressq (Priority 200), turning preemption on, submitting 16 low priority jobs requesting 1ncpu, then submitting a high priority job which requests 2:ncpus=8. Then triggered the seg fault.

Valgrind logs below (scroll to the bottom of the files, skip all the Python related errors):
[valgrind_after.log](https://github.com/PBSPro/pbspro/files/3898653/valgrind_after.log)
[valgrind_before.log](https://github.com/PBSPro/pbspro/files/3898654/valgrind_before.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
