### PR TITLE
Fix sigpipe handler in pbs_sched

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -201,7 +201,7 @@ schedinit(int nthreads)
 	Py_IgnoreEnvironmentFlag = 1;
 
 	set_py_progname();
-	Py_Initialize();
+	Py_InitializeEx(0);
 
 	PyRun_SimpleString(
 		"_err =\"\"\n"

--- a/test/tests/functional/pbs_sched_signal.py
+++ b/test/tests/functional/pbs_sched_signal.py
@@ -42,7 +42,7 @@ class TestSchedSignal(TestFunctional):
 
     def test_sigpipe(self):
         """
-        Test that pbs_sched handles sigpipe correctly
+        Test that pbs_sched receives a SIGPIPE correctly and it is not ignored
         """
         self.scheduler.signal('-PIPE')
         self.scheduler.log_match("We've received a sigpipe:")

--- a/test/tests/functional/pbs_sched_signal.py
+++ b/test/tests/functional/pbs_sched_signal.py
@@ -1,0 +1,48 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestSchedSignal(TestFunctional):
+
+    def test_sigpipe(self):
+        """
+        Test that pbs_sched handles sigpipe correctly
+        """
+        self.scheduler.signal('-PIPE')
+        self.scheduler.log_match("We've received a sigpipe: The server probably died")

--- a/test/tests/functional/pbs_sched_signal.py
+++ b/test/tests/functional/pbs_sched_signal.py
@@ -45,4 +45,4 @@ class TestSchedSignal(TestFunctional):
         Test that pbs_sched handles sigpipe correctly
         """
         self.scheduler.signal('-PIPE')
-        self.scheduler.log_match("We've received a sigpipe: The server probably died")
+        self.scheduler.log_match("We've received a sigpipe:")


### PR DESCRIPTION
#### Describe Bug or Feature
scheduler was not handling sigpipe correctly


#### Describe Your Change
Py_Initialize sets the handler of SIGPIPE to SIG_IGN. See [Signal#General-rules](https://docs.python.org/3/library/signal.html#general-rules) and [Py_InitializeEx](https://docs.python.org/3/c-api/init.html#c.Py_InitializeEx)

Changing Py_Initialize to Py_InitializeEx(0) tells python to not ignore SIGPIPE.


#### Attach Test and Valgrind Logs/Output

[after-fix.txt](https://github.com/PBSPro/pbspro/files/4207624/after-fix.txt)
[before-fix.txt](https://github.com/PBSPro/pbspro/files/4207625/before-fix.txt)

