### PR TITLE
Make is failing in ci

### DIFF
--- a/ci/do.sh
+++ b/ci/do.sh
@@ -114,7 +114,11 @@ if [ "x${ONLY_REBUILD}" != "x1" -a "x${ONLY_INSTALL}" != "x1" -a "x${ONLY_TEST}"
     else
       configure_opt='--prefix=/opt/pbs --enable-ptl'
     fi
-    ../configure CFLAGS="${_cflags}" ${configure_opt}
+    if [ -z ${_cflags} ]; then
+      ../configure ${configure_opt}
+    else
+      ../configure CFLAGS="${_cflags}" ${configure_opt}
+    fi
     if [ "x${ONLY_CONFIGURE}" == "x1" ];then
       exit 0
     fi


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The command ./ci --make fails when configured with default configure parameters "--prefix=/opt/pbs --enable-ptl"


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Passing empty CFLAGS parameter while calling configure was causing this failure to occour.
* added a check where this parameter is not invoked when the _cflags variable is empty

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [instance where make fails (before fix)](https://github.com/PBSPro/pbspro/files/4069426/fail.txt)
* [instance where make passes (after fix)](https://github.com/PBSPro/pbspro/files/4069427/pass.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
