### PR TITLE
Fix mom crash due to release_nodes_stageout=true

### DIFF
--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -188,6 +188,7 @@ void close_conn(int socket);
 pbs_net_t get_connectaddr(int sock);
 int  get_connecthost(int sock, char *namebuf, int size);
 pbs_net_t get_hostaddr(char *hostname);
+int  compare_short_hostname(char *shost, char *lhost);
 unsigned int  get_svrport(char *servicename, char *proto, unsigned int df);
 int  init_network(unsigned int port);
 int  init_network_add(int sock, int (*readyreadfunc)(int), void (*readfunc)(int));

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -109,7 +109,6 @@ extern int expand_resc_array(char *rname, int rtype, int rflag);
 extern void cnvrt_timer_init(void);
 extern int validate_nodespec(char *str);
 extern long longto_kbsize(char *val);
-extern int compare_short_hostname(char *shost, char *lhost);
 extern int is_vnode_up(char *vname);
 extern char* convert_long_to_time(long l);
 extern int svr_chk_history_conf(void);

--- a/src/lib/Libnet/get_hostaddr.c
+++ b/src/lib/Libnet/get_hostaddr.c
@@ -129,3 +129,34 @@ get_hostaddr(char *hostname)
 	freeaddrinfo(pai);
 	return (res);
 }
+
+/**
+ * @brief
+ * 		compare a short hostname with a FQ host match if same up to dot
+ *
+ * @param[in]	shost	- short hostname
+ * @param[in]	lhost	- FQ host
+ *
+ * @return	int
+ * @retval	0	- match
+ * @retval	1	- no match
+ */
+int
+compare_short_hostname(char *shost, char *lhost)
+{
+	size_t   len;
+	char    *pdot;
+
+	if ((shost == NULL) || (lhost == NULL))
+		return 1;
+
+	if ((pdot = strchr(shost, '.')) != NULL)
+		len = (size_t)(pdot - shost);
+	else
+		len = strlen(shost);
+	if ((strncasecmp(shost, lhost, len) == 0) &&
+		((*(lhost+len) == '.') || (*(lhost+len) == '\0')))
+		return 0;	/* match */
+	else
+		return 1;	/* no match */
+}

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -5409,7 +5409,7 @@ join_err:
 			resc_idx = -1;
 			for (i=0; i < pjob->ji_numrescs; i++) {
 				if ((pjob->ji_resources[i].nodehost != NULL) &&
-				    (strcmp(pjob->ji_resources[i].nodehost, nodehost) == 0)) {
+				    (compare_short_hostname(pjob->ji_resources[i].nodehost, nodehost) == 0)) {
 					resc_idx = i;
 					break;
 				}
@@ -5439,6 +5439,8 @@ join_err:
 				 	 	"strdup failure setting nodehost");
 					goto err;
 				}
+				clear_attr(&pjob->ji_resources[resc_idx].nr_used,
+						&job_attr_def[JOB_ATR_resc_used]);
 				pjob->ji_numrescs++;
 
 			}

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -77,7 +77,6 @@
  * 	cross_link_mom_vnode()
  * 	update2_to_vnode()
  * 	check_and_set_multivnode()
- * 	compare_short_hostname()
  * 	mom_running_jobs()
  * 	is_request()
  * 	write_single_node_state()
@@ -4292,36 +4291,6 @@ check_and_set_multivnode(struct pbsnode *pnode)
 			}
 		}
 	}
-}
-
-/**
- * @brief
- * 		compare a short hostname with a FQ host match if same up to dot
- * @see
- * 		node_np_action
- *
- * @param[in]	shost	- short hostname
- * @param[in]	lhost	- FQ host
- *
- * @return	int
- * @retval	0	- match
- * @retval	1	- no match
- */
-int
-compare_short_hostname(char *shost, char *lhost)
-{
-	size_t   len;
-	char    *pdot;
-
-	if ((pdot = strchr(shost, '.')) != NULL)
-		len = (size_t)(pdot - shost);
-	else
-		len = strlen(shost);
-	if ((strncasecmp(shost, lhost, len) == 0) &&
-		((*(lhost+len) == '.') || (*(lhost+len) == '\0')))
-		return 0;	/* match */
-	else
-		return 1;	/* no match */
 }
 
 /**


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* MS mom crashed while updating a job's resources_used info, obtained from a sister mom that has been released early from the job (i.e. release_nodes_stageout=true).
* For some reason, a sister mom reported resources_used info tagged as FQDN nodehost earlier in the job process, but later tagged in the form of short hostname nodehost. This caused MS mom to allocate an extra pjob-ji.resources[] entry for the different nodehost name, but the new pjob->ji_resources[x].nr_used entry was not properly initialized. This caused the crash in update_ajob_status_using_cmd().
* When a mom starts up, it uses as nodehost to report back to MS mom the mom_host value. The mom_host value is fairly static through the life of a mom, either getting the value from gethostbyname() or from the PBS_MOM_NODE_NAME. Perhaps while job is running, the sister mom could have been restarted and a different form of mom_host is used.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* In mom_comm.c:im_request() under IM_SEND_RESC, ensure if new entry to pjob->ji_resources[] is added, the pjob->ji_resources[].nr_used should be initialized as well.
* Whether or not the resources_used data is tagged under FQDN mom hostname or short mom hostname, both data are for the same Mom. Thus, compare_short_hostname() is done instead of strcmp() when deciding if a new entry to pjob->ji_resources[] is needed.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* Verification of this bug is manual, as writing a PTL test is tricky given that it requires from the time a job is ending, and before stageout kicks in, the mom_host value of a sister mom would need to change in form.  To reproduce the bug, a special mom was built and run on the sister node, as detailed below:
[bug_verify.txt](https://github.com/PBSPro/pbspro/files/3957251/bug_verify.txt)
* Valgrind log when the fix is executed:
[valgrind.mom.txt](https://github.com/PBSPro/pbspro/files/3957260/valgrind.mom.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
