### PR TITLE
In test "test_set_as_non_admin" Hostname is not required to match error message

### DIFF
--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -391,8 +391,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         host_name = str(self.server.hostname)
         self.server.create_hook(hook_name, attrs={'enabled': "False"})
         attrs = {'event': "periodic", 'freq': '120'}
-        match_str1 = "unauthorized to access hooks data from server " + \
-            host_name
+        match_str1 = "unauthorized to access hooks data from server"
         try:
             self.server.manager(MGR_CMD_SET, HOOK, attrs, hook_name,
                                 runas=TEST_USER1)

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -391,8 +391,8 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         host_name = str(self.server.hostname)
         self.server.create_hook(hook_name, attrs={'enabled': "False"})
         attrs = {'event': "periodic", 'freq': '120'}
-        match_str1 = str(TEST_USER1) + "@" + host_name + \
-            " is unauthorized to access hooks data from server " + host_name
+        match_str1 = "unauthorized to access hooks data from server " + \
+            host_name
         try:
             self.server.manager(MGR_CMD_SET, HOOK, attrs, hook_name,
                                 runas=TEST_USER1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
 Hostname is not required to match error message because test purpose is, can a hook be set by non admin user or not?.

#### Describe Your Change
 Removed the hostname from error message string.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[non_admin_user.txt](https://github.com/PBSPro/pbspro/files/4095917/non_admin_user.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
