### PR TITLE
PTL framework accepts special characters in job_name string

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1191,6 +1191,7 @@ class BatchUtils(object):
     def __init__(self):
         self.logger = logging.getLogger(__name__)
         self.du = DshUtils()
+        self.platform = self.du.get_platform()
 
     def list_to_attrl(self, l):
         """
@@ -2383,7 +2384,12 @@ class BatchUtils(object):
             attrs = attrs.items()
 
         for a, v in attrs:
-            if a == "Job_Name":
+            # In job name string, use prefix "\" with special charater
+            # to read as an ordinary character on
+            # cray, carysim and shasta platform
+            if (a == "Job_Name") and (self.platform == 'cray' or
+                                      self.platform == 'craysim' or
+                                      self.platform == 'shasta'):
                 v = v.translate({ord(c): "\\" +
                                  c for c in r"~`!@#$%^&*()[]{};:,./<>?\|-=_+"})
             if exclude_attrs is not None and a in exclude_attrs:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2386,7 +2386,7 @@ class BatchUtils(object):
         for a, v in attrs:
             # In job name string, use prefix "\" with special charater
             # to read as an ordinary character on
-            # cray, carysim and shasta platform
+            # cray, craysim, and shasta platform
             if (a == "Job_Name") and (self.platform == 'cray' or
                                       self.platform == 'craysim' or
                                       self.platform == 'shasta'):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2383,7 +2383,7 @@ class BatchUtils(object):
             attrs = attrs.items()
 
         for a, v in attrs:
-            if a=="Job_Name":
+            if a == "Job_Name":
                 v = v.translate({ord(c): "\\" +
                                  c for c in r"~`!@#$%^&*()[]{};:,./<>?\|-=_+"})
             if exclude_attrs is not None and a in exclude_attrs:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2383,8 +2383,9 @@ class BatchUtils(object):
             attrs = attrs.items()
 
         for a, v in attrs:
-            v = v.translate({ord(c): "\\" +
-                             c for c in r"~`!@#$%^&*()[]{};:,./<>?\|-=_+"})
+            if a=="Job_Name":
+                v = v.translate({ord(c): "\\" +
+                                 c for c in r"~`!@#$%^&*()[]{};:,./<>?\|-=_+"})
             if exclude_attrs is not None and a in exclude_attrs:
                 continue
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2383,6 +2383,7 @@ class BatchUtils(object):
             attrs = attrs.items()
 
         for a, v in attrs:
+            v = v.translate ({ord(c): "\\"+c for c in "~`!@#$%^&*()[]{};:,./<>?\|-=_+"})
             if exclude_attrs is not None and a in exclude_attrs:
                 continue
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -2383,7 +2383,8 @@ class BatchUtils(object):
             attrs = attrs.items()
 
         for a, v in attrs:
-            v = v.translate ({ord(c): "\\"+c for c in "~`!@#$%^&*()[]{};:,./<>?\|-=_+"})
+            v = v.translate({ord(c): "\\" +
+                             c for c in r"~`!@#$%^&*()[]{};:,./<>?\|-=_+"})
             if exclude_attrs is not None and a in exclude_attrs:
                 continue
 

--- a/test/tests/functional/pbs_validate_job_qsub_attributes.py
+++ b/test/tests/functional/pbs_validate_job_qsub_attributes.py
@@ -93,7 +93,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "submitted job with long select" )
         This test case validates, illlegal characters in job name,
         cause qsub to error out
         """
-        J = Job(TEST_USER, attrs={ATTR_N: 'j&whoami&gt;/tmp/b&'})
+        J = Job(TEST_USER, attrs={ATTR_N: r'j\&whoami\&gt\;/tmp/b\&'})
         try:
             jid = self.server.submit(J)
         except PbsSubmitError as e:
@@ -133,7 +133,11 @@ pbs.logmsg(pbs.LOG_DEBUG, "submitted job with long select" )
         This test case validates, illlegal characters in job name
         for a job array, cause qsub to error out
         """
-        J = Job(TEST_USER, attrs={ATTR_N: 'j&whoami&g;/tmp/b&', ATTR_J: '1-2'})
+        J = Job(
+            TEST_USER,
+            attrs={
+                ATTR_N: r'j\&whoami\&gt\;/tmp/b\&',
+                ATTR_J: "1-2"})
         try:
             jid = self.server.submit(J)
         except PbsSubmitError as e:

--- a/test/tests/functional/pbs_validate_job_qsub_attributes.py
+++ b/test/tests/functional/pbs_validate_job_qsub_attributes.py
@@ -93,7 +93,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "submitted job with long select" )
         This test case validates, illlegal characters in job name,
         cause qsub to error out
         """
-        J = Job(TEST_USER, attrs={ATTR_N: r'j\&whoami\&gt\;/tmp/b\&'})
+        J = Job(TEST_USER, attrs={ATTR_N: "j&whoami&gt;/tmp/b&"})
         try:
             jid = self.server.submit(J)
         except PbsSubmitError as e:
@@ -136,7 +136,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "submitted job with long select" )
         J = Job(
             TEST_USER,
             attrs={
-                ATTR_N: r'j\&whoami\&gt\;/tmp/b\&',
+                ATTR_N: "j&whoami&gt;/tmp/b&",
                 ATTR_J: "1-2"})
         try:
             jid = self.server.submit(J)

--- a/test/tests/functional/pbs_validate_job_qsub_attributes.py
+++ b/test/tests/functional/pbs_validate_job_qsub_attributes.py
@@ -93,7 +93,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "submitted job with long select" )
         This test case validates, illlegal characters in job name,
         cause qsub to error out
         """
-        J = Job(TEST_USER, attrs={ATTR_N: "j&whoami&gt;/tmp/b&"})
+        J = Job(TEST_USER, attrs={ATTR_N: 'j&whoami&gt;/tmp/b&'})
         try:
             jid = self.server.submit(J)
         except PbsSubmitError as e:
@@ -133,11 +133,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "submitted job with long select" )
         This test case validates, illlegal characters in job name
         for a job array, cause qsub to error out
         """
-        J = Job(
-            TEST_USER,
-            attrs={
-                ATTR_N: "j&whoami&gt;/tmp/b&",
-                ATTR_J: "1-2"})
+        J = Job(TEST_USER, attrs={ATTR_N: 'j&whoami&g;/tmp/b&', ATTR_J: '1-2'})
         try:
             jid = self.server.submit(J)
         except PbsSubmitError as e:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When we submit job with job name like "qsub -N jobname_string" and jobname_string has special character but we want special character as a ordinary character then cmdline unable to read special character as a ordinary character.

#### Describe Your Change
Prefixing a special character with "\\" to turn it into ordinary character.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[qsub_N_cmdline_platform_1.txt](https://github.com/PBSPro/pbspro/files/4179262/qsub_N_cmdline_platform_1.txt)
[qsub_N_cmdline_platform_2.txt](https://github.com/PBSPro/pbspro/files/4179263/qsub_N_cmdline_platform_2.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
