### PR TITLE
Add decorator '@skipOnCpuset' to test suites which are not supported on cpuset machine

### DIFF
--- a/test/tests/functional/pbs_calendaring.py
+++ b/test/tests/functional/pbs_calendaring.py
@@ -45,6 +45,7 @@ class TestCalendaring(TestFunctional):
     This test suite tests if PBS scheduler calendars events correctly
     """
 
+    @skipOnCpuSet
     def test_topjob_start_time(self):
         """
         In this test we test that the top job which gets added to the
@@ -102,6 +103,7 @@ class TestCalendaring(TestFunctional):
         # Third subjob should set estimated.start_time in future.
         self.assertGreater(est_epoch1, time_now)
 
+    @skipOnCpuSet
     def test_topjob_start_time_of_subjob(self):
         """
         In this test we test that the subjob which gets added to the
@@ -138,6 +140,7 @@ class TestCalendaring(TestFunctional):
         errmsg = jid + ";Error in calculation of start time of top job"
         self.scheduler.log_match(errmsg, existence=False, max_attempts=10)
 
+    @skipOnCpuSet
     def test_topjob_fail(self):
         """
         Test that when we fail to add a job to the calendar it doesn't

--- a/test/tests/functional/pbs_eligible_time.py
+++ b/test/tests/functional/pbs_eligible_time.py
@@ -73,6 +73,7 @@ class TestEligibleTime(TestFunctional):
         # lag on some slow systems, add a little leeway.
         self.server.expect(JOB, {'eligible_time': 10}, op=LT)
 
+    @skipOnCpuSet
     def test_job_array(self):
         """
         Test that a job array switches from accruing eligible time
@@ -151,6 +152,7 @@ class TestEligibleTime(TestFunctional):
             else:
                 raise PtlLogMatchError(rc=1, rv=False, msg=e.msg)
 
+    @skipOnCpuSet
     def test_after_depend(self):
         """
         Make sure jobs accrue eligible time (or not) approprately with an

--- a/test/tests/functional/pbs_equiv_classes.py
+++ b/test/tests/functional/pbs_equiv_classes.py
@@ -67,6 +67,7 @@ class TestEquivClass(TestFunctional):
 
         return ret_jids
 
+    @skipOnCpuSet
     def test_basic(self):
         """
         Test the basic behavior of job equivalence classes: submit two
@@ -91,6 +92,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_select(self):
         """
         Test to see if jobs with select resources not in the resources line
@@ -119,6 +121,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_place(self):
         """
         Test to see if jobs with different place statements
@@ -145,6 +148,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_reslist1(self):
         """
         Test to see if jobs with resources in Resource_List that are not in
@@ -181,6 +185,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_reslist2(self):
         """
         Test to see if jobs with resources in Resource_List that are in the
@@ -219,6 +224,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 5",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_nolimits(self):
         """
         Test to see that jobs from different users, groups, and projects
@@ -256,6 +262,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_user(self):
         """
         Test to see that jobs from different users fall into the same
@@ -281,6 +288,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_user_old(self):
         """
         Test to see that jobs from different users fall into different
@@ -308,6 +316,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_user_server(self):
         """
         Test to see that jobs from different users fall into different
@@ -335,6 +344,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_user_server_soft(self):
         """
         Test to see that jobs from different users fall into different
@@ -362,6 +372,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_user_queue(self):
         """
         Test to see that jobs from different users fall into different
@@ -390,6 +401,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_user_queue_without_limits(self):
         """
         Test that jobs from different users submitted to a queue without
@@ -426,6 +438,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_user_queue_soft(self):
         """
         Test to see that jobs from different users fall into different
@@ -454,6 +467,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_user_queue_without_soft_limits(self):
         """
         Test that jobs from different users submitted to a queue without
@@ -487,6 +501,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_group(self):
         """
         Test to see that jobs from different groups fall into the same
@@ -516,6 +531,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     @skipOnShasta
     def test_group_old(self):
         """
@@ -549,6 +565,7 @@ class TestEquivClass(TestFunctional):
                                  starttime=self.t)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_group_server(self):
         """
         Test to see that jobs from different groups fall into different
@@ -581,6 +598,7 @@ class TestEquivClass(TestFunctional):
                                  starttime=self.t)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_group_server_soft(self):
         """
         Test to see that jobs from different groups fall into different
@@ -613,6 +631,7 @@ class TestEquivClass(TestFunctional):
                                  starttime=self.t)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_group_queue(self):
         """
         Test to see that jobs from different groups fall into different
@@ -648,6 +667,7 @@ class TestEquivClass(TestFunctional):
                                  starttime=self.t)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_group_queue_soft(self):
         """
         Test to see that jobs from different groups fall into different
@@ -682,6 +702,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_proj(self):
         """
         Test to see that jobs from different projects fall into the same
@@ -711,6 +732,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_proj_server(self):
         """
         Test to see that jobs from different projects fall into different
@@ -742,6 +764,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_proj_server_soft(self):
         """
         Test to see that jobs from different projects fall into different
@@ -773,6 +796,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_proj_queue(self):
         """
         Test to see that jobs from different groups fall into different
@@ -804,6 +828,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_proj_queue_soft(self):
         """
         Test to see that jobs from different groups fall into different
@@ -835,6 +860,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_queue(self):
         """
         Test to see that jobs from different generic queues fall into
@@ -871,6 +897,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_queue_limits(self):
         """
         Test to see if jobs in a queue with limits use their queue as part
@@ -927,6 +954,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 4",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_queue_nodes(self):
         """
         Test to see if jobs that are submitted into a queue with nodes
@@ -981,6 +1009,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_prime_queue(self):
         """
         Test to see if a job in a primetime queue has its queue be part of
@@ -1043,6 +1072,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 4",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_non_prime_queue(self):
         """
         Test to see if a job in a non-primetime queue has its queue be part of
@@ -1106,6 +1136,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 4",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_ded_time_queue(self):
         """
         Test to see if a job in a dedicated time queue has its queue be part
@@ -1154,6 +1185,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_job_array(self):
         """
         Test that various job types will fall into single equivalence
@@ -1180,6 +1212,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 1",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_reservation(self):
         """
         Test that similar jobs inside reservations falls under same
@@ -1211,6 +1244,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_time_limit(self):
         """
         Test that various time limits will have their own
@@ -1249,6 +1283,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_fairshare(self):
         """
         Test that scheduler do not create any equiv classes
@@ -1282,6 +1317,7 @@ class TestEquivClass(TestFunctional):
         self.scheduler.log_match("Number of job equivalence classes: 1",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_server_hook(self):
         """
         Test that job equivalence classes are updated
@@ -1351,6 +1387,7 @@ e.job.Resource_List["cput"] = 20
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_mom_hook(self):
         """
         Test for job equivalence classes with mom hooks.
@@ -1408,6 +1445,7 @@ else:
         self.scheduler.log_match("Number of job equivalence classes: 3",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_incr_decr(self):
         """
         Test for varying job equivalence class values
@@ -1486,6 +1524,7 @@ else:
             "Number of job equivalence classes message " +
             "not present when there are no jobs as expected")
 
+    @skipOnCpuSet
     def test_server_queue_limit(self):
         """
         Test with mix of hard and soft limits
@@ -1585,6 +1624,7 @@ else:
         self.scheduler.log_match("Number of job equivalence classes: 8",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_preemption(self):
         """
         Suspended jobs are placed into their own equivalence class.  If
@@ -1637,6 +1677,7 @@ else:
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
 
+    @skipOnCpuSet
     def test_preemption2(self):
         """
         Suspended jobs are placed into their own equivalence class.  If
@@ -1695,6 +1736,7 @@ else:
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid5)
 
+    @skipOnCpuSet
     def test_multiple_job_preemption_order(self):
         """
         Test that when multiple jobs from same eqivalence class are
@@ -1818,6 +1860,7 @@ else:
         self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid6)
 
+    @skipOnCpuSet
     def test_multiple_equivalence_class_preemption(self):
         """
         This test is to test that -
@@ -1913,6 +1956,7 @@ else:
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_held_jobs_equiv_class(self):
         """
         1) Test that held jobs do not go into another equivalence class.
@@ -1936,6 +1980,7 @@ else:
         self.scheduler.log_match("Number of job equivalence classes: 1",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_queue_resav(self):
         """
         Test that jobs in queues with resources_available limits use queue as
@@ -1974,6 +2019,7 @@ else:
         self.scheduler.log_match("Number of job equivalence classes: 2",
                                  starttime=self.t)
 
+    @skipOnCpuSet
     def test_overlap_resv(self):
         """
         Test that 2 overlapping reservation creates 2 different
@@ -2028,6 +2074,7 @@ else:
         self.server.expect(JOB, {"job_state": 'R'}, id=jid1)
         self.server.expect(JOB, {"job_state": 'R'}, id=jid3)
 
+    @skipOnCpuSet
     def test_limit_res(self):
         """
         Test when resources are being limited on, but those resources are not
@@ -2075,6 +2122,7 @@ else:
             attribs['resource_available.mem'] = '4gb'
         return attribs
 
+    @skipOnCpuSet
     def test_equiv_class_not_marked_on_suspend(self):
         """
         Test that if a job is suspended then scheduler does not mark its

--- a/test/tests/functional/pbs_indirect_resources.py
+++ b/test/tests/functional/pbs_indirect_resources.py
@@ -40,6 +40,7 @@ from tests.functional import *
 
 class TestHostResources(TestFunctional):
 
+    @skipOnCpuSet
     def test_set_direct_on_indirect_resc(self):
         """
         Set a direct resource on indirect resource and make sure
@@ -60,6 +61,7 @@ class TestHostResources(TestFunctional):
         self.server.expect(NODE, {'resources_assigned.fooi': ''},
                            id='vnode[1]', op=UNSET, max_attempts=1)
 
+    @skipOnCpuSet
     def test_set_direct_on_indirect_resc_busy(self):
         """
         Set a direct resource on indirect resource
@@ -93,6 +95,7 @@ class TestHostResources(TestFunctional):
             self.server.expect(NODE, {'resources_available.fooi': 100},
                                id='vnode[1]', op=UNSET, max_attempts=1)
 
+    @skipOnCpuSet
     def test_set_direct_on_target_node(self):
         """
         Set a direct resource on target node which should
@@ -123,6 +126,7 @@ class TestHostResources(TestFunctional):
             _msg = "Setting indirect resources on a target object should fail"
             self.assertTrue(False, _msg)
 
+    @skipOnCpuSet
     def test_create_node_without_resc_set(self):
         """
         Create a consumable resource then create a new node.

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -705,6 +705,7 @@ class TestJobArray(TestFunctional):
         # ensure all the subjobs are running
         self.server.expect(JOB, {'job_state=R': 200}, extend='t')
 
+    @skipOnCpuSet
     def test_recover_big_array_job(self):
         """
         Test that during server restart, server is able to recover valid

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -87,6 +87,7 @@ class TestJobArray(TestFunctional):
         _msg = 'No license found on server %s' % (self.server.shortname)
         self.assertTrue(rv, _msg)
 
+    @skipOnCpuSet
     def test_running_subjob_survive_restart(self):
         """
         Test to check if a running subjob of an array job survive a
@@ -134,6 +135,7 @@ class TestJobArray(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         self.test_running_subjob_survive_restart()
 
+    @skipOnCpuSet
     def test_suspended_subjob_survive_restart(self):
         """
         Test to check if a suspended subjob of an array job survive a
@@ -185,6 +187,7 @@ class TestJobArray(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         self.test_suspended_subjob_survive_restart()
 
+    @skipOnCpuSet
     def test_deleted_q_subjob_survive_restart(self):
         """
         Test to check if a deleted queued subjob of an array job survive a
@@ -218,6 +221,7 @@ class TestJobArray(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         self.test_deleted_q_subjob_survive_restart()
 
+    @skipOnCpuSet
     def test_deleted_r_subjob_survive_restart(self):
         """
         Test to check if a deleted running subjob of an array job survive a
@@ -252,6 +256,7 @@ class TestJobArray(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, attr)
         self.test_deleted_q_subjob_survive_restart()
 
+    @skipOnCpuSet
     def test_qdel_expired_subjob(self):
         """
         Test to check if qdel of a subjob is disallowed
@@ -292,6 +297,7 @@ class TestJobArray(TestFunctional):
         else:
             raise self.failureException("subjob in X state can be deleted")
 
+    @skipOnCpuSet
     def test_subjob_comments(self):
         """
         Test subjob comments for finished and terminated subjobs
@@ -312,6 +318,7 @@ class TestJobArray(TestFunctional):
         self.server.expect(
             JOB, {'comment': 'Subjob finished'}, subjid_1, max_attempts=1)
 
+    @skipOnCpuSet
     def test_subjob_comments_with_history(self):
         """
         Test subjob comments for finished, failed and terminated subjobs
@@ -357,6 +364,7 @@ class TestJobArray(TestFunctional):
             JOB, {'comment': (MATCH_RE, 'Job run at.*and failed')}, subjid_2,
             extend='x')
 
+    @skipOnCpuSet
     def test_multiple_server_restarts(self):
         """
         Test subjobs wont rerun after multiple server restarts
@@ -376,6 +384,7 @@ class TestJobArray(TestFunctional):
             self.server.expect(
                 JOB, a, subjid_1, attrop=PTL_AND, max_attempts=1)
 
+    @skipOnCpuSet
     def test_job_array_history_duration(self):
         """
         Test that job array and subjobs are purged after history duration
@@ -406,6 +415,7 @@ class TestJobArray(TestFunctional):
         self.server.expect(JOB, 'job_state', op=UNSET,
                            id=subjid_2, extend='x')
 
+    @skipOnCpuSet
     def test_queue_deletion_after_terminated_subjob(self):
         """
         Test that queue can be deleted after the job array is
@@ -424,6 +434,7 @@ class TestJobArray(TestFunctional):
         self.server.delete(j_id, wait=True)
         self.server.manager(MGR_CMD_DELETE, QUEUE, id='workq')
 
+    @skipOnCpuSet
     def test_held_job_array_survive_server_restart(self):
         """
         Test held job array can be released after server restart
@@ -457,6 +468,7 @@ class TestJobArray(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, a)
         self.test_held_job_array_survive_server_restart()
 
+    @skipOnCpuSet
     def test_subjobs_qrun(self):
         """
         Test that job array's subjobs can be qrun
@@ -474,6 +486,7 @@ class TestJobArray(TestFunctional):
         self.server.expect(JOB, {'job_state': 'B'}, j_id)
         self.server.expect(JOB, {'job_state': 'R'}, subjid_1)
 
+    @skipOnCpuSet
     def test_dependent_job_array_server_restart(self):
         """
         Check Job array dependency is not released after server restart
@@ -502,6 +515,7 @@ class TestJobArray(TestFunctional):
                            j_id, extend='x', interval=5)
         self.server.expect(JOB, {'job_state': 'B'}, j_id2, interval=5)
 
+    @skipOnCpuSet
     def test_rerun_subjobs_server_restart(self):
         """
         Test that subjobs which are requeued remain queued after server restart
@@ -527,6 +541,7 @@ class TestJobArray(TestFunctional):
         a = {'job_state': 'R'}
         self.server.expect(JOB, a, subjid_1)
 
+    @skipOnCpuSet
     def test_rerun_node_fail_requeue(self):
         """
         Test sub jobs gets requeued after node_fail_requeue time
@@ -544,6 +559,7 @@ class TestJobArray(TestFunctional):
         self.mom.stop()
         self.server.expect(JOB, {'job_state': 'Q'}, subjid_1, offset=5)
 
+    @skipOnCpuSet
     def test_qmove_job_array(self):
         """
         Test job array's can be qmoved to a high priority queue
@@ -572,6 +588,7 @@ class TestJobArray(TestFunctional):
         self.server.expect(JOB, {'job_state': 'S'}, subjid_1)
         self.server.expect(JOB, {'job_state': 'R'}, subjid_3)
 
+    @skipOnCpuSet
     def test_delete_history_subjob_server_restart(self):
         """
         Test that subjobs can be deleted from history
@@ -592,6 +609,7 @@ class TestJobArray(TestFunctional):
         self.kill_and_restart_svr()
         self.server.expect(JOB, 'job_state', op=UNSET, extend='x', id=j_id)
 
+    @skipOnCpuSet
     def test_job_id_duplicate_server_restart(self):
         """
         Test that after server restart there is no duplication

--- a/test/tests/functional/pbs_job_array_comment.py
+++ b/test/tests/functional/pbs_job_array_comment.py
@@ -43,6 +43,7 @@ class TestJobArrayComment(TestFunctional):
     Testing job array comment is accurate
     """
 
+    @skipOnCpuSet
     def test_job_array_comment(self):
         """
         Testing job array comment is correct when one or more sub jobs

--- a/test/tests/functional/pbs_job_comment_on_resume.py
+++ b/test/tests/functional/pbs_job_comment_on_resume.py
@@ -44,6 +44,7 @@ class TestJobComment(TestFunctional):
     Testing job comment is accurate
     """
 
+    @skipOnCpuSet
     def test_job_comment_on_resume(self):
         """
         Testing whether job comment is accurate

--- a/test/tests/functional/pbs_job_purge.py
+++ b/test/tests/functional/pbs_job_purge.py
@@ -43,6 +43,7 @@ class TestJobPurge(TestFunctional):
     This test suite tests the Job purge process
     """
 
+    @skipOnCpuSet
     def test_job_files_after_execution(self):
         """
         Checks the job related files and ensures that files are

--- a/test/tests/functional/pbs_job_routing.py
+++ b/test/tests/functional/pbs_job_routing.py
@@ -51,6 +51,7 @@ class TestJobRouting(TestFunctional):
 
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'false'})
 
+    @skipOnCpuSet
     def test_t1(self):
         """
         This test case validates Job array state when one
@@ -109,6 +110,7 @@ class TestJobRouting(TestFunctional):
         self.server.expect(JOB, {ATTR_queue + '=' + dflt_q: 3}, count=True,
                            id=jid, extend='t')
 
+    @skipOnCpuSet
     def test_t2(self):
         """
         This test case validates Job array state when running subjobs

--- a/test/tests/functional/pbs_job_script.py
+++ b/test/tests/functional/pbs_job_script.py
@@ -62,6 +62,7 @@ class TestPbsJobScript(TestFunctional):
         jid = self.server.submit(j)
         return jid
 
+    @skipOnCpuSet
     def test_long_select_spec(self):
         """
         Test that PBS is able to accept jobs scripts with very long select
@@ -75,6 +76,7 @@ class TestPbsJobScript(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R', 'exec_vnode': execvnode},
                            id=jid)
 
+    @skipOnCpuSet
     def test_long_select_spec_extend(self):
         """
         Test that PBS is able to accept jobs scripts with very long select

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -189,6 +189,7 @@ class TestMultipleSchedulers(TestFunctional):
                 self.server.expect(JOB, {'job_state': 'Q'}, id=jid2)
                 self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
+    @skipOnCpuSet
     def test_set_sched_priv(self):
         """
         Test sched_priv can be only set to valid paths
@@ -468,6 +469,7 @@ class TestMultipleSchedulers(TestFunctional):
             jid1 + ';Job preempted by suspension',
             max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_preemption_two_sched(self):
         """
         Test two schedulers preempting jobs at the same time
@@ -768,6 +770,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.assertEqual(n.nshares, sc3_shares)
         self.assertEqual(n.usage, sc3_usage)
 
+    @skipOnCpuSet
     def test_fairshare_usage(self):
         """
         Test the schedulers fairshare usage file and
@@ -996,6 +999,7 @@ class TestMultipleSchedulers(TestFunctional):
         n = self.scheds['sc1'].query_fairshare().get_node(name=str(TEST_USER))
         self.assertTrue(n.usage, 25)
 
+    @skipOnCpuSet
     def test_pbsfs_revert_to_defaults(self):
         """
         Test if revert_to_defaults() works properly with multi scheds.
@@ -1572,6 +1576,7 @@ class TestMultipleSchedulers(TestFunctional):
             self.assertTrue(err_msg in e.msg[0],
                             "Error message is not expected")
 
+    @skipOnCpuSet
     def test_job_sort_formula_threshold(self):
         """
         Test the scheduler attribute job_sort_formula_threshold for multisched
@@ -2084,6 +2089,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid1)
 
+    @skipOnCpuSet
     def test_multi_sched_node_sort_key(self):
         """
         Test to make sure nodes are sorted in the order

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -122,6 +122,7 @@ class TestMultipleSchedulers(TestFunctional):
                 self.assertFalse(True, str(vnode) +
                                  " is not in exec_vnode list as expected")
 
+    @skipOnCpuSet
     def test_job_sort_formula_multisched(self):
         """
         Test that job_sort_formula can be set for each sched
@@ -249,6 +250,7 @@ class TestMultipleSchedulers(TestFunctional):
         # Blocked by PP-1202 will revisit once its fixed
         # self.server.expect(SCHED, 'comment', id='sc1', op=UNSET)
 
+    @skipOnCpuSet
     def test_start_scheduler(self):
         """
         Test that scheduler wont start without appropriate folders created.
@@ -300,6 +302,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(SCHED, {'state': 'scheduling'},
                            id='sc5', max_attempts=10)
 
+    @skipOnCpuSet
     def test_resource_sched_reconfigure(self):
         """
         Test all schedulers will reconfigure while creating,
@@ -351,6 +354,7 @@ class TestMultipleSchedulers(TestFunctional):
         # Blocked by PP-1202 will revisit once its fixed
         # self.server.manager(MGR_CMD_UNSET, SCHED, 'partition', id="sc2")
 
+    @skipOnCpuSet
     def test_job_queue_partition(self):
         """
         Test job submitted to a queue associated to a partition will land
@@ -382,6 +386,7 @@ class TestMultipleSchedulers(TestFunctional):
             jid + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
 
+    @skipOnCpuSet
     def test_multiple_partition_same_sched(self):
         """
         Test that scheduler will serve the jobs from different
@@ -414,6 +419,7 @@ class TestMultipleSchedulers(TestFunctional):
             jid3 + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
 
+    @skipOnCpuSet
     def test_multiple_queue_same_partition(self):
         """
         Test multiple queue associated with same partition
@@ -440,6 +446,7 @@ class TestMultipleSchedulers(TestFunctional):
             jid + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
 
+    @skipOnCpuSet
     def test_preemption_highp_queue(self):
         """
         Test preemption occures only within queues which are assigned
@@ -529,6 +536,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=hj1_jid)
         self.server.expect(JOB, {'job_state': 'R'}, id=hj2_jid)
 
+    @skipOnCpuSet
     def test_backfill_per_scheduler(self):
         """
         Test backfilling is applicable only per scheduler
@@ -560,6 +568,7 @@ class TestMultipleSchedulers(TestFunctional):
             jid4 + ';Job is a top job and will run at',
             max_attempts=5, starttime=t, existence=False)
 
+    @skipOnCpuSet
     def test_resource_per_scheduler(self):
         """
         Test resources will be considered only by scheduler
@@ -622,6 +631,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(SCHED, a, id='sc1',
                            attrop=PTL_AND, max_attempts=10)
 
+    @skipOnCpuSet
     def test_resv_default_sched(self):
         """
         Test reservations will only go to defualt scheduler
@@ -638,6 +648,7 @@ class TestMultipleSchedulers(TestFunctional):
             rid + ';Reservation Confirmed',
             max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_job_sorted_per_scheduler(self):
         """
         Test jobs are sorted as per job_sort_formula
@@ -671,6 +682,7 @@ class TestMultipleSchedulers(TestFunctional):
                             {'scheduling': 'True'}, id="sc3")
         self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
 
+    @skipOnCpuSet
     def test_qrun_job(self):
         """
         Test jobs can be run by qrun by a newly created scheduler.
@@ -686,6 +698,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.runjob(jid1)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
+    @skipOnCpuSet
     def test_run_limts_per_scheduler(self):
         """
         Test run_limits applied at server level is
@@ -714,6 +727,7 @@ class TestMultipleSchedulers(TestFunctional):
         jc = "Not Running: User has reached server running job limit."
         self.server.expect(JOB, {'comment': jc}, id=jid4)
 
+    @skipOnCpuSet
     def test_multi_fairshare(self):
         """
         Test different schedulers have their own fairshare trees with
@@ -1096,6 +1110,7 @@ class TestMultipleSchedulers(TestFunctional):
 
         return ret_jids
 
+    @skipOnCpuSet
     def test_equiv_partition(self):
         """
         Test the basic behavior of job equivalence classes: submit two
@@ -1121,6 +1136,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].log_match("Number of job equivalence classes: 4",
                                      max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_equiv_multisched(self):
         """
         Test the basic behavior of job equivalence classes: submit two
@@ -1157,6 +1173,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc2'].log_match("Number of job equivalence classes: 2",
                                      max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_select_partition(self):
         """
         Test to see if jobs with select resources not in the resources line
@@ -1198,6 +1215,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].log_match("Number of job equivalence classes: 4",
                                      max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_select_res_partition(self):
         """
         Test to see if jobs with select resources in the resources line and
@@ -1238,6 +1256,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].log_match("Number of job equivalence classes: 6",
                                      max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_multiple_res_partition(self):
         """
         Test to see if jobs with select resources in the resources line
@@ -1284,6 +1303,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].log_match("Number of job equivalence classes: 6",
                                      max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_place_partition(self):
         """
         Test to see if jobs with different place statements and different
@@ -1329,6 +1349,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].log_match("Number of job equivalence classes: 6",
                                      max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_nolimits_partition(self):
         """
         Test to see that jobs from different users, groups, and projects
@@ -1380,6 +1401,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].log_match("Number of job equivalence classes: 4",
                                      max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_limits_partition(self):
         """
         Test to see that jobs from different users fall into different
@@ -1417,6 +1439,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].log_match("Number of job equivalence classes: 6",
                                      max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_job_array_partition(self):
         """
         Test that various job types will fall into single equivalence
@@ -1451,6 +1474,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].log_match("Number of job equivalence classes: 2",
                                      max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_equiv_suspend_jobs(self):
         """
         Test that jobs fall into different equivalence classes
@@ -1487,6 +1511,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc1'].log_match("Number of job equivalence classes: 4",
                                      max_attempts=10, starttime=t)
 
+    @skipOnCpuSet
     def test_equiv_single_partition(self):
         """
         Test that jobs fall into same equivalence class if jobs fall
@@ -1635,6 +1660,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_key': 'switch'})
         self.server.manager(MGR_CMD_SET, SERVER, {'node_group_enable': 't'})
 
+    @skipOnCpuSet
     def test_multi_sched_explicit_ps(self):
         """
         Test only_explicit_ps set to sched attr will be in affect
@@ -1687,6 +1713,7 @@ class TestMultipleSchedulers(TestFunctional):
                            'comment': 'Not Running: Placement set switch=A'
                            ' has too few free resources'}, id=j6id)
 
+    @skipOnCpuSet
     def test_jobs_do_not_span_ps(self):
         """
         Test do_not_span_psets set to sched attr will be in affect
@@ -1716,6 +1743,7 @@ class TestMultipleSchedulers(TestFunctional):
         j2id = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=j2id)
 
+    @skipOnCpuSet
     def test_sched_preempt_enforce_resumption(self):
         """
         Test sched_preempt_enforce_resumption can be set to a multi sched
@@ -1798,6 +1826,7 @@ class TestMultipleSchedulers(TestFunctional):
         p_day = 'sunday'
         self.scheds[scid].holidays_set_day(p_day, p_hhmm, np_hhmm)
 
+    @skipOnCpuSet
     def test_prime_time_backfill(self):
         """
         Test opt_backfill_fuzzy can be set to a multi sched and
@@ -1841,6 +1870,7 @@ class TestMultipleSchedulers(TestFunctional):
         prime_mod = prime_start % 60  # ignoring the seconds
         self.assertEqual((prime_start - prime_mod), est_epoch)
 
+    @skipOnCpuSet
     def test_prime_time_multisched(self):
         """
         Test prime time queue can be set partition and multi sched
@@ -1869,6 +1899,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.scheds['sc2'].log_match(jid2 + ";Job only runs in primetime",
                                      starttime=self.server.ctime)
 
+    @skipOnCpuSet
     def test_dedicated_time_multisched(self):
         """
         Test dedicated time queue can be set partition and multi sched
@@ -2008,6 +2039,7 @@ class TestMultipleSchedulers(TestFunctional):
             "scheduler priv directory has changed to " + new_sched_priv,
             max_attempts=10, starttime=self.server.ctime)
 
+    @skipOnCpuSet
     def test_set_msched_update_inbuilt_attrs_accrue_type(self):
         """
         Test to make sure Multisched is able to update any one of the builtin
@@ -2039,6 +2071,7 @@ class TestMultipleSchedulers(TestFunctional):
         # This makes sure that accrue_type is indeed getting changed
         self.server.expect(JOB, {ATTR_accrue_type: 3}, id=jid2)
 
+    @skipOnCpuSet
     def test_multisched_not_crash(self):
         """
         Test to make sure Multisched does not crash when all nodes in partition
@@ -2067,6 +2100,7 @@ class TestMultipleSchedulers(TestFunctional):
         # If job goes to R state means scheduler is still alive.
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
+    @skipOnCpuSet
     def test_multi_sched_job_sort_key(self):
         """
         Test to make sure that jobs are sorted as per
@@ -2132,6 +2166,7 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
         self.check_vnodes(j, ['vnode[0]'], jid3)
 
+    @skipOnCpuSet
     def test_multi_sched_priority_sockets(self):
         """
         Test scheduler socket connections from all the schedulers

--- a/test/tests/functional/pbs_qrun.py
+++ b/test/tests/functional/pbs_qrun.py
@@ -95,6 +95,7 @@ class TestQrun(TestFunctional):
         self.assertTrue(self.server.isUp(), msg)
         self.logger.info("As expected server is up and running")
 
+    @skipOnCpuSet
     def test_qrun_hangs(self):
         """
         This test submit 500 jobs with differnt equivalence class,

--- a/test/tests/functional/pbs_qrun.py
+++ b/test/tests/functional/pbs_qrun.py
@@ -50,6 +50,7 @@ class TestQrun(TestFunctional):
         self.pbs_exec = self.server.pbs_conf['PBS_EXEC']
         self.qrun = os.path.join(self.pbs_exec, 'bin', 'qrun')
 
+    @skipOnCpuSet
     def test_invalid_host_val(self):
         """
         Tests that pbs_server should not crash when the node list in

--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -42,7 +42,6 @@ class TestQstat(TestFunctional):
     """
     This test suite validates output of qstat with various options
     """
-
     @skipOnCpuSet
     def test_qstat_pt(self):
         """
@@ -50,7 +49,7 @@ class TestQstat(TestFunctional):
         """
 
         attr = {'resources_available.ncpus': 1}
-        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.shortname)
+        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.hostname)
 
         job_count = 10
         j = Job(TEST_USER)
@@ -104,6 +103,7 @@ class TestQstat(TestFunctional):
         if ret['rc'] != 0:
             self.assertFalse(ret['err'][0], ret_msg)
 
+    @skipOnCpuSet
     def test_qstat_n_ip(self):
         """
         Test qstat -n output reports the correct node name
@@ -128,6 +128,7 @@ class TestQstat(TestFunctional):
                       "Incorrect node name in qstat -n when "
                       "node created using IP address")
 
+    @skipOnCpuSet
     def test_qstat_n_fqdn(self):
         """
         Test qstat -n output reports task slot and processor info

--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -103,7 +103,6 @@ class TestQstat(TestFunctional):
         if ret['rc'] != 0:
             self.assertFalse(ret['err'][0], ret_msg)
 
-    @skipOnCpuSet
     def test_qstat_n_ip(self):
         """
         Test qstat -n output reports the correct node name
@@ -113,7 +112,7 @@ class TestQstat(TestFunctional):
         ipaddr = socket.gethostbyname(self.mom.hostname)
         attr_A = {'Mom': self.mom.hostname}
         self.server.manager(MGR_CMD_CREATE, NODE, id=ipaddr, attrib=attr_A)
-        self.server.expect(NODE, {'state=free': 1})
+        self.server.expect(NODE, {'state': 'free'}, id=ipaddr)
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
@@ -128,7 +127,6 @@ class TestQstat(TestFunctional):
                       "Incorrect node name in qstat -n when "
                       "node created using IP address")
 
-    @skipOnCpuSet
     def test_qstat_n_fqdn(self):
         """
         Test qstat -n output reports task slot and processor info
@@ -136,7 +134,7 @@ class TestQstat(TestFunctional):
         """
         self.server.manager(MGR_CMD_DELETE, NODE, None, '')
         self.server.manager(MGR_CMD_CREATE, NODE, id=self.mom.hostname)
-        self.server.expect(NODE, {'state=free': 1})
+        self.server.expect(NODE, {'state': 'free'}, id=self.mom.hostname)
         j = Job(TEST_USER)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)

--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -43,6 +43,7 @@ class TestQstat(TestFunctional):
     This test suite validates output of qstat with various options
     """
 
+    @skipOnCpuSet
     def test_qstat_pt(self):
         """
         Test that checks correct output for qstat -pt

--- a/test/tests/functional/pbs_qstat_formats.py
+++ b/test/tests/functional/pbs_qstat_formats.py
@@ -409,6 +409,7 @@ class TestQstatFormats(TestFunctional):
         except ValueError:
             self.assertTrue(False)
 
+    @skipOnCpuSet
     def test_qstat_json_valid_multiple_jobs_p(self):
         """
         Test json output of qstat -f is in valid format when multiple jobs are

--- a/test/tests/functional/pbs_qsub_opts_args.py
+++ b/test/tests/functional/pbs_qsub_opts_args.py
@@ -141,6 +141,7 @@ bhtiusabsdlg' % (os.environ['HOME'])
         rv = self.du.run_cmd(self.server.hostname, cmd=cmd)
         self.assertEqual(rv['rc'], 0, 'qsub failed')
 
+    @skipOnCpuSet
     def test_qsub_with_option_a(self):
         """
         Test submission of job with execution time(future and past)

--- a/test/tests/functional/pbs_schedule_indirect_resources.py
+++ b/test/tests/functional/pbs_schedule_indirect_resources.py
@@ -67,6 +67,7 @@ class TestIndirectResources(TestFunctional):
 
         return (jobid, job)
 
+    @skipOnCpuSet
     def test_node_grouping_with_indirect_res(self):
         """
         Test node grouping with indirect resources set on some nodes

--- a/test/tests/functional/pbs_test_entity_limits.py
+++ b/test/tests/functional/pbs_test_entity_limits.py
@@ -133,6 +133,7 @@ class TestEntityLimits(TestFunctional):
             self.assertFalse(True, "Job violating limits got submitted after "
                              "server restart.")
 
+    @skipOnCpuSet
     def test_server_generic_user_limits_queued(self):
         """
         Test queued_jobs_threshold for any user at the server level.
@@ -142,6 +143,7 @@ class TestEntityLimits(TestFunctional):
         m = "qsub: would exceed complex's per-user limit of jobs in 'Q' state"
         self.common_limit_test(True, a, queued=True, exp_err=m)
 
+    @skipOnCpuSet
     def test_server_user_limits_queued(self):
         """
         Test queued_jobs_threshold for user TEST_USER at the server level.
@@ -152,6 +154,7 @@ class TestEntityLimits(TestFunctional):
             str(TEST_USER) + ' already in complex'
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_project_limits_queued(self):
         """
         Test queued_jobs_threshold for project p1 at the server level.
@@ -162,6 +165,7 @@ class TestEntityLimits(TestFunctional):
             + "already in complex"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_generic_project_limits_queued(self):
         """
         Test queued_jobs_threshold for any project at the server level.
@@ -172,6 +176,7 @@ class TestEntityLimits(TestFunctional):
             + "'Q' state"
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     @skipOnShasta
     def test_server_group_limits_queued(self):
         """
@@ -183,6 +188,7 @@ class TestEntityLimits(TestFunctional):
             str(TSTGRP0) + ' already in complex'
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     @skipOnShasta
     def test_server_generic_group_limits_queued(self):
         """
@@ -193,6 +199,7 @@ class TestEntityLimits(TestFunctional):
         m = "qsub: would exceed complex's per-group limit of jobs in 'Q' state"
         self.common_limit_test(True, a, queued=True, exp_err=m)
 
+    @skipOnCpuSet
     def test_server_overall_limits_queued(self):
         """
         Test queued_jobs_threshold for any entity at the server level.
@@ -201,6 +208,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: Maximum number of jobs in 'Q' state already in complex"
         self.common_limit_test(True, a, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_generic_user_limits_queued(self):
         """
         Test queued_jobs_threshold for any user for the default queue.
@@ -212,6 +220,7 @@ class TestEntityLimits(TestFunctional):
             + "jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_user_limits_queued(self):
         """
         Test queued_jobs_threshold for user pbsuser1 for the default queue.
@@ -224,6 +233,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_queue_group_limits_queued(self):
         """
         Test queued_jobs_threshold for group TSTGRP0 for the default queue.
@@ -235,6 +245,7 @@ class TestEntityLimits(TestFunctional):
             str(TSTGRP0) + ' already in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_project_limits_queued(self):
         """
         Test queued_jobs_threshold for project p1 for the default queue.
@@ -245,6 +256,7 @@ class TestEntityLimits(TestFunctional):
             'already in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_generic_project_limits_queued(self):
         """
         Test queued_jobs_threshold for any project for the default queue.
@@ -256,6 +268,7 @@ class TestEntityLimits(TestFunctional):
             "'s per-project limit of jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     @skipOnShasta
     def test_queue_generic_group_limits_queued(self):
         """
@@ -268,6 +281,7 @@ class TestEntityLimits(TestFunctional):
             "'s per-group limit of jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_overall_limits_queued(self):
         """
         Test queued_jobs_threshold for all entities for the default queue.
@@ -278,6 +292,7 @@ class TestEntityLimits(TestFunctional):
             + self.server.default_queue
         self.common_limit_test(False, a, attrs, queued=True, exp_err=emsg)
 
+    @skipOnCpuSet
     def test_server_generic_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any user at the server level.
@@ -289,6 +304,7 @@ class TestEntityLimits(TestFunctional):
             + "complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for user pbsuser1 at the server level.
@@ -301,6 +317,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_server_generic_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any group at the server level.
@@ -312,6 +329,7 @@ class TestEntityLimits(TestFunctional):
             + "complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_project_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for project p1 at the server level.
@@ -323,6 +341,7 @@ class TestEntityLimits(TestFunctional):
             + " complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_generic_project_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any project at the server level.
@@ -335,6 +354,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_server_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for group pbsuser1 at the server level.
@@ -346,6 +366,7 @@ class TestEntityLimits(TestFunctional):
             "'s limit on resource ncpus in complex for jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_overall_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for all entities at the server level.
@@ -357,6 +378,7 @@ class TestEntityLimits(TestFunctional):
             + "jobs in 'Q' state"
         self.common_limit_test(True, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_generic_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for all users for the default queue.
@@ -369,6 +391,7 @@ class TestEntityLimits(TestFunctional):
             + self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=emsg)
 
+    @skipOnCpuSet
     def test_queue_user_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for user pbsuser1 for the default queue.
@@ -383,6 +406,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_queue_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for group pbsuser1 for the default queue
@@ -397,6 +421,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_queue_generic_group_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any group for the default queue.
@@ -409,6 +434,7 @@ class TestEntityLimits(TestFunctional):
             + 'queue ' + self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_project_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for project p1 for the default queue.
@@ -421,6 +447,7 @@ class TestEntityLimits(TestFunctional):
             'in queue ' + self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_generic_project_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any project for the default queue.
@@ -433,6 +460,7 @@ class TestEntityLimits(TestFunctional):
             + ' queue ' + self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_overall_limits_res_queued(self):
         """
         Test queued_jobs_threshold_res for any entity for the default queue.
@@ -445,6 +473,7 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue + " for jobs in 'Q' state"
         self.common_limit_test(False, a, attrs, queued=True, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_generic_user_limits_max(self):
         """
         Test max_queued for any user at the server level.
@@ -454,6 +483,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed complex's per-user limit"
         self.common_limit_test(True, a, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_user_limits_max(self):
         """
         Test max_queued for user pbsuser1 at the server level.
@@ -464,6 +494,7 @@ class TestEntityLimits(TestFunctional):
             ' already in complex'
         self.common_limit_test(True, a, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_project_limits_max(self):
         """
         Test max_queued for project p1 at the server level.
@@ -473,6 +504,7 @@ class TestEntityLimits(TestFunctional):
         msg = 'qsub: Maximum number of jobs for project p1 already in complex'
         self.common_limit_test(True, a, attrs, exp_err=msg)
 
+    @skipOnCpuSet
     def test_server_generic_project_limits_max(self):
         """
         Test max_queued for any project at the server level.
@@ -483,6 +515,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_server_group_limits_max(self):
         """
         Test max_queued for group TSTGRP0 at the server level.
@@ -494,6 +527,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_server_generic_group_limits_max(self):
         """
         Test max_queued for any group at the server level.
@@ -503,6 +537,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed complex's per-group limit"
         self.common_limit_test(True, a, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_overall_limits_max(self):
         """
         Test max_queued for any entity at the server level.
@@ -511,6 +546,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = 'qsub: Maximum number of jobs already in complex'
         self.common_limit_test(True, a, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_generic_user_limits_max(self):
         """
         Test max_queued for any user for the default queue.
@@ -521,6 +557,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = "qsub: would exceed queue generic's per-user limit"
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_user_limits_max(self):
         """
         Test max_queued for user pbsuser1 for the default queue.
@@ -533,6 +570,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_queue_group_limits_max(self):
         """
         Test max_queued for group pbsuser1 for the default queue.
@@ -544,6 +582,7 @@ class TestEntityLimits(TestFunctional):
             ' already in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_project_limits_max(self):
         """
         Test max_queued for project p1 for the default queue.
@@ -554,6 +593,7 @@ class TestEntityLimits(TestFunctional):
             + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=msg)
 
+    @skipOnCpuSet
     def test_queue_generic_project_limits_max(self):
         """
         Test max_queued for any project for the default queue.
@@ -566,6 +606,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_queue_generic_group_limits_max(self):
         """
         Test max_queued for any group for the default queue.
@@ -577,6 +618,7 @@ class TestEntityLimits(TestFunctional):
             "'s per-group limit"
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_overall_limits_max(self):
         """
         Test max_queued for all entities for the default queue.
@@ -587,6 +629,7 @@ class TestEntityLimits(TestFunctional):
             self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_generic_user_limits_res_max(self):
         """
         Test max_queued_res for any user at the server level.
@@ -597,6 +640,7 @@ class TestEntityLimits(TestFunctional):
         emsg = 'qsub: would exceed per-user limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=emsg)
 
+    @skipOnCpuSet
     def test_server_user_limits_res_max(self):
         """
         Test max_queued_res for user pbsuser1 at the server level.
@@ -609,6 +653,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_server_generic_group_limits_res_max(self):
         """
         Test max_queued_res for any group at the server level.
@@ -619,6 +664,7 @@ class TestEntityLimits(TestFunctional):
         msg = 'qsub: would exceed per-group limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=msg)
 
+    @skipOnCpuSet
     def test_server_project_limits_res_max(self):
         """
         Test max_queued_res for project p1 at the server level.
@@ -630,6 +676,7 @@ class TestEntityLimits(TestFunctional):
             + " complex"
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_generic_project_limits_res_max(self):
         """
         Test max_queued_res for any project at the server level.
@@ -641,6 +688,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(True, a, attrs, exp_err=m)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_server_group_limits_res_max(self):
         """
         Test max_queued_res for group pbsuser1 at the server level.
@@ -652,6 +700,7 @@ class TestEntityLimits(TestFunctional):
             "'s limit on resource ncpus in complex"
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_server_overall_limits_res_max(self):
         """
         Test max_queued_res for all entities at the server level.
@@ -662,6 +711,7 @@ class TestEntityLimits(TestFunctional):
         errmsg = 'qsub: would exceed limit on resource ncpus in complex'
         self.common_limit_test(True, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_generic_user_limits_res_max(self):
         """
         Test max_queued_res for all users for the default queue.
@@ -674,6 +724,7 @@ class TestEntityLimits(TestFunctional):
             + ' queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_user_limits_res_max(self):
         """
         Test max_queued_res for user pbsuser1 for the default queue.
@@ -688,6 +739,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_queue_group_limits_res_max(self):
         """
         Test max_queued_res for group pbsuser1 for the default queue
@@ -701,6 +753,7 @@ class TestEntityLimits(TestFunctional):
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
     @skipOnShasta
+    @skipOnCpuSet
     def test_queue_generic_group_limits_res_max(self):
         """
         Test max_queued_res for any group for the default queue.
@@ -713,6 +766,7 @@ class TestEntityLimits(TestFunctional):
             + ' queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_project_limits_res_max(self):
         """
         Test max_queued_res for project p1 for the default queue.
@@ -725,6 +779,7 @@ class TestEntityLimits(TestFunctional):
             ' in queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_generic_project_limits_res_max(self):
         """
         Test max_queued_res for any project for the default queue.
@@ -737,6 +792,7 @@ class TestEntityLimits(TestFunctional):
             + ' queue ' + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_queue_overall_limits_res_max(self):
         """
         Test max_queued_res for any entity for the default queue.
@@ -749,6 +805,7 @@ class TestEntityLimits(TestFunctional):
                  + self.server.default_queue
         self.common_limit_test(False, a, attrs, exp_err=errmsg)
 
+    @skipOnCpuSet
     def test_qalter_resource(self):
         """
         Test that qaltering a job's resource list is accounted
@@ -796,6 +853,7 @@ class TestEntityLimits(TestFunctional):
                 raise self.failureException("rcvd unexpected err message: " +
                                             e.msg[0])
 
+    @skipOnCpuSet
     def test_multiple_queued_limits(self):
         defqname = self.server.default_queue
         q2name = 'q2'
@@ -846,6 +904,7 @@ class TestEntityLimits(TestFunctional):
         else:
             self.assertFalse(True, "Job violating limits got submitted.")
 
+    @skipOnCpuSet
     def test_pbs_all_soft_limits(self):
         """
         Set resource soft limit on server for PBS_ALL and see that the job
@@ -891,6 +950,7 @@ class TestEntityLimits(TestFunctional):
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
 
+    @skipOnCpuSet
     def test_user_soft_limits(self):
         """
         Set resource soft limit on server for a user and see that the job
@@ -937,6 +997,7 @@ class TestEntityLimits(TestFunctional):
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
 
+    @skipOnCpuSet
     def test_group_soft_limits(self):
         """
         Set resource soft limit on server for a group and see that the job
@@ -985,6 +1046,7 @@ class TestEntityLimits(TestFunctional):
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid4)
 
+    @skipOnCpuSet
     def test_project_soft_limits(self):
         """
         Set resource soft limit on server for a project and see that the job


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Few of the tests failed during regression on Cpuset machine.


#### Describe Your Change

- The tests were failing as they were changing either changing the value of 'resources_available.ncpus' or creating vnodes. On cpuset mom if we try to change the available ncpus value or create vnodes then we get the following msg "make_cpuset_inner, vnode uv-01:  hv_ncpus (1) > mvi_acpus (0) (you are not expected to understand this)" which results in unexpected behavior of the test

- Need to skip those tests on Cpuset machine


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
