### PR TITLE
Adjustment to fix 4f7bed8 (mom crash due release_nodes_stageout=true)

### DIFF
--- a/src/lib/Libnet/get_hostaddr.c
+++ b/src/lib/Libnet/get_hostaddr.c
@@ -158,7 +158,8 @@ compare_short_hostname(char *shost, char *lhost)
 	is_shost_ip = inet_pton(AF_INET, shost, &(check_ip.sin_addr));
 	is_lhost_ip = inet_pton(AF_INET, lhost, &(check_ip.sin_addr));
 	if ((is_shost_ip > 0) || (is_lhost_ip > 0)) {
-		if (strcasecmp(shost, lhost) == 0)
+		/* ((3 * 4) + 3) = 15 characters, max length dotted decimal addr */
+		if (strncmp(shost, lhost, 15) == 0)
 			return 0;
 		return 1;
 	}

--- a/src/lib/Libnet/get_hostaddr.c
+++ b/src/lib/Libnet/get_hostaddr.c
@@ -42,6 +42,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <memory.h>
+#include <arpa/inet.h>
 #include "portability.h"
 #include "server_limits.h"
 #include "pbs_ifl.h"
@@ -146,9 +147,22 @@ compare_short_hostname(char *shost, char *lhost)
 {
 	size_t   len;
 	char    *pdot;
+	int	is_shost_ip;
+	int	is_lhost_ip;
+	struct	sockaddr_in check_ip;
 
 	if ((shost == NULL) || (lhost == NULL))
 		return 1;
+
+	/* check if hostnames given are in IPV4 dotted-decimal form: ddd.ddd.ddd.ddd */
+	is_shost_ip = inet_pton(AF_INET, shost, &(check_ip.sin_addr));
+	is_lhost_ip = inet_pton(AF_INET, lhost, &(check_ip.sin_addr));
+	if ((is_shost_ip > 0) || (is_lhost_ip > 0)) {
+		if (strcasecmp(shost, lhost) == 0)
+			return 0;
+		return 1;
+	}
+
 
 	if ((pdot = strchr(shost, '.')) != NULL)
 		len = (size_t)(pdot - shost);

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -5409,7 +5409,7 @@ join_err:
 			resc_idx = -1;
 			for (i=0; i < pjob->ji_numrescs; i++) {
 				if ((pjob->ji_resources[i].nodehost != NULL) &&
-				    (strcmp(pjob->ji_resources[i].nodehost, nodehost) == 0)) {
+				    (compare_short_hostname(pjob->ji_resources[i].nodehost, nodehost) == 0)) {
 					resc_idx = i;
 					break;
 				}

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -5409,7 +5409,7 @@ join_err:
 			resc_idx = -1;
 			for (i=0; i < pjob->ji_numrescs; i++) {
 				if ((pjob->ji_resources[i].nodehost != NULL) &&
-				    (compare_short_hostname(pjob->ji_resources[i].nodehost, nodehost) == 0)) {
+				    (strcmp(pjob->ji_resources[i].nodehost, nodehost) == 0)) {
 					resc_idx = i;
 					break;
 				}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* There's a slight problem to the fix to "mom crash due release_nodes_stageout=true)" in that if mom hosts are added to the PBS as IP addresses, the compare_short_hostname() would always be true.

PR#1448: https://github.com/PBSPro/pbspro/pull/1448


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Adjust compare_short_hostname() function to check if at least one of the given hostnames is in IPV4 dotted-decimal form. If so, then just do a strcasecmp().

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* WIth the updated fix, reran the manual test and it still passed:
[bug_verify.txt](https://github.com/PBSPro/pbspro/files/3958290/bug_verify.txt)
* valgrind of mom with reproduction case rerun:
[valgrind.mom.txt](https://github.com/PBSPro/pbspro/files/4024996/valgrind.mom.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
