### PR TITLE
pbs_benchpress -> ptl_test_db.py JSONDecodeError

### DIFF
--- a/test/fw/bin/pbs_benchpress
+++ b/test/fw/bin/pbs_benchpress
@@ -108,9 +108,9 @@ def usage():
     msg += ['.Plugin\n']
     msg += ['--db-type=<type>: Type of database to use.']
     msg += [' can be one of "html", "file", "sqlite", "pgsql", "json".']
-    msg += [' Default to "file"\n']
+    msg += [' Default to "json"\n']
     msg += ['--db-name=<name>: database name. Default to']
-    msg += [' ptl_test_results.db\n']
+    msg += [' ptl_test_results.json\n']
     msg += ['--db-access=<path>: Path to a file that defines db options '
             '(PostreSQL only)\n']
     msg += ['--lcov-bin=<bin>: path to lcov binary. Defaults to lcov\n']

--- a/test/fw/ptl/utils/plugins/ptl_test_db.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_db.py
@@ -1622,6 +1622,7 @@ class JSONDb(DBType):
             self.__dbobj[_TESTRESULT_TN].seek(0)
             jdata = json.load(self.__dbobj[_TESTRESULT_TN])
         jsondata = self.res_data.get_json(data=data, prev_data=jdata)
+        self.__dbobj[_TESTRESULT_TN].truncate(0)
         self.__dbobj[_TESTRESULT_TN].seek(0)
         json.dump(jsondata, self.__dbobj[_TESTRESULT_TN], indent=2)
 
@@ -1637,6 +1638,7 @@ class JSONDb(DBType):
             df = json.load(self.__dbobj[_TESTRESULT_TN])
             dur = str(result.stop - result.start)
             df['test_summary']['test_duration'] = dur
+            self.__dbobj[_TESTRESULT_TN].truncate(0)
             self.__dbobj[_TESTRESULT_TN].seek(0)
             json.dump(df, self.__dbobj[_TESTRESULT_TN], indent=2)
         for v in self.__dbobj.values():
@@ -1657,7 +1659,7 @@ class PTLTestDb(Plugin):
     def __init__(self):
         Plugin.__init__(self)
         self.__dbconn = None
-        self.__dbtype = 'JSONDb'
+        self.__dbtype = None
         self.__dbpath = None
         self.__dbaccess = None
         self.__dbmapping = {'file': FileDb,

--- a/test/fw/ptl/utils/plugins/ptl_test_db.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_db.py
@@ -1647,6 +1647,7 @@ class JSONDb(DBType):
                 fd.flush()
                 fd.write("\n")
 
+
 class PTLTestDb(Plugin):
 
     """


### PR DESCRIPTION
#### Describe Bug or Feature
The JSON database was being overwritten, but the size of the file was
not being reduced, this was leaving garbage at the end of the file and
causing the JSON parser to fail.

#### Describe Your Change
Truncated the file to prevent the file from having leftover garbage.
The default type is set to "json", therefore corrected the "default"
in pbs_benchpress.  Also set __dbtype to None as the default is 
"json" and 'JSONDb' was not valid.

This is a fix for issue #1522 