### PR TITLE
pbs_snapshot fails because file command not found

### DIFF
--- a/src/cmds/scripts/pbs_snapshot
+++ b/src/cmds/scripts/pbs_snapshot
@@ -35,20 +35,52 @@
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
 
-pbs_conf=${PBS_CONF_FILE:-/etc/pbs.conf}
-if [ -r "${pbs_conf}" ]; then
-	. ${pbs_conf}
+ptllibpath=
+ptlbinpath=
+
+if [ -f "/etc/debian_version" ]; then
+        ptl_prefix_lib=$( dpkg -L pbspro-ptl 2>/dev/null | grep -m 1 lib$ 2>/dev/null )
 else
-	echo "***" >&2
-	echo "*** No PBS_CONF_FILE found, exiting" >&2
-	echo "***" >&2
-	exit 1
+        ptl_prefix_lib=$( rpm -ql pbspro-ptl 2>/dev/null | grep -m 1 lib$ 2>/dev/null )
+fi
+if [ "x${ptl_prefix_lib}" != "x" ]; then
+        python_dir=$( /bin/ls -1 ${ptl_prefix_lib} )
+        prefix=$( dirname ${ptl_prefix_lib} )
+
+        ptllibpath=${prefix}/lib/${python_dir}/site-packages
+        ptlbinpath=${prefix}/bin
+else
+        conf="${PBS_CONF_FILE:-/etc/pbs.conf}"
+        if [ -r "${conf}" ]; then
+                # we only need PBS_EXEC from pbs.conf
+                __PBS_EXEC=$( grep '^[[:space:]]*PBS_EXEC=' "$conf" | tail -1 | sed 's/^[[:space:]]*PBS_EXEC=\([^[:space:]]*\)[[:space:]]*/\1/' )
+                if [ "X${__PBS_EXEC}" != "X" ]; then
+                        # Define PATH and PYTHONPATH for the users
+                        PTL_PREFIX=$( dirname ${__PBS_EXEC} )/ptl
+                        python_dir=$( /bin/ls -1 ${PTL_PREFIX}/lib )/site-packages
+                        if [ -d "${PTL_PREFIX}/bin" ];then
+                            ptllibpath=${PTL_PREFIX}/lib/${python_dir}
+                        fi
+                        if [ -d "${PTL_PREFIX}/lib/${python_dir}" ];then
+                            ptlbinpath=${PTL_PREFIX}/bin
+                        fi
+                fi
+                unset __PBS_EXEC
+                unset PTL_PREFIX
+                unset conf
+                unset python_dir
+        fi
 fi
 
-export PYTHONPATH=${PBS_EXEC}/unsupported/fw:${PYTHONPATH}
+export PYTHONPATH=${ptllibpath}:${PYTHONPATH}
+
+if [ -z $ptlbinpath ];then
+    echo "Error: PTL bin path not found"
+    exit 1
+fi
 
 if [ -x "${PBS_EXEC}/python/bin/python" ]; then
-	${PBS_EXEC}/python/bin/python ${PBS_EXEC}/unsupported/fw/bin/pbs_snapshot.py "${@}"
+	${PBS_EXEC}/python/bin/python ${ptlbinpath}/pbs_snapshot "${@}"
 else
-	python3 ${PBS_EXEC}/unsupported/fw/bin/pbs_snapshot.py "${@}"
+	python3 ${ptlbinpath}/pbs_snapshot "${@}"
 fi

--- a/src/cmds/scripts/pbs_snapshot
+++ b/src/cmds/scripts/pbs_snapshot
@@ -38,14 +38,24 @@
 ptllibpath=
 ptlbinpath=
 
+# Try rpm install paths
 if [ -f "/etc/debian_version" ]; then
-        ptl_prefix_lib=$( dpkg -L pbspro-ptl 2>/dev/null | grep -m 1 lib$ 2>/dev/null )
+        ptl_prefix_lib=$(dpkg -L pbspro-ptl 2>/dev/null | grep -m 1 lib$ 2>/dev/null)
 else
-        ptl_prefix_lib=$( rpm -ql pbspro-ptl 2>/dev/null | grep -m 1 lib$ 2>/dev/null )
+        ptl_prefix_lib=$(rpm -ql pbspro-ptl 2>/dev/null | grep -m 1 lib$ 2>/dev/null)
 fi
+
+# Try system paths
+if [ ! -d  ${ptl_prefix_lib} ]; then
+    ptl_prefix_lib=/usr/local/lib/python3.[[:digit:]]/site-packages
+    if [ ! -d  ${ptl_prefix_lib} ]; then
+        ptl_prefix_lib=/usr/lib/python3.[[:digit:]]/site-packages
+    fi
+fi
+
 if [ "x${ptl_prefix_lib}" != "x" ]; then
-        python_dir=$( /bin/ls -1 ${ptl_prefix_lib} )
-        prefix=$( dirname ${ptl_prefix_lib} )
+        python_dir=$(/bin/ls -1 ${ptl_prefix_lib})
+        prefix=$(dirname ${ptl_prefix_lib})
 
         ptllibpath=${prefix}/lib/${python_dir}/site-packages
         ptlbinpath=${prefix}/bin
@@ -56,8 +66,8 @@ else
                 __PBS_EXEC=$( grep '^[[:space:]]*PBS_EXEC=' "$conf" | tail -1 | sed 's/^[[:space:]]*PBS_EXEC=\([^[:space:]]*\)[[:space:]]*/\1/' )
                 if [ "X${__PBS_EXEC}" != "X" ]; then
                         # Define PATH and PYTHONPATH for the users
-                        PTL_PREFIX=$( dirname ${__PBS_EXEC} )/ptl
-                        python_dir=$( /bin/ls -1 ${PTL_PREFIX}/lib )/site-packages
+                        PTL_PREFIX=$(dirname ${__PBS_EXEC})/ptl
+                        python_dir=$(/bin/ls -1 ${PTL_PREFIX}/lib)/site-packages
                         if [ -d "${PTL_PREFIX}/bin" ];then
                             ptllibpath=${PTL_PREFIX}/lib/${python_dir}
                         fi

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -1765,7 +1765,7 @@ quit()
                     # itself with sudo, not the cmd
                     # So, append sudo as a prefix to the cmd instead
                     cmd_list_cpy[0] = (' '.join(self.du.sudo_cmd) +
-                                       cmd_list_cpy[0])
+                                       ' ' + cmd_list_cpy[0])
             else:
                 as_script = False
                 if key in sudo_cmds:

--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -933,12 +933,11 @@ pbs.logmsg(pbs.EVENT_DEBUG,"%s")
                     if not fpath.startswith(sched_priv_dir):
                         self.fail("Unexpected file " + fpath + " captured")
 
-    @classmethod
-    def tearDownClass(self):
+    def tearDown(self):
         # Delete the snapshot directories and tarballs created
         for snap_dir in self.snapdirs:
             self.du.rm(path=snap_dir, recursive=True, force=True)
         for snap_tar in self.snaptars:
             self.du.rm(path=snap_tar, sudo=True, force=True)
 
-        TestFunctional.tearDownClass()
+        TestFunctional.tearDown(self)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
pbs_snapshot relies on the file command to be present on the system to find core files and capture traces from them. Some special systems might not have the file command, right now the command just fails, we should instead check to see if file command is present and only then use it.

Also, pbs_snapshot was not able to find the python and PTL libraries correctly and was not working properly, so I had to make necessary changes to the script, these are derived from the ptl.csh script

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[snapptl.log](https://github.com/PBSPro/pbspro/files/3942233/snapptl.log)

pbs_snapshot output on a system with no file command:
[snapout.log](https://github.com/PBSPro/pbspro/files/3943188/snapout.log)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
