### PR TITLE
qstat doesn't supply full machine name with -n when nodes added by IP address

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -602,7 +602,6 @@ prt_nodes(char *nodes, int no_newl)
 	int  i, l;
 	char linebuf[78];
 	char *rest;
-	char *saveptr;
 	char *token;
 	char *token_cp;
 	char *subtoken;

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -601,13 +601,13 @@ prt_nodes(char *nodes, int no_newl)
 {
 	int  i, len;
 	char linebuf[78];
-	char *rest;
-	char *saveptr;
-	char *token;
-	char *token_cp;
-	char *subtoken;
+	char *rest = NULL;
+	char *saveptr = NULL;
+ 	char *token = NULL;
+	char *token_cp = NULL;
+	char *subtoken = NULL;
 	char *node_name = NULL;
-	char *chunk;
+	char *chunk = NULL;
 	struct sockaddr_in check_ip;
 	int ret = 0;
 
@@ -668,10 +668,14 @@ prt_nodes(char *nodes, int no_newl)
 		printf((no_newl ? "%s\n" : "   %s\n"), show_nonprint_chars(linebuf));
 	} else if (no_newl)
 		printf("\n");
-	if (token_cp)
+	if (token_cp) {
 		free(token_cp);
-	if (rest)
+		token_cp = NULL;
+	}
+	if (rest) {
 		free(rest);
+		rest = NULL;
+	}
 }
 
 /**

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -600,7 +600,7 @@ static void
 prt_nodes(char *nodes, int no_newl)
 {
 	int  i, len;
-	char linebuf[78];
+	char linebuf[CHAR_LINE_LIMIT];
 	char *rest = NULL;
 	char *saveptr = NULL;
  	char *token = NULL;
@@ -644,7 +644,7 @@ prt_nodes(char *nodes, int no_newl)
 		/* Backing up node_name as we are modifying the pointer further in the code */
 		node_name_bkp = node_name;
 		len = strlen(node_name);
-		if (i + len < 77) {
+		if (i + len < CHAR_LINE_LIMIT - 1) {
 			for (;len > 0; i++, len--) {
 				linebuf[i] = *node_name++;
 			}

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -602,6 +602,7 @@ prt_nodes(char *nodes, int no_newl)
 	int  i, l;
 	char linebuf[78];
 	char *rest;
+	char *saveptr;
 	char *token;
 	char *token_cp;
 	char *subtoken;
@@ -614,7 +615,11 @@ prt_nodes(char *nodes, int no_newl)
 		return;
 
 	i = 0;
-	rest = nodes;
+	rest = malloc(strlen(nodes) + 1);
+	if(rest)
+		strcpy(rest, nodes);
+	else
+		exit_qstat("out of memory");
 	while ((token = strtok_r(rest, "+", &rest))){
 		token_cp = (char*)malloc(strlen(token) + 1);
 		if(token_cp)

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -607,6 +607,7 @@ prt_nodes(char *nodes, int no_newl)
 	char *token_cp = NULL;
 	char *subtoken = NULL;
 	char *node_name = NULL;
+	char *node_name_bkp = NULL;
 	char *chunk = NULL;
 	struct sockaddr_in check_ip;
 	int ret = 0;
@@ -640,13 +641,14 @@ prt_nodes(char *nodes, int no_newl)
 			/* Node name is not an IP address */
 			pbs_asprintf(&node_name, "%s%s", strtok(subtoken, "."), chunk);
 		}
+		/* Backing up node_name as we are modifying the pointer further in the code */
+		node_name_bkp = node_name;
 		len = strlen(node_name);
 		if (i + len < 77) {
-			while (len) {
-				linebuf[i++] = *node_name++;
-				len--;
+			for (;len > 0; i++, len--) {
+				linebuf[i] = *node_name++;
 			}
-			/* Appedning a  '+' here because we want to maintain the
+			/* Appending a  '+' here because we want to maintain the
 			 * exec_host format i.e. <host1>/<T1>*<P1>[+<host2>/<T2>*<P2>+.
 			 */
 			linebuf[i++] = '+';
@@ -654,10 +656,8 @@ prt_nodes(char *nodes, int no_newl)
 			/* flush line and start next */
 			linebuf[i] = '\0';
 			printf((no_newl ? "%s" : "   %s\n"), show_nonprint_chars(linebuf));
-			i = 0;
-			while (len) {
-				linebuf[i++] = *node_name++;
-				len--;
+			for (i = 0;len > 0; i++, len--) {
+				linebuf[i] = *node_name++;
 			}
 			linebuf[i++] = '+';
 		}
@@ -668,14 +668,12 @@ prt_nodes(char *nodes, int no_newl)
 		printf((no_newl ? "%s\n" : "   %s\n"), show_nonprint_chars(linebuf));
 	} else if (no_newl)
 		printf("\n");
-	if (token_cp) {
-		free(token_cp);
-		token_cp = NULL;
-	}
-	if (rest) {
-		free(rest);
-		rest = NULL;
-	}
+	free(token_cp);
+	free(rest);
+	free(node_name_bkp);
+	token_cp = NULL;
+	rest = NULL;
+	node_name_bkp = NULL;
 }
 
 /**

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -644,8 +644,8 @@ prt_nodes(char *nodes, int no_newl)
 		/* Backing up node_name as we are modifying the pointer further in the code */
 		node_name_bkp = node_name;
 		len = strlen(node_name);
-		if (i + len < CHAR_LINE_LIMIT - 1) {
-			for (;len > 0; i++, len--) {
+		if (i + len < (CHAR_LINE_LIMIT - 1)) {
+			for (; len > 0; i++, len--) {
 				linebuf[i] = *node_name++;
 			}
 			/* Appending a  '+' here because we want to maintain the
@@ -656,7 +656,7 @@ prt_nodes(char *nodes, int no_newl)
 			/* flush line and start next */
 			linebuf[i] = '\0';
 			printf((no_newl ? "%s" : "   %s\n"), show_nonprint_chars(linebuf));
-			for (i = 0;len > 0; i++, len--) {
+			for (i = 0; len > 0; i++, len--) {
 				linebuf[i] = *node_name++;
 			}
 			linebuf[i++] = '+';

--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -104,6 +104,10 @@ class TestQstat(TestFunctional):
             self.assertFalse(ret['err'][0], ret_msg)
 
     def test_qstat_n_ip(self):
+        """
+        Test qstat -n output reports the correct node name
+        when node is created using IP address as name of the node.
+        """
         self.server.manager(MGR_CMD_DELETE, NODE, None, '')
         ipaddr = socket.gethostbyname(self.mom.hostname)
         attr_A = {'Mom': self.mom.hostname}
@@ -124,6 +128,10 @@ class TestQstat(TestFunctional):
                       "node created using IP address")
 
     def test_qstat_n_fqdn(self):
+        """
+        Test qstat -n output reports task slot and processor info
+        when node is created using FQDN.
+        """
         self.server.manager(MGR_CMD_DELETE, NODE, None, '')
         self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom.hostname)
         self.server.expect(NODE, {'state=free': 1})

--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -62,8 +62,8 @@ class TestQstat(TestFunctional):
         self.logger.info('Sleep for 7 seconds to let at least one job finish.')
         time.sleep(7)
 
-        qstat_cmd = \
-            os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin', 'qstat')
+        qstat_cmd = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                 'bin', 'qstat')
         qstat_cmd_pt = [qstat_cmd, '-pt', str(jid)]
         ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_pt)
 
@@ -112,8 +112,8 @@ class TestQstat(TestFunctional):
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        qstat_cmd = \
-            os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin', 'qstat')
+        qstat_cmd = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                 'bin', 'qstat')
         qstat_cmd_n = [qstat_cmd, '-n', str(jid)]
         ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_n)
         self.assertEqual(ret['rc'], 0,
@@ -130,8 +130,8 @@ class TestQstat(TestFunctional):
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        qstat_cmd = \
-            os.path.join(self.server.pbs_conf['PBS_EXEC'], 'bin', 'qstat')
+        qstat_cmd = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                 'bin', 'qstat')
         qstat_cmd_n = [qstat_cmd, '-n', str(jid)]
         ret = self.du.run_cmd(self.server.hostname, cmd=qstat_cmd_n)
         self.assertEqual(ret['rc'], 0,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* When nodes are created using IP address, qstat -n does not show the full node name. Node name is truncated after the first dot.
* When we create nodes using FQDN, qstat -n does not display a valid exec_host string in the expected format of <host1>/<T1>*<P1>.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Changed how "." is handled in a node name. If the node name is a valid IP address, the string is not truncated at the first ".".
* Concatenating the <T1>*<P1> information to the short name of the node, if nodes are created using FQDN.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
NA


#### Attach Test and Valgrind Logs/Output
[qstat_n.txt](https://github.com/PBSPro/pbspro/files/3904359/qstat_n.txt)
[qstat_n_win.txt](https://github.com/PBSPro/pbspro/files/3911762/qstat_n_win.txt)
[valgrind.log](https://github.com/PBSPro/pbspro/files/3926570/valgrind.log)






<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
