### PR TITLE
Reducing sched attributes update to Server ...

### DIFF
--- a/src/include/server.h
+++ b/src/include/server.h
@@ -282,7 +282,7 @@ extern int			sched_save_db(pbs_sched *, int mode);
 extern enum failover_state	are_we_primary(void);
 extern int			have_socket_licensed_nodes(void);
 extern void			unlicense_socket_licensed_nodes(void);
-extern void			set_sched_default(pbs_sched *,  int from_scheduler);
+extern void			set_sched_default(pbs_sched *, int from_scheduler);
 extern void			set_attr_svr(attribute *pattr, attribute_def *pdef, char *value);
 extern int			license_sanity_check(void);
 extern void			memory_debug_log(struct work_task *ptask);

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -282,7 +282,7 @@ extern int			sched_save_db(pbs_sched *, int mode);
 extern enum failover_state	are_we_primary(void);
 extern int			have_socket_licensed_nodes(void);
 extern void			unlicense_socket_licensed_nodes(void);
-extern void			set_sched_default(pbs_sched *, int unset_flag, int from_scheduler);
+extern void			set_sched_default(pbs_sched *,  int from_scheduler);
 extern void			set_attr_svr(attribute *pattr, attribute_def *pdef, char *value);
 extern int			license_sanity_check(void);
 extern void			memory_debug_log(struct work_task *ptask);

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -570,7 +570,6 @@ schedule(int cmd, int sd, char *runjobid)
 			 * server through qmgr.
 			 */
 			if (!validate_sched_attrs(connector)) {
-				log_err(-1, __func__, "validate_sched_attrs failed");
 				return 0;
 			}
 			break;
@@ -2694,7 +2693,6 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 		return 1;
 
 	if (!validate_sched_attrs(connector)) {
-		log_err(-1, __func__, "validate_sched_attrs failed");
 		return 0;
 	}
 
@@ -2766,6 +2764,8 @@ validate_sched_attrs(int connector)
 	ss = bs_find(all_ss, sc_name);
 
 	if (ss == NULL) {
+		snprintf(log_buffer, sizeof(log_buffer), "Unable to retrieve the scheduler attributes from server");
+		log_err(-1, __func__, log_buffer);
 		pbs_statfree(all_ss);
 		return 0;
 	}

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2693,8 +2693,10 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	if (cmd == SCH_ERROR || connector < 0)
 		return 1;
 
-	if (!validate_sched_attrs(connector))
+	if (!validate_sched_attrs(connector)) {
+		log_err(-1, __func__, "validate_sched_attrs failed");
 		return 0;
+	}
 
 	/* update the sched with new values */
 	attribs = calloc(4, sizeof(struct attropl));

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2686,16 +2686,11 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 {
 	char tempstr[128];
 	char port_str[MAX_INT_LEN];
-	static int svr_knows_me = 0;
-	int err;
 	struct attropl*attribs, *patt;
 	char sched_host[PBS_MAXHOSTNAME + 1];
 
-	/* This command is only sent on restart of the server */
-	if (cmd == SCH_SCHEDULE_FIRST)
-		svr_knows_me = 0;
 
-	if ((cmd != SCH_SCHEDULE_NULL && cmd != SCH_ATTRS_CONFIGURE && svr_knows_me) || cmd == SCH_ERROR || connector < 0)
+	if (cmd == SCH_ERROR || connector < 0)
 		return 1;
 
 	if (!validate_sched_attrs(connector))
@@ -2736,11 +2731,7 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	}
 	patt->next = NULL;
 
-	err = pbs_manager(connector,
-			  MGR_CMD_SET, MGR_OBJ_SCHED,
-			  sc_name, attribs, NULL);
-	if (err == 0)
-		svr_knows_me = 1;
+	pbs_manager(connector, MGR_CMD_SET, MGR_OBJ_SCHED, sc_name, attribs, NULL);
 
 	free(attribs);
 	return 1;
@@ -2773,7 +2764,6 @@ validate_sched_attrs(int connector)
 	ss = bs_find(all_ss, sc_name);
 
 	if (ss == NULL) {
-		log_err(-1, __func__,  "Unable to retrieve the scheduler attributes from server");
 		pbs_statfree(all_ss);
 		return 0;
 	}

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -230,6 +230,8 @@ int scheduler_simulation_task(int pbs_sd, int debug);
 
 int update_svr_schedobj(int connector, int cmd, int alarm_time);
 
+int validate_sched_attrs(int connector);
+
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -937,7 +937,7 @@ main(int argc, char *argv[])
 	int num_cores;
 	char *endp = NULL;
 	pthread_mutexattr_t attr;
-	static int update_svr = 1;
+	int update_svr = 1;
 
 	/*the real deal or show version and exit?*/
 

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -118,7 +118,6 @@ struct		connect_handle connection[NCONNECTS];
 int		connector;
 int		server_sock;
 int		second_connection = -1;
-static int	update_svr = 1;
 
 #define		START_CLIENTS	2	/* minimum number of clients */
 #define		MAX_PORT_NUM 65535
@@ -938,6 +937,7 @@ main(int argc, char *argv[])
 	int num_cores;
 	char *endp = NULL;
 	pthread_mutexattr_t attr;
+	static int update_svr = 1;
 
 	/*the real deal or show version and exit?*/
 

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -118,6 +118,7 @@ struct		connect_handle connection[NCONNECTS];
 int		connector;
 int		server_sock;
 int		second_connection = -1;
+static int	update_svr = 1;
 
 #define		START_CLIENTS	2	/* minimum number of clients */
 #define		MAX_PORT_NUM 65535
@@ -1483,8 +1484,11 @@ main(int argc, char *argv[])
 		cmd = server_command(&runjobid);
 
 		if (connector >= 0) {
-			/* update sched object attributes on server */
-			update_svr_schedobj(connector, cmd, alarm_time);
+			if (update_svr) {
+				/* update sched object attributes on server */
+				update_svr_schedobj(connector, cmd, alarm_time);
+				update_svr = 0;
+			}
 
 			if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)
 				log_err(errno, __func__, "sigprocmask(SIG_BLOCK)");

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -615,7 +615,7 @@ pbsd_init(int type)
 			/* No Schedulers found in DB */
 			/* Create and save default to DB*/
 			dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME);
-			set_sched_default(dflt_scheduler, 0, 0);
+			set_sched_default(dflt_scheduler, 0);
 			(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
 		} else {
 			while ((rc = pbs_db_cursor_next(conn, state, &obj)) == 0) {
@@ -662,7 +662,7 @@ pbsd_init(int type)
 		}
 		svr_save_db(&server, SVR_SAVE_NEW);
 		dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME);
-		set_sched_default(dflt_scheduler, 0, 0);
+		set_sched_default(dflt_scheduler, 0);
 		(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
 	}
 

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1701,9 +1701,9 @@ mgr_sched_set(struct batch_request *preq)
 		reply_badattr(rc, bad_attr, plist, preq);
 	else {
 		if (find_sched_from_sock(preq->rq_conn))
-			set_sched_default(psched, 0, 1);
+			set_sched_default(psched, 1);
 		else
-			set_sched_default(psched, 0, 0);
+			set_sched_default(psched, 0);
 		(void)sched_save_db(psched, SVR_SAVE_FULL);
 
 		(void)sprintf(log_buffer, msg_manager, msg_man_set,
@@ -1771,7 +1771,7 @@ mgr_sched_unset(struct batch_request *preq)
 	else {
 
 		/* save the attributes to disk */
-		set_sched_default(psched, 1, 0);
+		set_sched_default(psched, 0);
 		(void)sched_save_db(psched, SVR_SAVE_FULL);
 		(void)sprintf(log_buffer, msg_manager, msg_man_uns,
 			preq->rq_user, preq->rq_host);
@@ -3645,7 +3645,7 @@ mgr_sched_create(struct batch_request *preq)
 	} else {
 
 		/* save the attributes to disk */
-		set_sched_default(psched, 0, 0);
+		set_sched_default(psched, 0);
 		(void) sched_save_db(psched, SVR_SAVE_FULL);
 		snprintf(log_buffer, LOG_BUF_SIZE, msg_manager, msg_man_set,
 				preq->rq_user, preq->rq_host);

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -886,7 +886,7 @@ poke_scheduler(attribute *pattr, void *pobj, int actmode)
  *
   */
 void
-set_sched_default(pbs_sched *psched, int unset_flag, int from_scheduler)
+set_sched_default(pbs_sched *psched, int from_scheduler)
 {
 	char *temp;
 	char dir_path[MAXPATHLEN +1] = {0};
@@ -899,7 +899,7 @@ set_sched_default(pbs_sched *psched, int unset_flag, int from_scheduler)
 		set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_cycle_len]), &sched_attr_def[(int) SCHED_ATR_sched_cycle_len],
 			TOSTR(PBS_SCHED_CYCLE_LEN_DEFAULT));
 	}
-	if (!unset_flag && (psched->sch_attr[(int) SCHED_ATR_schediteration].at_flags & ATR_VFLAG_SET) == 0) {
+	if ((psched->sch_attr[(int) SCHED_ATR_schediteration].at_flags & ATR_VFLAG_SET) == 0) {
 		set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_schediteration]), &sched_attr_def[(int) SCHED_ATR_schediteration],
 			TOSTR(PBS_SCHEDULE_CYCLE));
 	}
@@ -956,7 +956,7 @@ set_sched_default(pbs_sched *psched, int unset_flag, int from_scheduler)
 		psched->sch_attr[SCHED_ATR_preempt_order].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_DEFLT;
 		flag = 1;
 	}
-	if (!unset_flag && !from_scheduler && !(psched->sch_attr[SCHED_ATR_preempt_sort].at_flags & ATR_VFLAG_SET)) {
+	if ( !from_scheduler && !(psched->sch_attr[SCHED_ATR_preempt_sort].at_flags & ATR_VFLAG_SET)) {
 		psched->sch_attr[SCHED_ATR_preempt_sort].at_val.at_str = strdup(PBS_PREEMPT_SORT_DEFAULT);
 		psched->sch_attr[SCHED_ATR_preempt_sort].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_DEFLT;
 		flag = 1;

--- a/test/tests/interfaces/pbs_sched_interface_test.py
+++ b/test/tests/interfaces/pbs_sched_interface_test.py
@@ -318,5 +318,4 @@ class TestSchedulerInterface(TestInterfaces):
              'scheduling': 'False',
              'scheduler_iteration': 600,
              'sched_cycle_length': '00:20:00'}
-        self.server.expect(SCHED, a, id='TestCommonSched',
-                           attrop=PTL_AND, max_attempts=10)
+        self.server.expect(SCHED, a, id='TestCommonSched', max_attempts=10)

--- a/test/tests/interfaces/pbs_sched_interface_test.py
+++ b/test/tests/interfaces/pbs_sched_interface_test.py
@@ -289,3 +289,14 @@ class TestSchedulerInterface(TestInterfaces):
                             runas=ROOT_USER)
         self.server.expect(SCHED, {'scheduler_iteration': 500},
                            id='default', max_attempts=10)
+
+    def test_scheduling_iteration(self):
+        """
+        Test scheduler_itration attribute after it is unset. It should go
+        to its default value which is 600. If this happens Server will not
+        kickoff infinite scheduling cycles.
+        """
+        self.server.manager(MGR_CMD_UNSET, SCHED,
+                            ATTR_schedit, id='TestCommonSched')
+        self.server.expect(SCHED, {ATTR_schedit: '600'},
+                           id='TestCommonSched', max_attempts=5)

--- a/test/tests/interfaces/pbs_sched_interface_test.py
+++ b/test/tests/interfaces/pbs_sched_interface_test.py
@@ -294,9 +294,29 @@ class TestSchedulerInterface(TestInterfaces):
         """
         Test scheduler_itration attribute after it is unset. It should go
         to its default value which is 600. If this happens Server will not
-        kickoff infinite scheduling cycles.
+        kickoff infinite scheduling cycles. Also make sure that all other
+        scheduler attributes are set to its correct default values after
+        this change.
         """
-        self.server.manager(MGR_CMD_UNSET, SCHED,
-                            ATTR_schedit, id='TestCommonSched')
-        self.server.expect(SCHED, {ATTR_schedit: '600'},
+        self.server.manager(MGR_CMD_SET, SCHED,
+                            {ATTR_schedit: 500},
+                            runas=ROOT_USER, id='TestCommonSched')
+        self.server.expect(SCHED, {ATTR_schedit: '500'},
                            id='TestCommonSched', max_attempts=5)
+
+        self.server.manager(MGR_CMD_UNSET, SCHED, ATTR_schedit,
+                            id='TestCommonSched')
+
+        sched_priv = os.path.join(
+            self.server.pbs_conf['PBS_HOME'], 'sched_priv_TestCommonSched')
+        sched_logs = os.path.join(
+            self.server.pbs_conf['PBS_HOME'], 'sched_logs_TestCommonSched')
+        a = {'sched_port': 15051,
+             'sched_host': self.server.hostname,
+             'sched_priv': sched_priv,
+             'sched_log': sched_logs,
+             'scheduling': 'False',
+             'scheduler_iteration': 600,
+             'sched_cycle_length': '00:20:00'}
+        self.server.expect(SCHED, a, id='TestCommonSched',
+                           attrop=PTL_AND, max_attempts=10)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
As of today Scheduler updates attributes like sched_host, sched_port etc. to Server during every scheduling cycle even though the frequency of them getting changed is very rare. Instead if we can send these attributes only once to Server we can improve the Scheduler's performance.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

- Make sure that we do update sched_host, sched_port etc. to Server as soon as Scheduler comes up as part of first scheduling cycle. We do not repeatedly update these attributes from the next scheduling cycle on words.
- Server can also change sched object attributes like sched_log, sched_priv etc. especially in case of Multiple Schedulers and sent to the Scheduler upon which it has to override the corresponding attributes at the Scheduler. As this is the existing behavior we should make sure that the current refactoring should not break this.
- Server sends SCH_ATTRS_CONFIGURE whenever any of the Scheduler's attributes change during which time update_svr_schedobj() is called. The problem with this function is 
      1) It updates the attributes like sched_host, sched_port etc. to Server and  
      2) Validates the current scheduler attributes like sched_log, sched_priv etc. with these ones and overrides them. 
      Ideally we should separate these two functionalities and in this case we should only do step 2).
      Code changes are made accordingly to re-factor the code.
- In the absence of the above changes PTL is currently hiding the following bug.
  **Issue:** When scheduler_iteration is unset it actually gets reset to "0". The effect of this is Scheduler kicks of infinite scheduling cycles. 
  Even though this bug is present in our code PTL is unable to find it out because of the following  
  reasons.
PTL resets to default by unsetting all the sched attributes. This will briefly unset scheduler_iteration.   When unsetting all the attributes, it unsets sched_priv/sched_log.  If we unset sched_priv/log, this sends the scheduler a SCH_ATTRS_CONFIGURE command.  On that command the scheduler will set various sched object attributes like scheduler version and host.  Since a sched attribute was set, we check if any attributes need to be set back to the default, and reset scheduler_iteration back to 600.
- Now that we have done the above mentioned re-factoring PTL shows this as bug. Solution for this bug is to remove the unset_flag and make sure if scheduler_iteration is unset, we do have to set it back to 600. Code changes are made accordingly
- Through code inspection found a very corner case memory leak and fixed it.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Have written possible PTL test cases to verify the code changes. Tested by using gdb to make sure that scheduler attributes updates to server are happening only once. As we cannot directly write a PTL test case for it, I used to gdb for the verification.

Also done the following testing and attached the logs.
1. All test cases of the test suite TestMultipleSchedulers 
[TestMultipleSchedulers.log](https://github.com/PBSPro/pbspro/files/4157722/TestMultipleSchedulers.log)

2. All test cases of the test suite TestSchedulerInterface 
[TestSchedulerInterface.log](https://github.com/PBSPro/pbspro/files/4157724/TestSchedulerInterface.log)

Following are the logs after implementing review comments.
[TestSchedulerInterface.log](https://github.com/PBSPro/pbspro/files/4180250/TestSchedulerInterface.log)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
