### PR TITLE
WIP: Server hangs for slow client network

### DIFF
--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -305,10 +305,11 @@ struct batch_reply {
 #define PBS_credentialtype_none 0
 #define PBS_IFF_CLIENT_ADDR	"PBS_IFF_CLIENT_ADDR"
 
-/* time out values for tcp_dis read */
+/* time out values for tcp_dis read/write */
 
 #define PBS_DIS_TCP_TIMEOUT_CONNECT  10
-#define PBS_DIS_TCP_TIMEOUT_SHORT    30
+#define PBS_DIS_TCP_TIMEOUT_REPLY    10
+#define PBS_DIS_TCP_TIMEOUT_SHORT    5
 #define PBS_DIS_TCP_TIMEOUT_RERUN    45	/* timeout used in pbs_rerunjob() */
 #define PBS_DIS_TCP_TIMEOUT_LONG    600
 #define PBS_DIS_TCP_TIMEOUT_VLONG 10800

--- a/src/lib/Libifl/tcp_dis.c
+++ b/src/lib/Libifl/tcp_dis.c
@@ -89,6 +89,7 @@
 #include "pbs_gss.h"
 
 #define THE_BUF_SIZE 1024
+volatile int reply_timedout = 0; /* for reply_send.c -- was alarm handler called? */
 
 struct tcpdisbuf {
 	size_t	tdis_lead;
@@ -385,10 +386,18 @@ __DIS_tcp_wflush(int fd)
 			/* not ready in TIMEOUT_SHORT seconds, fail   */
 			/* redo the poll if EINTR		      */
 			do {
-				pollfds[0].fd = fd;
-				pollfds[0].events = POLLOUT;
-				pollfds[0].revents = 0;
-				j = poll(pollfds, 1, PBS_DIS_TCP_TIMEOUT_SHORT * 1000);
+				if (reply_timedout) {
+					/* caught alarm - timeout spanning several writes for one reply */
+					/* alarm set up in dis_reply_write() */
+					/* treat identically to poll timeout */
+					j = 0;
+					reply_timedout = 0;
+				} else {
+					pollfds[0].fd = fd;
+					pollfds[0].events = POLLOUT;
+					pollfds[0].revents = 0;
+					j = poll(pollfds, 1, PBS_DIS_TCP_TIMEOUT_SHORT * 1000);
+				}
 			} while ((j == -1) && (errno == EINTR));
 
 			if (j == 0) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

If a customer have a flaky network connection that can make server hang for indefinite time. That mean for one flaky network client can cause server to denial of service to all other users in the cluster. This may also result hook alarming out in the cluster depending on how long the server hangs. 

This problem can happen, when server response to any of the client commands, suppose qstat.
For bigger reply (suppose "qstat -sw" for 10K jobs) Server does a DIS_tcp_wflush() which internally tries to write on client socket. If it is unable to write a single byte (among many bytes) and the OS errno is EAGAIN, it then polls until the socket's state changes and POLLOUT is on, i.e. the socket is ready to accept more data. If the poll() doesn't return in 30 seconds, then only it will actually return an error. 
For an unreliable client network connection, we can end up in poll() for multiple times, enough for us to stuck here. In practice, on most OSes, it would be enough for the connection to accept either one MTU or one memory page per every 30 seconds and we would never finally decide that we have to bail out – that can be a bandwidth as low as 0.13KB/s.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Introduced new macro PBS_DIS_TCP_TIMEOUT_REPLY to consider overall reply timeout.
Reduced PBS_DIS_TCP_TIMEOUT_SHORT from 30 to 5

- Set an alarm for PBS_DIS_TCP_TIMEOUT_REPLY which will set the global volatile variable (reply_timedout) upon alarming in the corresponding handler (reply_alarm). 
- Set the alarm before __DIS_tcp_wflush in dis_reply_write()
- While flushing out the data if its taking more than the overall threshold time (it will alarm out) then set the DIS_Proto error no and abort the connection.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->

NA

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

To produce a flaky network connection which cause write failure (EAGAIN) is difficult. This part of the code changes need to be reviewed by code inspection.
Although have tested the code changes in harness.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
