### PR TITLE
Write a different log message if ji_hosts isn't set yet

### DIFF
--- a/src/resmom/stage_func.c
+++ b/src/resmom/stage_func.c
@@ -64,7 +64,6 @@
 #include "batch_request.h"
 #include "pbs_nodes.h"
 #include "mom_func.h"
-#include "log.h"
 /**
  * @file	stage_func.c
  */

--- a/src/resmom/stage_func.c
+++ b/src/resmom/stage_func.c
@@ -483,7 +483,8 @@ is_direct_write(job *pjob, enum job_file which, char *path, int *direct_write_po
 	if (local_or_remote(&p) == 1) {
 		*direct_write_possible = 0;
 		if (pjob->ji_hosts != NULL) {
-			sprintf(log_buffer,
+			log_eventf(PBSEVENT_DEBUG3,
+				PBS_EVENTCLASS_JOB, LOG_DEBUG, pjob->ji_qs.ji_jobid,
 				"Direct write is requested for job: %s, but the destination: %s is not usecp-able from %s",
 				pjob->ji_qs.ji_jobid, p,
 				pjob->ji_hosts[pjob->ji_nodeid].hn_host);
@@ -492,8 +493,9 @@ is_direct_write(job *pjob, enum job_file which, char *path, int *direct_write_po
 			 * information is not available when this function is
 			 * called as part of req_mvjobfile
 			 */
-			sprintf(log_buffer, "Direct write is requested for "
-				"job: %s, but the destination %s is not usecp-able",
+			log_eventf(PBSEVENT_DEBUG3,
+				PBS_EVENTCLASS_JOB, LOG_DEBUG, pjob->ji_qs.ji_jobid,
+				"Direct write is requested for job: %s, but the destination: %s is not usecp-able",
 				pjob->ji_qs.ji_jobid, p);
 		}
 		log_event(PBSEVENT_DEBUG3,

--- a/src/resmom/stage_func.c
+++ b/src/resmom/stage_func.c
@@ -482,10 +482,20 @@ is_direct_write(job *pjob, enum job_file which, char *path, int *direct_write_po
 
 	if (local_or_remote(&p) == 1) {
 		*direct_write_possible = 0;
-		sprintf(log_buffer,
+		if (pjob->ji_hosts != NULL) {
+			sprintf(log_buffer,
 				"Direct write is requested for job: %s, but the destination: %s is not usecp-able from %s",
 				pjob->ji_qs.ji_jobid, p,
 				pjob->ji_hosts[pjob->ji_nodeid].hn_host);
+		} else {
+			/* When a job is requeued and later run, the ji_hosts
+			 * information is not available when this function is
+			 * called as part of req_mvjobfile
+			 */
+			sprintf(log_buffer, "Direct write is requested for "
+				"job: %s, but the destination %s is not usecp-able",
+				pjob->ji_qs.ji_jobid, p);
+		}
 		log_event(PBSEVENT_DEBUG3,
 		PBS_EVENTCLASS_JOB, LOG_DEBUG, pjob->ji_qs.ji_jobid, log_buffer);
 		return (0);

--- a/src/resmom/stage_func.c
+++ b/src/resmom/stage_func.c
@@ -64,6 +64,7 @@
 #include "batch_request.h"
 #include "pbs_nodes.h"
 #include "mom_func.h"
+#include "log.h"
 /**
  * @file	stage_func.c
  */
@@ -498,8 +499,6 @@ is_direct_write(job *pjob, enum job_file which, char *path, int *direct_write_po
 				"Direct write is requested for job: %s, but the destination: %s is not usecp-able",
 				pjob->ji_qs.ji_jobid, p);
 		}
-		log_event(PBSEVENT_DEBUG3,
-		PBS_EVENTCLASS_JOB, LOG_DEBUG, pjob->ji_qs.ji_jobid, log_buffer);
 		return (0);
 	}
 


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Mom crashes when trying to rerun a direct write job because a log message was dereferencing information that wasn't yet set.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I added a check to see if the information was not NULL before trying to put it in a log message.  If the information was NULL, I added code to print out a different log message that didn't need the information.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[withfix.txt](https://github.com/PBSPro/pbspro/files/4124721/withfix.txt)
[problem.txt](https://github.com/PBSPro/pbspro/files/4124722/problem.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
