### PR TITLE
failed pbs_ralter can oversubscribe nodes

### DIFF
--- a/src/scheduler/resv_info.h
+++ b/src/scheduler/resv_info.h
@@ -111,7 +111,7 @@ node_info **create_resv_nodes(nspec **nspec_arr, server_info *sinfo);
  *	adjust_alter_resv_nodes - adjust nodes resources for reservations that
  *				  that are being altered.
  */
-void adjust_alter_resv_nodes(resource_resv **all_resvs, node_info **all_nodes);
+void adjust_alter_resv_nodes(resource_resv *resv, node_info **all_nodes);
 
 /* Will we try and confirm this reservation in this cycle */
 int will_confirm(resource_resv *resv, time_t server_time);

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -451,8 +451,6 @@ query_server(status *pol, int pbs_sd)
 	}
 	sinfo->unordered_nodes[i] = NULL;
 
-	adjust_alter_resv_nodes(sinfo->resvs, sinfo->nodes);
-
 	/* Create placement sets  after collecting jobs on nodes because
 	 * we don't want to account for resources consumed by ghost jobs
 	 */


### PR DESCRIPTION

#### Describe Bug or Feature
If an alter request comes in for a running reservation and the alter request is rejected, the reservation's nodes can be oversubscribed.

#### Describe Your Change
For alter requests for running reservations, the scheduler will free the reservation nodes so it can allocate them back to the reservation with the new time.  If the alter request fails, the scheduler will continue on to do a normal cycle.  The nodes are still freed, so jobs can be run on those nodes.  Since the reservation is still running, the nodes will be oversubscribed.

To confirm a reservation, the scheduler will create a scratch PBS universe.  This is then modified to see if a reservation can be confirmed.  The fix is to move where the nodes are freed to the scratch universe instead of the real one.  The scratch universe is freed after attempting to reconfirm the reservation.

#### Attach Test and Valgrind Logs/Output
This is a really esoteric bug, so creating an automated test is not going to provide benefit over the long run.  I manually tested the bug.  I reproduced it in master and saw it fixed in my branch.