### PR TITLE
test_qstat_pt of TestQstat is failing while setting node attributes due to using hostname instead of shortname

### DIFF
--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -49,7 +49,8 @@ class TestQstat(TestFunctional):
         """
 
         attr = {'resources_available.ncpus': 1}
-        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.hostname)
+        self.server.manager(MGR_CMD_SET, NODE, attr,
+                            id=self.mom.shortname)
 
         job_count = 10
         j = Job(TEST_USER)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- test_qstat_pt of TestQstat is failing while setting node attributes due to using hostname instead of shortname


#### Describe Your Change
Instead of using mom.hostname use mom.shortname while setting node attributes in the test


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[Execution_logs_qstat_pt.txt](https://github.com/PBSPro/pbspro/files/4143596/Execution_logs_qstat_pt.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
