### PR TITLE
In test "test_not_buckets" used "mom.add_checkpoint_abort_script" to create checkpoint_abort_script

### DIFF
--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -436,11 +436,7 @@ class TestNodeBuckets(TestFunctional):
                 kill $1
                 exit 0
                 """
-        self.chk_file = self.du.create_temp_file(body=chk_script)
-        self.du.chmod(path=self.chk_file, mode=0o755)
-        self.du.chown(path=self.chk_file, uid=0, gid=0, sudo=True)
-        c = {'$action': 'checkpoint_abort 30 !' + self.chk_file + ' %sid'}
-        self.mom.add_config(c)
+        self.mom.add_checkpoint_abort_script(body=chk_script)
 
         self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'C'},
                             runas=ROOT_USER)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
For some platforms,  server and mom are different nodes, so test failed to get checkpoint_abort_script


#### Describe Your Change
Used "mom.add_checkpoint_abort_script" to create checkpoint_abort_script

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[test_node_buckets.txt](https://github.com/PBSPro/pbspro/files/4146676/test_node_buckets.txt)

[test_node_buket_platform2.txt](https://github.com/PBSPro/pbspro/files/4146668/test_node_buket_platform2.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
