### PR TITLE
fix mem error in node_down_requeue()

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -717,13 +717,11 @@ node_down_requeue(struct work_task *pwt)
 						if (pj->ji_wattr[(int)JOB_ATR_rerunable].at_val.at_long != 0) {
 							pj->ji_qs.ji_substate = JOB_SUBSTATE_RERUN3;
 							if (pj->ji_acctrec != NULL) {
-								tmp_acctrec = malloc(strlen(pj->ji_acctrec) + strlen(log_buffer) + 2);
-								if (tmp_acctrec != NULL) {
-									sprintf(tmp_acctrec, "%s %s", pj->ji_acctrec, log_buffer);
+								if (pbs_asprintf(&tmp_acctrec, "%s %s", pj->ji_acctrec, log_buffer) == -1) {
+									free(tmp_acctrec); /* free 1 byte malloc'd in pbs_asprintf() */
+								} else {
 									free(pj->ji_acctrec);
 									pj->ji_acctrec = tmp_acctrec;
-								} else {
-									log_err(ENOMEM, __func__, "malloc failed for tmp_acctrec");
 								}
 							} else {
 								pj->ji_acctrec = strdup(log_buffer);

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -717,10 +717,13 @@ node_down_requeue(struct work_task *pwt)
 						if (pj->ji_wattr[(int)JOB_ATR_rerunable].at_val.at_long != 0) {
 							pj->ji_qs.ji_substate = JOB_SUBSTATE_RERUN3;
 							if (pj->ji_acctrec != NULL) {
-								tmp_acctrec = realloc(pj->ji_acctrec, strlen(pj->ji_acctrec) + strlen(log_buffer) + 2);
+								tmp_acctrec = malloc(strlen(pj->ji_acctrec) + strlen(log_buffer) + 2);
 								if (tmp_acctrec != NULL) {
 									sprintf(tmp_acctrec, "%s %s", pj->ji_acctrec, log_buffer);
+									free(pj->ji_acctrec);
 									pj->ji_acctrec = tmp_acctrec;
+								} else {
+									log_err(ENOMEM, __func__, "malloc failed for tmp_acctrec");
 								}
 							} else {
 								pj->ji_acctrec = strdup(log_buffer);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
A rare invalid memory read can occur in below code snippet of `node_down_requeue()` 
https://github.com/PBSPro/pbspro/blob/33345beab9f57c6caf98efe1dbb2a0e0b70413fa/src/server/node_manager.c#L716-L719
as seen in below valgrind out
```
Invalid read of size 1
at 0x4C318A2: strlen (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
by 0x6ADD8C3: vfprintf (in /lib64/libc-2.26.so)
by 0x6AFED40: vsprintf (in /lib64/libc-2.26.so)
by 0x6AE4763: sprintf (in /lib64/libc-2.26.so)
by 0x48B0A7: node_down_requeue (node_manager.c:718)
by 0x509F98: dispatch_task (work_task.c:142)
by 0x50A254: default_next_task (work_task.c:316)
by 0x463F72: next_task (pbsd_main.c:2377)
by 0x463F72: main (pbsd_main.c:2037)
Address 0xc6ec450 is 0 bytes inside a block of size 16 free'd Block was alloc'd at
at 0x4C308BF: realloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
by 0x48B083: node_down_requeue (node_manager.c:716)
by 0x509F98: dispatch_task (work_task.c:142)
by 0x50A254: default_next_task (work_task.c:316)
by 0x463F72: next_task (pbsd_main.c:2377)
by 0x463F72: main (pbsd_main.c:2037)
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
replaced `realloc()` with `malloc()`

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[SmokeTest.zip](https://github.com/PBSPro/pbspro/files/4025552/SmokeTest.zip)

Not able to successfully reproduce the valgrind logs for fix due to the random nature of `realloc()` actually reallocating.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
