### PR TITLE
Post_analysis_data save failed due to invalid characters in test case doc string

### DIFF
--- a/test/tests/functional/pbs_mom_dynamic_resource.py
+++ b/test/tests/functional/pbs_mom_dynamic_resource.py
@@ -140,7 +140,7 @@ class TestMomDynRes(TestFunctional):
     def test_res_string_perticular_value(self):
         """
         Test for host level string resource
-        with mom dynamic value “This is a test”
+        with mom dynamic value "This is a test"
         """
 
         resc_name = ["foo"]


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestMomDynRes.test_res_string_perticular_value test case fails while saving post analysis data.

#### Describe Your Change
TestMomDynRes.test_res_string_perticular_value test case has doc string 
"Test for host level string resource with mom dynamic value “This is a test” "
And while saving post data, above string was decoded as "Test for host level string resource with mom dynamic value \u201cThis is a test\u201d". 
Hence, test case was exiting with failure : UnicodeEncodeError: 'ascii' codec can't encode character '\u201c' in position 339: ordinal not in range(128)

#### Solution
Replace “This is a test” -> "This is a test" in test case doc string

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[test_res_string_perticular_value_after_fix.txt](https://github.com/PBSPro/pbspro/files/4218039/test_res_string_perticular_value_after_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
