### PR TITLE
Support for reservation in multi-sched environment

### DIFF
--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -299,6 +299,8 @@ extern "C" {
 #define PBSE_SCHED_PARTITION_ALREADY_EXISTS 15224 /* Partition already exists */
 #define PBSE_INVALID_MAX_JOB_SEQUENCE_ID 15225 /* Invalid max_job_sequence_id < 9999999, or > 999999999999 */
 #define PBSE_SVR_SCHED_JSF_INCOMPAT 15226	/* Server's job_sort_formula is incompatible with sched's */
+#define PBSE_NODE_BUSY	15227		 /* Node is busy */
+#define PBSE_DEFAULT_PARTITION 15228	/* Default partition name is not allowed */
 
 /* the following structure is used to tie error number      */
 /* with text to be returned to a client, see svr_messages.c */

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -357,6 +357,7 @@ enum accrue_types {
 
 #define PBS_RESV_CONFIRM_FAIL "PBS_RESV_CONFIRM_FAIL"   /* Used to inform server that a reservation could not be confirmed */
 #define PBS_RESV_CONFIRM_SUCCESS "PBS_RESV_CONFIRM_SUCCESS"   /* Used to inform server that a reservation could be confirmed */
+#define DEFAULT_PARTITION "pbs-default" /* Default partition name set on the reservation queue when the reservation is confirmed by default scheduler */
 
 #define PBS_USE_IFF		1	/* pbs_connect() to call pbs_iff */
 

--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -127,6 +127,7 @@ extern int find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched);
 extern pbs_sched *find_sched_from_sock(int sock);
 extern pbs_sched *find_sched(char *sched_name);
 extern int validate_job_formula(attribute *pattr, void *pobject, int actmode);
+extern pbs_sched *find_sched_from_partition(char *partition);
 
 #ifdef	__cplusplus
 }

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -120,6 +120,7 @@ enum resv_atr {
 	RESV_ATR_del_idle_time,
 	RESV_ATR_job,
 	RESV_ATR_node_set,
+	RESV_ATR_partition,
 	RESV_ATR_UNKN,
 	RESV_ATR_LAST
 };
@@ -234,6 +235,12 @@ struct resc_resv {
 	struct work_task	*resv_start_task;
 	struct work_task	*resv_end_task;
 	int resv_from_job;
+
+	/* A count to keep track of how many schedulers have been requested and
+	 * responsed to this reservation request
+	 */
+	int			req_sched_count;
+	int			rep_sched_count;
 
 	/*
 	 * fixed size internal data - maintained via "quick save"

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -358,6 +358,7 @@ extern int   node_avail_complex(spec_and_context *pcon, int *navail, int *nalloc
 extern int   node_reserve(spec_and_context *pcon, pbs_resource_t tag);
 extern void  node_unreserve(pbs_resource_t handle);
 extern int   node_spec(struct spec_and_context *, int);
+extern void notify_scheds_about_resv(int cmd, resc_resv *resv);
 #endif	/* _RESERVATION_H */
 
 #ifdef	_LIST_LINK_H

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -139,7 +139,7 @@ extern void license_more_nodes(void);
 extern void reset_svr_sequence_window(void);
 extern void reply_preempt_jobs_request(int code, int aux, struct job *pjob);
 extern int copy_params_from_job(char *jobid, resc_resv *presv);
-extern int confirm_resv_locally(resc_resv *presv, struct batch_request *orig_preq);
+extern int confirm_resv_locally(resc_resv *presv, struct batch_request *orig_preq, char *partition_name);
 extern int set_select_and_place(int objtype, void *pobj, attribute *patr);
 extern pbs_queue *find_resvqueuebyname(char *quename);
 extern resc_resv *find_resv_by_quename(char *quename);

--- a/src/lib/Libattr/master_queue_attr_def.xml
+++ b/src/lib/Libattr/master_queue_attr_def.xml
@@ -1019,7 +1019,7 @@
 	</member_verify_function>
     </attributes>
     <attributes> 
-	/* ATTR_partition */
+	/* QA_ATR_partition */
 	<member_name><both>ATTR_partition</both></member_name>	<!-- partition --> 
 	<member_at_decode>decode_str</member_at_decode>
 	<member_at_encode>encode_str</member_at_encode>

--- a/src/lib/Libattr/master_resv_attr_def.xml
+++ b/src/lib/Libattr/master_resv_attr_def.xml
@@ -825,7 +825,20 @@
 	<member_at_action>NULL_FUNC</member_at_action>
 	<member_at_flags><SVR>ATR_DFLAG_SvWR|ATR_DFLAG_MGWR</SVR></member_at_flags>
 	<member_at_type><SVR>ATR_TYPE_ARST</SVR></member_at_type>
-	<member_at_parent>PARENT_TYPE_JOB</member_at_parent>
+	<member_at_parent>PARENT_TYPE_RESV</member_at_parent>
+   </attributes>
+   <attributes flag = 'SVR'> 
+   /*"partition" */
+	<member_name><SVR>ATTR_partition</SVR></member_name>
+	<member_at_decode>decode_str</member_at_decode>
+	<member_at_encode>encode_str</member_at_encode>
+	<member_at_set>set_str</member_at_set>
+	<member_at_comp>comp_str</member_at_comp>
+	<member_at_free>free_str</member_at_free>
+	<member_at_action>NULL_FUNC</member_at_action>
+	<member_at_flags><SVR>ATR_DFLAG_SSET | READ_ONLY</SVR></member_at_flags>
+	<member_at_type><SVR>ATR_TYPE_STR</SVR></member_at_type>
+	<member_at_parent>PARENT_TYPE_RESV</member_at_parent>
    </attributes>
    <attributes flag = 'SVR'>
     #include "site_resv_attr_def.h"

--- a/src/lib/Libattr/master_sched_attr_def.xml
+++ b/src/lib/Libattr/master_sched_attr_def.xml
@@ -269,14 +269,14 @@
    </attributes>
    <attributes>	/* partition */
 	<member_name><both>ATTR_partition</both></member_name>		<!-- "partition" -->
-	<member_at_decode>decode_arst</member_at_decode>
-	<member_at_encode>encode_arst</member_at_encode>
-	<member_at_set>set_arst_uniq</member_at_set>
-	<member_at_comp>comp_arst</member_at_comp>
-	<member_at_free>free_arst</member_at_free>
+	<member_at_decode>decode_str</member_at_decode>
+	<member_at_encode>encode_str</member_at_encode>
+	<member_at_set>set_str</member_at_set>
+	<member_at_comp>comp_str</member_at_comp>
+	<member_at_free>free_str</member_at_free>
 	<member_at_action>action_sched_partition</member_at_action>
 	<member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
-	<member_at_type><both>ATR_TYPE_ARST</both></member_at_type>
+	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_SCHED</member_at_parent>
 	<member_verify_function>
 	<ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -420,7 +420,8 @@ char *msg_stdg_resv_occr_conflict = "Requested time(s) will interfere with a lat
 char *msg_alps_switch_err = "Switching ALPS reservation failed";
 
 char *msg_softwt_stf = "soft_walltime is not supported with Shrink to Fit jobs";
-
+char *msg_node_busy = "Node is busy";
+char *msg_default_partition = "Default partition name is not allowed";
 /*
  * The following table connects error numbers with text
  * to be returned to the client.  Each is guaranteed to be pure text.
@@ -602,6 +603,8 @@ struct pbs_err_to_txt pbs_err_to_txt[] = {
 	{PBSE_SCHED_PARTITION_ALREADY_EXISTS, &msg_sched_part_already_used},
 	{PBSE_INVALID_MAX_JOB_SEQUENCE_ID, &msg_invalid_max_job_sequence_id},
 	{PBSE_SVR_SCHED_JSF_INCOMPAT, &msg_jsf_incompatible},
+	{PBSE_NODE_BUSY, &msg_node_busy},
+	{PBSE_DEFAULT_PARTITION, &msg_default_partition},
 	{ 0, NULL }		/* MUST be the last entry */
 };
 

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1323,7 +1323,6 @@ free_string_array(char **arr)
 	}
 }
 
-
 /**
  * @brief
  * 		Convert a duration to HH:MM:SS format string

--- a/src/scheduler/buckets.c
+++ b/src/scheduler/buckets.c
@@ -1079,8 +1079,6 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
 
 		if (qinfo->has_nodes)
 			ninfo_arr = qinfo->nodes;
-		else if (qinfo->partition != NULL)
-			ninfo_arr = qinfo->nodes_in_partition;
 		else
 			ninfo_arr = sinfo->unassoc_nodes;
 

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1588,8 +1588,6 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 			/* if there are nodes assigned to the queue, then check those */
 			if (qinfo->has_nodes)
 				ninfo_arr = qinfo->nodes;
-			else if (qinfo->partition != NULL)
-				ninfo_arr = qinfo->nodes_in_partition;
 			else
 				ninfo_arr = sinfo->unassoc_nodes;
 		} else

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -398,7 +398,7 @@ struct server_info
 	int num_resvs;			/* number of reservations on the server */
 	int num_preempted;		/* number of jobs currently preempted */
 	long sched_cycle_len;		/* length of cycle in seconds */
-	char **partitions;		/* partitions associated */
+	char *partition;		/* partition associated */
 	long opt_backfill_fuzzy_time;	/* time window for fuzzy backfill opt */
 	char **node_group_key;		/* the node grouping resources */
 	state_count sc;			/* number of jobs in each state */
@@ -505,7 +505,6 @@ struct queue_info
 	resource_resv **jobs;		/* array of jobs that reside in queue */
 	resource_resv **running_jobs;	/* array of jobs in the running state */
 	node_info **nodes;		/* array of nodes associated with the queue */
-	node_info **nodes_in_partition; /* array of nodes associated with the queue's partition */
 	counts *group_counts;		/* group resource and running counts */
 	counts *project_counts;		/* project resource and running counts */
 	counts *user_counts;		/* user resource and running counts */
@@ -747,6 +746,7 @@ struct resv_info
 	enum resv_states resv_substate;			/* reservation substate */
 	queue_info 	 *resv_queue;			/* general resv: queue which is owned by resv */
 	node_info 	 **resv_nodes;			/* node universe for reservation */
+	char		 *partition;			/* name of the partition in which the reservation was confirmed */
 };
 
 /* resource reservation - used for both jobs and advanced reservations */
@@ -949,7 +949,6 @@ struct resresv_set
 	char *user;			/* user of set, can be NULL */
 	char *group;			/* group of set, can be NULL */
 	char *project;			/* project of set, can be NULL */
-	char *partition;		/* partition of set, can be NULL */
 	selspec *select_spec;		/* select spec of set */
 	place *place_spec;		/* place spec of set */
 	resource_req *req;		/* ATTR_L (qsub -l) resources of set.  Only contains resources on the resources line */

--- a/src/scheduler/job_info.h
+++ b/src/scheduler/job_info.h
@@ -369,7 +369,7 @@ resresv_set **dup_resresv_set_array(resresv_set **osets, server_info *nsinfo);
 resresv_set *create_resresv_set_by_resresv(status *policy, server_info *sinfo, resource_resv *resresv);
 
 /* find a resresv_set by its internal components */
-int find_resresv_set(status *policy, resresv_set **rsets, char *user, char *group, char *project, char *partition, selspec *sel, place *pl, resource_req *req, queue_info *qinfo);
+int find_resresv_set(status *policy, resresv_set **rsets, char *user, char *group, char *project, selspec *sel, place *pl, resource_req *req, queue_info *qinfo);
 
 /* find a resresv_set with a resresv as a template */
 int find_resresv_set_by_resresv(status *policy, resresv_set **rsets, resource_resv *resresv);

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -890,6 +890,41 @@ remove_ptr_from_array(void **arr, void *ptr)
 
 /**
  * @brief
+ *		remove_str_from_array - remove a string from a ptr list and move
+ *				the rest of the pointers up to fill the hole
+ *				Pointer array size will not change - an extra
+ *				NULL is added to the end
+ *
+ *	  arr - pointer array
+ *	  str - string  to remove from array
+ *
+ *	returns non-zero if the str was successfully removed from the array
+ *		zero if the array has not been modified
+ *
+ */
+int
+remove_str_from_array(char **arr, char *str)
+{
+	int i, j;
+
+	if (arr == NULL || str == NULL)
+		return 0;
+
+	for (i = 0; arr[i] != NULL && (strcmp(arr[i], str) != 0); i++)
+		;
+
+	if (arr[i] != NULL) {
+		free(arr[i]);
+		for (j = i; arr[j] != NULL; j++)
+			arr[j] = arr[j + 1];
+		return 1;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief
  *		is_valid_pbs_name - is str a valid pbs username (POSIX.1 + ' ')
  *			    a valid name is: alpha numeric '-' '_' '.' ' '
  * 			    For fairshare entities: colen ':'

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -170,6 +170,17 @@ int count_array(void **arr);
 int remove_ptr_from_array(void **arr, void *ptr);
 
 /*
+ *	remove_str_from_array - remove a string from a ptr list and move
+ *				the rest of the pointers up to fill the hole
+ *				Pointer array size will not change - an extra
+ *				NULL is added to the end
+ *
+ *	returns non-zero if the str was successfully removed from the array
+ *		zero if the array has not been modified
+ */
+int remove_str_from_array(char **arr, char *str);
+
+/*
  *      is_valid_pbs_name - is str a valid pbs username (POSIX.1 + ' ')
  *                          a valid name is: alpha numeric '-' '_' '.' or ' '
  */

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -202,7 +202,7 @@ query_node_info_chunk(th_data_query_ninfo *data)
 			return;
 		}
 
-		if (node_in_partition(ninfo, sinfo->partitions)) {
+		if (node_in_partition(ninfo, sinfo->partition)) {
 			if (first_talk_with_mom) {	/* need to acquire a lock for talk_with_mom the first time */
 				pthread_mutex_lock(&general_lock);
 				if (!first_talk_with_mom)
@@ -1309,8 +1309,8 @@ talk_with_mom(node_info *ninfo)
  * @param[in]	filter_func	-	pointer to a function that will filter the nodes
  *								- returns 1: job will be added to filtered array
  *								- returns 0: job will NOT be added to filtered array
- *	  							arg - an optional arg passed to filter_func
- *	  							flags - describe how nodes are filtered
+ * @param[in]	arg - an optional arg passed to filter_func
+ * @param[in]	flags - describe how nodes are filtered
  *
  * @return pointer to filtered array
  *
@@ -6270,7 +6270,7 @@ check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, plac
  *	node_in_partition	-  Tells whether the given node belongs to this scheduler
  *
  * @param[in]	ninfo		-  node information
- * @param[in]	partitions	-  array of partitions associated to scheduler
+ * @param[in]	partition	-  partition associated to scheduler
  *
  *
  * @return	int
@@ -6278,7 +6278,7 @@ check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, plac
  * @retval	0	: if failure
  */
 int
-node_in_partition(node_info *ninfo, char **partitions)
+node_in_partition(node_info *ninfo, char *partition)
 {
 	if (dflt_sched) {
 		if (ninfo->partition == NULL)
@@ -6289,7 +6289,7 @@ node_in_partition(node_info *ninfo, char **partitions)
 	if (ninfo->partition == NULL)
 		return 0;
 
-	if (is_string_in_arr(partitions, ninfo->partition))
+	if (strcmp(partition, ninfo->partition) == 0)
 		return 1;
 	else
 		return 0;

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -660,7 +660,7 @@ check_node_eligibility_chunk(th_data_nd_eligible *data);
 void check_node_array_eligibility(node_info **ninfo_arr, resource_resv *resresv, place *pl,
 		int num_nodes, schd_error *err);
 
-int node_in_partition(node_info *ninfo, char **partitions);
+int node_in_partition(node_info *ninfo, char *partition);
 /* add a node to a node array*/
 node_info **add_node_to_array(node_info **ninfo_arr, node_info *node);
 

--- a/src/scheduler/node_partition.h
+++ b/src/scheduler/node_partition.h
@@ -109,9 +109,10 @@ node_partition **copy_node_partition_ptr_array(node_partition **onp_arr, node_pa
  *
  *      create_node_partitions - break apart nodes into partitions
  *
- *         IN: sinfo - nodes to create partitions from
+ *         IN: policy - policy info
+ *         IN: nodes  -  the nodes to create partitions from
  *	   IN: resname - node grouping resource name
- *         IN: dont_set_node - don't set the np_arr flags on the nodes
+ *         IN: flags - flags which change operations of node partition creation
  *	  OUT: num_parts - the number of node partitions created
  *
  *      returns node_partition array or NULL on error
@@ -214,7 +215,7 @@ int resresv_can_fit_nodepart(status *policy, node_partition *np, resource_resv *
  *				   nodes, rather than from a placement
  *				   set resource=value
  */
-node_partition *create_specific_nodepart(status *policy, char *name, node_info **nodes);
+node_partition *create_specific_nodepart(status *policy, char *name, node_info **nodes, int flags );
 /* create the placement sets for the server and queues */
 int create_placement_sets(status *policy, server_info *sinfo);
 

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -693,8 +693,7 @@ server_command(char **jid)
 			free(jid2);
 		}
 	} else {
-		log_event(PBSEVENT_DEBUG, LOG_DEBUG,
-			PBS_EVENTCLASS_SERVER, __func__,
+		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG, __func__,
 			"warning: timed-out getting second_connection");
 	}
 

--- a/src/scheduler/queue_info.h
+++ b/src/scheduler/queue_info.h
@@ -108,7 +108,7 @@ void
 update_queue_on_end(queue_info *qinfo, resource_resv *resresv,
 	char *job_state);
 
-int queue_in_partition(queue_info *qinfo, char **partitions);
+int queue_in_partition(queue_info *qinfo, char *partition);
 
 
 #ifdef	__cplusplus

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -473,6 +473,7 @@ alloc_tdata_dup_nodes(resource_resv **oresresv_arr, resource_resv **nresresv_arr
 	tdata->nqinfo = nqinfo;
 	tdata->sidx = sidx;
 	tdata->eidx = eidx;
+	tdata->error = 0;
 
 	return tdata;
 }
@@ -593,7 +594,7 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 
 	if (oresresv == NULL || nsinfo == NULL || err == NULL)
 		return NULL;
-	
+
 	clear_schd_error(err);
 
 	if (!is_resource_resv_valid(oresresv, err)) {

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -86,7 +86,6 @@
 #include "node_partition.h"
 #include "pbs_internal.h"
 
-
 /**
  * @brief
  * 		Statuses reservations from the server in batch status form.
@@ -188,6 +187,21 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 
 	for (cur_resv = resvs; cur_resv != NULL; cur_resv = cur_resv->next) {
 		int ignore_resv = 0;
+		clear_schd_error(err);
+		struct attrl	*attrp = NULL;
+		/* Check if this reservation belongs to this scheduler */
+		for (attrp = cur_resv->attribs; attrp != NULL; attrp = attrp->next) {
+			if (strcmp(attrp->name, ATTR_partition) == 0) {
+				if (sinfo->partition != NULL && (strcmp(attrp->value, sinfo->partition) != 0))
+					ignore_resv = 1;
+				break;
+			}
+		}
+		if (ignore_resv == 1) {
+			sinfo->num_resvs--;
+			continue;
+		}
+
 		/* convert resv info from server batch_status into resv_info */
 		if ((resresv = query_resv(cur_resv, sinfo)) == NULL) {
 			free_resource_resv_array(resresv_arr);
@@ -573,6 +587,9 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 	long		count = 0; 		/* used to convert string -> num */
 	char		*selectspec = NULL;	/* used for holding select specification. */
 
+	if (resv == NULL)
+		return NULL;
+
 	if ((advresv = new_resource_resv()) == NULL)
 		return NULL;
 
@@ -695,6 +712,9 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 		}
 		else if (!strcmp(attrp->name, ATTR_resv_count))
 			advresv->resv->count = atoi(attrp->value);
+		else if (!strcmp(attrp->name, ATTR_partition)) {
+			advresv->resv->partition = strdup(attrp->value);
+		}
 		attrp = attrp->next;
 	}
 	/* If reservation is unconfirmed and the number of occurrences is 0 then flag
@@ -757,6 +777,7 @@ new_resv_info()
 	rinfo->is_standing = 0;
 	rinfo->check_alternate_nodes = 0;
 	rinfo->occr_start_arr = NULL;
+	rinfo->partition = NULL;
 
 	return rinfo;
 }
@@ -790,6 +811,8 @@ free_resv_info(resv_info *rinfo)
 
 	if (rinfo->occr_start_arr != NULL)
 		free(rinfo->occr_start_arr);
+
+	free(rinfo->partition);
 
 	free(rinfo);
 
@@ -833,6 +856,8 @@ dup_resv_info(resv_info *rinfo, server_info *sinfo)
 	nrinfo->resv_idx = rinfo->resv_idx;
 	nrinfo->execvnodes_seq = string_dup(rinfo->execvnodes_seq);
 	nrinfo->count = rinfo->count;
+	if (rinfo->partition != NULL)
+		nrinfo->partition = string_dup(rinfo->partition);
 
 	/* the queues may not be available right now.  If they aren't, we'll
 	 * catch this when we duplicate the queues
@@ -903,7 +928,6 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 	qsort(sinfo->resvs, sinfo->num_resvs, sizeof(resource_resv*), cmp_resv_state);
 
 	for (i = 0; sinfo->resvs[i] != NULL; i++) {
-
 		if (sinfo->resvs[i]->resv ==NULL) {
 			log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
 				sinfo->resvs[i]->name,
@@ -1088,8 +1112,7 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 				/* increment the count if we successfully processed all occurrences */
 				if (j == occr_count)
 					count++;
-			}
-			else if (pbsrc == RESV_CONFIRM_FAIL) {
+			} else if (pbsrc == RESV_CONFIRM_FAIL) {
 				/* For a degraded reservation, it had already been confirmed in a
 				 * previous scheduling cycle. We retrieve the existing object from
 				 * the all_resresv list and update the retry_time to break out of
@@ -1139,7 +1162,6 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 			return -1;
 		}
 	}
-
 	free_schd_error(err);
 	return count;
 }
@@ -1245,6 +1267,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 	err = new_schd_error();
 	if (err == NULL)
 		return RESV_CONFIRM_FAIL;
+
 
 	/* If the number of occurrences is not set, this is a first time confirmation
 	 * otherwise it is a reconfirmation request
@@ -1519,6 +1542,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 	/* Finished simulating occurrences now time to confirm if ok. Currently
 	 * the confirmation is an all or nothing process but may come to change. */
 	if (confirmd_occr == occr_count) {
+		char confirm_msg[LOG_BUF_SIZE] = {0};
 		/* We either confirm a standing or advance reservation, the standing
 		 * has a special sequence of execvnodes while the advance has a single
 		 * execvnode. The sequence of execvnodes is created by concatenating
@@ -1535,8 +1559,11 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		/* Send a reservation confirm message, if anything goes wrong pbsrc
 		 * will return an error
 		 */
+		snprintf(confirm_msg, LOG_BUF_SIZE, "%s:partition=%s", PBS_RESV_CONFIRM_SUCCESS,
+			 nsinfo->partition?nsinfo->partition:DEFAULT_PARTITION);
+
 		pbsrc = pbs_confirmresv(pbs_sd, nresv_parent->name, short_xc,
-			resv_start_time, PBS_RESV_CONFIRM_SUCCESS);
+			resv_start_time, confirm_msg);
 	}
 	else {
 		/* This message is sent to inform that we could not confirm the reservation.

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1749,8 +1749,7 @@ try_db_again:
 				/* if time or event says to run scheduler, do it */
 
 				/* if we have a high prio sched command, send it 1st */
-				if (psched->sch_attr[SCHED_ATR_scheduling].at_val.at_long &&
-					psched->svr_do_sched_high != SCH_SCHEDULE_NULL)
+				if (psched->svr_do_sched_high != SCH_SCHEDULE_NULL)
 					schedule_high(psched);
 				if (psched->svr_do_schedule == SCH_SCHEDULE_RESTART_CYCLE) {
 

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -479,6 +479,9 @@ action_queue_partition(attribute *pattr, void *pobj, int actmode)
 	if (((pbs_queue *)pobj)->qu_qs.qu_type  == QTYPE_RoutePush)
 		return PBSE_ROUTE_QUE_NO_PARTITION;
 
+	if (strcmp(pattr->at_val.at_str, DEFAULT_PARTITION) == 0)
+		return PBSE_DEFAULT_PARTITION;
+
 	for (i=0; i < svr_totnodes; i++) {
 		if (pbsndlist[i]->nd_pque) {
 			if (strcmp(pbsndlist[i]->nd_pque->qu_qs.qu_name, ((pbs_queue *) pobj)->qu_qs.qu_name) == 0) {

--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -896,7 +896,6 @@ req_modifyReservation(struct batch_request *preq)
 	if (psatl)
 		rc = modify_resv_attr(presv, psatl, preq->rq_perm, &bad);
 
-
 	/* If Authorized_Groups is modified, we need to update the queue's acl_users
 	 * Authorized_Users cannot be unset, it must always have a value
 	 * The queue will have acl_user_enable set to 1 by default
@@ -932,8 +931,11 @@ req_modifyReservation(struct batch_request *preq)
 		}
 	}
 
-	if (send_to_scheduler)
-		set_scheduler_flag(SCH_SCHEDULE_RESV_RECONFIRM, dflt_scheduler);
+	if (send_to_scheduler) {
+		presv->rep_sched_count = 0;
+		presv->req_sched_count = 0;
+		notify_scheds_about_resv(SCH_SCHEDULE_RESV_RECONFIRM, presv);
+	}
 
 	(void)sprintf(log_buffer, "Attempting to modify reservation");
 	if (presv->ri_alter_flags & RESV_START_TIME_MODIFIED) {

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -3552,7 +3552,7 @@ confirm_resv_locally(resc_resv *presv, struct batch_request *orig_preq, char *pa
 	/* extend field format is "PBS_RESV_CONFIRM_SUCCESS:partition=<partition name>"
 	 * allocate enough memory to be able to support the format.
 	 */
-	extend_size = strlen(PBS_RESV_CONFIRM_SUCCESS) + strlen(partition_name) + 16;
+	extend_size = strlen(PBS_RESV_CONFIRM_SUCCESS) + strlen(partition_name) + 12;
 	preq->rq_extend = malloc(extend_size);
 	if (preq->rq_extend == NULL) {
 		free_br(preq);

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -213,17 +213,16 @@ find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched)
 
 	if (pq->qu_attr[QA_ATR_partition].at_flags & ATR_VFLAG_SET) {
 		attribute *part_attr;
+		if (strcmp(pq->qu_attr[QA_ATR_partition].at_val.at_str, DEFAULT_PARTITION) == 0) {
+			*target_sched = dflt_scheduler;
+			return 1;
+		}
 		for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
 			part_attr = &(psched->sch_attr[SCHED_ATR_partition]);
 			if (part_attr->at_flags & ATR_VFLAG_SET) {
-				int k;
-				for (k = 0; k < part_attr->at_val.at_arst->as_usedptr; k++) {
-					if ((part_attr->at_val.at_arst->as_string[k] != NULL)
-							&& (!strcmp(part_attr->at_val.at_arst->as_string[k],
-									pq->qu_attr[QA_ATR_partition].at_val.at_str))) {
-						*target_sched = psched;
-						return 1;
-					}
+				if(!strcmp(part_attr->at_val.at_str, pq->qu_attr[QA_ATR_partition].at_val.at_str)) {
+					*target_sched = psched;
+					return 1;
 				}
 			}
 		}
@@ -576,7 +575,7 @@ was_job_alteredmoved(job *pjob)
  * 		set_scheduler_flag - set the flag to call the Scheduler
  *		certain flag values should not be overwritten
  *
- * @param[in]	flag	-	pointer to job in question.
+ * @param[in]	flag	-	scheduler command.
  * @parm[in] psched -   pointer to sched object. Then set the flag only for this object.
  *                                     NULL. Then set the flag for all the scheduler objects.
  */

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -47,7 +47,7 @@ class TestMultipleSchedulers(TestFunctional):
     """
 
     def setup_sc1(self):
-        a = {'partition': 'P1,P4',
+        a = {'partition': 'P1',
              'sched_host': self.server.hostname,
              'sched_port': '15050'}
         self.server.manager(MGR_CMD_CREATE, SCHED,
@@ -92,21 +92,17 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq1')
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq2')
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq3')
-        self.server.manager(MGR_CMD_CREATE, QUEUE, a, id='wq4')
         p1 = {'partition': 'P1'}
         self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq1')
         p2 = {'partition': 'P2'}
         self.server.manager(MGR_CMD_SET, QUEUE, p2, id='wq2')
         p3 = {'partition': 'P3'}
         self.server.manager(MGR_CMD_SET, QUEUE, p3, id='wq3')
-        p4 = {'partition': 'P4'}
-        self.server.manager(MGR_CMD_SET, QUEUE, p4, id='wq4')
         a = {'resources_available.ncpus': 2}
-        self.server.create_vnodes('vnode', a, 5, self.mom)
+        self.server.create_vnodes('vnode', a, 4, self.mom)
         self.server.manager(MGR_CMD_SET, NODE, p1, id='vnode[0]')
         self.server.manager(MGR_CMD_SET, NODE, p2, id='vnode[1]')
         self.server.manager(MGR_CMD_SET, NODE, p3, id='vnode[2]')
-        self.server.manager(MGR_CMD_SET, NODE, p4, id='vnode[3]')
 
     def common_setup(self):
         self.setup_sc1()
@@ -121,6 +117,15 @@ class TestMultipleSchedulers(TestFunctional):
             if vnode not in nodes:
                 self.assertFalse(True, str(vnode) +
                                  " is not in exec_vnode list as expected")
+
+    def get_tzid(self):
+        if 'PBS_TZID' in self.conf:
+            tzone = self.conf['PBS_TZID']
+        elif 'PBS_TZID' in os.environ:
+            tzone = os.environ['PBS_TZID']
+        else:
+            tzone = 'America/Los_Angeles'
+        return tzone
 
     @skipOnCpuSet
     def test_job_sort_formula_multisched(self):
@@ -341,11 +346,8 @@ class TestMultipleSchedulers(TestFunctional):
         unsets partition attribute on scheduler and update scheduler logs.
         """
         self.setup_sc1()
-        # self.setup_sc2()
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'partition': (DECR, 'P1')}, id="sc1")
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'partition': (DECR, 'P4')}, id="sc1")
+        self.server.manager(MGR_CMD_UNSET, SCHED,
+                            'partition', id="sc1")
         self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
                             id="sc1")
         log_msg = "Scheduler does not contain a partition"
@@ -387,39 +389,6 @@ class TestMultipleSchedulers(TestFunctional):
             starttime=self.server.ctime)
 
     @skipOnCpuSet
-    def test_multiple_partition_same_sched(self):
-        """
-        Test that scheduler will serve the jobs from different
-        partition and run on nodes assigned to respective partitions.
-        """
-        self.setup_sc1()
-        self.setup_queues_nodes()
-        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
-                                   'Resource_List.select': '1:ncpus=1'})
-        jid1 = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
-        self.check_vnodes(j, ['vnode[0]'], jid1)
-        self.scheds['sc1'].log_match(
-            jid1 + ';Job run', max_attempts=10,
-            starttime=self.server.ctime)
-        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
-                                   'Resource_List.select': '1:ncpus=1'})
-        jid2 = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
-        self.check_vnodes(j, ['vnode[3]'], jid2)
-        self.scheds['sc1'].log_match(
-            jid2 + ';Job run', max_attempts=10,
-            starttime=self.server.ctime)
-        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
-                                   'Resource_List.select': '1:ncpus=1'})
-        jid3 = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
-        self.check_vnodes(j, ['vnode[0]'], jid3)
-        self.scheds['sc1'].log_match(
-            jid3 + ';Job run', max_attempts=10,
-            starttime=self.server.ctime)
-
-    @skipOnCpuSet
     def test_multiple_queue_same_partition(self):
         """
         Test multiple queue associated with same partition
@@ -436,8 +405,8 @@ class TestMultipleSchedulers(TestFunctional):
             jid + ';Job run', max_attempts=10,
             starttime=self.server.ctime)
         p1 = {'partition': 'P1'}
-        self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq4')
-        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+        self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq3')
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
                                    'Resource_List.select': '1:ncpus=1'})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
@@ -454,19 +423,19 @@ class TestMultipleSchedulers(TestFunctional):
         """
         self.common_setup()
         prio = {'Priority': 150, 'partition': 'P1'}
-        self.server.manager(MGR_CMD_SET, QUEUE, prio, id='wq4')
+        self.server.manager(MGR_CMD_SET, QUEUE, prio, id='wq3')
         j = Job(TEST_USER1, attrs={ATTR_queue: 'wq1',
                                    'Resource_List.select': '1:ncpus=2'})
         jid1 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
 
         t = time.time()
-        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
                                    'Resource_List.select': '1:ncpus=2'})
         jid2 = self.server.submit(j)
 
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
-        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq4',
+        j = Job(TEST_USER1, attrs={ATTR_queue: 'wq3',
                                    'Resource_List.select': '1:ncpus=2'})
         jid3 = self.server.submit(j)
         self.server.expect(JOB, ATTR_comment, op=SET, id=jid3)
@@ -631,24 +600,6 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.expect(SCHED, a, id='sc1',
                            attrop=PTL_AND, max_attempts=10)
 
-    @skipOnCpuSet
-    def test_resv_default_sched(self):
-        """
-        Test reservations will only go to defualt scheduler
-        """
-        self.setup_queues_nodes()
-        t = int(time.time())
-        r = Reservation(TEST_USER)
-        a = {'Resource_List.select': '2:ncpus=1'}
-        r.set_attributes(a)
-        rid = self.server.submit(r)
-        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
-        self.server.expect(RESV, a, rid)
-        self.scheds['default'].log_match(
-            rid + ';Reservation Confirmed',
-            max_attempts=10, starttime=t)
-
-    @skipOnCpuSet
     def test_job_sorted_per_scheduler(self):
         """
         Test jobs are sorted as per job_sort_formula
@@ -1111,32 +1062,6 @@ class TestMultipleSchedulers(TestFunctional):
         return ret_jids
 
     @skipOnCpuSet
-    def test_equiv_partition(self):
-        """
-        Test the basic behavior of job equivalence classes: submit two
-        different types of jobs into 2 partitions and see they are
-        in four different equivalence classes
-        """
-        self.setup_sc1()
-        self.setup_queues_nodes()
-        t = int(time.time())
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'False'}, id="sc1")
-        # Eat up all the resources with the first job to each queue
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq1'}
-        self.submit_jobs(4, a)
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq4'}
-        self.submit_jobs(4, a)
-        a = {'Resource_List.select': '1:ncpus=1', ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a)
-        a = {'Resource_List.select': '1:ncpus=1', ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1")
-        self.scheds['sc1'].log_match("Number of job equivalence classes: 4",
-                                     max_attempts=10, starttime=t)
-
-    @skipOnCpuSet
     def test_equiv_multisched(self):
         """
         Test the basic behavior of job equivalence classes: submit two
@@ -1174,260 +1099,34 @@ class TestMultipleSchedulers(TestFunctional):
                                      max_attempts=10, starttime=t)
 
     @skipOnCpuSet
-    def test_select_partition(self):
-        """
-        Test to see if jobs with select resources not in the resources line
-        fall into the same equivalence class and jobs in different partition
-        fall into different equivalence classes
-        """
-        self.server.manager(MGR_CMD_CREATE, RSC,
-                            {'type': 'long', 'flag': 'nh'}, id='foo')
-        self.setup_sc1()
-        self.setup_queues_nodes()
-        t = int(time.time())
-        # Eat up all the resources
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq1'}
-        J = Job(TEST_USER, attrs=a)
-        self.server.submit(J)
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq4'}
-        J = Job(TEST_USER, attrs=a)
-        self.server.submit(J)
-
-        a = {'Resource_List.select': '1:ncpus=1:foo=4', ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a)
-
-        a = {'Resource_List.select': '1:ncpus=1:foo=4', ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-
-        a = {'Resource_List.select': '1:ncpus=1:foo=8', ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a)
-
-        a = {'Resource_List.select': '1:ncpus=1:foo=8', ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1")
-
-        # Four equivalence classes: two for the resource eating job in each
-        # partition and two for the other jobs in each partition. While jobs
-        # have different amount of the foo resources which isn't in the
-        # resources line
-        self.scheds['sc1'].log_match("Number of job equivalence classes: 4",
-                                     max_attempts=10, starttime=t)
-
-    @skipOnCpuSet
-    def test_select_res_partition(self):
-        """
-        Test to see if jobs with select resources in the resources line and
-        in different partitions fall into the different equivalence class
-        """
-        self.server.manager(MGR_CMD_CREATE, RSC,
-                            {'type': 'long', 'flag': 'nh'}, id='foo')
-        self.setup_sc1()
-        self.setup_queues_nodes()
-        self.scheds['sc1'].add_resource("foo")
-        t = int(time.time())
-        # Eat up all the resources
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq1'}
-        J = Job(TEST_USER, attrs=a)
-        self.server.submit(J)
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq4'}
-        J = Job(TEST_USER, attrs=a)
-        self.server.submit(J)
-
-        a = {'Resource_List.select': '1:ncpus=1:foo=4', ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a)
-
-        a = {'Resource_List.select': '1:ncpus=1:foo=4', ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-
-        a = {'Resource_List.select': '1:ncpus=1:foo=8', ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a)
-
-        a = {'Resource_List.select': '1:ncpus=1:foo=8', ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1")
-
-        # Six equivalence classes: two for the resource eating jobs in each
-        # partition and 4 for the other jobs requesting different amounts of
-        # the foo resource in each partition.
-        self.scheds['sc1'].log_match("Number of job equivalence classes: 6",
-                                     max_attempts=10, starttime=t)
-
-    @skipOnCpuSet
-    def test_multiple_res_partition(self):
-        """
-        Test to see if jobs with select resources in the resources line
-        with multiple custom resources fall into the different equiv class
-        and jobs in different partitions fall into different equiv classes
-        """
-        self.server.manager(MGR_CMD_CREATE, RSC,
-                            {'type': 'long', 'flag': 'nh'}, id='foo')
-        self.server.manager(MGR_CMD_CREATE, RSC,
-                            {'type': 'string', 'flag': 'h'}, id='colour')
-        self.setup_sc1()
-        self.setup_queues_nodes()
-        self.scheds['sc1'].add_resource("foo")
-        self.scheds['sc1'].add_resource("colour")
-        t = int(time.time())
-        # Eat up all the resources
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq1'}
-        J = Job(TEST_USER, attrs=a)
-        self.server.submit(J)
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq4'}
-        J = Job(TEST_USER, attrs=a)
-        self.server.submit(J)
-
-        a = {'Resource_List.select': '1:ncpus=1:foo=4', ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a)
-
-        a = {'Resource_List.select': '1:ncpus=1:foo=4', ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-
-        a = {'Resource_List.select': '1:ncpus=1:colour=blue',
-             ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a)
-
-        a = {'Resource_List.select': '1:ncpus=1:colour=blue',
-             ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1")
-
-        # Six equivalence classes: two for the resource eating job in each
-        # partition and four for the other jobs. While jobs have different
-        # resource requests two for each resource in different partitions
-        self.scheds['sc1'].log_match("Number of job equivalence classes: 6",
-                                     max_attempts=10, starttime=t)
-
-    @skipOnCpuSet
-    def test_place_partition(self):
-        """
-        Test to see if jobs with different place statements and different
-        partitions fall into the different equivalence classes
-        """
-        self.setup_sc1()
-        self.setup_queues_nodes()
-        t = int(time.time())
-
-        # Eat up all the resources
-        a = {'Resource_List.select': '1:ncpus=2',
-             ATTR_queue: 'wq1'}
-        J = Job(TEST_USER, attrs=a)
-        self.server.submit(J)
-        a = {'Resource_List.select': '1:ncpus=2',
-             ATTR_queue: 'wq4'}
-        J = Job(TEST_USER, attrs=a)
-        self.server.submit(J)
-
-        a = {'Resource_List.select': '1:ncpus=1',
-             'Resource_List.place': 'free',
-             ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a)
-        a = {'Resource_List.select': '1:ncpus=1',
-             'Resource_List.place': 'free',
-             ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-
-        a = {'Resource_List.select': '1:ncpus=1',
-             'Resource_List.place': 'excl',
-             ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a)
-        a = {'Resource_List.select': '1:ncpus=1',
-             'Resource_List.place': 'excl',
-             ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1")
-
-        # Six equivalence classes: two for the resource eating job in
-        # each partition and one for each place statement in each partition
-        self.scheds['sc1'].log_match("Number of job equivalence classes: 6",
-                                     max_attempts=10, starttime=t)
-
-    @skipOnCpuSet
-    def test_nolimits_partition(self):
-        """
-        Test to see that jobs from different users, groups, and projects
-        all fall into the same equivalence class when there are no limits
-        but fall into different equivalence classes for each partition
-        """
-        self.setup_sc1()
-        self.setup_queues_nodes()
-        t = int(time.time())
-
-        # Eat up all the resources
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq1'}
-        J = Job(TEST_USER, attrs=a)
-        self.server.submit(J)
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq4'}
-        J = Job(TEST_USER, attrs=a)
-        self.server.submit(J)
-        a = {ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a, user=TEST_USER)
-        self.submit_jobs(3, a, user=TEST_USER2)
-        a = {ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a, user=TEST_USER)
-        self.submit_jobs(3, a, user=TEST_USER2)
-
-        b = {'group_list': TSTGRP1, ATTR_queue: 'wq1'}
-        self.submit_jobs(3, b, TEST_USER1)
-        b = {'group_list': TSTGRP2, ATTR_queue: 'wq1'}
-        self.submit_jobs(3, b, TEST_USER1)
-        b = {'group_list': TSTGRP1, ATTR_queue: 'wq4'}
-        self.submit_jobs(3, b, TEST_USER1)
-        b = {'group_list': TSTGRP2, ATTR_queue: 'wq4'}
-        self.submit_jobs(3, b, TEST_USER1)
-
-        b = {'project': 'p1', ATTR_queue: 'wq1'}
-        self.submit_jobs(3, b)
-        b = {'project': 'p2', ATTR_queue: 'wq1'}
-        self.submit_jobs(3, b)
-        b = {'project': 'p1', ATTR_queue: 'wq4'}
-        self.submit_jobs(3, b)
-        b = {'project': 'p2', ATTR_queue: 'wq4'}
-        self.submit_jobs(3, b)
-
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1")
-
-        # Four equivalence classes: two for the resource eating job in each
-        # partition and two for the rest. Since there are no limits, user,
-        # group, nor project are taken into account
-        self.scheds['sc1'].log_match("Number of job equivalence classes: 4",
-                                     max_attempts=10, starttime=t)
-
-    @skipOnCpuSet
-    def test_limits_partition(self):
+    def test_limits_queues(self):
         """
         Test to see that jobs from different users fall into different
-        equivalence classes with queue hard limits and partitions
+        equivalence classes with queue hard limits.
         """
         self.setup_sc1()
         self.setup_queues_nodes()
+        p1 = {'partition': 'P1'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq3')
         t = int(time.time())
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'False'}, id="sc1")
         self.server.manager(MGR_CMD_SET, QUEUE,
                             {'max_run': '[u:PBS_GENERIC=1]'}, id='wq1')
         self.server.manager(MGR_CMD_SET, QUEUE,
-                            {'max_run': '[u:PBS_GENERIC=1]'}, id='wq4')
+                            {'max_run': '[u:PBS_GENERIC=1]'}, id='wq3')
 
         # Eat up all the resources
         a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq1'}
         J = Job(TEST_USER, attrs=a)
         self.server.submit(J)
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq4'}
+        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq3'}
         J = Job(TEST_USER, attrs=a)
         self.server.submit(J)
         a = {ATTR_queue: 'wq1'}
         self.submit_jobs(3, a, user=TEST_USER1)
         self.submit_jobs(3, a, user=TEST_USER2)
-        a = {ATTR_queue: 'wq4'}
+        a = {ATTR_queue: 'wq3'}
         self.submit_jobs(3, a, user=TEST_USER1)
         self.submit_jobs(3, a, user=TEST_USER2)
 
@@ -1437,107 +1136,6 @@ class TestMultipleSchedulers(TestFunctional):
         # Six equivalence classes. Two for the resource eating job in
         # different partitions and one for each user per partition.
         self.scheds['sc1'].log_match("Number of job equivalence classes: 6",
-                                     max_attempts=10, starttime=t)
-
-    @skipOnCpuSet
-    def test_job_array_partition(self):
-        """
-        Test that various job types will fall into single equivalence
-        class with same type of request and will only fall into different
-        equivalence class if partition is different
-        """
-        self.setup_sc1()
-        self.setup_queues_nodes()
-        t = int(time.time())
-        # Eat up all the resources
-        a = {'Resource_List.select': '1:ncpus=2', 'queue': 'wq1'}
-        J = Job(TEST_USER1, attrs=a)
-        self.server.submit(J)
-        a = {'Resource_List.select': '1:ncpus=2', 'queue': 'wq4'}
-        J = Job(TEST_USER1, attrs=a)
-        self.server.submit(J)
-
-        # Submit a job array
-        j = Job(TEST_USER)
-        j.set_attributes(
-            {ATTR_J: '1-3:1',
-             'Resource_List.select': '1:ncpus=2',
-             'queue': 'wq1'})
-        self.server.submit(j)
-        j.set_attributes(
-            {ATTR_J: '1-3:1',
-             'Resource_List.select': '1:ncpus=2',
-             'queue': 'wq4'})
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1")
-        # Two equivalence class one for each partition
-        self.scheds['sc1'].log_match("Number of job equivalence classes: 2",
-                                     max_attempts=10, starttime=t)
-
-    @skipOnCpuSet
-    def test_equiv_suspend_jobs(self):
-        """
-        Test that jobs fall into different equivalence classes
-        after they get suspended
-        """
-        self.setup_sc1()
-        self.setup_queues_nodes()
-        t = int(time.time())
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'False'}, id="sc1")
-        # Eat up all the resources
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq1'}
-        J = Job(TEST_USER, attrs=a)
-        jid1 = self.server.submit(J)
-        self.server.submit(J)
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq4'}
-        J = Job(TEST_USER, attrs=a)
-        jid3 = self.server.submit(J)
-        self.server.submit(J)
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1")
-        # 2 equivalence classes one for each partition
-        self.scheds['sc1'].log_match("Number of job equivalence classes: 2",
-                                     max_attempts=10, starttime=t)
-        t = int(time.time())
-        # Make sure that Job is in R state before issuing a signal to suspend
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
-        self.server.sigjob(jobid=jid1, signal="suspend")
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
-        self.server.sigjob(jobid=jid3, signal="suspend")
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1")
-        # 4 equivalance classes 2 for partition 2 for suspended jobs
-        self.scheds['sc1'].log_match("Number of job equivalence classes: 4",
-                                     max_attempts=10, starttime=t)
-
-    @skipOnCpuSet
-    def test_equiv_single_partition(self):
-        """
-        Test that jobs fall into same equivalence class if jobs fall
-        into queues set to same partition
-        """
-        self.setup_sc1()
-        self.setup_queues_nodes()
-        t = int(time.time())
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'False'}, id="sc1")
-        self.server.manager(MGR_CMD_SET, QUEUE,
-                            {'partition': 'P1'}, id='wq4')
-        # Eat up all the resources with the first job to  wq1
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq1'}
-        self.submit_jobs(4, a)
-        a = {'Resource_List.select': '1:ncpus=2', ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-        a = {'Resource_List.select': '1:ncpus=1', ATTR_queue: 'wq1'}
-        self.submit_jobs(3, a)
-        a = {'Resource_List.select': '1:ncpus=1', ATTR_queue: 'wq4'}
-        self.submit_jobs(3, a)
-        self.server.manager(MGR_CMD_SET, SCHED,
-                            {'scheduling': 'True'}, id="sc1")
-        # 2 equivalence classes one for each with different ncpus request
-        # as both queues are having same partition
-        self.scheds['sc1'].log_match("Number of job equivalence classes: 2",
                                      max_attempts=10, starttime=t)
 
     def test_list_multi_sched(self):
@@ -1753,8 +1351,10 @@ class TestMultipleSchedulers(TestFunctional):
         """
         self.setup_sc1()
         self.setup_queues_nodes()
+        p1 = {'partition': 'P1'}
+        self.server.manager(MGR_CMD_SET, QUEUE, p1, id='wq3')
         prio = {'Priority': 150, 'partition': 'P1'}
-        self.server.manager(MGR_CMD_SET, QUEUE, prio, id='wq4')
+        self.server.manager(MGR_CMD_SET, QUEUE, prio, id='wq3')
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'sched_preempt_enforce_resumption': 'true'},
                             id='sc1')
@@ -1787,7 +1387,7 @@ class TestMultipleSchedulers(TestFunctional):
         j = Job(TEST_USER, {'queue': 'highp', 'Resource_List.walltime': '60',
                             'Resource_List.ncpus': '2'})
         jid3 = self.server.submit(j)
-        j = Job(TEST_USER, {'queue': 'wq4', 'Resource_List.walltime': '60',
+        j = Job(TEST_USER, {'queue': 'wq3', 'Resource_List.walltime': '60',
                             'Resource_List.ncpus': '2'})
         jid4 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
@@ -2143,28 +1743,26 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[2]')
         a = {'resources_available.ncpus': 4}
         self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[3]')
-        # Offlining the node as we do not need for the test
-        a = {'state': 'offline'}
-        self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[4]')
+
         a = {'Resource_List.select': '1:ncpus=1',
              'Resource_List.place': 'excl',
              ATTR_queue: 'wq1'}
         j = Job(TEST_USER1, a)
-        jid = self.server.submit(j)
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.check_vnodes(j, ['vnode[3]'], jid)
-        j = Job(TEST_USER1, a)
         jid1 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
-        self.check_vnodes(j, ['vnode[2]'], jid1)
+        self.check_vnodes(j, ['vnode[3]'], jid1)
         j = Job(TEST_USER1, a)
         jid2 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
-        self.check_vnodes(j, ['vnode[1]'], jid2)
+        self.check_vnodes(j, ['vnode[2]'], jid2)
         j = Job(TEST_USER1, a)
         jid3 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
-        self.check_vnodes(j, ['vnode[0]'], jid3)
+        self.check_vnodes(j, ['vnode[1]'], jid3)
+        j = Job(TEST_USER1, a)
+        jid4 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid4)
+        self.check_vnodes(j, ['vnode[0]'], jid4)
 
     @skipOnCpuSet
     def test_multi_sched_priority_sockets(self):
@@ -2195,3 +1793,380 @@ class TestMultipleSchedulers(TestFunctional):
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id='sc2')
         self.server.log_match("processing priority socket", starttime=t)
+
+    def test_advance_resv_in_multi_sched(self):
+        """
+        Test that advance reservations in a multi-sched environment can be
+        serviced by any scheduler
+        """
+        # Create 3 multi-scheds sc1, sc2 and sc3, 3 partitions and 4 vnodes
+        self.common_setup()
+        # Consume all resources in partitions serviced by sc1 and sc3 and
+        # default scheduler
+        a = {ATTR_queue: 'wq1',
+             'Resource_List.select': '1:ncpus=2',
+             'Resource_List.walltime': 60}
+        j = Job(TEST_USER1, attrs=a)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        a = {ATTR_queue: 'wq3',
+             'Resource_List.select': '1:ncpus=2'}
+        j2 = Job(TEST_USER, attrs=a)
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+
+        a = {ATTR_queue: 'workq',
+             'Resource_List.select': '1:ncpus=2'}
+        j3 = Job(TEST_USER, attrs=a)
+        jid3 = self.server.submit(j3)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
+
+        # Now submit a reservation which only sc2 can confirm because
+        # it has free nodes
+        t = int(time.time())
+        a = {'Resource_List.select': '1:ncpus=2', 'reserve_start': t + 5,
+             'reserve_end': t + 15}
+        r = Reservation(TEST_USER, a)
+        rid = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, rid)
+        rnodes = {'resv_nodes': '(vnode[1]:ncpus=2)'}
+        self.server.expect(RESV, rnodes, id=rid)
+
+        # Wait for reservation to run and then submit a job to the
+        # reservation
+        a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, a, rid)
+        a = {ATTR_q: rid.split('.')[0]}
+        j4 = Job(TEST_USER, attrs=a)
+        jid4 = self.server.submit(j4)
+        result = {'job_state': 'R', 'exec_vnode': '(vnode[1]:ncpus=1)'}
+        self.server.expect(JOB, result, id=jid4)
+
+    def test_resv_in_empty_multi_sched_env(self):
+        """
+        Test that advance reservations gets confirmed by all the schedulers
+        running in the complex
+        """
+        # Create 3 multi-scheds sc1, sc2 and sc3, 3 partitions and 4 vnodes
+        self.common_setup()
+        # Submit 4 reservations and check they get confirmed
+        for _ in range(4):
+            t = int(time.time())
+            a = {'Resource_List.select': '1:ncpus=2', 'reserve_start': t + 25,
+                 'reserve_end': t + 55}
+            r = Reservation(TEST_USER, attrs=a)
+            rid = self.server.submit(r)
+            a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+            self.server.expect(RESV, a, rid)
+
+        # Submit 5th reservation and check that it is denied
+        t = int(time.time())
+        a = {'Resource_List.select': '1:ncpus=2', 'reserve_start': t + 25,
+             'reserve_end': t + 55}
+        r = Reservation(TEST_USER, a)
+        rid = self.server.submit(r)
+        msg = "Resv;" + rid + ";Reservation denied"
+        self.server.log_match(msg)
+
+    def test_asap_resv(self):
+        """
+        Test ASAP reservation in multisched environment. It should not
+        matter if a job is part of a partition. An ASAP reservation could
+        confirm on any of the existing partitions and then moved to the
+        reservation queue.
+        """
+        # Create 3 multi-scheds sc1, sc2 and sc3, 4 partitions and 4 vnodes
+        self.common_setup()
+        # Turn off scheduling in all schedulers but one (say sc3)
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="sc1")
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="sc2")
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="default")
+
+        # submit a job in partition serviced by sc1
+        a = {ATTR_queue: 'wq1',
+             'Resource_List.select': '1:ncpus=2',
+             'Resource_List.walltime': 600}
+        j = Job(TEST_USER, attrs=a)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+
+        # Now turn this job into a reservation and notice that it runs inside
+        # a reservation running on vnode[2] which is part of sc3
+        a = {ATTR_convert: jid}
+        r = Reservation(TEST_USER, a)
+        r.unset_attributes(['reserve_start', 'reserve_end'])
+        rid = self.server.submit(r)
+        exp_attrs = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, exp_attrs, id=rid)
+        result = {'job_state': 'R', 'exec_vnode': '(vnode[2]:ncpus=2)'}
+        self.server.expect(JOB, result, id=jid)
+
+    def test_standing_resv_reject(self):
+        """
+        Test that if a scheduler serving a partition is not able to
+        confirm all the occurrences of the standing reservation on the same
+        partition then it will reject it.
+        """
+
+        self.common_setup()
+        # Turn off scheduling in all schedulers but sc1 because sc1 serves
+        # partition P1
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="sc2")
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="sc3")
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="default")
+
+        # Submit an advance reservation which is going to occupy full
+        # partition in future
+        t = int(time.time())
+        a = {'Resource_List.select': '1:ncpus=2', 'reserve_start': t + 200,
+             'reserve_end': t + 4000}
+        r = Reservation(TEST_USER, a)
+        rid = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, rid)
+
+        # Submit a standing reservation such that it consumes one partition
+        # and an occurrence finishes before the advance reservation starts.
+        # This means scheduler will try to place the first occurance right
+        # before the advance reservation was confirmed because the
+        # node is free, it will not be able to place the second occurrence
+        # because of the advance reservation
+        start = int(time.time()) + 10
+        end = start + 150
+        tzone = self.get_tzid()
+        a = {ATTR_resv_rrule: 'FREQ=HOURLY;COUNT=2',
+             ATTR_resv_timezone: tzone,
+             'reserve_start': start,
+             'reserve_end': end,
+             'Resource_List.select': '1:ncpus=2'
+             }
+        sr = Reservation(TEST_USER, attrs=a)
+        srid = self.server.submit(sr)
+        msg = "Resv;" + srid + ";Reservation denied"
+        self.server.log_match(msg)
+
+    def test_printing_partition_resv_hook(self):
+        """
+        Test if a reservation having a partition set on it is readable in
+        a reservation hook
+        """
+        hook_body = """
+import pbs
+e = pbs.event()
+resv = e.resv
+pbs.logmsg(pbs.EVENT_DEBUG, "Resv partition is %s" % resv.partition)
+e.accept()
+"""
+        a = {'event': 'resv_end', 'enabled': 'true', 'debug': 'true'}
+        self.server.create_import_hook("h1", a, hook_body)
+        # Create 3 multi-scheds sc1, sc2 and sc3, 3 partitions and 4 vnodes
+        self.common_setup()
+        # Turn off scheduling in all schedulers but one (say sc3)
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="sc1")
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="sc2")
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="default")
+        t = int(time.time())
+        a = {'Resource_List.select': '1:ncpus=2', 'reserve_start': t + 5,
+             'reserve_end': t + 15}
+        r = Reservation(TEST_USER, a)
+        rid = self.server.submit(r)
+        a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, a, rid)
+        self.logger.info("Wait for reservation to end")
+        time.sleep(10)
+        msg = "Resv partition is P3"
+        self.server.log_match(msg)
+
+    def test_setting_partition_resv_hook(self):
+        """
+        Test if a reservation can set partition name on reservation object
+        """
+        hook_body = """
+import pbs
+e = pbs.event()
+resv = e.resv
+resv.partition = "P-3"
+pbs.logmsg(pbs.EVENT_DEBUG, "Resv partition is %s" % resv.partition)
+e.accept()
+"""
+        a = {'event': 'resvsub', 'enabled': 'true', 'debug': 'true'}
+        self.server.create_import_hook("h1", a, hook_body)
+        # Create 3 multi-scheds sc1, sc2 and sc3, 3 partitions and 4 vnodes
+        self.common_setup()
+        t = int(time.time())
+        a = {'Resource_List.select': '1:ncpus=2', 'reserve_start': t + 5,
+             'reserve_end': t + 15}
+        r = Reservation(TEST_USER, a)
+        with self.assertRaises(PbsSubmitError) as e:
+            rid = self.server.submit(r)
+        msg = "resv attribute 'partition' is readonly"
+        self.server.log_match(msg)
+        self.assertIn("hook 'h1' encountered an exception",
+                      e.exception.msg[0])
+
+    def test_resv_alter(self):
+        """
+        Test if a reservation confirmed by a multi-sched can be altered by the
+        same scheduler.
+        """
+        self.common_setup()
+        # Submit 4 reservations to fill up the system and check they are
+        # confirmed
+        for _ in range(4):
+            t = int(time.time())
+            a = {'Resource_List.select': '1:ncpus=2', 'reserve_start': t + 60,
+                 'reserve_end': t + 120}
+            r = Reservation(TEST_USER, a)
+            rid = self.server.submit(r)
+            attr = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+            self.server.expect(RESV, attr, rid)
+            partition = self.server.status(RESV, 'partition', id=rid)
+            if (partition[0]['partition'] == 'P1'):
+                    old_end_time = a['reserve_end']
+                    modify_resv = rid
+        # Modify the endtime of reservation confirmed on partition P1 and
+        # make sure the node solution is correct.
+        end_time = old_end_time + 60
+        bu = BatchUtils()
+        new_end_time = bu.convert_seconds_to_datetime(end_time)
+        attrs = {'reserve_end': new_end_time}
+        time_now = time.time()
+        self.server.alterresv(modify_resv, attrs)
+        attr = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2'),
+                'partition': 'P1'}
+        self.server.expect(RESV, attr, modify_resv)
+        rnodes = {'resv_nodes': '(vnode[0]:ncpus=2)'}
+        self.server.expect(RESV, rnodes, id=modify_resv)
+        msg = modify_resv + ";Reservation Confirmed"
+        self.scheds['sc1'].log_match(msg, starttime=time_now)
+
+    def test_setting_default_partition(self):
+        """
+        Test if setting default partition on pbs scheduler/queue/node fails
+        """
+
+        self.common_setup()
+        a = {'partition': 'pbs-default'}
+        with self.assertRaises(PbsManagerError) as e:
+            self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq')
+        self.assertIn("Default partition name is not allowed",
+                      e.exception.msg[0])
+        with self.assertRaises(PbsManagerError) as e:
+            self.server.manager(MGR_CMD_SET, NODE, a, id='vnode[3]')
+        self.assertIn("Default partition name is not allowed",
+                      e.exception.msg[0])
+        with self.assertRaises(PbsManagerError) as e:
+            self.server.manager(MGR_CMD_SET, SCHED, a, id='sc1')
+        self.assertIn("Default partition name is not allowed",
+                      e.exception.msg[0])
+
+    def degraded_resv_reconfirm(self, start, end, rrule=None, run=False):
+        """
+        Test that a degraded reservation gets reconfirmed in a multi-sched env
+        """
+        # Add two nodes to partition P1 and turn off scheduling for all other
+        # schedulers serving partition P2 and P3. Make scheduler sc1 serve
+        # only partition P1 (vnode[0], vnode[1]).
+        self.common_setup()
+        p1 = {'partition': 'P1'}
+        self.server.manager(MGR_CMD_SET, NODE, p1, id="vnode[1]")
+        self.server.expect(SCHED, p1, id="sc1")
+
+        a = {'reserve_retry_time': 5}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="sc2")
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="sc3")
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="default")
+
+        attr = {'Resource_List.select': '1:ncpus=2',
+                'reserve_start': start,
+                'reserve_end': end}
+        if rrule is not None:
+            attr.update({ATTR_resv_rrule: rrule,
+                         ATTR_resv_timezone: self.get_tzid()})
+        resv = Reservation(TEST_USER, attr)
+        rid = self.server.submit(resv)
+
+        a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
+        self.server.expect(RESV, a, id=rid)
+
+        self.server.status(RESV, 'resv_nodes', id=rid)
+        resv_node = self.server.reservations[rid].get_vnodes()[0]
+
+        if run:
+            resv_state = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+            self.logger.info('Sleeping until reservation starts')
+            offset = start - int(time.time())
+            self.server.expect(RESV, resv_state, id=rid,
+                               offset=offset, interval=1)
+        else:
+            resv_state = {'reserve_state': (MATCH_RE, 'RESV_DEGRADED|10')}
+
+        ret = self.server.status(RESV, 'partition', id=rid)
+        a = {'state': 'offline'}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=resv_node)
+
+        a = {'reserve_substate': 10}
+        a.update(resv_state)
+        self.server.expect(RESV, a, id=rid)
+
+        other_node = "vnode[1]"
+        if resv_node == "vnode[1]":
+            other_node = "vnode[0]"
+
+        if run:
+            a = {'reserve_substate': 5}
+        else:
+            a = {'reserve_substate': 2}
+        a.update({'resv_nodes': (MATCH_RE, re.escape(other_node))})
+
+        self.server.expect(RESV, a, id=rid, interval=1)
+
+    def test_advance_confimred_resv_reconfirm(self):
+        """
+        Test degraded reservation gets reconfirmed on a different
+        node of the same partition in multi-sched environment
+        """
+        now = int(time.time())
+        self.degraded_resv_reconfirm(start=now + 20, end=now + 200)
+
+    def test_advance_running_resv_reconfirm(self):
+        """
+        Test degraded running reservation gets reconfirmed on a different
+        node of the same partition in multi-sched environment
+        """
+        now = int(time.time())
+        self.degraded_resv_reconfirm(start=now + 20, end=now + 200, run=True)
+
+    def test_standing_confimred_resv_reconfirm(self):
+        """
+        Test degraded standing resv gets reconfirmed on a different
+        node of the same partition in multi-sched environment
+        """
+        now = int(time.time())
+        self.degraded_resv_reconfirm(start=now + 20, end=now + 200,
+                                     rrule='FREQ=HOURLY;COUNT=2')
+
+    def test_standing_running_resv_reconfirm(self):
+        """
+        Test degraded running standing resv gets reconfirmed on a different
+        node of the same partition in multi-sched environment
+        """
+        now = int(time.time())
+        self.degraded_resv_reconfirm(start=now + 20, end=now + 200, run=True,
+                                     rrule='FREQ=HOURLY;COUNT=2')


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Adding support to confirm/run reservations in multi-sched environment.
Interface 8 of [Multi-sched](https://pbspro.atlassian.net/wiki/spaces/PD/pages/50947131/PP-337+Multiple+schedulers+servicing+the+PBS+cluster) design

#### Describe Your Change
With this change in place, from now on, PBS server will send reservation confirmation requests to all schedulers in the complex. Reservation is marked confirmed as soon as any of the schedulers is able to confirm the reservation.

#### Link to Design Doc
Interface 8 of [Multi-sched](https://pbspro.atlassian.net/wiki/spaces/PD/pages/50947131/PP-337+Multiple+schedulers+servicing+the+PBS+cluster) design



#### Attach Test and Valgrind Logs/Output
[test_multi_sched.txt](https://github.com/PBSPro/pbspro/files/4167363/test_multi_sched.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
