### PR TITLE
hwloc keeps opened devices (like /dev/nvidia*)

### DIFF
--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -11012,8 +11012,6 @@ mom_topology(void)
 	} else {
 		close(fd[1]);
 
-		waitpid(pid, NULL, 0);
-
 		read(fd[0], &ret, sizeof(ret));
 		read(fd[0], &xmllen, sizeof(xmllen));
 		if ((xmlbuf = malloc(xmllen + 1)) == NULL) {
@@ -11024,6 +11022,8 @@ mom_topology(void)
 		read(fd[0], xmlbuf, xmllen);
 
 		close(fd[0]);
+
+		waitpid(pid, NULL, 0);
 	}
 	if (ret < 0) {
 		/* on any failure above, issue log message */

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -10969,24 +10969,61 @@ mom_topology(void)
 #ifndef NAS /* localmod 113 */
 	extern char mom_short_name[];
 	extern callfunc_t vn_callback;
-	int ret;
+	int ret = -1;
 	char *xmlbuf = NULL;
 	int xmllen = 0;
 	vnl_t *vtp = NULL;
 	char *topology_type;
+	int fd[2];
+	int pid;
 
 #ifndef	WIN32
-	hwloc_topology_t topology;
-	ret = 0;
-	if (hwloc_topology_init(&topology) == -1)
-		ret = -1;
-	else if ((hwloc_topology_set_flags(topology,
-			HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM | HWLOC_TOPOLOGY_FLAG_IO_DEVICES)
-			== -1) || (hwloc_topology_load(topology) == -1)
-			|| (hwloc_topology_export_xmlbuffer(topology, &xmlbuf, &xmllen)
-					== -1)) {
+	pipe(fd);
+
+	if ((pid = fork()) == -1) {
+		log_err(PBSE_SYSTEM, __func__, "fork failed");
+		return;
+	}
+
+	if (pid == 0) {
+		hwloc_topology_t topology;
+		ret = 0;
+
+		close(fd[0]);
+
+		if (hwloc_topology_init(&topology) == -1)
+			ret = -1;
+		else if ((hwloc_topology_set_flags(topology,
+				HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM | HWLOC_TOPOLOGY_FLAG_IO_DEVICES)
+				== -1) || (hwloc_topology_load(topology) == -1)
+				|| (hwloc_topology_export_xmlbuffer(topology, &xmlbuf, &xmllen)
+						== -1)) {
+			ret = -1;
+		}
+
+		write(fd[1], &ret, (sizeof(ret)));
+		write(fd[1], &xmllen, (sizeof(xmllen)));
+		write(fd[1], xmlbuf, xmllen);
+
+		hwloc_free_xmlbuffer(topology, xmlbuf);
 		hwloc_topology_destroy(topology);
-		ret = -1;
+
+		exit(0);
+	} else {
+		close(fd[1]);
+
+		waitpid(pid, NULL, 0);
+
+		read(fd[0], &ret, sizeof(ret));
+		read(fd[0], &xmllen, sizeof(xmllen));
+		if ((xmlbuf = malloc(xmllen + 1)) == NULL) {
+			log_err(PBSE_SYSTEM, __func__, "malloc failed");
+			return;
+		}
+		xmlbuf[xmllen] = '\0';
+		read(fd[0], xmlbuf, xmllen);
+
+		close(fd[0]);
 	}
 	if (ret < 0) {
 		/* on any failure above, issue log message */
@@ -11107,8 +11144,7 @@ mom_topology(void)
 	}
 bad:
 #ifndef WIN32
-	hwloc_free_xmlbuffer(topology, xmlbuf);
-	hwloc_topology_destroy(topology);
+	free(xmlbuf);
 #else
 	;
 #endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
hwloc does not close opened devices (like /dev/nvidia*). It means you need to kill mom for upgrading the drivers. hwloc also catches the segfault, which can lead to not creating a core dump when is needed.

38670 is mom's pid
```
~# ls -l /proc/38670/fd/ | grep nvidia
lrwx------ 1 root root 64 úno 12 11:01 18 -> /dev/nvidiactl
lrwx------ 1 root root 64 úno 12 11:01 19 -> /dev/nvidia-uvm
lrwx------ 1 root root 64 úno 12 11:01 20 -> /dev/nvidia0
lrwx------ 1 root root 64 úno 12 11:01 21 -> /dev/nvidia1
lrwx------ 1 root root 64 úno 12 11:01 22 -> /dev/nvidia0
lrwx------ 1 root root 64 úno 12 11:01 23 -> /dev/nvidia0
lrwx------ 1 root root 64 úno 12 11:01 24 -> /dev/nvidia1
lrwx------ 1 root root 64 úno 12 11:01 25 -> /dev/nvidia1
```

#### Describe Your Change
This is a bug in hwloc. The issue is resolved by calling hwloc in a forked process and the result is conveyed by a pipe

#### Link to Design Doc
None


#### Attach Test and Valgrind Logs/Output
Travis test is sufficient.



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
