### PR TITLE
Removed job_info->parent_job

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -581,7 +581,6 @@ struct job_info
 	/* subjob information */
 	char *array_id;			/* job id of job array if we are a subjob */
 	int array_index;		/* array index if we are a subjob */
-	resource_resv *parent_job;	/* parent job if we are a subjob*/
 
 	/* job array information */
 	range *queued_subjobs;		/* a list of ranges of queued subjob indices */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1545,15 +1545,9 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 	}
 	else {
 		if (resresv->is_job && resresv->job->is_subjob) {
-			if (resresv->job->parent_job == NULL) {
-				resresv->job->parent_job =
-				find_resource_resv(sinfo->jobs, resresv->job->array_id);
-			}
-			array = resresv->job->parent_job;
+			array = find_resource_resv(sinfo->jobs, resresv->job->array_id);
 			rr = resresv;
-		}
-
-		else if(resresv->is_job && resresv->job->is_array) {
+		} else if (resresv->is_job && resresv->job->is_array) {
 			array = resresv;
 			rr = queue_subjob(resresv, sinfo, qinfo);
 			if(rr == NULL) {


### PR DESCRIPTION
#### Describe Bug or Feature
When the scheduler is querying subjobs, it will try and find the parent job in its job array.  The job array should be NULL terminated, but it is not.  If the parent job isn't found, it will run off the end of the array.  It is possible the parent job could be queried by a different thread, so it won't be in the array.

#### Describe Your Change
The parent_job member is not used much.  It was easier to just remove it, and query it at the point it was needed (when subjobs are run).

#### Attach Test and Valgrind Logs/Output
[valgrind-before.log](https://github.com/PBSPro/pbspro/files/3952897/valgrind-before.log)
[valgrind-after.log](https://github.com/PBSPro/pbspro/files/3952896/valgrind-after.log)

Look for query_jobs_chunk()
