### PR TITLE
Fix race condition on qrerun and qrun with end job hook

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -441,6 +441,7 @@ struct ajtrk {
 	int trk_exitstat;  /* if executed and exitstat set */
 	int trk_substate; /* sub state    */
 	int trk_stgout; /* stageout status  */
+	int trk_discarding; /* indicate job is discarding */
 	struct job *trk_psubjob; /* pointer to instantiated subjob */
 };
 
@@ -585,6 +586,7 @@ struct job {
 	int		ji_ports[2];	/* ports for stdout/err */
 	int		ji_hook_running_bg_on; /* set when hook starts in the background*/
 #else					/* END Mom ONLY -  start Server ONLY */
+	int		ji_discarding;	/* discarding job */
 	struct batch_request *ji_prunreq; /* outstanding runjob request */
 	pbs_list_head	ji_svrtask;	/* links to svr work_task list */
 	struct pbs_queue  *ji_qhdr;	/* current queue header */
@@ -853,7 +855,7 @@ typedef struct	infoent {
 #define IM_RESTART		16
 #define IM_DELETE_JOB		17
 #define IM_REQUEUE		18
-#define	IM_DELETE_JOB_REPLY	19
+/* skip 19 to avoid confilict with IS_DISCARD_JOB */
 #define IM_SETUP_JOB		20
 #define IM_DELETE_JOB2		21	/* sent by sister mom to delete job early */
 #define IM_SEND_RESC		22
@@ -861,6 +863,7 @@ typedef struct	infoent {
 #define IM_EXEC_PROLOGUE	24
 #define IM_CRED 		25
 #define IM_PMIX			26
+#define	IM_DELETE_JOB_REPLY	27
 
 #define IM_ERROR		99
 #define IM_ERROR2		100

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -504,6 +504,15 @@ struct jbdscrd {
 #define	ji_taskid	ji_extended.ji_ext.ji_taskidx
 #define	ji_nodeid	ji_extended.ji_ext.ji_nodeidx
 
+enum bg_hook_request {
+	BG_NONE,
+	BG_IS_DISCARD_JOB,
+	BG_PBS_BATCH_DeleteJob,
+	BG_PBSE_SISCOMM,
+	BG_IM_DELETE_JOB_REPLY,
+	BG_IM_DELETE_JOB
+};
+
 struct job {
 
 	/* 
@@ -584,7 +593,7 @@ struct job {
 	int		ji_stdout;	/* socket for stdout */
 	int		ji_stderr;	/* socket for stderr */
 	int		ji_ports[2];	/* ports for stdout/err */
-	int		ji_hook_running_bg_on; /* set when hook starts in the background*/
+	enum	bg_hook_request	ji_hook_running_bg_on; /* set when hook starts in the background*/
 #else					/* END Mom ONLY -  start Server ONLY */
 	int		ji_discarding;	/* discarding job */
 	struct batch_request *ji_prunreq; /* outstanding runjob request */
@@ -855,7 +864,7 @@ typedef struct	infoent {
 #define IM_RESTART		16
 #define IM_DELETE_JOB		17
 #define IM_REQUEUE		18
-/* skip 19 to avoid confilict with IS_DISCARD_JOB */
+#define IM_DELETE_JOB_REPLY		19
 #define IM_SETUP_JOB		20
 #define IM_DELETE_JOB2		21	/* sent by sister mom to delete job early */
 #define IM_SEND_RESC		22
@@ -863,7 +872,6 @@ typedef struct	infoent {
 #define IM_EXEC_PROLOGUE	24
 #define IM_CRED 		25
 #define IM_PMIX			26
-#define	IM_DELETE_JOB_REPLY	27
 
 #define IM_ERROR		99
 #define IM_ERROR2		100

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -187,6 +187,7 @@ extern job  *create_subjob(job *parent, char *newjid, int *rc);
 extern char *cvt_range(struct ajtrkhd *t, int state);
 extern job  *find_arrayparent(char *subjobid);
 extern int   get_subjob_state(job *parent, int offset);
+extern int   get_subjob_discarding(job *parent, int offset);
 extern char *mk_subjob_id(job *parent, int offset);
 extern void  set_subjob_tblstate(job *, int, int);
 extern void  update_subjob_state(job *, int newstate);

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -3744,7 +3744,7 @@ join_err:
 				PBS_MOM_SERVICE_NAME, mom_host, hook_input_ptr,
 				hook_output_ptr, NULL, 0, 1) ==
 						HOOK_RUNNING_IN_BACKGROUND) {
-					pjob->ji_hook_running_bg_on = command;
+					pjob->ji_hook_running_bg_on = (command == IM_DELETE_JOB)? BG_IM_DELETE_JOB: BG_IM_DELETE_JOB_REPLY;
 					break;
 				}
 

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3424,7 +3424,32 @@ void reply_hook_bg(job *pjob)
 	struct	batch_request *preq = pjob->ji_preq;
 #endif
 
-	if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_HERE) { /*MS*/
+	if (pjob->ji_hook_running_bg_on == IS_DISCARD_JOB) {
+		/**
+		 * IS_DISCARD_JOB can be received by sister node as well,
+		 * when node fail requeue is activated 
+		 */
+		n = pjob->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long;
+		strcpy(jobid, pjob->ji_qs.ji_jobid);
+
+		del_job_resc(pjob);	/* rm tmpdir, cpusets, etc */
+		pjob->ji_hook_running_bg_on = 0;
+		job_purge(pjob);
+		dorestrict_user();
+
+		if ((ret = is_compose(server_stream, IS_DISCARD_DONE)) != DIS_SUCCESS)
+			goto err;
+
+		if ((ret = diswst(server_stream, jobid)) != DIS_SUCCESS)
+			goto err;
+
+		if ((ret = diswsi(server_stream, n)) != DIS_SUCCESS)
+			goto err;
+
+		rpp_flush(server_stream);
+		rpp_eom(server_stream); 
+
+	} else if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_HERE) { /*MS*/
 		switch (pjob->ji_hook_running_bg_on) {
 			case PBS_BATCH_DeleteJob:
 			case (PBS_BATCH_DeleteJob + PBSE_SISCOMM):
@@ -3448,6 +3473,7 @@ void reply_hook_bg(job *pjob)
 						(PBS_BATCH_DeleteJob + PBSE_SISCOMM))
 							req_reject(PBSE_SISCOMM, 0, preq); /* sis down */
 #endif
+					pjob->ji_hook_running_bg_on = 0;
 					job_purge(pjob);
 				}
 				/*
@@ -3457,32 +3483,13 @@ void reply_hook_bg(job *pjob)
 				*/
 				break;
 
-			case IS_DISCARD_JOB:
-				n = pjob->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long;
-				strcpy(jobid, pjob->ji_qs.ji_jobid);
-
-				del_job_resc(pjob);	/* rm tmpdir, cpusets, etc */
-				job_purge(pjob);
-				dorestrict_user();
-
-				if ((ret = is_compose(server_stream, IS_DISCARD_DONE)) != DIS_SUCCESS)
-					goto err;
-
-				if ((ret = diswst(server_stream, jobid)) != DIS_SUCCESS)
-					goto err;
-
-				if ((ret = diswsi(server_stream, n)) != DIS_SUCCESS)
-					goto err;
-
-				rpp_flush(server_stream);
-				rpp_eom(server_stream); 
-				break;
 		}
 	} else { /*SISTER MOM*/
 		switch (pjob->ji_hook_running_bg_on) {
 			case IM_DELETE_JOB_REPLY:
 				post_reply(pjob, 0);
 			case IM_DELETE_JOB:
+				pjob->ji_hook_running_bg_on = 0;
 				mom_deljob(pjob);
 		}
 	}

--- a/src/resmom/mom_server.c
+++ b/src/resmom/mom_server.c
@@ -1127,13 +1127,14 @@ is_request(int stream, int version)
 									JOB_SVFLG_HERE)	/* MS */
 								(void)send_sisters(pjob,
 								IM_DELETE_JOB, NULL);
+							free(jobid);
+							jobid = NULL;
+							break;
 						}
-					else {
-					    mom_deljob(pjob);
-					    free(phook_output->reject_errcode);
-					    free(phook_output);
-					    free(phook_input);
-					}
+					mom_deljob(pjob);
+					free(phook_output->reject_errcode);
+					free(phook_output);
+					free(phook_input);
 				}
 			}
 			if ((ret=is_compose(server_stream, IS_DISCARD_DONE)) != DIS_SUCCESS) {

--- a/src/resmom/mom_server.c
+++ b/src/resmom/mom_server.c
@@ -1122,7 +1122,7 @@ is_request(int stream, int version)
 					if (mom_process_hooks(HOOK_EVENT_EXECJOB_END,
 						PBS_MOM_SERVICE_NAME, mom_host,
 						phook_input, phook_output, NULL, 0, 1) == HOOK_RUNNING_IN_BACKGROUND) {
-							pjob->ji_hook_running_bg_on = IS_DISCARD_JOB;
+							pjob->ji_hook_running_bg_on = BG_IS_DISCARD_JOB;
 							if (pjob->ji_qs.ji_svrflags &
 									JOB_SVFLG_HERE)	/* MS */
 								(void)send_sisters(pjob,

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -652,7 +652,7 @@ req_deletejob(struct batch_request *preq)
 		PBS_MOM_SERVICE_NAME, mom_host, hook_input,
 		hook_output, NULL, 0, 1) == HOOK_RUNNING_IN_BACKGROUND) {
 		
-		pjob->ji_hook_running_bg_on = PBS_BATCH_DeleteJob;
+		pjob->ji_hook_running_bg_on = BG_PBS_BATCH_DeleteJob;
 
 		/*
 		* save number of nodes in sisterhood in case
@@ -668,7 +668,7 @@ req_deletejob(struct batch_request *preq)
 				* no messages sent, but there are sisters
 				* must be all down
 				*/
-				pjob->ji_hook_running_bg_on += PBSE_SISCOMM;
+				pjob->ji_hook_running_bg_on = BG_PBSE_SISCOMM;
 			}
 		}
 		/* 

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -537,6 +537,24 @@ update_subjob_state(job *pjob, int newstate)
 }
 /**
  * @brief
+ * 		get_subjob_discarding - return the discarding flag of a subjob given by the parent job
+ * 		and integer index into the table for the subjob
+ *
+ * @param[in]	parent - pointer to the parent job
+ * @param[in]	iindx - first number of range
+ *
+ * @return	status
+ * @retval	-1	-  error
+ */
+int
+get_subjob_discarding(job *parent, int iindx)
+{
+	if (iindx == -1)
+		return -1;
+	return (parent->ji_ajtrk->tkm_tbl[iindx].trk_discarding);
+}
+/**
+ * @brief
  * 		get_subjob_state - return the state of a subjob given by the parent job
  * 		and integer index into the table for the subjob
  *
@@ -682,6 +700,7 @@ static struct ajtrkhd *mk_subjob_index_tbl(char *range, int initalstate, int *pb
 		t->tkm_tbl[j].trk_index = i;
 		t->tkm_tbl[j].trk_status = initalstate;
 		t->tkm_tbl[j].trk_error  = 0;
+		t->tkm_tbl[j].trk_discarding = 0;
 		t->tkm_tbl[j].trk_substate  = JOB_SUBSTATE_FINISHED;
 		t->tkm_tbl[j].trk_stgout  = -1;
 		t->tkm_tbl[j].trk_exitstat  = 0;

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -398,6 +398,7 @@ job_alloc(void)
 	pj->ji_stderr = 0;
 	pj->ji_setup = NULL;
 #else	/* SERVER */
+	pj->ji_discarding = 0;
 	pj->ji_prunreq = NULL;
 	pj->ji_pmt_preq = NULL;
 	CLEAR_HEAD(pj->ji_svrtask);

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -383,7 +383,7 @@ job_alloc(void)
 	pj->ji_parent2child_job_update_status_pipe = -1;
 	pj->ji_parent2child_moms_status_pipe = -1;
 	pj->ji_updated = 0;
-	pj->ji_hook_running_bg_on = 0;
+	pj->ji_hook_running_bg_on = BG_NONE;
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 #if defined(HAVE_LIBKAFS) || defined(HAVE_LIBKOPENAFS)
 	pj->ji_extended.ji_ext.ji_pag = 0;

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -782,9 +782,15 @@ post_discard_job(job *pjob, mominfo_t *pmom, int newstate)
 	char	        *downmom = NULL;
 	struct jbdscrd  *pdsc;
 
-	if (pjob->ji_discard == NULL)
+	if (pjob->ji_discard == NULL) {
+		if (pjob->ji_discarding) {
+			pjob->ji_discarding = 0;
+			if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) {
+				((pjob->ji_parentaj)->ji_ajtrk)->tkm_tbl[pjob->ji_subjindx].trk_discarding = pjob->ji_discarding;
+			}
+		}
 		return;
-
+	}
 	if (pmom != NULL) {
 		for (pdsc = pjob->ji_discard; pdsc->jdcd_mom; ++pdsc) {
 			if (pdsc->jdcd_mom == pmom) {
@@ -840,8 +846,14 @@ post_discard_job(job *pjob, mominfo_t *pmom, int newstate)
 		return;
 	}
 
-	if (pjob->ji_qs.ji_substate == JOB_SUBSTATE_RERUN3) {
-		static char ndreque[] = "Job requeued, execution node %s down";
+	if (pjob->ji_qs.ji_substate == JOB_SUBSTATE_RERUN3 || pjob->ji_discarding) {
+		
+		static char *ndreque;
+
+		if (pjob->ji_discarding)
+			ndreque = "Job requeued, discard response received";
+		else
+			ndreque = "Job requeued, execution node %s down";
 
 		/*
 		 * Job to be rerun,   no need to check if job is rerunnable
@@ -864,6 +876,10 @@ post_discard_job(job *pjob, mominfo_t *pmom, int newstate)
 			((pjob->ji_qs.ji_svrflags & (JOB_SVFLG_CHKPT | JOB_SVFLG_ChkptMig)) == 0))
 			job_attr_def[(int)JOB_ATR_resc_used].at_free(&pjob->ji_wattr[(int)JOB_ATR_resc_used]);
 
+		pjob->ji_discarding = 0;
+		if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) {
+			((pjob->ji_parentaj)->ji_ajtrk)->tkm_tbl[pjob->ji_subjindx].trk_discarding = pjob->ji_discarding;
+		}
 		return;
 	}
 
@@ -4443,6 +4459,10 @@ mom_running_jobs(int stream)
 				/* for any other disagreement of state except */
 				/* in Exiting or RUNNING, discard job         */
 				send_discard_job(stream, jobid, runver, "state mismatch");
+				pjob->ji_discarding = 1;
+				if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) {
+					((pjob->ji_parentaj)->ji_ajtrk)->tkm_tbl[pjob->ji_subjindx].trk_discarding = pjob->ji_discarding;
+				}
 			}
 
 			/*

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -465,8 +465,12 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 			reply_preempt_jobs_request(rc, PREEMPT_METHOD_REQUEUE, pjob);
 
 		pjob->ji_qs.ji_substate = JOB_SUBSTATE_RERUN3;
-		discard_job(pjob, "Force rerun", 1);
-		force_reque(pjob);
+		discard_job(pjob, "Force rerun", 0);
+		pjob->ji_discarding = 1;
+		/**
+		 * force_reque will be called in post_discard_job,
+		 * after receiving IS_DISCARD_DONE from the MOM.
+		 */
 		reply_ack(preq);
 		return;
 

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -359,6 +359,10 @@ req_runjob(struct batch_request *preq)
 		pjob = chk_job_torun(preq, parent);
 		if (pjob == NULL)
 			return;
+		if (pjob->ji_discarding) {
+			req_reject(PBSE_BADSTATE, 0, preq);
+			return;
+		}
 
 	} else if (jt == IS_ARRAY_Single) {
 
@@ -375,6 +379,9 @@ req_runjob(struct batch_request *preq)
 			return;
 		} else if (i != JOB_STATE_QUEUED) {
 			/* job already running */
+			req_reject(PBSE_BADSTATE, 0, preq);
+			return;
+		} else if (get_subjob_discarding(parent, i) == 1) {
 			req_reject(PBSE_BADSTATE, 0, preq);
 			return;
 		}
@@ -405,8 +412,10 @@ req_runjob(struct batch_request *preq)
 				break;	/* no more in the range */
 			for (; x <= y; x += z) {
 				if ((i = numindex_to_offset(parent, x)) >= 0) {
-					if (get_subjob_state(parent, i) == JOB_STATE_QUEUED)
-						anygood = 1;
+					if ((get_subjob_state(parent, i) == JOB_STATE_QUEUED) &&
+						get_subjob_discarding(parent, i) != 1) {
+							anygood = 1;
+					}
 				}
 			}
 			range = pc;
@@ -641,6 +650,7 @@ req_runjob2(struct batch_request *preq, job *pjob)
 	char		 *dest;
 	int		 rq_type = 0;
 
+		
 	/* Check if prov is required, if so, reply_ack and let prov finish */
 	/* else follow normal flow */
 	prov_rc = check_and_provision_job(preq, pjob, &need_prov);

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -381,7 +381,7 @@ req_runjob(struct batch_request *preq)
 			/* job already running */
 			req_reject(PBSE_BADSTATE, 0, preq);
 			return;
-		} else if (get_subjob_discarding(parent, i) == 1) {
+		} else if (get_subjob_discarding(parent, offset) == 1) {
 			req_reject(PBSE_BADSTATE, 0, preq);
 			return;
 		}

--- a/test/tests/functional/pbs_hook_execjob_end.py
+++ b/test/tests/functional/pbs_hook_execjob_end.py
@@ -37,6 +37,20 @@
 from tests.functional import *
 from ptl.utils.pbs_logutils import PBSLogUtils
 
+hook_body = """
+import pbs
+import time
+e = pbs.event()
+
+if e.type == pbs.EXECJOB_EPILOGUE:
+    hook_type = "EXECJOB_EPILOGUE"
+elif e.type == pbs.EXECJOB_END:
+    hook_type = "EXECJOB_END"
+pbs.logjobmsg(e.job.id, "starting hook event %s" % (hook_type))
+time.sleep(5)
+pbs.logjobmsg(e.job.id, "ending hook event %s" % (hook_type))
+"""
+
 
 class TestPbsExecjobEnd(TestFunctional):
     """
@@ -336,3 +350,110 @@ class TestPbsExecjobEnd(TestFunctional):
         self.momB.start()
         # Verify sister mom is not down
         self.assertTrue(self.momB.isUp())
+
+    def test_rerun_on_epilogue_hook(self):
+        """
+        Test force qrerun when epilogue hook is running
+        """
+
+        hook_name = "epiend_hook"
+        global hook_body
+
+        attr = {'event': 'execjob_epilogue,execjob_end', 'enabled': 'True'}
+        self.server.create_import_hook(hook_name, attr, hook_body)
+        j = Job(TEST_USER)
+        j.set_sleep_time(1)
+        jid = self.server.submit(j)
+        self.mom.log_match("starting hook event EXECJOB_EPILOGUE")
+        # Force rerun job
+        self.server.rerunjob(jid, extend='force')
+        self.mom.log_match("starting hook event EXECJOB_END")
+        self.server.expect(JOB, {'job_state': 'R'}, jid)
+        self.mom.log_match("ending hook event EXECJOB_END")
+
+    def common_steps(self, jid, host):
+        """
+        Function to run common steps for test job on mom breakdown
+        and restarts
+        """
+
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+        host.signal('-KILL')
+        self.logger.info(
+            "Successfully killed mom process on %s" %
+            host.shortname)
+
+        # set scheduling false
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+
+        # check for the job's state after the node_fail_requeue time hits
+        self.logger.info("Waiting for 30s so that node_fail_requeue time hits")
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid, offset=30)
+
+        host.start()
+        self.logger.info(
+            "Successfully started mom process on %s" %
+            host.shortname)
+        self.server.expect(NODE, {'state': 'free'}, id=host.shortname)
+
+        self.server.expect(JOB, {ATTR_state: 'Q'}, id=jid)
+        # run job
+        try:
+            # qrun will fail as it is discarding the job
+            self.server.runjob(jid)
+        except PbsRunError as e:
+            self.logger.info("Runjob throws error: " + e.msg[0])
+            self.assertTrue(
+                'qrun: Request invalid for state of job'
+                in e.msg[0])
+            now = int(time.time())
+            self.mom.log_match("ending hook event EXECJOB_END",
+                               starttime=now, interval=2)
+            time.sleep(5)
+            self.server.runjob(jid)
+            self.server.expect(JOB, {'job_state': 'R'}, jid)
+            now = int(time.time())
+            self.mom.log_match(
+                "starting hook event EXECJOB_END",
+                starttime=now, interval=2)
+            time.sleep(5)
+            self.mom.log_match("ending hook event EXECJOB_END",
+                               starttime=now, interval=2)
+
+    def test_qrun_on_mom_breakdown(self):
+        """
+        Test qrun when mom breaksdown and restarts
+        """
+
+        hook_name = "end_hook"
+        global hook_body
+        attr = {'event': 'execjob_end', 'enabled': 'True', 'alarm': '50'}
+        self.server.create_import_hook(hook_name, attr, hook_body)
+        attrib = {ATTR_nodefailrq: 30}
+        self.server.manager(MGR_CMD_SET, SERVER, attrib=attrib)
+        j = Job(TEST_USER)
+        j.set_sleep_time(10)
+        jid = self.server.submit(j)
+        self.common_steps(jid, self.mom)
+
+    def test_qrun_arrayjob_on_mom_breakdown(self):
+        """
+        Test qrun array job when mom breaksdown and restarts
+        """
+
+        hook_name = "end_hook"
+        global hook_body
+        attr = {'event': 'execjob_end', 'enabled': 'True', 'alarm': '50'}
+        self.server.create_import_hook(hook_name, attr, hook_body)
+        attrib = {ATTR_nodefailrq: 30}
+        self.server.manager(MGR_CMD_SET, SERVER, attrib=attrib)
+        j = Job(TEST_USER, attrs={
+            ATTR_J: '1-2', ATTR_k: 'oe',
+            'Resource_List.select': 'ncpus=1'
+        })
+        j.set_sleep_time(10)
+        jid = self.server.submit(j)
+        # check job array has begun
+        self.server.expect(JOB, {'job_state': 'B'}, jid)
+        subjid_1 = j.create_subjob_id(jid, 1)
+        self.common_steps(subjid_1, self.mom)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
job stays in substate 41 after qrerun in epilogue script and a single rerun with an execjob_end hook leads to run_count 3 and intermittently Exit_Status=-3

Cause:
Race condition occur on force qrerun and qrun of same job, while asynchronous hook (exec_job_end) is running in the background.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Allowing job to rerun only when it's discard request is acknowledged

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[TestPbsExecjobEnd.ptl.log](https://github.com/PBSPro/pbspro/files/3983291/TestPbsExecjobEnd.ptl.log)
[TestPbsExecjobEnd.ptl.log](https://github.com/PBSPro/pbspro/files/3974527/TestPbsExecjobEnd.ptl.log)
[valgrind.log](https://github.com/PBSPro/pbspro/files/3974528/valgrind.log)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->