### PR TITLE
Server resolves node name when they are added using IP address

### DIFF
--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -2380,15 +2380,13 @@ decode_Mom_list(struct attribute *patr, char *name, char *rescn, char *val)
 	for (i = 0; (p = str_arr[i]) != NULL; i++) {
 		clear_attr(&new, &node_attr_def[(int)ND_ATR_Mom]);
 		is_node_name_ip = inet_pton(AF_INET, p, &(check_ip.sin_addr)) ;
-		if(!is_node_name_ip) {
-			if (get_fullhostname(p, buf, (sizeof(buf) - 1)) != 0) {
-				strncpy(buf, p, (sizeof(buf) - 1));
-				buf[sizeof(buf) - 1] = '\0';
-			}
-		} else {
+		if(!is_node_name_ip)
+			is_node_name_ip = inet_pton(AF_INET6, p, &(check_ip.sin_addr)) ;
+		if(is_node_name_ip || get_fullhostname(p, buf, (sizeof(buf) - 1)) != 0) {
 			strncpy(buf, p, (sizeof(buf) - 1));
 			buf[sizeof(buf) - 1] = '\0';
 		}
+		
 		rc = decode_arst(&new, ATTR_NODE_Mom, NULL, buf);
 		if (rc != 0)
 			continue;

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -2380,8 +2380,6 @@ decode_Mom_list(struct attribute *patr, char *name, char *rescn, char *val)
 	for (i = 0; (p = str_arr[i]) != NULL; i++) {
 		clear_attr(&new, &node_attr_def[(int)ND_ATR_Mom]);
 		is_node_name_ip = inet_pton(AF_INET, p, &(check_ip.sin_addr)) ;
-		if(!is_node_name_ip)
-			is_node_name_ip = inet_pton(AF_INET6, p, &(check_ip.sin_addr)) ;
 		if(is_node_name_ip || get_fullhostname(p, buf, (sizeof(buf) - 1)) != 0) {
 			strncpy(buf, p, (sizeof(buf) - 1));
 			buf[sizeof(buf) - 1] = '\0';

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -2340,6 +2340,8 @@ decode_Mom_list(struct attribute *patr, char *name, char *rescn, char *val)
 	static char		**str_arr = NULL;
 	static long int		  str_arr_len = 0;
 	attribute		  new;
+	struct sockaddr_in check_ip;
+	int is_node_name_ip;
 
 	if ((val == NULL) || (strlen(val) == 0) || count_substrings(val, &ns)) {
 		node_attr_def[(int)ND_ATR_Mom].at_free(patr);
@@ -2377,7 +2379,13 @@ decode_Mom_list(struct attribute *patr, char *name, char *rescn, char *val)
 
 	for (i = 0; (p = str_arr[i]) != NULL; i++) {
 		clear_attr(&new, &node_attr_def[(int)ND_ATR_Mom]);
-		if (get_fullhostname(p, buf, (sizeof(buf) - 1)) != 0) {
+		is_node_name_ip = inet_pton(AF_INET, p, &(check_ip.sin_addr)) ;
+		if(!is_node_name_ip) {
+			if (get_fullhostname(p, buf, (sizeof(buf) - 1)) != 0) {
+				strncpy(buf, p, (sizeof(buf) - 1));
+				buf[sizeof(buf) - 1] = '\0';
+			}
+		} else {
 			strncpy(buf, p, (sizeof(buf) - 1));
 			buf[sizeof(buf) - 1] = '\0';
 		}

--- a/test/tests/functional/pbs_sched_load_balancing.py
+++ b/test/tests/functional/pbs_sched_load_balancing.py
@@ -58,7 +58,7 @@ class TestSchedLoadBalancing(TestFunctional):
         cmd = os.path.join(self.server.pbs_conf[
                            'PBS_EXEC'], 'unsupported', 'pbs_rmget')
         cmd += ' -m ' + self.mom.hostname + ' loadave '
-        ret = self.server.du.run_cmd(self.mom.hostname, cmd)
+        ret = self.du.run_cmd(self.mom.hostname, cmd)
         current_load = float(ret['out'][0].split('=')[1])
         # Considering our job will need 1 cpu
         ideal_load = current_load + 1

--- a/test/tests/functional/pbs_sched_load_balancing.py
+++ b/test/tests/functional/pbs_sched_load_balancing.py
@@ -1,0 +1,75 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestSchedLoadBalancing(TestFunctional):
+    """
+    Test suite for PBSPro's Scheduler load balancing
+    """
+    def setUp(self):
+        """
+        Set scheduler load_balancing
+        """
+        TestFunctional.setUp(self)
+        self.scheduler.set_sched_config({'load_balancing': 'true	ALL'})
+
+    def test_load_bal_node_ip(self):
+        """
+        This test case tests scheduler load balancing
+        feature, when node is added using ip address.
+        """
+        # Check current load in system
+        cmd = os.path.join(self.server.pbs_conf[
+                           'PBS_EXEC'], 'unsupported', 'pbs_rmget')
+        cmd += ' -m ' + self.mom.hostname + ' loadave '
+        ret = self.server.du.run_cmd(self.mom.hostname, cmd)
+        current_load = float(ret['out'][0].split('=')[1])
+        # Considering our job will need 1 cpu
+        ideal_load = current_load + 1
+        max_load = current_load + 2
+        self.mom.add_config({'$ideal_load': ideal_load})
+        self.mom.add_config({'$max_load': max_load})
+        self.server.manager(MGR_CMD_DELETE, NODE, None, '')
+        ipaddr = socket.gethostbyname(self.mom.hostname)
+        self.server.manager(MGR_CMD_CREATE, NODE,  id=ipaddr)
+        self.server.expect(NODE, {'state=free': 1})
+
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Load balancing doesn't work when nodes are added using ip address and Server resolves that to node name (hostname).

Snippet of "pbsnodes -av"
10.0.9.120
     Mom = ip-10-0-9-120.us-west-1.compute.internal
     

#### Describe Your Change
When nodes are added using their ip address, server shouldn't try to resolve their name.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
 
[Before_fix.txt](https://github.com/PBSPro/pbspro/files/3938493/Before_fix.txt)
[After_fix.txt](https://github.com/PBSPro/pbspro/files/3938494/After_fix.txt)
[PTL_logs.txt](https://github.com/PBSPro/pbspro/files/3938509/PTL_logs.txt)


Valgring Log : [val.txt](https://github.com/PBSPro/pbspro/files/3938864/val.txt)


Passed all existing regression tests & Build and tests across platforms.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
