### PR TITLE
Fix for pbs_benchpress -L issuing traceback

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_info.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_info.py
@@ -129,7 +129,8 @@ class PTLTestInfo(Plugin):
         """
         Is the class wanted?
         """
-        if not issubclass(cls, unittest.TestCase) or cls is PBSTestSuite or cls is unittest.TestCase:
+        if not issubclass(cls, unittest.TestCase) or cls is PBSTestSuite \
+                or cls is unittest.TestCase:
             return False
         self._tree.setdefault(cls.__name__, cls)
         if len(cls.__bases__) > 0:

--- a/test/fw/ptl/utils/plugins/ptl_test_info.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_info.py
@@ -129,7 +129,7 @@ class PTLTestInfo(Plugin):
         """
         Is the class wanted?
         """
-        if not issubclass(cls, unittest.TestCase) or cls is PBSTestSuite:
+        if not issubclass(cls, unittest.TestCase) or cls is PBSTestSuite or cls is unittest.TestCase:
             return False
         self._tree.setdefault(cls.__name__, cls)
         if len(cls.__bases__) > 0:

--- a/test/fw/ptl/utils/plugins/ptl_test_info.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_info.py
@@ -135,9 +135,13 @@ class PTLTestInfo(Plugin):
     def _get_hierarchy(self, cls, level=0):
         delim = '    ' * level
         msg = [delim + cls.__name__]
-        subclses = cls.__subclasses__()
-        for subcls in subclses:
-            msg.extend(self._get_hierarchy(subcls, level + 1))
+        try:
+            subclses = cls.__subclasses__()
+        except TypeError:
+            pass
+        else:
+            for subcls in subclses:
+                msg.extend(self._get_hierarchy(subcls, level + 1))
         return msg
 
     def _print_suite_info(self, suite):

--- a/test/fw/ptl/utils/plugins/ptl_test_info.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_info.py
@@ -37,6 +37,7 @@
 
 import sys
 import logging
+import unittest
 from nose.plugins.base import Plugin
 from ptl.utils.pbs_testsuite import PBSTestSuite
 from ptl.utils.plugins.ptl_test_tags import TAGKEY
@@ -128,6 +129,8 @@ class PTLTestInfo(Plugin):
         """
         Is the class wanted?
         """
+        if not issubclass(cls, unittest.TestCase) or cls is unittest.TestCase:
+            return False
         self._tree.setdefault(cls.__name__, cls)
         if len(cls.__bases__) > 0:
             self.wantClass(cls.__bases__[0])

--- a/test/fw/ptl/utils/plugins/ptl_test_info.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_info.py
@@ -129,7 +129,7 @@ class PTLTestInfo(Plugin):
         """
         Is the class wanted?
         """
-        if not issubclass(cls, unittest.TestCase) or cls is unittest.TestCase:
+        if not issubclass(cls, unittest.TestCase) or cls is PBSTestSuite:
             return False
         self._tree.setdefault(cls.__name__, cls)
         if len(cls.__bases__) > 0:
@@ -251,7 +251,7 @@ class PTLTestInfo(Plugin):
             self.__ts_tree[n]['tclist'] = tcs
 
     def finalize(self, result):
-        if self.list_test or self.gen_ts_tree:
+        if (self.list_test and not self.suites) or self.gen_ts_tree:
             suites = list(self._tree.keys())
         else:
             suites = self.suites


### PR DESCRIPTION
#### Describe Bug or Feature
Execution of "/opt/ptl/bin/pbs_benchpress -f pbs_smoketest.py -L"
causes a traceback inside ptl_test_info._get_hierarchy.

```
Traceback (most recent call last):
  File "/opt/ptl/bin/pbs_benchpress", line 508, in <module>
    nose.main(defaultTest=tests, argv=[sys.argv[0]], plugins=plugins)
  File "/usr/lib/python3.6/site-packages/nose/core.py", line 121, in __init__
    **extra_args)
  File "/usr/lib64/python3.6/unittest/main.py", line 95, in __init__
    self.runTests()
  File "/usr/lib/python3.6/site-packages/nose/core.py", line 207, in runTests
    result = self.testRunner.run(self.test)
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/plugins/ptl_test_info.py", line 70, in run
    self.config.plugins.finalize(None)
  File "/usr/lib/python3.6/site-packages/nose/plugins/manager.py", line 99, in __call__
    return self.call(*arg, **kw)
  File "/usr/lib/python3.6/site-packages/nose/plugins/manager.py", line 167, in simple
    result = meth(*arg, **kw)
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/plugins/ptl_test_info.py", line 263, in finalize
    func(suite)
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/plugins/ptl_test_info.py", line 183, in _print_suite_info
    lines = self._get_hierarchy(suite, 1)[1:]
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/plugins/ptl_test_info.py", line 140, in _get_hierarchy
    msg.extend(self._get_hierarchy(subcls, level + 1))
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/plugins/ptl_test_info.py", line 138, in _get_hierarchy
    subclses = cls.__subclasses__()
TypeError: descriptor '__subclasses__' of 'type' object needs an argument
```

#### Describe Your Change
Wrapped the call to `__subclasses__()` within ptl_test_info._get_hierarchy with a try pass block.

#### Open Issues:
After applying this fix, we noted that object is getting considered a TestSuite and inserted into the suite list.  object appears to be inserted into self._tree.  We have yet to find where self._tree is populated.

While searching for self._tree, we noticed that wantClass seems to not be used.  Should we remove in all cases?  wantClass is defined in three places, but nothing appears to call it.


