### PR TITLE
Fix standing reservation occurences not releasing resources

### DIFF
--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -1512,7 +1512,7 @@ check_block_wt(struct work_task *ptask)
 		/* Set socket to Non-blocking */
 		sock_flags = fcntl(blockj->fd, F_GETFL, 0);
 		if (fcntl(blockj->fd, F_SETFL, sock_flags | O_NONBLOCK) == -1) {
-			sprintf(log_buffer, "Failed to set non-blocking flag on socket for job %s", 
+			sprintf(log_buffer, "Failed to set non-blocking flag on socket for job %s",
 			blockj->jobid);
 			goto err;
 		}
@@ -1584,7 +1584,7 @@ retry:
 		set_task(WORK_Timed, time_now + 10, check_block_wt, blockj);
 		return;
 	} else {
-		sprintf(log_buffer, "Unable to reply to client %s for job %s", 
+		sprintf(log_buffer, "Unable to reply to client %s for job %s",
 		blockj->client, blockj->jobid);
 	}
 err:
@@ -1594,7 +1594,7 @@ err:
 	}
 	log_err(-1, __func__, log_buffer);
 end:
-	if (blockj->fd != -1) 
+	if (blockj->fd != -1)
 		close(blockj->fd);
 	free(blockj->msg);
 	free(blockj);
@@ -1613,7 +1613,7 @@ check_block(job *pjob, char *message)
 	int			port;
 	char			*phost;
 	char			*jobid = pjob->ji_qs.ji_jobid;
-	struct 			block_job_reply *blockj; 
+	struct 			block_job_reply *blockj;
 
 	if ((pjob->ji_wattr[(int)JOB_ATR_block].at_flags & ATR_VFLAG_SET) == 0)
 		return;
@@ -1658,7 +1658,7 @@ check_block(job *pjob, char *message)
 	blockj->fd = -1;
 	blockj->reply_time = time(NULL);
 	blockj->exitstat = pjob->ji_qs.ji_un.ji_exect.ji_exitstat;
-	strcpy(blockj->jobid, pjob->ji_qs.ji_jobid);	
+	strcpy(blockj->jobid, pjob->ji_qs.ji_jobid);
 
 	set_task(WORK_Immed, 0, check_block_wt, blockj);
 	return;
@@ -3396,6 +3396,11 @@ Time4occurrenceFinish(resc_resv *presv)
 	free(short_xc);
 	free(execvnodes);
 	free_execvnode_seq(tofree);
+
+	/* Set reservation state to finished. Will re-evaluate
+	 * the state for the next occurrence later in the function.
+	 */
+	resv_setResvState(presv, RESV_FINISHED, RESV_FINISHED);
 
 	/* Decrement resources assigned */
 	if (presv->ri_giveback == 1) {

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -1938,3 +1938,42 @@ class TestReservations(TestFunctional):
         self.server.expect(JOB, 'queue', op=UNSET, id=jid)
         self.server.expect(JOB, {'job_state=F': 6}, count=True,
                            extend='xt', id=jid)
+
+    def test_standing_resv_resc_used(self):
+        """
+        Test that resources are released from the server when a
+        standing reservation's occurrence finishes
+        """
+
+        self.server.expect(SERVER, {'resources_assigned.ncpus': 0})
+        now = int(time.time())
+
+        # submitting 25 seconds from now to allow some of the older testbed
+        # systems time to process (discovered empirically)
+        rid = self.submit_reservation(user=TEST_USER,
+                                               select='1:ncpus=1',
+                                               rrule='FREQ=MINUTELY;COUNT=2',
+                                               start=now + 25,
+                                               end=now + 35)
+
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+        self.server.expect(SERVER, {'resources_assigned.ncpus': 0})
+
+        offset = now + 25 - int(time.time())
+        a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, a, id=rid, offset=offset, interval=1)
+        self.server.expect(SERVER, {'resources_assigned.ncpus': 1})
+
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid, offset=10, interval=1)
+        self.server.expect(SERVER, {'resources_assigned.ncpus': 0})
+
+        offset = now + 85 - int(time.time())
+        a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, a, id=rid, offset=offset, interval=1)
+        self.server.expect(SERVER, {'resources_assigned.ncpus': 1})
+
+        self.server.expect(RESV, 'queue', op=UNSET, id=rid, offset=10)
+        self.server.expect(SERVER, {'resources_assigned.ncpus': 0})
+

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -1951,10 +1951,10 @@ class TestReservations(TestFunctional):
         # submitting 25 seconds from now to allow some of the older testbed
         # systems time to process (discovered empirically)
         rid = self.submit_reservation(user=TEST_USER,
-                                               select='1:ncpus=1',
-                                               rrule='FREQ=MINUTELY;COUNT=2',
-                                               start=now + 25,
-                                               end=now + 35)
+                                      select='1:ncpus=1',
+                                      rrule='FREQ=MINUTELY;COUNT=2',
+                                      start=now + 25,
+                                      end=now + 35)
 
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
         self.server.expect(RESV, a, id=rid)
@@ -1976,4 +1976,3 @@ class TestReservations(TestFunctional):
 
         self.server.expect(RESV, 'queue', op=UNSET, id=rid, offset=10)
         self.server.expect(SERVER, {'resources_assigned.ncpus': 0})
-


### PR DESCRIPTION
#### Describe Bug or Feature
For standing reservations values of resources_assigned in server in not released when occurrence finishes

pbs_rsub -l select=1:ncpus=2 -R 201911181523 -D 59 -r "FREQ=MINUTELY;COUNT=3"
The value of resources_assigned.ncpus keeps on incrementing,  and at the end of three reservations is set to 6

#### Describe Your Change
Time4occurrenceFinish is called when a standing reservation occurrence ends




#### Attach Test and Valgrind Logs/Output
[after-fix.txt](https://github.com/PBSPro/pbspro/files/4124718/after-fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
