### PR TITLE
Tests of "TestJobTask" are failing during regression due to permission issue while checking job's output file

### DIFF
--- a/test/tests/functional/pbs_job_task.py
+++ b/test/tests/functional/pbs_job_task.py
@@ -50,7 +50,6 @@ class TestJobTask(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER,
                             {'job_history_enable': 'true'})
 
-
     def check_jobs_file(self, out_file):
         """
         This function validates job's output file
@@ -72,7 +71,7 @@ class TestJobTask(TestFunctional):
         a = {ATTR_S: '/bin/bash'}
         job = Job(TEST_USER, attrs=a)
         pbsdsh_cmd = os.path.join(self.server.pbs_conf['PBS_EXEC'],
-                                      'bin', 'pbsdsh')
+                                  'bin', 'pbsdsh')
         script = ['%s echo "OK"' % pbsdsh_cmd]
         job.create_script(body=script)
         jid = self.server.submit(job)
@@ -91,7 +90,7 @@ class TestJobTask(TestFunctional):
         a = {ATTR_S: '/bin/bash'}
         job = Job(TEST_USER, attrs=a)
         pbstmrsh_cmd = os.path.join(self.server.pbs_conf['PBS_EXEC'],
-                                      'bin', 'pbs_tmrsh')
+                                    'bin', 'pbs_tmrsh')
         script = ['%s $(hostname -f) echo "OK"' % pbstmrsh_cmd]
         job.create_script(body=script)
         jid = self.server.submit(job)

--- a/test/tests/functional/pbs_job_task.py
+++ b/test/tests/functional/pbs_job_task.py
@@ -69,9 +69,9 @@ class TestJobTask(TestFunctional):
         ret = self.du.cat(hostname=self.mom.shortname,
                           filename=job_output_file,
                           runas=TEST_USER)
-        _msg = "cat command failed with error:%s" % ret['err']
+        _msg = "cat command failed with error: %s" % ret['err']
         self.assertEqual(ret['rc'], 0, _msg)
-        _msg = 'Job\'s error file has error:"%s"' % ret['out']
+        _msg = 'Job\'s error file has error: "%s"' % ret['out']
         self.assertEqual(ret['out'][0], "OK", _msg)
         self.logger.info("Job has executed without any error")
 
@@ -95,8 +95,8 @@ class TestJobTask(TestFunctional):
         ret = self.du.cat(hostname=self.mom.shortname,
                           filename=job_output_file,
                           runas=TEST_USER)
-        _msg = "cat command failed with error:%s" % ret['err']
+        _msg = "cat command failed with error: %s" % ret['err']
         self.assertEqual(ret['rc'], 0, _msg)
-        _msg = 'Job\'s error file has error:"%s"' % ret['out']
+        _msg = 'Job\'s error file has error: "%s"' % ret['out']
         self.assertEqual(ret['out'][0], "OK", _msg)
         self.logger.info("Job has executed without any error")

--- a/test/tests/functional/pbs_job_task.py
+++ b/test/tests/functional/pbs_job_task.py
@@ -55,31 +55,33 @@ class TestJobTask(TestFunctional):
         This test case validates that task started by pbsdsh runs
         properly within a single-noded job.
         """
-
-        job = Job(TEST_USER)
+        a = {ATTR_S: '/bin/bash'}
+        job = Job(TEST_USER, attrs=a)
         script = ['pbsdsh echo "OK"']
         job.create_script(body=script)
         jid = self.server.submit(job)
-
         self.server.expect(JOB, {'job_state': 'F'}, id=jid, extend='x')
 
         job_status = self.server.status(JOB, id=jid, extend='x')
         if job_status:
             job_output_file = job_status[0]['Output_Path'].split(':')[1]
 
-        with open(job_output_file, 'r') as fd:
-            job_out = fd.read().strip()
-            self.logger.info("job_out=%s" % (job_out,))
-
-        self.assertEqual(job_out, "OK")
+        ret = self.du.cat(hostname=self.mom.shortname,
+                          filename=job_output_file,
+                          runas=TEST_USER)
+        _msg = "cat command failed with error:%s" % ret['err']
+        self.assertEqual(ret['rc'], 0, _msg)
+        _msg = 'Job\'s error file has error:"%s"' % ret['out']
+        self.assertEqual(ret['out'][0], "OK", _msg)
+        self.logger.info("Job has executed without any error")
 
     def test_singlenode_pbs_tmrsh(self):
         """
         This test case validates that task started by pbs_tmrsh runs
         properly within a single-noded job.
         """
-
-        job = Job(TEST_USER)
+        a = {ATTR_S: '/bin/bash'}
+        job = Job(TEST_USER, attrs=a)
         script = ['pbs_tmrsh $(hostname -f) echo "OK"']
         job.create_script(body=script)
         jid = self.server.submit(job)
@@ -90,8 +92,11 @@ class TestJobTask(TestFunctional):
         if job_status:
             job_output_file = job_status[0]['Output_Path'].split(':')[1]
 
-        with open(job_output_file, 'r') as fd:
-            job_out = fd.read().strip()
-            self.logger.info("job_out=%s" % (job_out,))
-
-        self.assertEqual(job_out, "OK")
+        ret = self.du.cat(hostname=self.mom.shortname,
+                          filename=job_output_file,
+                          runas=TEST_USER)
+        _msg = "cat command failed with error:%s" % ret['err']
+        self.assertEqual(ret['rc'], 0, _msg)
+        _msg = 'Job\'s error file has error:"%s"' % ret['out']
+        self.assertEqual(ret['out'][0], "OK", _msg)
+        self.logger.info("Job has executed without any error")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Tests of "TestJobTask" are failing during regression due to permission issue while checking job's output file

#### Describe Your Change
Instead of opening the file and reading, read the contents of the job's output file using cat command. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [test_singlenode_pbs_tmrsh`_bfr_fix.txt](https://github.com/PBSPro/pbspro/files/4103392/test_singlenode_pbs_tmrsh._bfr_fix.txt)

- [test_singlenode_pbsdsh_bfr_fix.txt](https://github.com/PBSPro/pbspro/files/4103393/test_singlenode_pbsdsh_bfr_fix.txt)

- [Execution_logs_TestJobTask_after_fix.txt](https://github.com/PBSPro/pbspro/files/4103643/Execution_logs_TestJobTask_after_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
