### PR TITLE
Removed NAS mod 49

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -461,8 +461,6 @@ struct server_info
 	node_bucket **buckets;		/* node bucket array */
 	node_info **unordered_nodes;
 #ifdef NAS
-	/* localmod 049 */
-	node_info **nodes_by_NASrank;	/* nodes indexed by NASrank */
 	/* localmod 034 */
 	share_head *share_head;	/* root of share info */
 #endif
@@ -707,8 +705,6 @@ struct node_info
 	/* localmod 034 */
 	int	sh_cls;			/* Share class supplied by node */
 	int	sh_type;		/* Share type of node */
-	/* localmod 049 */
-	int   NASrank;		/* NAS order in which nodes were queried */
 #endif
 
 	char *current_aoe;		/* AOE name instantiated on node */

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -132,11 +132,7 @@ void dup_node_info_chunk(th_data_dup_nd_info *data);
 /*
  *      dup_nodes - duplicate an array of nodes
  */
-#ifdef NAS /* localmod 049 */
-node_info **dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags, int allocNASrank);
-#else
 node_info **dup_nodes(node_info **onodes, server_info *nsinfo, unsigned int flags);
-#endif /* localmod 049 */
 
 /*
  *      set_node_type - set the node type bits
@@ -207,13 +203,7 @@ int should_talk_with_mom(node_info *ninfo);
  *                            This means we have to use the names from the
  *                            first array and find them in the second array
  */
-#ifdef NAS /* localmod 049 */
-node_info **copy_node_ptr_array(node_info  **oarr, node_info  **narr, server_info *sinfo);
-#else
 node_info **copy_node_ptr_array(node_info  **oarr, node_info  **narr);
-#endif /* localmod 049 */
-
-
 
 /*
  *      create_execvnode - create an execvnode to run a multi-node job
@@ -242,20 +232,12 @@ void free_nspec(nspec *ns);
 /*
  *      dup_nspec - duplicate an nspec
  */
-#ifdef NAS /* localmod 049 */
-nspec *dup_nspec(nspec *ons, node_info **ninfo_arr, server_info *sinfo);
-#else
 nspec *dup_nspec(nspec *ons, node_info **ninfo_arr);
-#endif /* localmod 049 */
 
 /*
  *      dup_nspecs - duplicate an array of nspecs
  */
-#ifdef NAS /* localmod 049 */
-nspec **dup_nspecs(nspec **onspecs, node_info **ninfo_arr, server_info *sinfo);
-#else
 nspec **dup_nspecs(nspec **onspecs, node_info **ninfo_arr);
-#endif /* localmod 049 */
 
 /*
  *	empty_nspec_array - free the contents of an nspec array but not

--- a/src/scheduler/node_partition.c
+++ b/src/scheduler/node_partition.c
@@ -256,11 +256,7 @@ dup_node_partition(node_partition *onp, server_info *nsinfo)
 	nnp->tot_nodes = onp->tot_nodes;
 	nnp->free_nodes = onp->free_nodes;
 	nnp->res = dup_resource_list(onp->res);
-#ifdef NAS /* localmod 049 */
-	nnp->ninfo_arr = copy_node_ptr_array(onp->ninfo_arr, nsinfo->nodes, nsinfo);
-#else
 	nnp->ninfo_arr = copy_node_ptr_array(onp->ninfo_arr, nsinfo->nodes);
-#endif
 
 	nnp->bkts = dup_node_bucket_array(onp->bkts, nsinfo);
 	nnp->rank = onp->rank;

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -649,41 +649,23 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 	nresresv->node_set_str = dup_string_array(oresresv->node_set_str);
 
 	nresresv->resresv_ind = oresresv->resresv_ind;
-#ifdef NAS /* localmod 049 */
-	nresresv->node_set = copy_node_ptr_array(oresresv->node_set, nsinfo->nodes, nsinfo);
-#else
 	nresresv->node_set = copy_node_ptr_array(oresresv->node_set, nsinfo->nodes);
-#endif /* localmod 049 */
 
 	if (oresresv->is_job) {
 		nresresv->is_job = 1;
 		nresresv->job = dup_job_info(oresresv->job, nqinfo, nsinfo);
 		if (nresresv->job != NULL) {
 			if (nresresv->job->resv !=NULL) {
-#ifdef NAS /* localmod 049 */
-				nresresv->ninfo_arr = copy_node_ptr_array(oresresv->ninfo_arr,
-					nresresv->job->resv->resv->resv_nodes, NULL);
-				nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr,
-					nresresv->job->resv->ninfo_arr, NULL);
-#else
 				nresresv->ninfo_arr = copy_node_ptr_array(oresresv->ninfo_arr,
 					nresresv->job->resv->resv->resv_nodes);
 				nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr,
 					nresresv->job->resv->ninfo_arr);
-#endif /* localmod 049 */
 			}
 			else {
-#ifdef NAS /* localmod 049 */
-				nresresv->ninfo_arr = copy_node_ptr_array(oresresv->ninfo_arr,
-					nsinfo->nodes, nsinfo);
-				nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr,
-					nsinfo->nodes, nsinfo);
-#else
 				nresresv->ninfo_arr = copy_node_ptr_array(oresresv->ninfo_arr,
 					nsinfo->nodes);
 				nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr,
 					nsinfo->nodes);
-#endif /* localmod 049 */
 			}
 		}
 	}
@@ -691,17 +673,10 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 		nresresv->is_resv = 1;
 		nresresv->resv = dup_resv_info(oresresv->resv, nsinfo);
 
-#ifdef NAS /* localmod 049 */
-		nresresv->ninfo_arr = copy_node_ptr_array(oresresv->ninfo_arr,
-			nsinfo->nodes, nsinfo);
-		nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr,
-			nsinfo->nodes, nsinfo);
-#else
 		nresresv->ninfo_arr = copy_node_ptr_array(oresresv->ninfo_arr,
 			nsinfo->nodes);
 		nresresv->nspec_arr = dup_nspecs(oresresv->nspec_arr,
 			nsinfo->nodes);
-#endif /* localmod 049 */
 	}
 	else  { /* error */
 		free_resource_resv(nresresv);

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -850,12 +850,7 @@ dup_resv_info(resv_info *rinfo, server_info *sinfo)
 	if (rinfo->resv_queue != NULL)
 		nrinfo->resv_queue = find_queue_info(sinfo->queues, rinfo->queuename);
 
-	if (rinfo->resv_nodes != NULL)
-#ifdef NAS /* localmod 049 */
-		nrinfo->resv_nodes = dup_nodes(rinfo->resv_nodes, sinfo, NO_FLAGS, 0);
-#else
-		nrinfo->resv_nodes = dup_nodes(rinfo->resv_nodes, sinfo, NO_FLAGS);
-#endif /* localmod 049 */
+	nrinfo->resv_nodes = dup_nodes(rinfo->resv_nodes, sinfo, NO_FLAGS);
 
 	return nrinfo;
 }

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1146,9 +1146,6 @@ free_server_info(server_info *sinfo)
 #ifdef NAS
 	/* localmod 034 */
 	site_free_shares(sinfo);
-	/* localmod 049 */
-	if (sinfo->nodes_by_NASrank != NULL)
-		free(sinfo->nodes_by_NASrank);
 #endif
 }
 
@@ -1306,8 +1303,6 @@ new_server_info(int limallocflag)
 #ifdef NAS
 	/* localmod 034 */
 	sinfo->share_head = NULL;
-	/* localmod 049 */
-	sinfo->nodes_by_NASrank = NULL;
 #endif
 
 	return sinfo;
@@ -2325,11 +2320,7 @@ dup_server_info(server_info *osinfo)
 	nsinfo->num_nodes = osinfo->num_nodes;
 
 	/* dup the nodes, if there are any nodes */
-#ifdef NAS /* localmod 049 */
-	nsinfo->nodes = dup_nodes(osinfo->nodes, nsinfo, NO_FLAGS, 1);
-#else
 	nsinfo->nodes = dup_nodes(osinfo->nodes, nsinfo, NO_FLAGS);
-#endif /* localmod 049 */
 	
 	if (nsinfo->has_nodes_assoc_queue) {
 		nsinfo->unassoc_nodes =


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
NASA Ames (NAS) makes local modifications to the source code.  They are #ifdef'd out and only they use them.  When node buckets were introduced, we introduced our own solution to one of their mods.  This PR is removing their mod in favor of our own solution.

#### Describe Your Change
localmod 49 is where we keep track of an unsorted array of nodes on the server.  Each node knows their index into this unsorted array.  We can look up nodes in an O(1) search by indexing into the array directly.  We no longer have to do an O(N) search to find a node.

The scheduler now has its own unsorted array of nodes, and each node knows its index into the array.  The function find_node_by_indrank() will either index into that array, or if it can't, do the O(N) search by rank.

This PR removed the ifdef and NAS's code.  No pbspro compiled code was changed since the NAS side of the ifdef doesn't normally get compiled in.

#### Attach Test and Valgrind Logs/Output
Since no compiled code has changed, the smoke test that travis runs should be sufficient testing.