### PR TITLE
Fixed issue preemption issue with RASSN resources

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -5295,10 +5295,6 @@ static int cull_preemptible_jobs(resource_resv *job, void *arg)
 			if (job->job->queue != inp->job->job->queue)
 				return 0;
 		case INSUFFICIENT_SERVER_RESOURCE:
-			/* If the control is here that means the resource must be present in resources
-			 * line and it must also be a RASSN resource because this error number is relevant
-			 * to RASSN resources only.
-			 */
 			if (find_resource_req(job->resreq, inp->err->rdef))
 				return 1;
 			break;

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -556,4 +556,3 @@ exit 3
         jid_high = self.server.submit(j)
 
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid_high)
-


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
There are two problems being fixed in this pull - 
1 - Scheduler fails to preempt a job when the resource in contention is a RASSN resource that can also be converted to select specification (like ncpus/mem). 
2 - Scheduler tries to filter preemptable candidates even in cases when the reason of not running a high priority job in the simulated universe does not change (especially when the reason is not related to a resource).


#### Describe Your Change
The first problem is fixed by checking that in case of INSUFFICIENT_SERVER_RESOURCE error lower priority job has requested the said resource. 
The second problem is fixed by checking if the old error code related to why job didn't run matches the new error code. If it matches and the resource definition is not set then the scheduler knows that the reason for not running the job is the same and it does not try to filter the running jobs again.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_out_after.txt](https://github.com/PBSPro/pbspro/files/3913794/test_out_after.txt)
[test_out_before.txt](https://github.com/PBSPro/pbspro/files/3913795/test_out_before.txt)
I have not added any test for the second fix, I thought that externally there is no visible change. It will have some improvement in performance but in my manual test I could see only milliseconds difference between filter_preemptable_jobs being called 3900 time to only 2 times.
If reviewers strongly feel that I should add a test for the second fix then I will add one.

!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
