### PR TITLE
PP-823: qsub -Wblock=true hangs server for 190 seconds per job at exit if submission host is unresponsive

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -477,6 +477,18 @@ struct jbdscrd {
 #define TKMFLG_REVAL_IND_REMAINING 0x02 /* Flag to re-evaluate "array_indices_remaining" */
 #define TKMFLG_CHK_ARRAY           0x04 /* chk_array_doneness() already in call stack*/
 
+/* Structure for block job reply processing */
+struct block_job_reply {
+	char jobid[PBS_MAXSVRJOBID + 1];
+	char client[PBS_MAXHOSTNAME + 1];
+	int port;
+	int exitstat;
+	time_t reply_time;	/* The timestamp at which the block job tried it's first attempt to reply */
+	char *msg;	/* Abort message to be send to client */
+	int fd;
+};
+#define BLOCK_JOB_REPLY_TIMEOUT 60
+
 /*
  * THE JOB
  *

--- a/test/tests/functional/pbs_qsub_wblock.py
+++ b/test/tests/functional/pbs_qsub_wblock.py
@@ -1,0 +1,67 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestQsubWblock(TestFunctional):
+    """
+    This test suite contains the block job feature tests
+    """
+    def test_block_job(self):
+        """
+        Test to submit a block job and verify the Server response
+        """
+        j = Job(TEST_USER, attrs={ATTR_block: 'true'})
+        j.set_sleep_time(1)
+        jid = self.server.submit(j)
+        msg = 'Server@%s;Job;%s;check_block_wt: Write successful' \
+              ' to client %s for job %s' % \
+              (self.server.shortname, jid, self.server.client, jid)
+        self.server.log_match(msg, tail=True, interval=2, max_attempts=30)
+
+    def test_block_job_array(self):
+        """
+        Test to submit a block array job and verify the Server response
+        """
+        j = Job(TEST_USER, attrs={ATTR_block: 'true', ATTR_J: '1-3'})
+        j.set_sleep_time(1)
+        jid = self.server.submit(j)
+        msg = 'Server@%s;Job;%s;check_block_wt: Write successful ' \
+              'to client %s for job %s' % \
+              (self.server.shortname, jid, self.server.client, jid)
+        self.server.log_match(msg, tail=True, interval=2, max_attempts=30)


### PR DESCRIPTION
#### Describe Bug or Feature
[PP-823](https://pbspro.atlassian.net/browse/PP-823) 

#### Describe Your Change
Introduced a new structure for handling block jobs. 

Once the job has finished, Server checks if the job is a block job and tries to connect to a non-blocking socket with the client. If the socket is connected or it is in progress  then the server sets a work task which will be triggered after 10 seconds and stores the socket alive in the block job structure. 

In the work task - 
1. If the socket is connected, server immediately sends the response to the client and deletes the job. 
2. If the socket connection is in progress, then work task tries to poll the socket for POLLOUT event with a 0 timeout.  If the polling does not work in the first try, server tries to connect for maximum of 60 seconds and after that it deletes the block job structure irrespective of client is available to receive. 

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[PP-823-valgrind-logs.txt](https://github.com/PBSPro/pbspro/files/3960381/PP-823-valgrind-logs.txt)
[automated_test_logs.txt](https://github.com/PBSPro/pbspro/files/3960382/automated_test_logs.txt)
[block_job_retries_logs.txt](https://github.com/PBSPro/pbspro/files/3960383/block_job_retries_logs.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
