### PR TITLE
TestPbsAccumulateRescUsed expects string in wrong order

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2091,7 +2091,7 @@ class BatchUtils(object):
         :returns: int or float or string
         """
         if re.search('(\{.*:.*[,]?.*\})', str(value)):
-            value = json.loads(eval(str(value)))
+            value = ast.literal_eval(eval(str(value)))
             return value
 
         if value is None or isinstance(value, collections.Callable):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2083,16 +2083,12 @@ class BatchUtils(object):
         of it, if it is made of alphanumeric values only, return
         it as a string, if it is of type size, i.e., with a memory
         unit such as b,kb,mb,gb then return the converted size to
-        kb without the unit, if value is a dictionary string return
-        dictionary value
+        kb without the unit
 
         :param value: attribute/resource value
         :type value: str or int
         :returns: int or float or string
         """
-        if re.search('(\{.*:.*[,]?.*\})', str(value)):
-            value = ast.literal_eval(ast.literal_eval(str(value)))
-            return value
 
         if value is None or isinstance(value, collections.Callable):
             return value

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2083,12 +2083,17 @@ class BatchUtils(object):
         of it, if it is made of alphanumeric values only, return
         it as a string, if it is of type size, i.e., with a memory
         unit such as b,kb,mb,gb then return the converted size to
-        kb without the unit
+        kb without the unit, if value is a dictionary string return 
+        dictionary value
 
         :param value: attribute/resource value
         :type value: str or int
         :returns: int or float or string
         """
+        if re.search('\'{\".*\":.*',str(value)):
+            value = eval(eval(str(value)))
+            return value
+        
         if value is None or isinstance(value, collections.Callable):
             return value
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2083,7 +2083,7 @@ class BatchUtils(object):
         of it, if it is made of alphanumeric values only, return
         it as a string, if it is of type size, i.e., with a memory
         unit such as b,kb,mb,gb then return the converted size to
-        kb without the unit, if value is a dictionary string return 
+        kb without the unit, if value is a dictionary string return
         dictionary value
 
         :param value: attribute/resource value

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2091,7 +2091,7 @@ class BatchUtils(object):
         :returns: int or float or string
         """
         if re.search('(\{.*:.*[,]?.*\})', str(value)):
-            value = eval(eval(str(value)))
+            value = json.loads(eval(str(value)))
             return value
 
         if value is None or isinstance(value, collections.Callable):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2090,10 +2090,10 @@ class BatchUtils(object):
         :type value: str or int
         :returns: int or float or string
         """
-        if re.search('\'{\".*\":.*',str(value)):
+        if re.search('\'{\".*\":.*', str(value)):
             value = eval(eval(str(value)))
             return value
-        
+
         if value is None or isinstance(value, collections.Callable):
             return value
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2090,7 +2090,7 @@ class BatchUtils(object):
         :type value: str or int
         :returns: int or float or string
         """
-        if re.search('\'{\".*\":.*', str(value)):
+        if re.search('(\{.*:.*[,]?.*\})', str(value)):
             value = eval(eval(str(value)))
             return value
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2091,7 +2091,7 @@ class BatchUtils(object):
         :returns: int or float or string
         """
         if re.search('(\{.*:.*[,]?.*\})', str(value)):
-            value = ast.literal_eval(eval(str(value)))
+            value = ast.literal_eval(ast.literal_eval(str(value)))
             return value
 
         if value is None or isinstance(value, collections.Callable):

--- a/test/tests/functional/pbs_accumulate_resc_used.py
+++ b/test/tests/functional/pbs_accumulate_resc_used.py
@@ -35,6 +35,7 @@
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
 from tests.functional import *
+import ast
 
 
 @requirements(num_moms=3)
@@ -1252,11 +1253,16 @@ time.sleep(15)
 
         # Verify the resource values
         a = {'resources_used.foo_i': 29,
-             'resources_used.foo_f': 0.29,
-             'resources_used.foo_str':
-             "\'{\"eight\": 8, \"seven\": 7, \"nine\": 9}\'"}
+             'resources_used.foo_f': 0.29}
+        a_dict = {'eight': 8, 'seven': 7, 'nine': 9}
+
         self.server.expect(JOB, a, extend='x', attrop=PTL_AND,
                            offset=5, id=jid, interval=1)
+        # check for dictionary resource
+        job_status = self.server.status(JOB, id=jid, extend='x')
+        job_str_resource = dict(job_status[0])['resources_used.foo_str']
+        job_str_resource = ast.literal_eval(ast.literal_eval(job_str_resource))
+        self.assertEqual(job_str_resource, a_dict)
 
         # Restart server while hook is still executing
         self.server.restart()
@@ -1264,6 +1270,11 @@ time.sleep(15)
         # Verify that values again
         self.server.expect(JOB, a, extend='x', attrop=PTL_AND,
                            id=jid)
+        # check for dictionary resource
+        job_status = self.server.status(JOB, id=jid, extend='x')
+        job_str_resource = dict(job_status[0])['resources_used.foo_str']
+        job_str_resource = ast.literal_eval(ast.literal_eval(job_str_resource))
+        self.assertEqual(job_str_resource, a_dict)
 
     def test_mom_down2(self):
         """
@@ -1319,11 +1330,16 @@ else:
         self.server.expect(JOB,
                            {'job_state': 'F',
                             'resources_used.foo_i': '19',
-                            'resources_used.foo_f': '0.19',
-                            'resources_used.foo_str':
-                            '\'{\"eight\": 8, \"seven\": 7, \"nine\": 9}\''},
+                            'resources_used.foo_f': '0.19'},
                            offset=10, id=jid, interval=1, extend='x',
                            attrop=PTL_AND)
+        a_dict = {'eight': 8, 'nine': 9, 'seven': 7}
+
+        # check for dictionary resource
+        job_status = self.server.status(JOB, id=jid, extend='x')
+        job_str_resource = dict(job_status[0])['resources_used.foo_str']
+        job_str_resource = ast.literal_eval(ast.literal_eval(job_str_resource))
+        self.assertEqual(job_str_resource, a_dict)
 
         # Bring the mom back up
         self.momB.start()


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
In tests TestPbsAccumulateRescUsed.test_mom_down2 and TestPbsAccumulateRescUsed.test_server_restart2, the mom hooks set foo_str as a json object. The primary mom then merges the json objects and returns it.

The test expects the object's keys to appear in a certain order, but the mom returns it in a different order:

ptl.lib.pbs_testlib.PtlExpectError: rc=1, rv=False, msg=expected on server pbs-server@/etc/pbs.conf2: resources_used.foo_i = 29 && resources_used.foo_f = 0.29 && resources_used.foo_str = '{"eight": 8, "seven": 7, "nine": 9}' job 85.pbs-server attempt: 60 got: resources_used.foo_str = '{"eight": 8, "nine": 9, "seven": 7}'

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
While decoding the values it was being returned in a string form. The function decode_value now identifies a dictionary in string form and returns a dictionary value instead.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[PTL logs for TestPbsAccumulateRescUsed.test_mom_down2 and TestPbsAccumulateRescUsed.test_server_restart2 ](https://github.com/PBSPro/pbspro/files/3938750/ptl_logs.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
