### PR TITLE
Fix invalid reads reported by valgrind

### DIFF
--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3433,7 +3433,6 @@ void reply_hook_bg(job *pjob)
 					del_job_resc(pjob);	/* rm tmpdir, cpusets, etc */
 					pjob->ji_preq = NULL;
 					(void) kill_job(pjob, SIGKILL);
-					job_purge(pjob);
 					dorestrict_user();
 #if !MOM_ALPS
 					/*
@@ -3441,8 +3440,7 @@ void reply_hook_bg(job *pjob)
 					* been or will be replied to and freed by the
 					* alps_cancel_reservation code in the sequence
 					* of functions started with the above call to
-					* del_job_resc(). Set preq to NULL here so we
-					* don't try, mistakenly, to use it again.
+					* del_job_resc().
 					*/ 
 					if (pjob->ji_numnodes == 1) 
 						reply_ack(preq);
@@ -3450,6 +3448,7 @@ void reply_hook_bg(job *pjob)
 						(PBS_BATCH_DeleteJob + PBSE_SISCOMM))
 							req_reject(PBSE_SISCOMM, 0, preq); /* sis down */
 #endif
+					job_purge(pjob);
 				}
 				/*
 				* otherwise, job_purge() and dorestrict_user() are called in

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -10078,7 +10078,7 @@ main(int argc, char *argv[])
 			nxpjob = (job *)GET_NEXT(pjob->ji_alljobs);
 
 			/* check for job stuck waiting for Svr to ack obit */
-			if (pjob->ji_qs.ji_substate == JOB_SUBSTATE_OBIT &&
+			if (!pjob->ji_hook_running_bg_on && pjob->ji_qs.ji_substate == JOB_SUBSTATE_OBIT &&
 				pjob->ji_sampletim < time_now - 45) {
 				send_obit(pjob, 0);	/* resend obit */
 			}

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -5029,6 +5029,18 @@ req_del_hookfile(struct batch_request *preq) /* ptr to the decoded request   */
 			preq->rq_ind.rq_hookfile.rq_filename);
 		strcat(p, HOOK_FILE_SUFFIX);
 		if ((phook = find_hook(hook_name)) != NULL) {
+#ifndef WIN32
+			if (phook->event & HOOK_EVENT_EXECJOB_END) {
+				/** 
+				 * This event runs hook in the background,
+				 * and it's deferred task created while
+				 * running the hook, is required for graceful
+				 * exit of the job. 
+				 */
+				reply_ack(preq);
+				return;
+			}
+#endif
 			delete_task_by_parm1(phook, DELETE_ONE);
 			log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_HOOK,
 				LOG_INFO, phook->hook_name,

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -315,6 +315,7 @@ req_quejob(struct batch_request *preq)
 	char		*namebuf;
 	int		hook_errcode = 0;
 	int		hook_rc = 0;
+	int		isrpp;
 	char		hook_buf[HOOK_MSG_SIZE];
 	hook		*last_phook = NULL;
 	unsigned int	hook_fail_action = 0;
@@ -550,13 +551,14 @@ req_quejob(struct batch_request *preq)
 
 		if (pj->ji_qs.ji_svrflags & JOB_SVFLG_CHKPT) {
 			pj->ji_qs.ji_substate = JOB_SUBSTATE_TRANSIN;
+			isrpp = preq->isrpp;
 			if (reply_jobid(preq, pj->ji_qs.ji_jobid,
 				BATCH_REPLY_CHOICE_Queue) == 0) {
 				delete_link(&pj->ji_alljobs);
 				append_link(&svr_newjobs, &pj->ji_alljobs, pj);
 				pj->ji_qs.ji_un_type = JOB_UNION_TYPE_NEW;
 				pj->ji_qs.ji_un.ji_newt.ji_fromsock = sock;
-				if (!preq->isrpp) {
+				if (!isrpp) {
 					pj->ji_qs.ji_un.ji_newt.ji_fromaddr = get_connectaddr(sock);
 				} else {
 					struct sockaddr_in* addr = rpp_getaddr(sock);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Below are the invalid reads reported on valgrind build.

==349== Invalid read of size 4
==349==    at 0x4642C6: reply_hook_bg (mom_hook_func.c:3447)
==349==    by 0x464487: mom_process_background_hooks (mom_hook_func.c:3554)
==349==    by 0x4BF158: dispatch_task (work_task.c:142)
==349==    by 0x4BF394: default_next_task (work_task.c:308)
==349==    by 0x43C321: main (mom_main.c:9803)
==349==  Address 0xb619f2c is 252 bytes inside a block of size 6,560 free'd
==349==    at 0x4C2ACBD: free (vg_replace_malloc.c:530)
==349==    by 0x43F767: job_purge (job_func.c:829)
==349==    by 0x4642C0: reply_hook_bg (mom_hook_func.c:3436)
==349==    by 0x464487: mom_process_background_hooks (mom_hook_func.c:3554)
==349==    by 0x4BF158: dispatch_task (work_task.c:142)
==349==    by 0x4BF394: default_next_task (work_task.c:308)
==349==    by 0x43C321: main (mom_main.c:9803)
==349==  Block was alloc'd at
==349==    at 0x4C29BC3: malloc (vg_replace_malloc.c:299)
==349==    by 0x43EE83: job_alloc (job_func.c:321)
==349==    by 0x442D64: req_quejob (req_quejob.c:579)
==349==    by 0x470ED4: process_IS_CMD (mom_server.c:479)
==349==    by 0x470ED4: is_request (mom_server.c:1159)
==349==    by 0x46CFF8: do_rpp (mom_main.c:6268)
==349==    by 0x46D055: rpp_request (mom_main.c:6307)
==349==    by 0x48E3DB: process_socket (net_server.c:504)
==349==    by 0x48E591: wait_request (net_server.c:620)
==349==    by 0x43C7D9: finish_loop (mom_main.c:6573)
==349==    by 0x43C7D9: main (mom_main.c:9794)

Invalid read of size 4
   at 0x18CAC5: req_quejob (req_quejob.c:559)
   by 0x18ABB8: dispatch_request (process_request.c:682)
   by 0x1D393C: process_IS_CMD (mom_server.c:479)
   by 0x1D4FFC: is_request (mom_server.c:1158)
   by 0x1CA994: do_rpp (mom_main.c:6279)
   by 0x1CAA12: rpp_request (mom_main.c:6318)
   by 0x2000E1: process_socket (net_server.c:512)
   by 0x20047E: wait_request (net_server.c:628)
   by 0x1CAED3: finish_loop (mom_main.c:6595)
   by 0x1D20E3: main (mom_main.c:9827)
Address 0x9665f90 is 608 bytes inside a block of size 2,264 free'd Block was alloc'd at
   at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x18B863: free_br (process_request.c:1479)
   by 0x18C023: reply_send (reply_send.c:303)
   by 0x18C7BD: reply_jobid (reply_send.c:553)
   by 0x18CA65: req_quejob (req_quejob.c:553)
   by 0x18ABB8: dispatch_request (process_request.c:682)
   by 0x1D393C: process_IS_CMD (mom_server.c:479)
   by 0x1D4FFC: is_request (mom_server.c:1158)
   by 0x1CA994: do_rpp (mom_main.c:6279)
   by 0x1CAA12: rpp_request (mom_main.c:6318)
   by 0x2000E1: process_socket (net_server.c:512)
   by 0x20047E: wait_request (net_server.c:628)

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fix the incorrect memory access code.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[valgrind.log.txt](https://github.com/PBSPro/pbspro/files/3903751/valgrind.log.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
