### PR TITLE
PTL use-current-setup fails to load multiple values in node configuration

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4256,7 +4256,7 @@ class PBSService(PBSObject):
                 # Load hooks
                 elif k == "hooks":
                     fpath = self.du.create_temp_file()
-                    print_hooks = '\n'.join(v)
+                    print_hooks = '\n'.join(v['qmgr_print_hook'])
                     with open(fpath, 'w') as f:
                         f.write(print_hooks)
                     file_qmgr = open(fpath)
@@ -4307,7 +4307,7 @@ class PBSService(PBSObject):
                 continue
             k = str(node_atb)
             v = str(val)
-            execcmd = "set node %s %s=%s" % (node_name, k, v)
+            execcmd = "set node %s %s='%s'" % (node_name, k, v)
             cmd = [qmgr, "-c", execcmd]
             ret = self.du.run_cmd(self.hostname, cmd, sudo=True,
                                   level=logging.DEBUG)


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Node attributes with multiple values fails to load during load_configuration() when PTL test is run with --use-current-setup option


#### Describe Your Change
1. Using single quotes to load multiple values set on nodes ex: qmgr -c "s n node_name resources_available.**node_attribute='value1,value2'**"
2. Loading of site hook failed, reason is that in load_configuration it was trying to access wrong values of hook saved data.
Before:
print_hooks = '\n'.join(v)
After:
print_hooks = '\n'.join(v["qmgr_print_hook"])


#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[PTL test logs.txt](https://github.com/PBSPro/pbspro/files/4004428/PTL.test.logs.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines]
NA
