### PR TITLE
Removing obsolete sort_queues from sched_config

### DIFF
--- a/src/scheduler/pbs_sched_config
+++ b/src/scheduler/pbs_sched_config
@@ -244,15 +244,6 @@ node_sort_key: "sort_priority HIGH"	ALL
 
 provision_policy: "aggressive_provision"
 
-#
-# sort_queues 
-#	sort queues by the priority attribute
-#
-#	PRIME OPTION
-#
-
-sort_queues:	true	ALL
-
 #### SMP JOB OPTIONS: 
 
 #


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
https://pbspro.atlassian.net/browse/PP-419

sort_queues was obsoleted a long time back but it was still present in sched_config, which meant that scheduler would log the following message every time it reconfigured:
02/10/2020 17:19:05.824393;0040;pbs_sched;Sched;reconfigure;Scheduler is reconfiguring
02/10/2020 17:19:05.825235;0040;pbs_sched;Fil;sched_config;Obsolete config name sort_queues

Since the option has been obsolete for some time, I'm removing it so that we stop seeing this warning.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Just remove sort_queues from sched_config

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Smoke tests should suffice, sched logs can be inspected to verify that the log message goes away now. It's not worth writing a PTL test for this.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
