### PR TITLE
TestSchedAllPart.test_vscatter2 is failing due to Job's comment not found

### DIFF
--- a/test/tests/functional/pbs_allpart.py
+++ b/test/tests/functional/pbs_allpart.py
@@ -96,7 +96,8 @@ class TestSchedAllPart(TestFunctional):
              'Resource_List.place': 'vscatter'}
         j = Job(TEST_USER, a)
         jid = self.server.submit(j)
-
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+        
         a = {'job_state': 'Q', 'comment':
              'Can Never Run: Not enough total nodes available'}
         self.server.expect(JOB, a, id=jid)

--- a/test/tests/functional/pbs_allpart.py
+++ b/test/tests/functional/pbs_allpart.py
@@ -97,7 +97,7 @@ class TestSchedAllPart(TestFunctional):
         j = Job(TEST_USER, a)
         jid = self.server.submit(j)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        
+
         a = {'job_state': 'Q', 'comment':
              'Can Never Run: Not enough total nodes available'}
         self.server.expect(JOB, a, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestSchedAllPart.test_vscatter2 test case is failing due to Job's comment not found.
In test case, initially setting scheduling to "False" and submitting the job. Due to which there is no comment for Job not running.

#### Describe Your Change
Trigger the scheduling cycle after submitting the job.

#### Attach Test Logs
[test_vscatter2_after_fix.txt](https://github.com/PBSPro/pbspro/files/4116798/test_vscatter2_after_fix.txt)
[test_vscatter2_before_fix.txt](https://github.com/PBSPro/pbspro/files/4116799/test_vscatter2_before_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
