### PR TITLE
Fix TestQstat.test_qstat_pt not truncating job id

### DIFF
--- a/test/tests/functional/pbs_qstat.py
+++ b/test/tests/functional/pbs_qstat.py
@@ -74,6 +74,8 @@ class TestQstat(TestFunctional):
 
         sjids = [j.create_subjob_id(jid, x) for x in range(1, job_count)]
         for sjid in sjids:
+            if len(sjid) > 17:
+                sjid = sjid[0:16] + '*'
             self.assertIn(sjid, qstat_out, 'Job %s not in output' % sjid)
             sj_escaped = re.escape(sjid)
             match = re.search(


### PR DESCRIPTION
#### Describe Bug or Feature
The test would fail, as qstat would truncate the job id.


#### Describe Your Change
Change the test to look for the truncated job id.


#### Attach Test and Valgrind Logs/Output
[after-fix.txt](https://github.com/PBSPro/pbspro/files/4221425/after-fix.txt)
[before-fix.txt](https://github.com/PBSPro/pbspro/files/4221426/before-fix.txt)

