### PR TITLE
Scheduler does not requeue jobs for preemption if rrtros is set

### DIFF
--- a/src/scheduler/queue_info.c
+++ b/src/scheduler/queue_info.c
@@ -151,8 +151,8 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 	if ((queues = pbs_statque(pbs_sd, NULL, NULL, NULL)) == NULL) {
 		errmsg = pbs_geterrmsg(pbs_sd);
 		if (errmsg == NULL)
-			errmsg = "";	
-	log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_QUEUE, LOG_NOTICE, "queue_info", 
+			errmsg = "";
+	log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_QUEUE, LOG_NOTICE, "queue_info",
 			"Statque failed: %s (%d)", errmsg, pbs_errno);
 		free_schd_error(sch_err);
 		return NULL;
@@ -241,7 +241,7 @@ query_queues(status *policy, int pbs_sd, server_info *sinfo)
 							/* Message was PBSEVENT_SCHED - moved to PBSEVENT_DEBUG2 for
 							 * failover reasons (see bz3002)
 							 */
-							log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_REQUEST, LOG_INFO, qinfo->name, 
+							log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_REQUEST, LOG_INFO, qinfo->name,
 								"Can not connect to peer %s", conf.peer_queues[j].remote_server);
 							conf.peer_queues[j].peer_sd = -1;
 							peer_on = 0; /* do not proceed */
@@ -666,7 +666,7 @@ update_queue_on_run(queue_info *qinfo, resource_resv *resresv, char *job_state)
 			multi_node_sort);
 
 
-	if ((job_state != NULL) && (*job_state == 'S'))
+	if ((job_state != NULL) && (*job_state == 'S') && (resresv->job->resreq_rel != NULL))
 		req = resresv->job->resreq_rel;
 	else
 		req = resresv->resreq;
@@ -746,7 +746,7 @@ update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 	if (qinfo == NULL || resresv == NULL)
 		return;
 
-	if (resresv->is_job && resresv->job ==NULL)
+	if (resresv->is_job && resresv->job == NULL)
 		return;
 
 	if (resresv->is_job) {
@@ -760,7 +760,7 @@ update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 		state_count_add(&(qinfo->sc), job_state, 1);
 	}
 
-	if ((job_state != NULL) && (*job_state == 'S') && (resresv->server->policy->rel_on_susp != NULL))
+	if ((job_state != NULL) && (*job_state == 'S') && (resresv->job->resreq_rel != NULL))
 		req = resresv->job->resreq_rel;
 	else
 		req = resresv->resreq;
@@ -772,7 +772,7 @@ update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 			res->assigned -= req->amount;
 
 			if (res->assigned < 0) {
-				log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE, LOG_DEBUG, __func__, 
+				log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE, LOG_DEBUG, __func__,
 					"%s turned negative %.2lf, setting it to 0", res->name, res->assigned);
 				res->assigned = 0;
 			}

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -1804,7 +1804,7 @@ update_server_on_run(status *policy, server_info *sinfo,
 	 *      double count them
 	 */
 	if (resresv->is_resv || (qinfo != NULL && qinfo->resv == NULL)) {
-		if (resresv->is_job && (job_state != NULL) && (*job_state == 'S'))
+		if (resresv->is_job && (job_state != NULL) && (*job_state == 'S') && (resresv->job->resreq_rel != NULL))
 			req = resresv->job->resreq_rel;
 		else
 			req = resresv->resreq;
@@ -1953,8 +1953,7 @@ update_server_on_end(status *policy, server_info *sinfo, queue_info *qinfo,
 	 */
 	if (resresv->is_resv || (qinfo != NULL && qinfo->resv == NULL)) {
 
-		if (resresv->is_job && (job_state != NULL) && (*job_state == 'S') &&
-		    (policy->rel_on_susp != NULL))
+		if (resresv->is_job && (job_state != NULL) && (*job_state == 'S') && (resresv->job->resreq_rel != NULL))
 			req = resresv->job->resreq_rel;
 		else
 			req = resresv->resreq;

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -699,7 +699,6 @@ exit 3
         jid1 = self.server.submit(Job(attrs=a))
         jid2 = self.server.submit(Job(attrs=a))
 
-
         self.server.expect(JOB, {'job_state=R': 2})
         a = {'Resource_List.foo': 1,
              'queue': 'expressq'}

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -676,3 +676,34 @@ exit 3
         self.server.expect(JOB, {'job_state': 'S'}, id=jid_list[1])
         self.server.expect(JOB, {'job_state': 'S'}, id=jid_list[3])
         self.server.expect(JOB, {'job_state': 'S'}, id=jid_list[4])
+
+    @skipOnCpuSet
+    def test_preempt_requeue_static_resc(self):
+        """
+        Test that scheduler will preempt jobs for static resources
+        """
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+
+        a = {'type': 'long', 'flag': 'q'}
+        self.server.manager(MGR_CMD_CREATE, RSC, a, id='foo')
+
+        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'R'})
+
+        a = {'resources_available.foo': 2,
+             ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.scheduler.add_resource('foo')
+
+        a = {'Resource_List.foo': 1}
+        jid1 = self.server.submit(Job(attrs=a))
+        jid2 = self.server.submit(Job(attrs=a))
+
+
+        self.server.expect(JOB, {'job_state=R': 2})
+        a = {'Resource_List.foo': 1,
+             'queue': 'expressq'}
+        hjid = self.server.submit(Job(attrs=a))
+
+        self.server.expect(JOB, {'job_state': 'R'}, id=hjid)
+        self.server.expect(JOB, {'job_state=Q': 1})

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -678,9 +678,10 @@ exit 3
         self.server.expect(JOB, {'job_state': 'S'}, id=jid_list[4])
 
     @skipOnCpuSet
-    def test_preempt_requeue_static_resc(self):
+    def test_preempt_requeue_resc(self):
         """
-        Test that scheduler will preempt jobs for static resources
+        Test that scheduler will preempt jobs for resources with rrtros
+        set for other resources
         """
         a = {'resources_available.ncpus': 2}
         self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)


### PR DESCRIPTION
#### Describe Bug or Feature
If a high priority job that requests a static resource is submitted, and the scheduler had preempt order set to R, AND restrict_res_to_release_on_suspend was set, the scheduler would not preempt jobs to run the high priority job.


#### Describe Your Change
Instead of checking if the preemption type is S to use the released resource array, check if it is filled. If it is, use it, otherwise, use all the resources.


#### Attach Test and Valgrind Logs/Output
[after-fix.txt](https://github.com/PBSPro/pbspro/files/4162611/after-fix.txt)
[before-fix.txt](https://github.com/PBSPro/pbspro/files/4162612/before-fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
