### PR TITLE
Updating the work task from timed to immediate for block jobs

### DIFF
--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -1660,7 +1660,7 @@ check_block(job *pjob, char *message)
 	blockj->exitstat = pjob->ji_qs.ji_un.ji_exect.ji_exitstat;
 	strcpy(blockj->jobid, pjob->ji_qs.ji_jobid);	
 
-	set_task(WORK_Timed, time_now + 10, check_block_wt, blockj);
+	set_task(WORK_Immed, 0, check_block_wt, blockj);
 	return;
 }
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
As part of changes to this [PR](https://github.com/PBSPro/pbspro/pull/1450/), making the first work task as timed, could make the submit host wait for additional 10 seconds.

#### Describe Your Change
The connection can be successful in the first attempt and hence making the first work task to be immediate.

#### Attach Test and Valgrind Logs/Output
[test_logs.txt](https://github.com/PBSPro/pbspro/files/3986671/test_logs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
