### PR TITLE
Fix NoneType error when server hooks receive alarm

### DIFF
--- a/src/lib/Libpython/pbs_python_svr_external.c
+++ b/src/lib/Libpython/pbs_python_svr_external.c
@@ -584,10 +584,7 @@ pbs_python_do_vnode_set(void)
 void
 pbs_python_set_interrupt(void)
 {
-
-#ifdef PYTHON
-	PyErr_SetInterrupt();
-#endif
+	return;
 }
 
 /**


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Runjob hook fails with the following error when it receives hook alarm

> PBS server internal error (15011) in Error evaluating Python script, 'NoneType' object is not callable

This is caused by a behavior change in Python 3. Unlike Python 2, Python 3 interpreter converts a signal received to a keyboard interrupt automatically. So the hook scripts receive two interrupts. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Since python 3 sends a keyboard interrupt to the hook script by default, we no longer need to call `PyErr_SetInterrup()` in `pbs_python_set_interrupt`. 


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Manual test result on centos 7: 
[after_fix_centos_7.txt](https://github.com/PBSPro/pbspro/files/3952126/after_fix_centos_7.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
