### PR TITLE
afslog should be done in forked process

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -737,11 +737,6 @@ struct job {
 			unsigned long long	ji_pagg;
 			/* ALPS process aggregate ID */
 #endif	/* MOM_ALPS */
-#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
-#if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
-			int32_t	ji_pag;		/* afs token group id */
-#endif
-#endif
 #endif /* PBS_MOM */
 		} ji_ext;
 	} ji_extended;

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -1603,6 +1603,16 @@ end_loop:
 				free(pobit);
 			}
 			ptask->ti_qs.ti_status = TI_STATE_DEAD;
+
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+#if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
+			if (signal_afslog(ptask, SIGTERM)) {
+				log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR,
+					ptask->ti_job->ji_qs.ji_jobid, "sending SIGTERM to afslog process failed");
+			}
+#endif
+#endif
+
 			/*
 			 ** KLUDGE
 			 ** We need to save the value of the sid here just

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -1605,12 +1605,7 @@ end_loop:
 			ptask->ti_qs.ti_status = TI_STATE_DEAD;
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
-#if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
-			if (signal_afslog(ptask, SIGTERM)) {
-				log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR,
-					ptask->ti_job->ji_qs.ji_jobid, "sending SIGTERM to afslog process failed");
-			}
-#endif
+			AFSLOG_TERM(ptask);
 #endif
 
 			/*

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -6502,15 +6502,11 @@ kill_job(job *pjob, int sig)
 		ct += tsk_ct;
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
-#if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
 		if (sig == SIGKILL) { /* only stop afslog when the task is finally dying */
-			if (signal_afslog(ptask, SIGTERM)) {
-				log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR,
-					ptask->ti_job->ji_qs.ji_jobid, "sending SIGTERM to afslog process failed");
-			}
+			AFSLOG_TERM(ptask);
 		}
 #endif
-#endif
+
 		/*
 		 ** If this is an orphan task, force it to be EXITED
 		 ** since it will not be seen by scan_for_terminated.
@@ -6533,12 +6529,7 @@ kill_job(job *pjob, int sig)
 			if (ptask->ti_qs.ti_parenttask == TM_NULL_TASK)
 				exiting_tasks = 1;
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
-#if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
-			if (signal_afslog(ptask, SIGTERM)) {
-				log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR,
-					ptask->ti_job->ji_qs.ji_jobid, "sending SIGTERM to afslog process failed");
-			}
-#endif
+			AFSLOG_TERM(ptask);
 #endif
 		}
 	}

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -6501,6 +6501,16 @@ kill_job(job *pjob, int sig)
 		tsk_ct = kill_task(ptask, sig, 0);
 		ct += tsk_ct;
 
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+#if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
+		if (sig == SIGKILL) { /* only stop afslog when the task is finally dying */
+			if (signal_afslog(ptask, SIGTERM)) {
+				log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR,
+					ptask->ti_job->ji_qs.ji_jobid, "sending SIGTERM to afslog process failed");
+			}
+		}
+#endif
+#endif
 		/*
 		 ** If this is an orphan task, force it to be EXITED
 		 ** since it will not be seen by scan_for_terminated.
@@ -6522,6 +6532,14 @@ kill_job(job *pjob, int sig)
 			 */
 			if (ptask->ti_qs.ti_parenttask == TM_NULL_TASK)
 				exiting_tasks = 1;
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+#if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
+			if (signal_afslog(ptask, SIGTERM)) {
+				log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR,
+					ptask->ti_job->ji_qs.ji_jobid, "sending SIGTERM to afslog process failed");
+			}
+#endif
+#endif
 		}
 	}
 

--- a/src/resmom/renew_creds.c
+++ b/src/resmom/renew_creds.c
@@ -118,7 +118,7 @@ struct svrcred_data {
 };
 typedef struct svrcred_data svrcred_data;
 
-const char *str_cred_actions[] = { "singleshot", "renewal", "setenv", "destroy"};
+const char *str_cred_actions[] = { "singleshot", "renewal", "setenv", "close", "destroy"};
 
 extern char *path_jobs; /* job directory path */
 extern struct var_table vtable;

--- a/src/resmom/renew_creds.c
+++ b/src/resmom/renew_creds.c
@@ -125,6 +125,9 @@ extern struct var_table vtable;
 extern time_t time_now;
 extern int decode_block_base64(unsigned char *ascii_data, ssize_t ascii_len, unsigned char *bin_data, ssize_t *p_bin_len, char *msg, size_t msg_len);
 
+extern char *log_file;
+extern char *path_log;
+
 static int get_job_info_from_job(const job *pjob, const task *ptask, eexec_job_info job_info);
 static int get_job_info_from_principal(const char *principal, const char* jobid, eexec_job_info job_info);
 static krb5_error_code get_ticket_from_storage(struct krb_holder *ticket, char *errbuf, size_t errbufsz);
@@ -1414,6 +1417,10 @@ start_afslog(const task *ptask, struct krb_holder *ticket, int fd1, int fd2) {
 	}
 
 	close(fd);
+
+	log_close(0);
+	pbs_conf.locallog = 0;
+	log_open(log_file, path_log);
 
 	if (fd1 >= 0)
 		close(fd1);

--- a/src/resmom/renew_creds.c
+++ b/src/resmom/renew_creds.c
@@ -676,7 +676,7 @@ get_job_info_from_job(const job *pjob, const task *ptask, eexec_job_info job_inf
 		return PBS_KRB5_ERR_NO_KRB_PRINC;
 	}
 
-	if (krb_principal == NULL) // memory allocation error
+	if (krb_principal == NULL) /* memory allocation error */
 		return PBS_KRB5_ERR_INTERNAL;
 
 	if (ptask == NULL) {
@@ -1261,7 +1261,7 @@ do_afslog_on_signal(int signal) {
  */
 static void
 wait_afslog() {
-	// initialize signal catcher
+	/* initialize signal catcher */
 	struct sigaction sa;
 	memset(&sa, 0, sizeof(sa));
 	sa.sa_handler = do_afslog_on_signal;

--- a/src/resmom/renew_creds.c
+++ b/src/resmom/renew_creds.c
@@ -227,7 +227,7 @@ init_ticket_from_ccache(job *pjob, const task *ptask, struct krb_holder *ticket)
 		return ret;
 	}
 
-	if((ret = krb5_init_context(&ticket->context)) != 0) {
+	if ((ret = krb5_init_context(&ticket->context)) != 0) {
 		log_err(ret, __func__, "Failed to initialize kerberos context.");
 		return PBS_KRB5_ERR_CONTEXT_INIT;
 	}
@@ -264,7 +264,7 @@ init_ticket(struct krb_holder *ticket, int cred_action)
 	int ret;
 	char buf[LOG_BUF_SIZE];
 
-	if((ret = krb5_init_context(&ticket->context)) != 0) {
+	if ((ret = krb5_init_context(&ticket->context)) != 0) {
 		log_err(ret, __func__, "Failed to initialize context.");
 		return PBS_KRB5_ERR_CONTEXT_INIT;
 	}
@@ -283,7 +283,7 @@ init_ticket(struct krb_holder *ticket, int cred_action)
 			break;
 
 		case CRED_DESTROY:
-			if((ret = krb5_cc_resolve(ticket->context, ticket->job_info->ccache_name, &ticket->job_info->ccache))) {
+			if ((ret = krb5_cc_resolve(ticket->context, ticket->job_info->ccache_name, &ticket->job_info->ccache))) {
 				snprintf(buf, sizeof(buf), "Could not resolve ccache name \"krb5_cc_resolve()\" : %s.", error_message(ret));
 				log_err(errno, __func__, buf);
 				return(ret);
@@ -320,17 +320,17 @@ store_ticket(struct krb_holder *ticket, char *errbuf, size_t errbufsz)
 {
 	krb5_error_code  ret;
 
-	if((ret = krb5_cc_resolve(ticket->context, ticket->job_info->ccache_name, &ticket->job_info->ccache))) {
+	if ((ret = krb5_cc_resolve(ticket->context, ticket->job_info->ccache_name, &ticket->job_info->ccache))) {
 		snprintf(errbuf, errbufsz, "%s - Could not resolve cache name \"krb5_cc_resolve()\" : %s.", __func__, error_message(ret));
 		return(ret);
 	}
 
-	if((ret = krb5_cc_initialize(ticket->context, ticket->job_info->ccache, ticket->job_info->creds->client))) {
+	if ((ret = krb5_cc_initialize(ticket->context, ticket->job_info->ccache, ticket->job_info->creds->client))) {
 		snprintf(errbuf, errbufsz, "%s - Could not initialize cache \"krb5_cc_initialize()\" : %s.", __func__, error_message(ret));
 		return(ret);
 	}
 
-	if((ret = krb5_cc_store_cred(ticket->context, ticket->job_info->ccache, ticket->job_info->creds))) {
+	if ((ret = krb5_cc_store_cred(ticket->context, ticket->job_info->ccache, ticket->job_info->creds))) {
 		snprintf(errbuf, errbufsz, "%s - Could not store credentials initialize cache \"krb5_cc_store_cred()\" : %s.", __func__, error_message(ret));
 		return(ret);
 	}
@@ -366,20 +366,20 @@ get_renewed_creds(struct krb_holder *ticket, char *errbuf, size_t errbufsz)
 	}
 
 	/* Go user */
-	if(seteuid(ticket->job_info->job_uid) < 0) {
+	if (seteuid(ticket->job_info->job_uid) < 0) {
 		strerror_r(errno, strerrbuf, LOG_BUF_SIZE);
 		snprintf(errbuf, errbufsz, "%s - Could not set uid using \"setuid()\": %s.", __func__, strerrbuf);
 		return errno;
 	}
 
 	/* Store TGT */
-	if((ret = store_ticket(ticket, errbuf, errbufsz))) {
+	if ((ret = store_ticket(ticket, errbuf, errbufsz))) {
 		seteuid(0);
 		return ret;
 	}
 
 	/* Go root */
-	if(seteuid(0) < 0) {
+	if (seteuid(0) < 0) {
 		snprintf(errbuf, errbufsz, "%s - Could not reset root privileges.", __func__);
 		return errno;
 	}
@@ -499,14 +499,14 @@ get_ticket_from_ccache(struct krb_holder *ticket, char *errbuf, size_t errbufsz)
 	}
 	memset(mcreds, 0, sizeof(krb5_creds));
 
-	if((ret = krb5_copy_principal(ticket->context, ticket->job_info->client, &mcreds->client))) {
+	if ((ret = krb5_copy_principal(ticket->context, ticket->job_info->client, &mcreds->client))) {
 		const char *krb5_err = krb5_get_error_message(ticket->context, ret);
 		snprintf(errbuf, errbufsz,"krb5_get_ticket - couldn't copy client principal - (%s)", krb5_err);
 		krb5_free_error_message(ticket->context, krb5_err);
 		goto out;
 	}
 
-	if((ret = krb5_cc_resolve(ticket->context, ticket->job_info->ccache_name, &ticket->job_info->ccache))) {
+	if ((ret = krb5_cc_resolve(ticket->context, ticket->job_info->ccache_name, &ticket->job_info->ccache))) {
 		const char *krb5_err = krb5_get_error_message(ticket->context, ret);
 		snprintf(errbuf, errbufsz, "krb5_cc_resolve failed; Error text: %s", krb5_err);
 		krb5_free_error_message(ticket->context, krb5_err);
@@ -1239,7 +1239,7 @@ singleshot_afslog(struct krb_holder *ticket) {
 
 	if (k_hasafs()) {
 		/* Go user */
-		if(seteuid(ticket->job_info->job_uid) < 0) {
+		if (seteuid(ticket->job_info->job_uid) < 0) {
 			strerror_r(errno, errbuf, sizeof(errbuf));
 			snprintf(buf, sizeof(buf), "Could not set uid using \"setuid()\": %s.", errbuf);
 			log_err(errno, __func__, buf);
@@ -1251,7 +1251,7 @@ singleshot_afslog(struct krb_holder *ticket) {
 		do_afslog(ticket->context, ticket->job_info);
 
 		/* Go root */
-		if(seteuid(0) < 0) {
+		if (seteuid(0) < 0) {
 			strerror_r(errno, errbuf, sizeof(errbuf));
 			snprintf(buf, sizeof(buf), "Could not reset root privileges: %s.", errbuf);
 			log_err(errno, __func__, buf);
@@ -1386,7 +1386,7 @@ start_afslog(const task *ptask, struct krb_holder *ticket, int fd1, int fd2) {
 	pid = fork();
 	if (pid < 0) {
 		/* Go root on error */
-		if(seteuid(0) < 0) {
+		if (seteuid(0) < 0) {
 			strerror_r(errno, errbuf, sizeof(errbuf));
 			snprintf(buf, sizeof(buf), "Could not reset root privileges: %s.", errbuf);
 			log_err(errno, __func__, buf);
@@ -1402,7 +1402,7 @@ start_afslog(const task *ptask, struct krb_holder *ticket, int fd1, int fd2) {
 
 	if (pid > 0) {
 		/* Go root in parent */
-		if(seteuid(0) < 0) {
+		if (seteuid(0) < 0) {
 			strerror_r(errno ,errbuf, sizeof(errbuf));
 			snprintf(buf, sizeof(buf), "Could not reset root privileges: %s.", errbuf);
 			log_err(errno, __func__, buf);

--- a/src/resmom/renew_creds.h
+++ b/src/resmom/renew_creds.h
@@ -97,9 +97,11 @@ int im_cred_send(job *pjob, hnodent *xp, int stream);
 int im_cred_read(job *pjob, hnodent *np, int stream);
 
 #if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
+void singleshot_afslog(struct krb_holder *ticket);
+int start_afslog(const task *ptask, struct krb_holder *ticket, int, int);
+int signal_afslog(const task *ptask, int signal);
+
 int32_t getpag();
-void setpag(int32_t pag);
-void removepag();
 #endif /* OpenAFS */
 
 #endif

--- a/src/resmom/renew_creds.h
+++ b/src/resmom/renew_creds.h
@@ -105,7 +105,7 @@ int32_t getpag();
 
 #define AFSLOG_TERM(x) {if (signal_afslog(x, SIGTERM)) log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR, x->ti_job->ji_qs.ji_jobid, "sending SIGTERM to afslog process failed");}
 #else
-#define AFSLOG_TERM(x) {x = x;}
+#define AFSLOG_TERM(x) {}
 #endif /* OpenAFS */
 
 #endif

--- a/src/resmom/renew_creds.h
+++ b/src/resmom/renew_creds.h
@@ -102,6 +102,10 @@ int start_afslog(const task *ptask, struct krb_holder *ticket, int, int);
 int signal_afslog(const task *ptask, int signal);
 
 int32_t getpag();
+
+#define AFSLOG_TERM(x) {if (signal_afslog(x, SIGTERM)) log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ERR, x->ti_job->ji_qs.ji_jobid, "sending SIGTERM to afslog process failed");}
+#else
+#define AFSLOG_TERM(x) {x = x;}
 #endif /* OpenAFS */
 
 #endif

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -389,11 +389,15 @@ fork_to_user(struct batch_request *preq)
 	}
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
-        /* singleshot ticket, without renewal */
-        if (pjob != NULL)
+	/* singleshot ticket, without renewal */
+	if (pjob != NULL)
 		init_ticket_from_job(pjob, NULL, ticket, CRED_SINGLESHOT);
-        else
+	else
 		init_ticket_from_req(preq->rq_extend, preq->rq_ind.rq_cpyfile.rq_jobid, ticket, CRED_SINGLESHOT);
+
+#if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
+	singleshot_afslog(ticket);
+#endif
 #endif
 
 	if (preq->rq_type == PBS_BATCH_CopyFiles_Cred ||

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -384,11 +384,6 @@ job_alloc(void)
 	pj->ji_parent2child_moms_status_pipe = -1;
 	pj->ji_updated = 0;
 	pj->ji_hook_running_bg_on = BG_NONE;
-#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
-#if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
-	pj->ji_extended.ji_ext.ji_pag = 0;
-#endif
-#endif
 #ifdef WIN32
 	pj->ji_hJob = NULL;
 	pj->ji_user = NULL;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This bug was introduced in Kerberos support (#1281). The initial idea on how to deal with afslog turned out to be wrong. I thought I can manipulate the pag (process authentication group) of a process in order to provide afs tokens for the processes of a job. This is not true the pag number is not as decisive as I thought.

Right now, the afslog is done in the mom main process and the pag number is changed for a particular job task. The job always uses the same pag for each task and the afslog is done in the main process. This simplification is not possible. It can lead to losing afs tokens for a particular process or even for interchanging afs tokens between users! It is not reliable.


#### Describe Your Change
The proper afslog solution is provided: The storing of pag is removed and after the Kerberos credential cache is created and assigned to the job, we need to set a pag for each job task process. This pag is naturally inherited by the child precesses and they share the same pag. PBS starts a new child process with a new task as a child of the main mom process. Thus, we need to provide new pag for each job task. (also job process does not exist on sister mom - without a running task) After setting the pag, the afslog is done and the new child process is forked. This forked process naturally inherits the pag and thus it can do the afslog, which is its only purpose. If we do the renewal of the Kerberos credentials then afslog needs to be done again. At this moment a HUP signal is sent to the forked process and on this signal, the new process does the afslog. Once the job task ends, the TERM signal is sent to this process. 

The whole afs support is covered by macro HAVE_LIBKAFS or HAVE_LIBKOPENAFS - same as before.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Starting an interactive job and checking for the afs tokens: 
```
qsub -I
qsub: waiting for job 28511.torque1.grid.cesnet.cz to start
qsub: job 28511.torque1.grid.cesnet.cz ready

torque1.grid.cesnet.cz$ klist -T 
Credentials cache: FILE:/tmp/krb5cc_pbsjob_28511.torque1.grid.cesnet.cz
        Principal: vchlum@META

  Issued                Expires               Principal
Dec 10 12:29:27 2019  Dec 11 12:29:27 2019  krbtgt/META@META
Dec 10 12:29:27 2019  Dec 11 12:29:27 2019  afs/ics.muni.cz@META
Dec 10 12:29:27 2019  Dec 11 12:29:27 2019  krbtgt/ZCU.CZ@META
Dec 10 12:29:27 2019  Dec 11 04:29:27 2019  afs/zcu.cz@ZCU.CZ
Dec 10 12:29:27 2019  Dec 11 12:29:27 2019  krbtgt/RUK.CUNI.CZ@META

Dec 10 12:29:27 201  Dec 11 12:29:27 201  Tokens for ics.muni.cz
Dec 10 12:29:27 201  Dec 11 04:29:27 201  Tokens for zcu.cz
```
Starting a few of jobs of other users, waiting for renewing the credentials and checking the afs tokens again:
```
klist -T 
Credentials cache: FILE:/tmp/krb5cc_pbsjob_28511.torque1.grid.cesnet.cz
        Principal: vchlum@META

  Issued                Expires               Principal
Dec 10 12:37:09 2019  Dec 11 12:37:09 2019  krbtgt/META@META
Dec 10 12:37:09 2019  Dec 11 12:37:09 2019  afs/ics.muni.cz@META
Dec 10 12:37:09 2019  Dec 11 12:37:09 2019  krbtgt/ZCU.CZ@META
Dec 10 12:37:09 2019  Dec 11 04:37:09 2019  afs/zcu.cz@ZCU.CZ
Dec 10 12:37:09 2019  Dec 11 12:37:09 2019  krbtgt/RUK.CUNI.CZ@META

Dec 10 12:37:09 201  Dec 11 12:37:09 201  Tokens for ics.muni.cz
Dec 10 12:37:09 201  Dec 11 04:37:09 201  Tokens for zcu.cz
```

The afs tokens are still OK.



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
