### PR TITLE
test_release_nodes_error: insert job run check after submit

### DIFF
--- a/test/tests/functional/pbs_node_rampdown_keep_select.py
+++ b/test/tests/functional/pbs_node_rampdown_keep_select.py
@@ -1126,6 +1126,7 @@ class TestPbsNodeRampDownKeepSelect(TestFunctional):
         job = Job(TEST_USER, attrs={'Resource_List.select': qsub_sel})
         job.set_sleep_time(1000)
         jid = self.server.submit(job)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
         # 1. "pbs_release_nodes: -a and -k options cannot be used together"
         cmd = [self.rel_nodes_cmd, '-j', jid, '-a', '-k', keep_sel]


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
PTL TC `TestPbsNodeRampDownKeepSelect.test_release_nodes_error` is randomly failing because submitted test job was not in run state while executing further verification steps. Leading to below failure at line https://github.com/PBSPro/pbspro/blob/d1eb8b49323b893fcf5227d7a2bfc5ab627822cb/test/tests/functional/pbs_node_rampdown_keep_select.py#L1162-L1163
```
2020-02-11 10:30:20,467 INFOCLI2 x597-261-0: sudo -H -u pbsuser /opt/pbs/bin/pbs_release_nodes -j 8.x597-261-0 -k select=ncpus=2:unkownres=3
2020-02-11 10:30:20,481 ERROR    err: ['pbs_release_nodes: Request invalid for state of job ']

Traceback (most recent call last):
  File "/opt/ptl/lib/python3.6/site-packages/ptl/utils/pbs_testsuite.py", line 180, in wrapper
    function(self, *args, **kwargs)
  File "/opt/ptl/tests/functional/pbs_node_rampdown_keep_select.py", line 1163, in test_release_nodes_error
    'pbs_release_nodes: Unknown resource: unkownres'))
AssertionError: False is not true
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added check after job submit to wait till job goes to run state


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Before:
```
2020-02-12 11:51:57,682 INFO     job: executable set to /bin/sleep with arguments: 1000
2020-02-12 11:51:57,683 INFOCLI  bapy3vm: sudo -H -u pbsuser /opt/pbs/bin/qsub -l select=ncpus=1+2:ncpus=2+2:ncpus=3:mpiprocs=2 -- /bin/sleep 1000
2020-02-12 11:51:57,751 INFO     submit to bapy3vm as pbsuser: job 0.bapy3vm OrderedDict([('Resource_List.select', 'ncpus=1+2:ncpus=2+2:ncpus=3:mpiprocs=2')])
2020-02-12 11:51:57,752 INFOCLI2 bapy3vm: sudo -H -u pbsuser /opt/pbs/bin/pbs_release_nodes -j 0.bapy3vm -a -k select=ncpus=2+ncpus=3:mpiprocs=2
2020-02-12 11:51:57,777 ERROR    err: ['pbs_release_nodes: -a and -k options cannot be used together', 'usage: pbs_release_nodes [-j job_identifier] host_or_vnode1 host_or_vnode2 ...', '       pbs_release_nodes [-j job_identifier] -a', '       pbs_release_nodes [-j job_identifier] -k <select string>', '       pbs_release_nodes [-j job_identifier] -k <node count>', '       pbs_release_nodes --version']
```
After:
```
2020-02-12 11:56:36,992 INFO     job: executable set to /bin/sleep with arguments: 1000
2020-02-12 11:56:36,993 INFOCLI  bapy3vm: sudo -H -u pbsuser /opt/pbs/bin/qsub -l select=ncpus=1+2:ncpus=2+2:ncpus=3:mpiprocs=2 -- /bin/sleep 1000
2020-02-12 11:56:37,059 INFO     submit to bapy3vm as pbsuser: job 1.bapy3vm OrderedDict([('Resource_List.select', 'ncpus=1+2:ncpus=2+2:ncpus=3:mpiprocs=2')])
2020-02-12 11:56:37,060 INFOCLI  bapy3vm: /opt/pbs/bin/qstat -f 1.bapy3vm
2020-02-12 11:56:37,079 INFO     expect on server bapy3vm: job_state = R && substate = 42 job 1.bapy3vm  got: substate = 41
2020-02-12 11:56:37,581 INFOCLI  bapy3vm: /opt/pbs/bin/qmgr -c set server scheduling=True
2020-02-12 11:56:37,644 INFOCLI  bapy3vm: /opt/pbs/bin/qstat -f 1.bapy3vm
2020-02-12 11:56:37,868 INFO     expect on server bapy3vm: job_state = R && substate = 42 job 1.bapy3vm attempt: 2 ...  OK
2020-02-12 11:56:37,869 INFOCLI2 bapy3vm: sudo -H -u pbsuser /opt/pbs/bin/pbs_release_nodes -j 1.bapy3vm -a -k select=ncpus=2+ncpus=3:mpiprocs=2
2020-02-12 11:56:37,895 ERROR    err: ['pbs_release_nodes: -a and -k options cannot be used together', 'usage: pbs_release_nodes [-j job_identifier] host_or_vnode1 host_or_vnode2 ...', '       pbs_release_nodes [-j job_identifier] -a', '       pbs_release_nodes [-j job_identifier] -k <select string>', '       pbs_release_nodes [-j job_identifier] -k <node count>', '       pbs_release_nodes --version']
```

[ptl_out new.txt](https://github.com/PBSPro/pbspro/files/4190227/ptl_out.new.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
