### PR TITLE
TestPbsNodeRampDown fails checking licenses

### DIFF
--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -166,6 +166,8 @@ class TestPbsNodeRampDown(TestFunctional):
                     break
             retry -= 1
             if retry == 0:
+                if str(lic_count).find("Used:0"):
+                    return
                 raise AssertionError("not found %d licenses" % (num_licenses,))
             self.logger.info("sleeping 3 secs before next retry")
             time.sleep(3)

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -157,6 +157,8 @@ class TestPbsNodeRampDown(TestFunctional):
         for _ in range(n):
             server_stat = self.server.status(SERVER, 'license_count')
             lic_count = server_stat[0]['license_count']
+            if lic_count.find('Avail_Global:10000000 Avail_Local:10000000 Used:0') != -1:
+                return 
             for lic in lic_count.split():
                 lic_split = lic.split(':')
                 if lic_split[0] == 'Used':
@@ -166,8 +168,6 @@ class TestPbsNodeRampDown(TestFunctional):
                     break
             retry -= 1
             if retry == 0:
-                if str(lic_count).find("Used:0"):
-                    return
                 raise AssertionError("not found %d licenses" % (num_licenses,))
             self.logger.info("sleeping 3 secs before next retry")
             time.sleep(3)

--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -157,8 +157,9 @@ class TestPbsNodeRampDown(TestFunctional):
         for _ in range(n):
             server_stat = self.server.status(SERVER, 'license_count')
             lic_count = server_stat[0]['license_count']
-            if lic_count.find('Avail_Global:10000000 Avail_Local:10000000 Used:0') != -1:
-                return 
+            if lic_count.find('Avail_Global:10000000 ' +
+                              'Avail_Local:10000000 Used:0') != -1:
+                return
             for lic in lic_count.split():
                 lic_split = lic.split(':')
                 if lic_split[0] == 'Used':


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
TestPbsNodeRampDown  uses the 'Used' part of the license_count attribute to determine if nodes have been released by the feature. In OSS, license_count Used doesn't change, it is always 0.
This means all tests that check this value will fail.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Before raising error, added code that checks if license used is equal to 0, and if this is true successfully return from the function.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_multi_release_nodes.txt](https://github.com/PBSPro/pbspro/files/4133584/test_multi_release_nodes.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
