### PR TITLE
[WIP] performance: don't do db saves for accrue_type & unnecessary job state updates

### DIFF
--- a/src/lib/Libattr/master_job_attr_def.xml
+++ b/src/lib/Libattr/master_job_attr_def.xml
@@ -1937,7 +1937,7 @@
 				NULL_FUNC
 			#endif</member_at_action>
       <member_at_flags>
-         <both>NO_USER_SET | ATR_DFLAG_SSET | ATR_DFLAG_ALTRUN</both>
+         <both>NO_USER_SET | ATR_DFLAG_SSET | ATR_DFLAG_ALTRUN | ATR_DFLAG_NOSAVM</both>
       </member_at_flags>
       <member_at_type>
          <both>ATR_TYPE_LONG</both>
@@ -1960,7 +1960,7 @@
       <member_at_free>free_none</member_at_free>
       <member_at_action>NULL_FUNC</member_at_action>
       <member_at_flags>
-         <both>ATR_DFLAG_MGRD | ATR_DFLAG_ALTRUN | ATR_DFLAG_SvWR</both>
+         <both>ATR_DFLAG_MGRD | ATR_DFLAG_ALTRUN | ATR_DFLAG_SvWR | ATR_DFLAG_NOSAVM</both>
       </member_at_flags>
       <member_at_type>
          <both>ATR_TYPE_LONG</both>

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -610,7 +610,10 @@ svr_setjobstate(job *pjob, int newstate, int newsubstate)
 	 * to job state or substate.
 	 */
 	if (pjob->ji_qs.ji_state == JOB_STATE_FINISHED)
-		return (0);
+		return 0;
+
+	if (pjob->ji_qs.ji_state == newstate && pjob->ji_qs.ji_substate == newsubstate)
+		goto jobsave;
 
 	/*
 	 * if its is a new job, then don't update counts, svr_enquejob() will
@@ -712,6 +715,7 @@ svr_setjobstate(job *pjob, int newstate, int newsubstate)
 		}
 	}
 
+jobsave:
 	if (pjob->ji_modified)
 		return (job_save(pjob, SAVEJOB_FULL));
 	else if(changed)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
I noticed that alterjob requests for accrue_type were taking much longer than those for job comment because we call svr_setjobstate(), which does a job_save_db() for accrue_type, but not for job comment. We call svr_setjobstate() even if the job state & substate are the same as they were before, which seems unnecessary. But it seems like svr_setjobstate() is used as a way to do job_save_db() indirectly.

I'm proposing that we make accrue_type and eligible_time ATR_DFLAG_NOSAVM attributes. eligible_time is anyways not saved to db, so I think we can just make accrue_type a no-save attr as well and save on the job saves.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Added a check so that we only set job state/substate if they are different.
- Made accrue_type and eligible_time ATR_DFLAG_NOSAVM attributes.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Submitted 50k jobs on a 1 vnode system with 1 ncpus, eligible_time_enable set to False. Ran a cycle to let the job alters for comment go through. Then set eligible_time_enable to True and ran another cycle, this time no job comment alters happen as they are the same as before, so this measures only the accrue_type alter requests.

**Before**: Sched cycle took 7 minutes with server spending 60%+ time in req_modifyjob():
![Screen Shot 2020-02-18 at 4 13 39 PM](https://user-images.githubusercontent.com/4574875/74803954-c3bcbc00-52ac-11ea-91c2-53480f22d34e.png)


**After**: Sched cycle took around 2 minutes with the server now spending ~35% inside req_modifyjob() instead of 60%+:
<img width="1082" alt="Screen Shot 2020-02-19 at 8 57 22 PM" src="https://user-images.githubusercontent.com/4574875/74896429-3f2c7500-5362-11ea-98cc-d21d489fe28a.png">



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
