### PR TITLE
Fixed sched crash with maint reservations

### DIFF
--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1635,7 +1635,7 @@ check_vnodes_down(resource_resv *resv, int *tot_vnodes, char *names_of_down_vnod
 	int vnodes_down; /* number of unavailable vnodes */
 	int j;
 
-	if (resv == NULL || tot_vnodes == NULL)
+	if (resv == NULL || resv->nspec_arr == NULL || tot_vnodes == NULL)
 		return -2;
 
 	*tot_vnodes = 0; /* initialize the total number of vnodes */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In a recent change to the scheduler, the function check_vnodes_down() was changed to take the reservation itself instead of the nodes of the reservation.  Instead of looping over the passed in nodes, it will now loop over resv->nspec_arr.  There is a corner case of maintenance reservations where an in conflict reservation has all of its nodes stripped from it.  In that case, resv->nspec_arr is NULL.  We'd dereference it and crash.

#### Describe Your Change
Previously we'd check if the passed in nodes was NULL and return -1 (now -2).  I added a check for resv->nspec_arr != NULL as well.

#### Attach Test and Valgrind Logs/Output
[maint.log](https://github.com/PBSPro/pbspro/files/4155822/maint.log)
