### PR TITLE
fix bug where ci --build was failing and use absolute paths as entrypoint

### DIFF
--- a/ci/ci
+++ b/ci/ci
@@ -83,7 +83,7 @@ def commit_docker_image():
     env_file = os.path.join(pbs_dirname, ".env")
     image_name = read_from_file(env_file)
     image_name = image_name.split('=')[1]
-    if image_name.find('_ci_pbs') == -1:
+    if image_name[-7:] != '_ci_pbs':
         image_name += '_ci_pbs'
         image_name = image_name.replace(':', '_')
         try:
@@ -111,7 +111,7 @@ def delete_older_image(bad_images):
     '''
     When building a newer '_ci_pbs' image this fucntion will delete any older such instance
     '''
-    if bad_images.find('_ci_pbs') == -1:
+    if bad_images[-7:] != '_ci_pbs':
         bad_images = bad_images.replace(':', '_')
         bad_images += '_ci_pbs'
     cmd = "docker images -q " + bad_images
@@ -149,8 +149,8 @@ def check_for_existing_image():
     val = read_from_file(env_file)
     if val != '':
         val = val.split('=')[1]
-        if val.find('_ci_pbs') != -1:
-            val = val[:-7].replace('_', ':')
+        if val[-7:] == '_ci_pbs':
+            val = val[:-7][::-1].replace('_',':',1)[::-1]
     else:
         val = 'centos:7'
     search_str = val.replace(":", "_")
@@ -356,7 +356,7 @@ if __name__ == "__main__":
                 if val[-7:] == '_ci_pbs':
                     # remove '_ci_pbs' from string and replace '_' to ':'
                     # this will make it an image recognized by docker hub
-                    val = val[:-7].replace('_', ':')
+                    val = val[:-7][::-1].replace('_',':',1)[::-1]
                     write_to_file(env_file, "CONTAINER_PLATFORM="+val)
             ret = check_prerequisites()
             if ret == 1:

--- a/ci/ci
+++ b/ci/ci
@@ -150,7 +150,7 @@ def check_for_existing_image():
     if val != '':
         val = val.split('=')[1]
         if val[-7:] == '_ci_pbs':
-            val = val[:-7][::-1].replace('_',':',1)[::-1]
+            val = val[:-7][::-1].replace('_', ':', 1)[::-1]
     else:
         val = 'centos:7'
     search_str = val.replace(":", "_")
@@ -356,7 +356,7 @@ if __name__ == "__main__":
                 if val[-7:] == '_ci_pbs':
                     # remove '_ci_pbs' from string and replace '_' to ':'
                     # this will make it an image recognized by docker hub
-                    val = val[:-7][::-1].replace('_',':',1)[::-1]
+                    val = val[:-7][::-1].replace('_', ':', 1)[::-1]
                     write_to_file(env_file, "CONTAINER_PLATFORM="+val)
             ret = check_prerequisites()
             if ret == 1:

--- a/ci/ci
+++ b/ci/ci
@@ -353,6 +353,9 @@ if __name__ == "__main__":
             write_to_file(env_file, "CONTAINER_PLATFORM="+val)
             if args.build != None:
                 delete_older_image(val)
+                if val.find("ci_pbs") != -1:
+                    val = val[:-7].replace('_', ':')
+                    write_to_file(env_file, "CONTAINER_PLATFORM="+val)
             ret = check_prerequisites()
             if ret == 1:
                 log_error(

--- a/ci/ci
+++ b/ci/ci
@@ -353,7 +353,9 @@ if __name__ == "__main__":
             write_to_file(env_file, "CONTAINER_PLATFORM="+val)
             if args.build != None:
                 delete_older_image(val)
-                if val.find("ci_pbs") != -1:
+                if val[-7:] == '_ci_pbs':
+                    # remove '_ci_pbs' from string and replace '_' to ':'
+                    # this will make it an image recognized by docker hub
                     val = val[:-7].replace('_', ':')
                     write_to_file(env_file, "CONTAINER_PLATFORM="+val)
             ret = check_prerequisites()

--- a/ci/do.sh
+++ b/ci/do.sh
@@ -165,7 +165,13 @@ set -e
 pbs_config --make-ug
 
 if [ "x${RUN_TESTS}" == "x1" ];then
-  ptl_tests_dir=$(dirname ${prefix})/ptl/tests
+  if [ "x${ID}" == "xcentos" ];then
+    export LC_ALL=en_US.utf-8 
+    export LANG=en_US.utf-8
+  elif [ "x${ID}" == "xopensuse" ]; then
+    export LC_ALL=C.utf8
+  fi
+  ptl_tests_dir=/pbspro/test/tests
   cd ${ptl_tests_dir}/
   benchpress_opt="$( cat ${workdir}/.benchpress_opt )"
   eval_tag="$(echo ${benchpress_opt} | awk -F'"' '{print $2}')"

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -7,8 +7,8 @@ services:
         - ../../pbspro:/pbspro
         - ./:/src
         - ./logs:/logs
-      entrypoint: src/docker-entrypoint
-      env_file: .env
+      entrypoint: /src/docker-entrypoint
+      env_file: ./.env
       networks: 
         ci:
           aliases:

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         - ./:/src
         - ./logs:/logs
       entrypoint: /src/docker-entrypoint
-      env_file: ./.env
+      env_file: .env
       networks: 
         ci:
           aliases:
@@ -19,4 +19,3 @@ services:
 networks: 
   ci:
     driver: bridge
-    


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Using absolute path for entrypoint in docker-compose file is a good practice if a user wants to start container with a different workdir. This will make sure to avoid file not found error. This could fix the following ci issue : https://github.com/PBSPro/pbspro/issues/1517
* Fixed a bug where when trying to do --build with CONTAINER_PLATFORM=<platform_name>_ci_pbs was failing.  The issue was that .env file was not updating back with original name from docker hub (eg instead of centos:7 it was still centos_7_ci_pbs) which caused the pull to fail as the ci image was deleted.
* exported variable LC_ALL=en_US.utf-8 and LANG=en_US.utf-8 which were missing and causing some PTL test cases to fail.
* Changed ptl_test_directory to current repositories' tests directory so that user may run tests directly without installing pbs again, if they are only concerned with ptl test changes.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* After deleting the older image which ends with '_ci_pbs' the .env file is updated with original name of platform so it won't fail when trying to pull from the docker hub.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
sanidhya@ubuntu:/git_chng/git_iss/pbspro/ci$ cat .env 
CONTAINER_PLATFORM=centos_7_ci_pbs
sanidhya@ubuntu:~/git_chng/git_iss/pbspro/ci$ ./ci --start --build
11:26:45 ---> The following untagged images will be removed -> 313b7c17783f 
11:26:46 ---> No running service found
11:26:46 ---> Attempting to start container
Removing network ci_ci
WARNING: Network ci_ci not found.
Creating network "ci_ci" with driver "bridge"
Creating ci_pbs-build_1 ... done
11:26:48 ---> Waiting for container build to complete 
11:26:48 ---> Build logs can be found in /home/sanidhya/git_chng/git_iss/pbspro/ci/logs/build
11:27:18 ---> Current status ...... Loading mirror speeds from cached hostfile

11:27:48 ---> Current status ......  * updates: mirrors.piconets.webwerks.in

11:28:18 ---> Current status ...... ### First time build is complete ###

11:28:18 ---> build is now complete
11:28:18 ---> docker commit b74c2192aa31 centos_7_ci_pbs:latest
11:28:24 --->  done start container 
sanidhya@ubuntu:~/git_chng/git_iss/pbspro/ci$ cat .env 
CONTAINER_PLATFORM=centos:7


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
