### PR TITLE
test_direct_write_when_job_succeeds_controlled fails because it uses mkdtemp

### DIFF
--- a/test/tests/functional/pbs_qsub_direct_write.py
+++ b/test/tests/functional/pbs_qsub_direct_write.py
@@ -87,9 +87,9 @@ class TestQsub_direct_write(TestFunctional):
         """
         j = Job(TEST_USER4, attrs={ATTR_k: 'doe'})
         j.set_sleep_time(10)
-        sub_dir = self.du.mkdtemp(uid=TEST_USER4.uid)
-        mapping_dir = self.du.mkdtemp(
-            uid=TEST_USER5.uid, gid=TSTGRP4.gid, mode=0o770)
+        sub_dir = self.du.create_temp_dir(asuser=TEST_USER5)
+        mapping_dir = self.du.create_temp_dir(
+            asuser=TEST_USER4, asgroup=TSTGRP5, mode=0o770)
         self.mom.add_config(
             {'$usecp': self.server.hostname + ':' + sub_dir +
              ' ' + mapping_dir})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
test_direct_write_when_job_succeeds_controlled fails because it uses mkdtemp.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Use du.create_temp_dir to  creat temp directory.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[qsub_temp_dir.txt](https://github.com/PBSPro/pbspro/files/3899875/qsub_temp_dir.txt)
[qsub_direct_write.txt](https://github.com/PBSPro/pbspro/files/3899870/qsub_direct_write.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
