### PR TITLE
Passes user to create job script on remote and read job_output file from client

### DIFF
--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -74,14 +74,17 @@ class Test_passing_environment_variable_via_qsub(TestFunctional):
              'Resource_List.walltime': 10}
         script = ['#PBS -v "var1=\'A,B,C,D\'"']
         script += ['env | grep var1']
-        jid = self.create_and_submit_job(content=script)
+        jid = self.create_and_submit_job(user=TEST_USER, content=script)
         qstat = self.server.status(JOB, ATTR_o, id=jid)
         job_outfile = qstat[0][ATTR_o].split(':')[1]
 
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=10)
         job_output = ""
-        with open(job_outfile, 'r') as f:
-            job_output = f.read().strip()
+        runcmd = ['cat', job_outfile]
+        ret = self.du.run_cmd(self.server.client, runcmd,
+                              level=logging.INFOCLI, runas=TEST_USER,
+                              logerr=False)
+        job_output =(' '.join(map(str, ret['out']))).strip()
         self.assertEqual(job_output, "var1=A,B,C,D")
 
     def test_passing_shell_function(self):
@@ -115,13 +118,16 @@ exit 0
         script += ['env | grep -A 3 foo\n']
         script += ['foo\n']
         # Submit a job without hooks in the system
-        jid = self.create_and_submit_job(content=script)
+        jid = self.create_and_submit_job(user=TEST_USER, content=script)
         qstat = self.server.status(JOB, ATTR_o, id=jid)
         job_outfile = qstat[0][ATTR_o].split(':')[1]
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=2)
         job_output = ""
-        with open(job_outfile, 'r') as f:
-            job_output = f.read().strip()
+        runcmd = ['cat', job_outfile]
+        ret = self.du.run_cmd(self.server.client, runcmd,
+                              level=logging.INFOCLI, runas=TEST_USER,
+                              logerr=False)
+        job_output =(' '.join(map(str, ret['out']))).strip()
         match = n + \
             '=() {  if [ /bin/true ]; then\n echo hello;\n fi\n}\nhello'
         self.assertEqual(job_output, match,

--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -83,7 +83,7 @@ class Test_passing_environment_variable_via_qsub(TestFunctional):
         job_output = ""
         ret = self.du.cat(self.server.client, filename=job_outfile,
                           runas=TEST_USER, logerr=False)
-        job_output = (' '.join(map(str, ret['out']))).strip()
+        job_output = (' '.join(ret['out'])).strip()
         self.assertEqual(job_output, "var1=A,B,C,D")
 
     def test_passing_shell_function(self):
@@ -124,7 +124,7 @@ exit 0
         job_output = ""
         ret = self.du.cat(self.server.client, filename=job_outfile,
                           runas=TEST_USER, logerr=False)
-        job_output = (' '.join(map(str, ret['out']))).strip()
+        job_output = (' '.join(ret['out'])).strip()
         match = n + \
             '=() {  if [ /bin/true ]; then\n echo hello;\n fi\n}\nhello'
         self.assertEqual(job_output, match,

--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -42,6 +42,7 @@ class Test_passing_environment_variable_via_qsub(TestFunctional):
     """
     Test to check passing environment variables via qsub
     """
+
     def create_and_submit_job(self, user=None, attribs=None, content=None,
                               content_interactive=None, preserve_env=False):
         """
@@ -80,11 +81,9 @@ class Test_passing_environment_variable_via_qsub(TestFunctional):
 
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=10)
         job_output = ""
-        runcmd = ['cat', job_outfile]
-        ret = self.du.run_cmd(self.server.client, runcmd,
-                              level=logging.INFOCLI, runas=TEST_USER,
-                              logerr=False)
-        job_output =(' '.join(map(str, ret['out']))).strip()
+        ret = self.du.cat(self.server.client, filename=job_outfile,
+                          runas=TEST_USER, logerr=False)
+        job_output = (' '.join(map(str, ret['out']))).strip()
         self.assertEqual(job_output, "var1=A,B,C,D")
 
     def test_passing_shell_function(self):
@@ -123,11 +122,9 @@ exit 0
         job_outfile = qstat[0][ATTR_o].split(':')[1]
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=2)
         job_output = ""
-        runcmd = ['cat', job_outfile]
-        ret = self.du.run_cmd(self.server.client, runcmd,
-                              level=logging.INFOCLI, runas=TEST_USER,
-                              logerr=False)
-        job_output =(' '.join(map(str, ret['out']))).strip()
+        ret = self.du.cat(self.server.client, filename=job_outfile,
+                          runas=TEST_USER, logerr=False)
+        job_output = (' '.join(map(str, ret['out']))).strip()
         match = n + \
             '=() {  if [ /bin/true ]; then\n echo hello;\n fi\n}\nhello'
         self.assertEqual(job_output, match,
@@ -145,7 +142,7 @@ exit 0
         j = Job(self.du.get_current_user())
         jid = self.server.submit(j)
         self.server.expect(JOB, {'Variable_List': (MATCH_RE,
-                           'SET_IN_SUBMISSION=true')},
+                                                   'SET_IN_SUBMISSION=true')},
                            id=jid)
 
     def test_option_V_cmdline(self):
@@ -160,7 +157,7 @@ exit 0
         j = Job(self.du.get_current_user(), attrs=a)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'Variable_List': (MATCH_RE,
-                           'SET_IN_SUBMISSION=true')},
+                                                   'SET_IN_SUBMISSION=true')},
                            id=jid)
 
     def test_option_V_dfltqsubargs_qsub_daemon(self):
@@ -178,8 +175,8 @@ exit 0
         j1 = Job(self.du.get_current_user())
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {'Variable_List': (MATCH_RE,
-                           'SET_IN_SUBMISSION=true')},
+                                                   'SET_IN_SUBMISSION=true')},
                            id=jid)
         self.server.expect(JOB, {'Variable_List': (MATCH_RE,
-                           'SET_IN_SUBMISSION=false')},
+                                                   'SET_IN_SUBMISSION=false')},
                            id=jid1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Job output file is not on the server. Read it from client.
We should use a user to create job script on remote.


#### Describe Your Change
Passes test_user as a user to create a job script on remote and read job output file on client by using client hostname and job submitting user.


#### Link to Design Doc



#### Attach Test and Valgrind Logs/Output
[enviroment_variable (1).txt](https://github.com/PBSPro/pbspro/files/4084519/enviroment_variable.1.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
