### PR TITLE
pbs_mom segfaults when doing a rerun with an epilogue script	

### DIFF
--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -610,8 +610,8 @@ req_quejob(struct batch_request *preq)
 			return;
 		}
 		created_here = JOB_SVFLG_HERE;
+		free(namebuf);
 	}
-	free(namebuf);
 #endif          /* PBS_MOM */
 
 	(void)strcpy(pj->ji_qs.ji_jobid, jid);

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -312,7 +312,6 @@ req_quejob(struct batch_request *preq)
 #else
 	mom_hook_input_t  hook_input;
 	mom_hook_output_t hook_output;
-	char		*namebuf;
 	int		hook_errcode = 0;
 	int		hook_rc = 0;
 	char		hook_buf[HOOK_MSG_SIZE];
@@ -572,6 +571,7 @@ req_quejob(struct batch_request *preq)
 		/* unlink job from svr_alljobs since will be place on newjobs */
 		delete_link(&pj->ji_alljobs);
 	} else {
+		char *namebuf;
 		char basename[MAXPATHLEN + 1] = {0};
 
 		/* if not already here, allocate job struct */


### PR DESCRIPTION
#### Describe Bug or Feature
When an execjob_epilogue hook runs for a job and a qrerun is triggered right after that, mom exits with a segmentation fault. 

#### Describe Your Change
Mom is trying to free memory which has not been allocated. Freeing the variable belongs to an else block which is right above that. 

Note - The segmentation fault is visible only when testing the epilogue hook with qrerun manually. 

#### Attach Test and Valgrind Logs/Output
[manual_test_logs_after_fix.txt](https://github.com/PBSPro/pbspro/files/3895770/manual_test_logs_after_fix.txt)
[manual_test_logs_before_fix.txt](https://github.com/PBSPro/pbspro/files/3895771/manual_test_logs_before_fix.txt)
[mom_logs_after_fix.txt](https://github.com/PBSPro/pbspro/files/3895772/mom_logs_after_fix.txt)
[mom_logs_before_fix.txt](https://github.com/PBSPro/pbspro/files/3895773/mom_logs_before_fix.txt)
[automated_test_logs_after_fix.txt](https://github.com/PBSPro/pbspro/files/3895774/automated_test_logs_after_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
