### PR TITLE
test_prologue_hook_does_not_execute_twice_on_pbsdsh fails due to out of range error

### DIFF
--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -45,6 +45,7 @@ class TestPbsExecutePrologue(TestFunctional):
 
     PRE: Have a cluster of PBS with 3 mom hosts.
     """
+
     def setUp(self):
         if len(self.moms) != 3:
             self.skip_test(reason="need 3 mom hosts: -p moms=<m1>:<m2>:<m3>")
@@ -260,8 +261,9 @@ class TestPbsExecutePrologue(TestFunctional):
         ret = self.du.cat(hostname=host, filename=opath, runas=TEST_USER)
         _msg = "cat command failed with error: %s" % ret['err']
         self.assertEqual(ret['rc'], 0, _msg)
-        mom1 = ret['out'][2].split(".")[0]
-        mom2 = ret['out'][3].split(".")[0]
+        ret['out'] = ret['out'][-2:]
+        mom1 = ret['out'][0].split(".")[0]
+        mom2 = ret['out'][1].split(".")[0]
         self.exec_mom1 = self.moms[mom1]
         self.exec_mom2 = self.moms[mom2]
         self.exec_mom1.log_match("Job;%s;executed prologue hook" % jid)


### PR DESCRIPTION
 

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Cherry pick from the master branch to release_19_1_branch.
Previous PR link:
https://github.com/PBSPro/pbspro/pull/1416

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
