### PR TITLE
Scheduler preempts even when preemptee changes priority

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1756,8 +1756,8 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 			set_preempt_prio(resresv, qinfo, sinfo);
 		}
 
-		/* update_preemption_on_run() must be called post queue/server update */
-		update_preemption_on_run(sinfo, rr);
+		/* update_preemption_priority() must be called post queue/server update */
+		update_preemption_priority(sinfo, rr);
 
 		if (sinfo->policy->fair_share)
 			update_usage_on_run(rr);
@@ -1979,7 +1979,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 	if ((nsinfo = dup_server_info(sinfo)) == NULL)
 		return 0;
 
-	if ((njob = find_resource_resv_by_indrank(nsinfo->jobs, topjob->rank, topjob->resresv_ind)) == NULL) {
+	if ((njob = find_resource_resv_by_indrank(nsinfo->jobs, topjob->resresv_ind, topjob->rank)) == NULL) {
 		free_server(nsinfo);
 		return 0;
 	}

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3442,11 +3442,8 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 			clear_schd_error(tmp_err);
 			remove_resresv_from_array(rjobs_subset, pjob);
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_INFO, pjob->name,
-				  "Preempting this job will escalate its priority or priority of other jobs, ignoring it");
-			if ((ns_arr = is_ok_to_run(npolicy, nsinfo,
-				pjob->job->queue, pjob, NO_ALLPART, tmp_err)) != NULL) {
-				sim_run_update_resresv(npolicy, pjob, ns_arr, NO_ALLPART);
-			} else {
+				  "Preempting job will escalate its priority or priority of other jobs, not preempting it");
+			if (sim_run_update_resresv(npolicy, pjob, ns_arr, NO_ALLPART) != 1) {
 				log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_INFO, nhjob->name,
 					  "Trouble finding preemptable candidates");
 				free_schd_error_list(full_err);
@@ -3457,7 +3454,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 				return NULL;
 			}
 			if (indexfound > 0)
-				skipto = indexfound-1;
+				skipto = indexfound - 1;
 			else
 				skipto = 0;
 			continue;
@@ -5183,11 +5180,8 @@ static int cull_preemptible_jobs(resource_resv *job, void *arg)
 	if (job->job->is_running == 0)
 		return 0;
 
-	if (job->job->preempt >= inp->job->job->preempt) {
-		log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_INFO, job->name,
-			  "Preempting this job will escalate its priority or priority of other jobs, ignoring it");
+	if (job->job->preempt >= inp->job->job->preempt)
 		return 0;
-	}
 
 	switch (inp->err->error_code) {
 		case SERVER_USER_RES_LIMIT_REACHED:

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3416,7 +3416,8 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 		update_universe_on_end(npolicy, pjob,  "S", NO_ALLPART);
 		rjobs_count--;
 		/* Check if any of the previously preempted job increased its preemption priority to be more than the
-		 * high priority job */
+		 * high priority job
+		 */
 		for (ind = 0; pjobs[ind] != NULL; ind++) {
 			if (pjobs[ind]->job->preempt > nhjob->job->preempt) {
 				dont_preempt_job = 1;
@@ -3424,7 +3425,8 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 			}
 		}
 		/* Check if the job we just ended increases its preemption priority to be more than the high priority job.
-		 * If so, don't preempt this job */
+		 * If so, don't preempt this job
+		 */
 		if (dont_preempt_job || pjob->job->preempt > nhjob->job->preempt) {
 			remove_resresv_from_array(rjobs_subset, pjob);
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_INFO, pjob->name,

--- a/src/scheduler/limits.c
+++ b/src/scheduler/limits.c
@@ -2756,6 +2756,7 @@ check_max_group_res_soft(resource_resv *rr, counts *cts_list, void *limitctx, in
 	sch_resource_t	max_gengroup_res_soft;
 	sch_resource_t	used = 0;
 	resource_count  *rescts;
+	int		rc = 0;
 
 	if (rr == NULL)
 		return (-1);
@@ -2794,7 +2795,7 @@ check_max_group_res_soft(resource_resv *rr, counts *cts_list, void *limitctx, in
 			if (max_group_res_soft < used) {
 				if (rescts != NULL)
 					rescts->soft_limit_preempt_bit = preempt_bit;
-				return (preempt_bit);
+				rc = preempt_bit;
 			} else {
 				if (rescts != NULL)
 					rescts->soft_limit_preempt_bit = 0;
@@ -2803,11 +2804,15 @@ check_max_group_res_soft(resource_resv *rr, counts *cts_list, void *limitctx, in
 		} else if (max_gengroup_res_soft < used) {
 			if (rescts != NULL)
 				rescts->soft_limit_preempt_bit = preempt_bit;
-			return (preempt_bit);
+			rc = preempt_bit;
+		} else {
+			/* usage is under generic group soft limit, reset the preempt bit */
+			if (rescts != NULL)
+				rescts->soft_limit_preempt_bit = 0;
 		}
 	}
 
-	return (0);
+	return (rc);
 }
 
 /**
@@ -2917,6 +2922,7 @@ check_max_user_res_soft(resource_resv **rr_arr, resource_resv *rr,
 	sch_resource_t	max_genuser_res_soft;
 	sch_resource_t	used = 0;
 	resource_count  *rescts;
+	int		rc = 0;
 
 	if (rr == NULL)
 		return (-1);
@@ -2956,7 +2962,7 @@ check_max_user_res_soft(resource_resv **rr_arr, resource_resv *rr,
 			if (max_user_res_soft < used) {
 				if (rescts != NULL)
 					rescts->soft_limit_preempt_bit = preempt_bit;
-				return (preempt_bit);
+				rc = preempt_bit;
 			} else {
 				if (rescts != NULL)
 					rescts->soft_limit_preempt_bit = 0;
@@ -2965,11 +2971,15 @@ check_max_user_res_soft(resource_resv **rr_arr, resource_resv *rr,
 		} else if (max_genuser_res_soft < used) {
 			if (rescts != NULL)
 				rescts->soft_limit_preempt_bit = preempt_bit;
-			return (preempt_bit);
+			rc = preempt_bit;
+		} else {
+			/* usage is under generic user soft limit, reset the preempt bit */
+			if (rescts != NULL)
+				rescts->soft_limit_preempt_bit = 0;
 		}
 	}
 
-	return (0);
+	return (rc);
 }
 
 /**
@@ -3544,6 +3554,7 @@ check_max_project_res_soft(resource_resv *rr, counts *cts_list, void *limitctx, 
 	sch_resource_t	max_genproject_res_soft;
 	sch_resource_t	used = 0;
 	resource_count  *rescts;
+	int		rc = 0;
 
 	if (rr == NULL)
 		return (-1);
@@ -3583,7 +3594,7 @@ check_max_project_res_soft(resource_resv *rr, counts *cts_list, void *limitctx, 
 			if (max_project_res_soft < used){
 				if (rescts != NULL)
 					rescts->soft_limit_preempt_bit = preempt_bit;
-				return (preempt_bit);
+				rc = preempt_bit;
 			} else {
 				if (rescts != NULL)
 					rescts->soft_limit_preempt_bit = 0;
@@ -3592,11 +3603,15 @@ check_max_project_res_soft(resource_resv *rr, counts *cts_list, void *limitctx, 
 		} else if (max_genproject_res_soft < used) {
 			if (rescts != NULL)
 				rescts->soft_limit_preempt_bit = preempt_bit;
-			return (preempt_bit);
+			rc = preempt_bit;
+		} else {
+			/* usage is under generic project soft limit, reset the preempt bit */
+			if (rescts != NULL)
+				rescts->soft_limit_preempt_bit = 0;
 		}
 	}
 
-	return (0);
+	return (rc);
 }
 
 

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -1942,7 +1942,7 @@ collect_jobs_on_nodes(node_info **ninfo_arr, resource_resv **resresv_arr, int si
 					 * want to have the job in our array once.
 					 */
 					if (find_resource_resv_by_indrank(ninfo_arr[i]->job_arr,
-						job->rank, -1) == NULL) {
+						-1, job->rank) == NULL) {
 						if (ninfo_arr[i]->has_hard_limit) {
 						cts = find_alloc_counts(ninfo_arr[i]->group_counts,
 							job->group);
@@ -2053,7 +2053,7 @@ update_node_on_run(nspec *ns, resource_resv *resresv, char *job_state)
 
 	if (resresv->is_job) {
 		ninfo->num_jobs++;
-		if (find_resource_resv_by_indrank(ninfo->job_arr, resresv->rank, resresv->resresv_ind) == NULL) {
+		if (find_resource_resv_by_indrank(ninfo->job_arr, resresv->resresv_ind, resresv->rank) == NULL) {
 			tmp_arr = add_resresv_to_array(ninfo->job_arr, resresv, NO_FLAGS);
 			if (tmp_arr == NULL)
 				return;
@@ -2064,7 +2064,7 @@ update_node_on_run(nspec *ns, resource_resv *resresv, char *job_state)
 	}
 	else if (resresv->is_resv) {
 		ninfo->num_run_resv++;
-		if (find_resource_resv_by_indrank(ninfo->run_resvs_arr, resresv->rank, resresv->resresv_ind) == NULL) {
+		if (find_resource_resv_by_indrank(ninfo->run_resvs_arr, resresv->resresv_ind, resresv->rank) == NULL) {
 			tmp_arr = add_resresv_to_array(ninfo->run_resvs_arr, resresv, NO_FLAGS);
 			if (tmp_arr == NULL)
 				return;

--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -967,7 +967,7 @@ dup_queue_info(queue_info *oqinfo, server_info *nsinfo)
 	nqinfo->node_group_key = dup_string_array(oqinfo->node_group_key);
 
 	if (oqinfo->resv != NULL) {
-		nqinfo->resv = find_resource_resv_by_indrank(nsinfo->resvs, oqinfo->resv->rank, oqinfo->resv->resresv_ind);
+		nqinfo->resv = find_resource_resv_by_indrank(nsinfo->resvs, oqinfo->resv->resresv_ind, oqinfo->resv->rank);
 		/* just incase we we didn't set the reservation cross pointer */
 		if (nqinfo->resv != NULL && nqinfo->resv->resv != NULL)
 			nqinfo->resv->resv->resv_queue = nqinfo;

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -750,8 +750,8 @@ find_resource_resv(resource_resv **resresv_arr, char *name)
  * 		find a resource_resv by index in all_resresv array or by unique numeric rank
  *
  * @param[in]	resresv_arr	-	array of resource_resvs to search
- * @param[in]	rank        -	rank of resource_resv to find
  * @param[in]	index	    -	index of resource_resv to find
+ * @param[in]	rank        -	rank of resource_resv to find
  *
  * @return	resource_resv *
  * @retval resource_resv	: if found
@@ -759,7 +759,7 @@ find_resource_resv(resource_resv **resresv_arr, char *name)
  *
  */
 resource_resv *
-find_resource_resv_by_indrank(resource_resv **resresv_arr, int rank, int index)
+find_resource_resv_by_indrank(resource_resv **resresv_arr, int index, int rank)
 {
 	int i;
 	if (resresv_arr == NULL)
@@ -1995,7 +1995,7 @@ copy_resresv_array(resource_resv **resresv_arr,
 	}
 
 	for (i = 0, j = 0; resresv_arr[i] != NULL; i++) {
-		resresv = find_resource_resv_by_indrank(tot_arr, resresv_arr[i]->rank, resresv_arr[i]->resresv_ind);
+		resresv = find_resource_resv_by_indrank(tot_arr, resresv_arr[i]->resresv_ind, resresv_arr[i]->rank);
 
 		if (resresv != NULL) {
 			new_resresv_arr[j] = resresv;

--- a/src/scheduler/resource_resv.h
+++ b/src/scheduler/resource_resv.h
@@ -101,7 +101,7 @@ resource_resv *find_resource_resv(resource_resv **resresv_arr, char *name);
  * find a resource_resv by unique numeric rank
 
  */
-resource_resv *find_resource_resv_by_indrank(resource_resv **resresv_arr, int rank, int index);
+resource_resv *find_resource_resv_by_indrank(resource_resv **resresv_arr, int index, int rank);
 
 /**
  *  find_resource_resv_by_time - find a resource_resv by name and start time

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -944,7 +944,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 			 * standing reservation, the first to be found will be the "parent"
 			 * reservation
 			 */
-			nresv = find_resource_resv_by_indrank(nsinfo->resvs, sinfo->resvs[i]->rank, sinfo->resvs[i]->resresv_ind);
+			nresv = find_resource_resv_by_indrank(nsinfo->resvs, sinfo->resvs[i]->resresv_ind, sinfo->resvs[i]->rank);
 			if (nresv == NULL) {
 				log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
 					sinfo->resvs[i]->name,

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1861,7 +1861,6 @@ update_server_on_end(status *policy, server_info *sinfo, queue_info *qinfo,
 {
 	resource_req *req;		/* resource request from job */
 	schd_resource *res;		/* resource on server */
-	int i;
 
 	if (sinfo == NULL ||  resresv == NULL)
 		return;
@@ -1945,37 +1944,6 @@ update_server_on_end(status *policy, server_info *sinfo, queue_info *qinfo,
 			if (cts != NULL)
 				update_counts_on_end(cts, resresv->resreq);
 
-		}
-	}
-
-	/* The only thing which will change preemption priorities in the middle of
-	 * a scheduling cycle is soft user/group/project limits.  If a user, group,
-	 * or project  goes under a limit because of this job ending, we need to mark
-	 * those jobs differently
-	 */
-	if (cstat.preempting && resresv->is_job) {
-		if (sinfo->has_soft_limit || resresv->job->queue->has_soft_limit) {
-			for (i = 0; sinfo->jobs[i] != NULL; i++) {
-				if (sinfo->jobs[i]->job != NULL) {
-					int usrlim = resresv->job->queue->has_user_limit || sinfo->has_user_limit;
-					int grplim = resresv->job->queue->has_grp_limit || sinfo->has_grp_limit;
-					int projlim = resresv->job->queue->has_proj_limit || sinfo->has_proj_limit;
-					int alllim = resresv->job->queue->has_all_limit || sinfo->has_all_limit;
-					if (alllim || (usrlim && (!strcmp(resresv->user, sinfo->jobs[i]->user))) ||
-					    (grplim && (!strcmp(resresv->group, sinfo->jobs[i]->group))) ||
-					    (projlim && (!strcmp(resresv->project, sinfo->jobs[i]->project))))
-
-						set_preempt_prio(sinfo->jobs[i],
-							sinfo->jobs[i]->job->queue, sinfo);
-				}
-			}
-
-			/* now that we've set all the preempt levels, we need to count them */
-			memset(sinfo->preempt_count, 0, NUM_PPRIO * sizeof(int));
-			for (i = 0; sinfo->running_jobs[i] != NULL; i++)
-				if (!sinfo->running_jobs[i]->job->can_not_preempt)
-					sinfo->
-					preempt_count[preempt_level(sinfo->running_jobs[i]->job->preempt)]++;
 		}
 	}
 }
@@ -3116,6 +3084,7 @@ update_universe_on_end(status *policy, resource_resv *resresv, char *job_state, 
 #ifdef NAS /* localmod 057 */
 	site_update_on_end(sinfo, qinfo, resresv);
 #endif /* localmod 057 */
+	update_preemption_priority(sinfo, resresv);
 }
 
 /**
@@ -3325,8 +3294,8 @@ resolve_indirect_resources(node_info **nodes)
 
 /**
  * @brief
- * 		update_preemption_on_run - update preemption status when a
- *		job is run
+ * 		update_preemption_priority - update preemption status when a
+ *		job runs/ends
  *
  * @param[in]	sinfo 	- server where job was run
  * @param[in]	resresv - job which was run
@@ -3334,8 +3303,8 @@ resolve_indirect_resources(node_info **nodes)
  * @return	void
  *
  * @note
- * 		Must be called after update_server_on_run() and
- *		update_queue_on_run()
+ * 		Must be called after update_server_on_run/end() and
+ *		update_queue_on_run/end()
  *
  * @note
  * 		The only thing which will change preemption priorities
@@ -3346,7 +3315,7 @@ resolve_indirect_resources(node_info **nodes)
  * @par MT-Safe:	no
  */
 void
-update_preemption_on_run(server_info *sinfo, resource_resv *resresv)
+update_preemption_priority(server_info *sinfo, resource_resv *resresv)
 {
 	int i;
 

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -331,11 +331,11 @@ void update_universe_on_end(status *policy, resource_resv *resresv, char *job_st
 int set_resource(schd_resource *res, char *val, enum resource_fields field);
 
 /*
- *	update_preemption_on_run - update preemption status when a
- *   					resource resv is run
+ *	update_preemption_priority - update preemption status when a
+ *   					resource resv runs/ends
  *	returns nothing
  */
-void update_preemption_on_run(server_info *sinfo, resource_resv *resresv);
+void update_preemption_priority(server_info *sinfo, resource_resv *resresv);
 
 /*
  *	add_resource_list - add one resource list to another

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -1299,7 +1299,7 @@ find_event_ptr(timed_event *ote, server_info *nsinfo)
 				 * all_resresv list, so no need to search using start time of job
 				 */
 				event_ptr = find_resource_resv_by_indrank(nsinfo->all_resresv, 
-					    oep->rank, oep->resresv_ind);
+					    oep->resresv_ind, oep->rank);
 
 			if (event_ptr == NULL) {
 				log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SCHED, LOG_WARNING, ote->name,
@@ -1802,7 +1802,7 @@ simulate_resmin(schd_resource *reslist, time_t end, event_list *calendar,
 		te != NULL && (end == 0 || te->event_time < end);
 		te = find_next_timed_event(te, IGNORE_DISABLED_EVENTS, event_mask)) {
 		resresv = (resource_resv *) te->event_ptr;
-		if (incl_arr == NULL || find_resource_resv_by_indrank(incl_arr, resresv->rank, -1) !=NULL) {
+		if (incl_arr == NULL || find_resource_resv_by_indrank(incl_arr, -1, resresv->rank) !=NULL) {
 			if (resresv != exclude) {
 				req = resresv->resreq;
 

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -556,3 +556,131 @@ exit 3
         jid_high = self.server.submit(j)
 
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid_high)
+
+    def test_preemption_priority_escalation(self):
+        """
+        Test that scheduler does not try preempting a job that escalates its
+        preemption priority when preempted.
+        """
+        # create an addition queue
+        a = {'queue_type': 'execution',
+             'started': 'True',
+             'enabled': 'True'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, "workq2")
+
+        a = {'resources_available.ncpus': 8}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+
+        a = {'type': 'long', 'flag': 'nh'}
+        self.server.manager(MGR_CMD_CREATE, RSC, a, id='foo')
+
+        a = {'resources_available.foo': 6}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+        self.scheduler.add_resource('foo')
+
+        a = {'max_run_res_soft.ncpus': "[u:PBS_GENERIC=4]"}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq')
+        a = {'max_run_res_soft.ncpus': "[u:PBS_GENERIC=6]"}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq2')
+
+        p = "express_queue, normal_jobs, queue_softlimits"
+        a = {'preempt_prio': p}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events':  2047})
+
+        # Submit 4 jobs requesting 1 ncpu each in workq
+        a = {ATTR_l + '.select=1:ncpus': 1}
+        jid_list = []
+        for _ in range(4):
+            j = Job(attrs=a)
+            jid = self.server.submit(j)
+            jid_list.append(jid)
+
+        # Submit 5th job that will make all the job in workq to go over its
+        # softlimits
+        a = {ATTR_l + '.select=1:ncpus=1:foo': 4}
+        j = Job(attrs=a)
+        jid = self.server.submit(j)
+        jid_list.append(jid)
+        self.server.expect(JOB, {'job_state=R': 5})
+
+        # Submit a job in workq2 which requests for 4 ncpus and 3 foo resource
+        a = {ATTR_l + '.select=1:ncpus=4:foo': 3, ATTR_q: 'workq2'}
+        j = Job(attrs=a)
+        jid = self.server.submit(j)
+        jid_list.append(jid)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+        msg = ";Preempting this job will escalate its priority"
+        self.scheduler.log_match(jid_list[4] + msg)
+
+    def test_preemption_priority_escalation_2(self):
+        """
+        Test that scheduler does not try preempting a job that escalates its
+        preemption priority when preempted. But in this case ensure that the
+        job whose preemption priority gets escalated is one of the running
+        jobs that scheduler is yet to preempt in simulated universe.
+        """
+        # create an addition queue
+        a = {'queue_type': 'execution',
+             'started': 'True',
+             'enabled': 'True'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, "workq2")
+
+        a = {'resources_available.ncpus': 10}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+
+        a = {'type': 'long', 'flag': 'nh'}
+        self.server.manager(MGR_CMD_CREATE, RSC, a, id='foo')
+
+        a = {'resources_available.foo': 10}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+        self.scheduler.add_resource('foo')
+
+        a = {'max_run_res_soft.ncpus': "[u:PBS_GENERIC=5]"}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq')
+        # Set a soft limit on resource foo to 0 so that all jobs requesting
+        # this resource are over soft limits.
+        a = {'max_run_res_soft.foo': "[u:PBS_GENERIC=0]"}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq')
+        a = {'max_run_res_soft.ncpus': "[u:PBS_GENERIC=10]"}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, 'workq2')
+
+        p = "express_queue, normal_jobs, queue_softlimits"
+        a = {'preempt_prio': p}
+        self.server.manager(MGR_CMD_SET, SCHED, a)
+        self.server.manager(MGR_CMD_SET, SCHED, {'log_events':  2047})
+
+        # Submit 4 jobs requesting 1 ncpu each in workq
+        jid_list = []
+        for index in range(4):
+            a = {ATTR_l + '.select=1:ncpus=1:foo': 2}
+            if (index == 2):
+                # Since this job is not requesting foo, preempting one job
+                # from this queue will escalate its preemption priority to
+                # normal and scheduler will not attempt to preempt it.
+                a = {ATTR_l + '.select=1:ncpus': 1}
+            j = Job(attrs=a)
+            jid = self.server.submit(j)
+            jid_list.append(jid)
+            time.sleep(1)
+
+        # Submit 5th job that will make all the job in workq to go over its
+        # softlimits because if resource ncpus
+        time.sleep(1)
+        a = {ATTR_l + '.select=1:ncpus=2:foo': 2}
+        j = Job(attrs=a)
+        jid = self.server.submit(j)
+        jid_list.append(jid)
+        self.server.expect(JOB, {'job_state=R': 5})
+
+        # Submit a job in workq2 which requests for 8 ncpus and 3 foo resource
+        a = {ATTR_l + '.select=1:ncpus=8:foo': 3, ATTR_q: 'workq2'}
+        j = Job(attrs=a)
+        jid = self.server.submit(j)
+        jid_list.append(jid)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid_list[5])
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid_list[2])
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid_list[0])
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid_list[1])
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid_list[3])
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid_list[4])


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
This PR is a combination of the following problems - 

PBS Scheduler could preempt a job that could result in escalating the preemption priority of the preempted job or other jobs that the scheduler could possibly preempt. This is wrong because there is a potential that this escalated priority job could possibly preempt its preemptor.
This problem only happens when the jobs are just on the edge of being over the soft limits and preempting them would release resources and bring them below the soft limits.

There is another problem in soft limits code where scheduler was updating preempt bit and preempt_status of all the relevant jobs in the call to update_server_on_end but it was updating the entities in update_universe_on_end after calling update_server_on_end. This seems wrong because jobs were getting updated before the entities were updated that means preempt bit was not changing on any of the jobs. I have removed the functionality to update preempt bits on the job from update_server_on_end and now update_universe_on_end calls a function to update the preemption priorities on relevant jobs (after the entities are updated).

Check_max_user/group/project_res_soft functions were not resetting the soft limit preempt bit when the entities move under the said limit. 

Check_max_user/group/project_res_soft functions were returning right as soon as they were hitting a resource that was over its soft limits. This is wrong because there could be more than one resource on which limit might be set and it needs to update (possibly reset) the preempt bit for other resources too.

This PR also changes the order in which arguments are passed to function find_resource_resv_by_indrank to match the function name (i.e. index is passed before rank to match indrank)

#### Describe Your Change
There has been a slight change in how the scheduler finds preempt-able candidates to run a high priority job.
- When it ends the lower priority job in the simulated universe, it checks if the preemption priority of the preempted job or any of the previously (in the simulated universe) preempted jobs is equal to or more than the higher priority job (remember ending a job in the simulated universe changes preemption priority of all relevant jobs).
- If it finds that there is a job with equal or higher priority as the high priority job then it resumes back the most recent preempted job (because that is the job that caused the priority to change) and moves on.



#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[test_after_fix.txt](https://github.com/PBSPro/pbspro/files/3953127/test_after_fix.txt)
[test_before_fix.txt](https://github.com/PBSPro/pbspro/files/3947807/test_before_fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
