### PR TITLE
Update PTL doc on how to override tearDownClass() and setUpClass() in a test suite

### DIFF
--- a/test/fw/doc/howtotest.rst
+++ b/test/fw/doc/howtotest.rst
@@ -96,9 +96,17 @@ PBSTestSuite offers the following:
   - If no nodes are defined in the system, a single 8 cpu node is defined.
   - start process monitoring thread if process monitoring enabled
 
+.. topic:: setUpClass:
+
+  - If setUpClass is overridden, use super() instead of the class you are overriding to call setUpClass of the parent.
+
 .. topic:: tearDown:
 
   - If process monitoring is enabled the stop process monitoring thread and collect process metrics
+
+.. topic:: tearDownClass:
+
+  - If tearDownClass is overridden, use super() instead of the class you are overriding to call tearDownClass of the parent.
 
 .. topic:: analyze_logs:
 


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

When we override tearDownClass() in a test suite, calling the tearDownClass() of PBSTestSuite fails with the error AttributeError: type object 'TestFunctional' has no attribute 'use_cur_setup'. We get this error because 'use_cur_setup' is initialized in PtlTestRunner class and we are using parent class reference to call attribute of a derived class. The solution is to use super() instead of parent class name to call TearDownClass.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Update PTL doc on how to override tearDownClass() and setUpClass() in a test suite

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
