### PR TITLE
Fix test_res_set_timeout race condition

### DIFF
--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -556,6 +556,9 @@ class TestServerDynRes(TestFunctional):
         Test setting server_dyn_res script to timeout after 10 seconds
         """
 
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {ATTR_sched_server_dyn_res_alarm: 10})
+
         # Create a resource of type boolean
         resname = ["foo"]
         restype = ["boolean"]
@@ -564,9 +567,6 @@ class TestServerDynRes(TestFunctional):
         resval = ["sleep 20\necho true"]
 
         filenames = self.setup_dyn_res(resname, restype, resval)
-
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {ATTR_sched_server_dyn_res_alarm: 10})
 
         # Submit job
         a = {'Resource_List.foo': 'true'}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test_res_set_timeout has a race condition.
The scheduler restarts after adding the server dyn res script, causing a scheduling cycle. Then we set the sched attribute, but the scheduler has already queried the sched attrs at the beginning of the cycle. The script does not timeout, the resource is set, and the jobs are then queried. Since the job has been submitted, the scheduler runs the job. This should not happen.


#### Describe Your Change
Move manager call earlier. The scheduler will now timeout on the first scheduling cycle.



#### Attach Test and Valgrind Logs/Output
[uv-afterfix.txt](https://github.com/PBSPro/pbspro/files/4120260/uv-afterfix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
