### PR TITLE
Fix expect in perf test

### DIFF
--- a/test/tests/performance/pbs_sched_perf.py
+++ b/test/tests/performance/pbs_sched_perf.py
@@ -163,31 +163,36 @@ class TestSchedPerf(TestPerformance):
         self.compare_normal_path_to_buckets('free', num_jobs)
 
     @timeout(3600)
-    def test_run_many_jobs(self):
+    def test_run_many_normal_jobs(self):
         """
-        Submit many jobs and time the cycle that runs all of them.
+        Submit many normal path jobs and time the cycle that runs all of them.
         """
         num_jobs = 10000
         a = {'Resource_List.select': '1:ncpus=1'}
-        jids = self.submit_jobs(a, num_jobs, wt_start=1000)
+        jids = self.submit_jobs(a, num_jobs, wt_start=10000)
         t = self.run_cycle()
-        self.server.expect(JOB, {'job_state=R': num_jobs})
+        self.server.expect(JOB, {'job_state=R': num_jobs},
+                           trigger_sched_cycle=False, interval=5,
+                           max_attempts=240)
         self.logger.info('#' * 80)
         m = 'Time taken in cycle to run %d normal jobs: %.2f' % (num_jobs, t)
         self.logger.info(m)
         self.logger.info('#' * 80)
 
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
-
-        for j in jids:
-            self.server.rerunjob(j)
-            self.server.alterjob(j, {'Resource_List.place': 'excl'})
-
-        self.server.expect(JOB, {'state=Q': num_jobs})
-
+    @timeout(3600)
+    def test_run_many_bucket_jobs(self):
+        """
+        Submit many bucket path jobs and time the cycle that runs all of them.
+        """
+        num_jobs = 10000
+        a = {'Resource_List.select': '1:ncpus=1',
+             'Resource_List.place': 'excl'}
+        self.submit_jobs(a, num_jobs, wt_start=10000)
         t = self.run_cycle()
 
-        self.server.expect(JOB, {'job_state=R': num_jobs})
+        self.server.expect(JOB, {'job_state=R': num_jobs},
+                           trigger_sched_cycle=False, interval=5,
+                           max_attempts=240)
         self.logger.info('#' * 80)
         m = 'Time taken in cycle to run %d bucket jobs: %.2f' % (num_jobs, t)
         self.logger.info(m)
@@ -214,9 +219,10 @@ class TestSchedPerf(TestPerformance):
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
-        self.server.expect(SERVER, {'server_state': (NE, 'Scheduling')})
 
-        self.server.expect(JOB, {'job_state=R': 1430})
+        self.server.expect(JOB, {'job_state=R': 1430},
+                           trigger_sched_cycle=False, interval=5,
+                           max_attempts=240)
 
         a = {'Resource_List.select': '10000:ncpus=1'}
         tj = Job(TEST_USER, attrs=a)
@@ -224,8 +230,6 @@ class TestSchedPerf(TestPerformance):
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
-        self.server.expect(SERVER, {'server_state': (NE, 'Scheduling')},
-                           interval=5, max_attempts=240)
 
         cycle1 = self.scheduler.cycles(lastN=1)[0]
         cycle1_time = cycle1.end - cycle1.start
@@ -235,8 +239,6 @@ class TestSchedPerf(TestPerformance):
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
-        self.server.expect(SERVER, {'server_state': (NE, 'Scheduling')},
-                           interval=5, max_attempts=240)
 
         cycle2 = self.scheduler.cycles(lastN=1)[0]
         cycle2_time = cycle2.end - cycle2.start


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The bug can be caused in expect() where it checks the number of jobs in running state. expect() by default has max_attempts=60 and triggers scheduling cycle after every attempt

These tests look at cycle time after setting scheduling to false. Also default attempts in expect is 60 which might be less than number required for all jobs to go into running state. Therefore adding trigger_sched_cycle=False and max_attempts=240 to expect

Also divided _test_run_many_jobs_ into two tests _test_run_many_normal_jobs_ , _test_run_many_bucket_jobs_ -  so that it takes less time to run the tests and the test does not time out.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_run_many_bucket_jobs.txt](https://github.com/PBSPro/pbspro/files/4073929/test_run_many_bucket_jobs.txt)
[test_run_many_normal_jobs.txt](https://github.com/PBSPro/pbspro/files/4073931/test_run_many_normal_jobs.txt)
[test_pset_fuzzy_perf.txt](https://github.com/PBSPro/pbspro/files/4073932/test_pset_fuzzy_perf.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
