### PR TITLE
Fix cgroups not cleaned up on checkpoint_abort

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -525,7 +525,8 @@ enum bg_hook_request {
 	BG_PBS_BATCH_DeleteJob,
 	BG_PBSE_SISCOMM,
 	BG_IM_DELETE_JOB_REPLY,
-	BG_IM_DELETE_JOB
+	BG_IM_DELETE_JOB,
+	BG_CHECKPOINT_ABORT
 };
 
 struct job {

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -3895,6 +3895,26 @@ post_chkpt(job *pjob, int  ev)
 		 **	obit is sent.
 		 */
 		if (abort) {
+			mom_hook_input_t	hook_input;
+			mom_hook_output_t	hook_output;
+			int			hook_errcode = 0;
+			hook			*last_phook = NULL;
+			unsigned int		hook_fail_action = 0;
+			char			hook_msg[HOOK_MSG_SIZE+1];
+
+			mom_hook_input_init(&hook_input);
+			hook_input.pjob = pjob;
+
+			mom_hook_output_init(&hook_output);
+			hook_output.reject_errcode = &hook_errcode;
+			hook_output.last_phook = &last_phook;
+			hook_output.fail_action = &hook_fail_action;
+
+			(void)mom_process_hooks(HOOK_EVENT_EXECJOB_ABORT,
+						PBS_MOM_SERVICE_NAME, mom_host,
+						&hook_input, &hook_output, hook_msg,
+						sizeof(hook_msg), 1);
+
 			exiting_tasks = 1;
 			term_job(pjob);
 		} else if (pjob->ji_preq) {

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -3910,7 +3910,7 @@ post_chkpt(job *pjob, int  ev)
 			hook_output.last_phook = &last_phook;
 			hook_output.fail_action = &hook_fail_action;
 
-			(void)mom_process_hooks(HOOK_EVENT_EXECJOB_ABORT,
+			(void)mom_process_hooks(HOOK_EVENT_EXECJOB_END,
 						PBS_MOM_SERVICE_NAME, mom_host,
 						&hook_input, &hook_output, hook_msg,
 						sizeof(hook_msg), 1);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* With cgroups hook enabled, when scheduler preempts a lower priority multi-node job causing the mom to do a checkpoint_abort, the high priority job does not run.
* The reason being the cgroups hook did not clean up the cgroups resources on the secondary node of the preempted job.
* The high priority job fails on execjob_begin pbs_cgroups hook on the sister node, complaining about "CgroupProcessingError...Failed to assign resources"


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Have the execjob_abort hook execute when mom does a successful IM_CHECKPOINT_ABORT (checkpoint job then kill job).
* In this way, the execjob_abort side of pbs_cgroups hook would be called which does the cgroups clean up.
* It was a bug in the initial implementation of execjob_abort hook to not be called on a mom checkpoint_job abort request.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [ptl.test_checkpoint_abort_preemption.FAIL.txt](https://github.com/PBSPro/pbspro/files/4130800/ptl.test_checkpoint_abort_preemption.FAIL.txt)
* [ptl.test_checkpoint_abort_preemption.PASS.2.txt](https://github.com/PBSPro/pbspro/files/4201186/ptl.test_checkpoint_abort_preemption.PASS.2.txt)
* [ptl.cgroups.txt](https://github.com/PBSPro/pbspro/files/4130802/ptl.cgroups.txt)
* Valgrind Sister mom: [valgrind.td-08.sister.txt](https://github.com/PBSPro/pbspro/files/4201190/valgrind.td-08.sister.txt)

* Valgrind MS mom: [valgrind.td-09.ms.txt](https://github.com/PBSPro/pbspro/files/4201192/valgrind.td-09.ms.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
