### PR TITLE
Server hangs for slow client network

### DIFF
--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -305,9 +305,10 @@ struct batch_reply {
 #define PBS_credentialtype_none 0
 #define PBS_IFF_CLIENT_ADDR	"PBS_IFF_CLIENT_ADDR"
 
-/* time out values for tcp_dis read */
+/* time out values for tcp_dis read/write */
 
 #define PBS_DIS_TCP_TIMEOUT_CONNECT  10
+#define PBS_DIS_TCP_TIMEOUT_REPLY    10
 #define PBS_DIS_TCP_TIMEOUT_SHORT    30
 #define PBS_DIS_TCP_TIMEOUT_RERUN    45	/* timeout used in pbs_rerunjob() */
 #define PBS_DIS_TCP_TIMEOUT_LONG    600

--- a/src/server/reply_send.c
+++ b/src/server/reply_send.c
@@ -208,13 +208,13 @@ dis_reply_write(int sfds, struct batch_request *preq)
 		rc = encode_DIS_replyRPP(sfds, preq->rppcmd_msgid, preply);
 	} else {
 #ifndef WIN32
+		reply_timedout = 0;
 		/* set alarm to interrupt poll() etc. while flushing out data */
 		sigemptyset(&act.sa_mask);
 		act.sa_flags = 0;
 		act.sa_handler = reply_alarm;
 		if (sigaction(SIGALRM, &act, &oact) == -1)
 			return (PBS_NET_RC_RETRY);
-		reply_timedout = 0;
 		alarm(PBS_DIS_TCP_TIMEOUT_REPLY);
 		pbs_tcp_timeout = PBS_DIS_TCP_TIMEOUT_REPLY;
 #endif
@@ -234,7 +234,7 @@ dis_reply_write(int sfds, struct batch_request *preq)
 
 #ifndef WIN32
 	reply_timedout = 0; /* Resetting the value for next tcp connection */
-    if (!(preq->isrpp)) {
+	if (!(preq->isrpp)) {
         alarm(0);
         (void)sigaction(SIGALRM, &oact, NULL);  /* reset handler for SIGALRM */
     }

--- a/src/server/reply_send.c
+++ b/src/server/reply_send.c
@@ -60,6 +60,7 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/types.h>
+#include <signal.h>
 #include "libpbs.h"
 #include "dis.h"
 #include "log.h"
@@ -93,7 +94,9 @@ extern int pbs_tcp_errno;
 extern int rpp_flush(int index);
 
 void reply_free(struct batch_reply *prep);
-
+#ifndef WIN32
+extern volatile int reply_timedout; /* global to notify DIS routines reply took too long */
+#endif
 #define ERR_MSG_SIZE 256
 
 
@@ -161,6 +164,15 @@ set_err_msg(int code, char *msgbuf, size_t msglen)
 	}
 	msgbuf[msglen] = '\0';
 }
+#ifndef WIN32
+void
+reply_alarm(int sig)
+{
+    reply_timedout = 1;
+    log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_REQUEST, LOG_WARNING,
+              "dis_reply_write", "timeout attempting to send TCP reply");
+}
+#endif
 /**
  * @brief
  * 		reply is to be sent to a remote client
@@ -175,10 +187,25 @@ dis_reply_write(int sfds, struct batch_request *preq)
 {
 	int rc;
 	struct batch_reply *preply = &preq->rq_reply;
+#ifndef WIN32
+      struct sigaction act, oact;
+#endif
+
+	pbs_tcp_timeout = PBS_DIS_TCP_TIMEOUT_REPLY;
 
 	if (preq->isrpp) {
 		rc = encode_DIS_replyRPP(sfds, preq->rppcmd_msgid, preply);
 	} else {
+#ifndef WIN32
+		/* set alarm to interrupt poll() etc. while flushing out data */
+		sigemptyset(&act.sa_mask);
+		act.sa_flags = 0;
+		act.sa_handler = reply_alarm;
+		if (sigaction(SIGALRM, &act, &oact) == -1)
+			return (PBS_NET_RC_RETRY);
+		reply_timedout = 0;
+		alarm(PBS_DIS_TCP_TIMEOUT_REPLY);
+#endif
 		/*
 		 * clear pbs_tcp_errno - set on error in DIS_tcp_wflush when called
 		 * either in encode_DIS_reply() or directly below.
@@ -193,6 +220,13 @@ dis_reply_write(int sfds, struct batch_request *preq)
 		DIS_wflush(sfds, preq->isrpp);
 	}
 
+#ifndef WIN32
+	reply_timedout = 0; /* Resetting the value for next tcp connection */
+    if (!(preq->isrpp)) {
+        alarm(0);
+        (void)sigaction(SIGALRM, &oact, NULL);  /* reset handler for SIGALRM */
+    }
+#endif
 	if (rc) {
 		char hn[PBS_MAXHOSTNAME+1];
 

--- a/src/server/reply_send.c
+++ b/src/server/reply_send.c
@@ -188,9 +188,10 @@ dis_reply_write(int sfds, struct batch_request *preq)
 	int rc;
 	struct batch_reply *preply = &preq->rq_reply;
 #ifndef WIN32
-      struct sigaction act, oact;
+	struct sigaction act, oact;
 #endif
-
+	time_t  old_tcp_timeout;
+	old_tcp_timeout = pbs_tcp_timeout;
 	pbs_tcp_timeout = PBS_DIS_TCP_TIMEOUT_REPLY;
 
 	if (preq->isrpp) {
@@ -227,6 +228,7 @@ dis_reply_write(int sfds, struct batch_request *preq)
         (void)sigaction(SIGALRM, &oact, NULL);  /* reset handler for SIGALRM */
     }
 #endif
+	pbs_tcp_timeout = old_tcp_timeout;
 	if (rc) {
 		char hn[PBS_MAXHOSTNAME+1];
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

If the connectivity in a cluster is flaky then it is possible for one of the clients to hang the server indefinitely. It will result in denial of service by the server to other requested connections. This may also result hook alarming out in the cluster depending on how long the server hangs. 

Attached server stack trace [trace.txt](https://github.com/PBSPro/pbspro/files/4038884/stack.trace.of.server.daemon.txt)

In a flaky network, the above issue is observed when any of the client commands is issued to the server. 

For client commands like "qstat -sw 10K jobs"(where the response size could be huge), when server does a DIS_tcp_wflush() - It tries to write on client socket. If the server is unable to write a single byte and the OS errno is EAGAIN, it then polls until the client socket's state changes and POLLOUT is on, i.e. the client socket is ready to accept more data. If the poll() doesn't return in 30 seconds, then only server will actually return an error. 

The worst case could be that the server sends some data chunks and hangs for next 29 sec and again tries to send some data chunks and so on, which is the real cause mentioned above.

For an unreliable client network connection, the server can end up in polling multiple times, enough for it to get stuck here. In practice, on most OSes, it would be enough for the connection to accept either one MTU or one memory page per every 30 seconds and we would never finally decide that we have to bail out.



#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Introduced new macro PBS_DIS_TCP_TIMEOUT_REPLY to consider overall reply timeout.

- Set an alarm for PBS_DIS_TCP_TIMEOUT_REPLY which will set the global volatile variable (reply_timedout) upon alarming in the corresponding handler (reply_alarm). 
- Set the alarm before __DIS_tcp_wflush in dis_reply_write()
- While flushing out the data if its taking more than the overall threshold time (it will alarm out) then set the DIS_Proto error no and abort the connection.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->

NA

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

To produce a flaky network connection which cause write failure (EAGAIN) is difficult. This part of the code changes need to be reviewed by code inspection.
Although have tested the code changes in harness and for manual test logs for Windows is attached.

[Testlogs_server_win_client_mom.txt](https://github.com/PBSPro/pbspro/files/4038926/Testlogs_server_win_client_mom.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
