### PR TITLE
TestQstat.test_qstat_pt test using hostname instead of shortname whie setting node attrs

### DIFF
--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -49,7 +49,7 @@ class TestQstat(TestFunctional):
         """
 
         attr = {'resources_available.ncpus': 1}
-        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.hostname)
+        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.shortname)
 
         job_count = 10
         j = Job(TEST_USER)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In test case TestQstat.test_qstat_pt, ncpus on node is set using mom's hostname(Domain name) instead of shortname:

self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.hostname)

Change self.mom.hostname->self.mom.shortname

self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.shortname)

#### Attach Test Logs
[test_qstat_pt test_after_fix.txt](https://github.com/PBSPro/pbspro/files/4116692/test_qstat_pt.test_after_fix.txt)
[test_qstat_pt test_before_fix.txt](https://github.com/PBSPro/pbspro/files/4116695/test_qstat_pt.test_before_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
