### PR TITLE
Invalid read of freed memory in server

### DIFF
--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -890,7 +890,7 @@ dispatch_request(int sfds, struct batch_request *request)
 				return;
 			}
 			req_stat_job(request);
-			clear_non_blocking(conn);
+			clear_non_blocking(get_conn(sfds));
 			break;
 
 		case PBS_BATCH_StatusQue:
@@ -900,7 +900,7 @@ dispatch_request(int sfds, struct batch_request *request)
 				return;
 			}
 			req_stat_que(request);
-			clear_non_blocking(conn);
+			clear_non_blocking(get_conn(sfds));
 			break;
 
 		case PBS_BATCH_StatusNode:
@@ -910,7 +910,7 @@ dispatch_request(int sfds, struct batch_request *request)
 				return;
 			}
 			req_stat_node(request);
-			clear_non_blocking(conn);
+			clear_non_blocking(get_conn(sfds));
 			break;
 
 		case PBS_BATCH_StatusResv:
@@ -920,7 +920,7 @@ dispatch_request(int sfds, struct batch_request *request)
 				return;
 			}
 			req_stat_resv(request);
-			clear_non_blocking(conn);
+			clear_non_blocking(get_conn(sfds));
 			break;
 
 		case PBS_BATCH_StatusSvr:
@@ -951,7 +951,7 @@ dispatch_request(int sfds, struct batch_request *request)
 				return;
 			}
 			req_stat_hook(request);
-			clear_non_blocking(conn);
+			clear_non_blocking(get_conn(sfds));
 			break;
 
 		case PBS_BATCH_TrackJob:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When the server replies back to batch request it cleans up the associated client connection object (in case of failures). Then the server tries to access the already freed connection object to reset the flag on the socket. 
Here is the valgrind output - 

==15244== Invalid read of size 4
==15244==    at 0x46950A: clear_non_blocking (process_request.c:633)
==15244==    by 0x469AED: dispatch_request (process_request.c:913)
==15244==    by 0x469425: process_request (process_request.c:566)
==15244==    by 0x4F285B: process_socket (net_server.c:512)
==15244==    by 0x4F2B6A: wait_request (net_server.c:628)
==15244==    by 0x46796F: main (pbsd_main.c:1834)
==15244==  Address 0xa1685a0 is 0 bytes inside a block of size 632 free'd
==15244==    at 0x4C2ACDD: free (vg_replace_malloc.c:530)
==15244==    by 0x4F33E4: cleanup_conn (net_server.c:971)
==15244==    by 0x4F31E6: close_conn (net_server.c:916)
==15244==    by 0x469D44: close_client (process_request.c:1072)
==15244==    by 0x46BA68: dis_reply_write (reply_send.c:254)
==15244==    by 0x46BC62: reply_send (reply_send.c:346)
==15244==    by 0x4931E7: req_stat_node (req_stat.c:597)
==15244==    by 0x469AE1: dispatch_request (process_request.c:912)
==15244==    by 0x469425: process_request (process_request.c:566)
==15244==    by 0x4F285B: process_socket (net_server.c:512)
==15244==    by 0x4F2B6A: wait_request (net_server.c:628)
==15244==    by 0x46796F: main (pbsd_main.c:1834)
==15244==  Block was alloc'd at
==15244==    at 0x4C2B975: calloc (vg_replace_malloc.c:711)
==15244==    by 0x4F2D6A: add_conn_priority (net_server.c:752)
==15244==    by 0x4F2D1F: add_conn (net_server.c:720)
==15244==    by 0x4F2CCE: accept_conn (net_server.c:694)
==15244==    by 0x4F285B: process_socket (net_server.c:512)
==15244==    by 0x4F2B6A: wait_request (net_server.c:628)
==15244==    by 0x46796F: main (pbsd_main.c:1834)

#### Describe Your Change
While trying to reset flag on the socket, Instead of passing the connection object from a local pointer in dispatch_request, always try to access it from the connection table that the server maintains.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
Internal testing of node buckets PTL tests found this problem. It only happens in error cases when while trying to send a reply to client DIS encoding fails and that makes reply_send clean up the connection. After this, the caller (dispatch_request()) calls clear_non_blocking() to reset the socket flag and ends up touching freed connection object.

[server_mem_master.txt](https://github.com/PBSPro/pbspro/files/4196181/server_mem_master.txt)
[server_mem_fix.txt](https://github.com/PBSPro/pbspro/files/4196182/server_mem_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
