### PR TITLE
Install missing dep in builder docker image

### DIFF
--- a/docker/centos7/Dockerfile.base
+++ b/docker/centos7/Dockerfile.base
@@ -9,6 +9,7 @@ RUN yum install -y \
     libedit-devel \
     libical-devel \
     libtool \
+    libtool-ltdl-devel \
     libX11-devel \
     libXext \
     libXft \


### PR DESCRIPTION
This change fixes the following error during building in the docker
container:

    error: Failed build dependencies:
            libtool-ltdl-devel is needed by pbspro-19.0.0-0.x86_64
    The command '/bin/sh -c git clone https://github.com/pbspro/pbspro.git /src/pbspro &&     bash /src/pbspro/docker/centos7/build.sh' returned a non-zero code: 1

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Building PBSPro in Docker fails if you do

* docker build -f docker/centos7/Dockerfile.base .
* edit Dockerfile.build to use your builder image
* docker build -f docker/centos7/Dockerfile.build .

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Change builder image build script to install the missing build-time dependency of PBSPro.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Hope none is required in this case.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
