### PR TITLE
Queue resources becomes negative and remains even after unset the attribute

### DIFF
--- a/src/include/resource.h
+++ b/src/include/resource.h
@@ -133,6 +133,7 @@ extern int  parse_resc_flags(char *val, int *flag_ir_p, int *resc_flag_p);
 extern int verify_resc_name(char *name);
 extern int verify_resc_type_and_flags(int resc_type, int *pflag_ir, int *presc_flag, char *rescname, char *buf, int buflen, int autocorrect);
 extern void update_resc_sum(void);
+extern int check_resc_assign_val(resource *);
 
 /* Defines for entity limit tracking */
 #define PBS_ENTLIM_NOLIMIT  0	/* No entity limit has been set for this resc */

--- a/src/lib/Libattr/attr_resc_func.c
+++ b/src/lib/Libattr/attr_resc_func.c
@@ -447,3 +447,30 @@ parse_resc_flags(char *val, int *flag_ir_p, int *resc_flag_p)
 	*resc_flag_p = resc_flag;
 	return 0;
 }
+
+/**
+ * @brief
+ * 		check the resource "resources_assigned" attribute is eligible
+ * 		to unset or not at this point of time.
+ *
+ * @param[in] resc - the resource structure
+ *
+ * @retval  1 if eligible to unset
+ * @retval  0 if not eligible to unset
+ */
+int
+check_resc_assign_val(resource *resc) {
+
+	if (resc->rs_value.at_type == ATR_TYPE_FLOAT) {
+		if (resc->rs_value.at_val.at_float <= 0)
+			return 1;
+	} else if (resc->rs_value.at_type == ATR_TYPE_LONG) {
+		if (resc->rs_value.at_val.at_long <= 0)
+			return 1;
+	} else if (resc->rs_value.at_type == ATR_TYPE_SIZE) {
+		if (resc->rs_value.at_val.at_size.atsv_num <= 0)
+			return 1;
+	}
+	return 0;
+}
+

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1127,7 +1127,10 @@ mgr_unset_attr(attribute *pattr, attribute_def *pdef, int limit, svrattrl *plist
 							if (i >= 0) {
 								if ((pattr+i)->at_flags & ATR_VFLAG_SET) {
 									resource *nresc;
-									if ((nresc = find_resc_entry((pattr+i), prsdef)) != NULL) {
+									/* if resources_assigned value is non-zero then don't unset it, otherwise it
+									 * would appear as negative in qstat once job is finished.
+									 */
+									if (((nresc = find_resc_entry((pattr+i), prsdef)) != NULL) && (nresc->rs_value.at_val.at_long == 0)) {
 										nresc->rs_defin->rs_free(&nresc->rs_value);
 										delete_link(&nresc->rs_link);
 										free(nresc);

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1135,10 +1135,10 @@ mgr_unset_attr(attribute *pattr, attribute_def *pdef, int limit, svrattrl *plist
 											nresc->rs_defin->rs_free(&nresc->rs_value);
 											delete_link(&nresc->rs_link);
 											free(nresc);
-											nresc = (resource *)GET_NEXT((pattr+i)->at_val.at_list);
+											nresc = (resource *)GET_NEXT((pattr + i)->at_val.at_list);
 											if (nresc == NULL)
-												(pattr+i)->at_flags &= ~ATR_VFLAG_SET;
-											(pattr+i)->at_flags |= ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
+												(pattr + i)->at_flags &= ~ATR_VFLAG_SET;
+											(pattr + i)->at_flags |= ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 										}
 									}
 								}

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1127,17 +1127,19 @@ mgr_unset_attr(attribute *pattr, attribute_def *pdef, int limit, svrattrl *plist
 							if (i >= 0) {
 								if ((pattr+i)->at_flags & ATR_VFLAG_SET) {
 									resource *nresc;
-									/* if resources_assigned value is non-zero then don't unset it, otherwise it
-									 * would appear as negative in qstat once job is finished.
-									 */
-									if (((nresc = find_resc_entry((pattr+i), prsdef)) != NULL) && (nresc->rs_value.at_val.at_long == 0)) {
-										nresc->rs_defin->rs_free(&nresc->rs_value);
-										delete_link(&nresc->rs_link);
-										free(nresc);
-										nresc = (resource *)GET_NEXT((pattr+i)->at_val.at_list);
-										if (nresc == NULL)
-											(pattr+i)->at_flags &= ~ATR_VFLAG_SET;
-										(pattr+i)->at_flags |= ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
+									if ((nresc = find_resc_entry((pattr + i), prsdef)) != NULL) {
+										/* if resources_assigned value is non-zero then don't unset it, otherwise it
+										 * would appear as negative in qstat once job is finished.
+										 */
+										if (check_resc_assign_val(nresc)) {
+											nresc->rs_defin->rs_free(&nresc->rs_value);
+											delete_link(&nresc->rs_link);
+											free(nresc);
+											nresc = (resource *)GET_NEXT((pattr+i)->at_val.at_list);
+											if (nresc == NULL)
+												(pattr+i)->at_flags &= ~ATR_VFLAG_SET;
+											(pattr+i)->at_flags |= ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
+										}
 									}
 								}
 							}
@@ -1194,7 +1196,6 @@ mgr_unset_attr(attribute *pattr, attribute_def *pdef, int limit, svrattrl *plist
 		indirect_target_check(0);
 	return (0);
 }
-
 
 /**
  * @brief

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -505,10 +505,11 @@ set_resc_assigned(void *pobj, int objtype, enum batch_op op)
 				}
 				rscdef->rs_set(&pr->rs_value, &rescp->rs_value, op);
 
-				/* if matching resources_available doesn't exist in queue then remove resources_assigned also if it's
-				 * value is equal or less than 0 (except PBS in-built resources i.e. ncpus, nodect etc).
+				/* Validate the "resources_assigned" value of resource and if it's value is equal or less than 0
+				 * then check it's corresponding "resources_available" attribute in queue if not found then
+				 * remove "resources_assigned" also(except PBS in-built resources i.e. ncpus, nodect etc).
 				 */
-				if (pr->rs_value.at_val.at_long <= 0) {
+				if (check_resc_assign_val(pr)) {
 					resource *avail_resc = NULL;
 					avail_resc = find_resc_entry(&pjob->ji_qhdr->qu_attr[(int)QE_ATR_ResourceAvail], rscdef);
 					if (!avail_resc) {

--- a/test/tests/functional/pbs_que_resc_usage.py
+++ b/test/tests/functional/pbs_que_resc_usage.py
@@ -1,0 +1,180 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+import time
+
+
+class TestQueRescUsage(TestFunctional):
+    """
+    Test built-in and custom resource behavior after
+    set/unset/assign/release resource on the queue
+    """
+    err_msg = 'Failed to get the expected resource value/result'
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        self.server.manager(MGR_CMD_SET, NODE, {
+                            'resources_available.ncpus': 5},
+                            self.mom.shortname)
+        a = {'queue_type': 'execution', 'enabled': True, 'started': True}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='new_q')
+
+    def test_built_in_resc(self):
+        """
+        Test built-in resource and check the assigned resource value
+        after unset and shouldn't set to any negative value
+        """
+        # Unset the resource after job completion
+        a = {'resources_available.ncpus': 4}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id='new_q')
+        j_attr = {ATTR_queue: 'new_q', 'Resource_List.select': '1:ncpus=3'}
+        j = Job(TEST_USER, j_attr)
+        j.set_sleep_time(20)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, jid)
+        q_status = self.server.status(
+            QUEUE, 'resources_assigned.ncpus', id='new_q', extend='f')
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.ncpus']), 3, self.err_msg)
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid)
+        q_status = self.server.status(
+            QUEUE, 'resources_assigned.ncpus', id='new_q', extend='f')
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.ncpus']), 0, self.err_msg)
+        self.server.manager(MGR_CMD_UNSET, QUEUE,
+                            'resources_available.ncpus', id='new_q')
+        q_status = self.server.status(QUEUE, id='new_q', extend='f')
+        self.assertNotIn('resources_available.ncpus',
+                         q_status[0].keys(), self.err_msg)
+        self.assertNotIn('resources_assigned.ncpus',
+                         q_status[0].keys(), self.err_msg)
+
+        # Unset the resource before job completion
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id='new_q')
+        j = Job(TEST_USER, j_attr)
+        j.set_sleep_time(50)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, jid)
+        q_status = self.server.status(
+            QUEUE, 'resources_assigned.ncpus', id='new_q', extend='f')
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.ncpus']), 3, self.err_msg)
+        self.server.manager(MGR_CMD_UNSET, QUEUE,
+                            'resources_available.ncpus', id='new_q')
+        q_status = self.server.status(QUEUE, id='new_q', extend='f')
+        self.assertNotIn('resources_available.ncpus',
+                         q_status[0].keys(), self.err_msg)
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.ncpus']), 3, self.err_msg)
+        self.server.delete(jid, wait=True)
+        q_status = self.server.status(
+            QUEUE, 'resources_assigned.ncpus', id='new_q', extend='f')
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.ncpus']), 0, self.err_msg)
+
+    def test_custom_resc(self):
+        """
+        Test custom resource and check the assigned resource value
+        after unset and shouldn't set to any negative value
+        """
+        # Unset the resource after job completion
+        self.server.manager(MGR_CMD_CREATE, RSC, {
+                            'type': 'long', 'flag': 'q'}, id='foo')
+        self.scheduler.add_resource('foo')
+        self.server.manager(MGR_CMD_SET, QUEUE, {
+                            'resources_available.foo': 11}, id='new_q')
+        j_attr = {ATTR_queue: 'new_q',
+                  'Resource_List.select': '1:ncpus=1',
+                  'Resource_List.foo': '5'}
+        j = Job(TEST_USER, j_attr)
+        j.set_sleep_time(20)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, jid)
+        q_status = self.server.status(
+            QUEUE, 'resources_assigned.foo', id='new_q', extend='f')
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.foo']), 5, self.err_msg)
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid)
+        self.server.manager(MGR_CMD_UNSET, QUEUE,
+                            'resources_available.foo', id='new_q')
+        q_status = self.server.status(QUEUE, id='new_q', extend='f')
+        self.assertNotIn('resources_available.foo',
+                         q_status[0].keys(), self.err_msg)
+        self.assertNotIn(
+            'resources_assigned.foo',
+            q_status[0].keys(),
+            self.err_msg)
+
+        # Unset the resource before job completion
+        self.server.manager(MGR_CMD_SET, QUEUE, {
+                            'resources_available.foo': 11}, id='new_q')
+        j_attr = {ATTR_queue: 'new_q',
+                  'Resource_List.select': '1:ncpus=1',
+                  'Resource_List.foo': '5'}
+        j = Job(TEST_USER, j_attr)
+        j.set_sleep_time(50)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, jid)
+        j_1 = Job(TEST_USER, j_attr)
+        j_1.set_sleep_time(50)
+        jid_1 = self.server.submit(j_1)
+        self.server.expect(JOB, {'job_state': 'R'}, jid_1)
+        q_status = self.server.status(
+            QUEUE, 'resources_assigned.foo', id='new_q', extend='f')
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.foo']), 10, self.err_msg)
+        self.server.manager(MGR_CMD_UNSET, QUEUE,
+                            'resources_available.foo', id='new_q')
+        q_status = self.server.status(QUEUE, id='new_q', extend='f')
+        self.assertNotIn('resources_available.foo',
+                         q_status[0].keys(), self.err_msg)
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.foo']), 10, self.err_msg)
+        # delete one job only and check resource_assigned
+        self.server.delete(jid, wait=True)
+        q_status = self.server.status(
+            QUEUE, 'resources_assigned.foo', id='new_q', extend='f')
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.foo']), 5, self.err_msg)
+        # delete last job in queue
+        self.server.delete(jid_1, wait=True)
+        q_status = self.server.status(QUEUE, id='new_q', extend='f')
+        self.assertNotIn(
+            'resources_assigned.foo',
+            q_status[0].keys(),
+            self.err_msg)


### PR DESCRIPTION
#### Describe Bug or Feature
Queue resources_assigned goes negative because we unset a resource which is already been occupied by the job.
**Steps to reproduce:**
1. set q \<queue_name\> resources_available.ncpus=\<value\>
2. run a job
3. unset q <qeueu_name> resources_available.ncpus
4. qdel the job
5. qstat -Qf \<queue_name\> and see "resources_assigned" value
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
If we want to unset the resc, we will check it's **resources_assigned** value. If the value is **zero** then we will remove both the attribute **resources_available** and **resources_assigned** else we will remove only **resources_available** attribute. Once **resources_assigned** value becomes zero, PBS will search for the corresponding **resources_available** attribute and if not found, it will remove **resources_assigned** attribute as well else leave both the attributes as it is.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
PTL logs: [ptl_pbs_que_resc_usage.txt](https://github.com/PBSPro/pbspro/files/4213115/ptl_pbs_que_resc_usage.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
