### PR TITLE
Fix for hook NoneType Error instead KeyBoardInterrupt on hook alarm

### DIFF
--- a/src/lib/Libpython/pbs_python_external.c
+++ b/src/lib/Libpython/pbs_python_external.c
@@ -207,8 +207,8 @@ pbs_python_ext_start_interpreter(
 	 * Temporary set SIGINT to SIG_DFL, so Py_InitializeEx can setup proper SIGINT handler
 	 * see https://github.com/python/cpython/blob/3.6/Modules/signalmodule.c#L1280
 	 * as per above, If SIGINT is not set to SIG_DFL then Python won't register it's SIGINT handler
-	 * Which means Python won't raise KeyBoardInterrupt on PyErr_SetInterrupt()
-	 * instead it will throw NoneType not callable error
+	 * which means Python won't raise KeyBoardInterrupt on PyErr_SetInterrupt()
+	 * instead it will throw NoneType object is not callable exception
 	 */
 	sigemptyset(&act.sa_mask);
 	act.sa_flags   = 0;
@@ -233,10 +233,11 @@ pbs_python_ext_start_interpreter(
 
 	/* revert SIGINT to original sig handler */
 #ifndef WIN32
-	if (sigaction(SIGINT, &oact, NULL) != 0) {
+	if (sigaction(SIGINT, &oact, NULL) != 0)
 #else
-	if (signal(SIGINT, oact) == SIG_ERR) {
+	if (signal(SIGINT, oact) == SIG_ERR)
 #endif
+	{
 		log_err(errno, __func__, "Failed to revert signal handler for SIGINT");
 		return 1;
 	}

--- a/test/tests/functional/pbs_hook_set_interrupt.py
+++ b/test/tests/functional/pbs_hook_set_interrupt.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2019 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestHookInterrupt(TestFunctional):
+
+    """
+    This suite contains hook test to verify that pbs generates
+    KeyBoardInterrupt via hook alarm on long running hook
+    """
+
+    def test_hook_interrupt(self):
+        """
+        Test hook interrupt
+        """
+        hook_name = "testhook"
+        hook_body = """
+import pbs
+import time
+
+pbs.logmsg(pbs.LOG_DEBUG, "TestHook Started")
+time.sleep(100000)
+pbs.logmsg(pbs.LOG_DEBUG, "TestHook Ended")
+"""
+        a = {'event': 'runjob', 'enabled': 'True', 'alarm': '5'}
+        self.server.create_import_hook(hook_name, a, hook_body)
+        self.server.manager(MGR_CMD_SET, SERVER, {'log_events': -1})
+        j = Job(TEST_USER)
+        st = time.time()
+        jid = self.server.submit(j)
+
+        self.server.log_match("TestHook Started", starttime=st, max_attempts=5)
+
+        _msg = "Not Running: PBS Error: request rejected"
+        _msg += " as filter hook '%s' got an alarm call." % hook_name
+        _msg += " Please inform Admin"
+        self.server.expect(JOB,
+                           {'job_state': 'Q', 'comment': _msg},
+                           id=jid, offset=5, max_attempts=5)
+
+        self.server.log_match("Hook;catch_hook_alarm;alarm call received",
+                              starttime=st)
+        _msg1 = "PBS server internal error (15011)"
+        _msg1 += " in Python script received a KeyboardInterrupt, "
+        _msg2 = "<class 'KeyboardInterrupt'>"
+        _msg3 = "<could not figure out the exception value>"
+        self.server.log_match(_msg1 + _msg2, starttime=st)
+        self.server.log_match(_msg1 + _msg3, starttime=st)
+        self.server.log_match("Hook;%s;finished" % hook_name, starttime=st)
+        _msg = "alarm call while running runjob hook"
+        _msg += " '%s', request rejected" % hook_name
+        self.server.log_match(_msg, starttime=st)
+        self.server.log_match("TestHook Ended", existence=False, starttime=st)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS hook generates an exception 'NoneType' object is not callable instead KeyBoardInterrupt on hook alarm, this is due to while calling Py_Initialize SIGINT handler is not set to SIG_DFL due to which Python doesn't set its signal handler (Which raises keyboardInterrupt) for SIGINT


#### Describe Your Change
Temporary set signal handler for SIGINT to SIG_DFL, call Py_Initialize then revert original sig handler for SIGINT


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
* Before Fix:
  [before_fix.txt](https://github.com/PBSPro/pbspro/files/4005171/before_fix.txt)
```
12/27/2019 10:28:00.443119;0400;Server@testdev;Hook;testhook;started
12/27/2019 10:28:00.443246;0006;Server@testdev;Hook;Server@testdev;TestHook Started
12/27/2019 10:28:05.443223;0100;Server@testdev;Hook;catch_hook_alarm;alarm call received, interrupting hook execution.
12/27/2019 10:28:05.443329;0001;Server@testdev;Svr;Server@testdev;PBS server internal error (15011) in Error evaluating Python scri
pt, <class 'TypeError'>
12/27/2019 10:28:05.443347;0001;Server@testdev;Svr;Server@testdev;PBS server internal error (15011) in Error evaluating Python scri
pt, 'NoneType' object is not callable
12/27/2019 10:28:05.443378;0800;Server@testdev;Hook;hook_perf_stat;label=hook_runjob_testhook_2.testdev action=run_code walltime=5.
000178 cputime=0.000242
12/27/2019 10:28:05.443404;0400;Server@testdev;Hook;testhook;finished
12/27/2019 10:28:05.443490;0100;Server@testdev;Hook;testhook;runjob hook 'testhook' encountered an exception, request rejected
12/27/2019 10:28:05.443519;0800;Server@testdev;Hook;hook_perf_stat;label=hook_runjob_testhook_2.testdev action=server_process_hooks
 walltime=5.007482 cputime=0.007543 profile_stop
```
* After fix:
  [after_fix.txt](https://github.com/PBSPro/pbspro/files/4005170/after_fix.txt)
```
12/27/2019 10:33:11.771697;0800;Server@testdev;Hook;hook_perf_stat;label=hook_runjob_testhook_0.testdev action=populate:pbs.server() walltime=0.000328 cputime=0.000327
12/27/2019 10:33:11.773060;0400;Server@testdev;Hook;testhook;started
12/27/2019 10:33:11.773120;0086;Server@testdev;Svr;Server@testdev;Compiling script file: </var/spool/pbs/server_priv/hooks/testhook.PY>
12/27/2019 10:33:11.773435;0006;Server@testdev;Hook;Server@testdev;TestHook Started
12/27/2019 10:33:16.773301;0100;Server@testdev;Hook;catch_hook_alarm;alarm call received, interrupting hook execution.
12/27/2019 10:33:16.773413;0001;Server@testdev;Svr;Server@testdev;PBS server internal error (15011) in Python script received a KeyboardInterrupt, <class 'KeyboardInterrupt'>
12/27/2019 10:33:16.773439;0001;Server@testdev;Svr;Server@testdev;PBS server internal error (15011) in Python script received a KeyboardInterrupt, <could not figure out the exception value>
12/27/2019 10:33:16.773488;0800;Server@testdev;Hook;hook_perf_stat;label=hook_runjob_testhook_0.testdev action=run_code walltime=5.000212 cputime=0.000395
12/27/2019 10:33:16.773514;0400;Server@testdev;Hook;testhook;finished
12/27/2019 10:33:16.773548;0100;Server@testdev;Hook;testhook;alarm call while running runjob hook 'testhook', request rejected
12/27/2019 10:33:16.773568;0800;Server@testdev;Hook;hook_perf_stat;label=hook_runjob_testhook_0.testdev action=server_process_hooks walltime=5.004182 cputime=0.004354 profile_stop
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
