### PR TITLE
qsub crashes if environment variables contain backslashes

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -480,7 +480,7 @@ copy_env_value(char *dest, char *pv, int quote_flg)
 			case ESC_CHAR: /* backslash in value, escape it */
 				*dest++ = *pv;
 				if (*(pv + 1) != ',') /* do not escape if ESC_CHAR already escapes */
-					*dest++ = *pv;
+					*dest++ = *++pv;
 				break;
 
 			case ',':

--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -180,3 +180,24 @@ exit 0
         self.server.expect(JOB, {'Variable_List': (MATCH_RE,
                                                    'SET_IN_SUBMISSION=false')},
                            id=jid1)
+    def test_passing_env_special_char_via_qsub(self):
+        """
+        Submit a job with -v ENV_TEST=N:\\aa\\bb\\cc\\dd\\ee\\ff\\gg\\hh\\ii
+        and check that the value is passed correctly
+
+        NOTE: As per the Guide 5.2.4.7 Special Characters
+        in Variable_List Job Attribute
+        Python requires that double quotes
+        and backslashes also be escaped with a backslash
+        """
+        a = {ATTR_v: 'ENV_TEST="N:\\aa\\bb\\cc\\dd\\ee\\ff\\gg\\hh\\ii"'}
+        j2 = Job(TEST_USER, attrs=a)
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
+        qstat = self.server.status(JOB, ATTR_v, id=jid2)
+        job_outfile = qstat[0]['Variable_List']
+        var_list = job_outfile.split(",")
+        exp_string = "ENV_TEST=N:\\\\aa\\\\bb\\\\cc\\\\dd"
+        exp_string += "\\\\ee\\\\ff\\\\gg\\\\hh\\\\ii"
+        self.assertIn(exp_string, var_list)
+

--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -180,6 +180,7 @@ exit 0
         self.server.expect(JOB, {'Variable_List': (MATCH_RE,
                                                    'SET_IN_SUBMISSION=false')},
                            id=jid1)
+
     def test_passing_env_special_char_via_qsub(self):
         """
         Submit a job with -v ENV_TEST=N:\\aa\\bb\\cc\\dd\\ee\\ff\\gg\\hh\\ii
@@ -200,4 +201,3 @@ exit 0
         exp_string = "ENV_TEST=N:\\\\aa\\\\bb\\\\cc\\\\dd"
         exp_string += "\\\\ee\\\\ff\\\\gg\\\\hh\\\\ii"
         self.assertIn(exp_string, var_list)
-


### PR DESCRIPTION
#### Describe Bug or Feature
qsub crashes if environment variables contain backslashes 

#### Describe Your Change

- qsub crashes if environment variables contain backslashes because it does not have enough memory allocated for the exported environmental variable. 

- Earlier, when we copy an environment variable value,  "copy_env_value" was adding extra special characters. Now, removed adding extra special characters while copying env variable.


[Before_fix.txt](https://github.com/PBSPro/pbspro/files/4217811/Before_fix.txt)
[After_fix.txt](https://github.com/PBSPro/pbspro/files/4217814/After_fix.txt)







