### PR TITLE
scheduler: check for bucket_ind while adding to calendar

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2054,7 +2054,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 			int ind = bjob->nspec_arr[i]->ninfo->node_ind;
 			add_te_list(&(bjob->nspec_arr[i]->ninfo->node_events), te_start);
 
-			if (ind != -1) {
+			if (ind != -1 && sinfo->unordered_nodes[ind]->bucket_ind != -1) {
 				node_bucket *bkt;
 
 				bkt = sinfo->buckets[sinfo->unordered_nodes[ind]->bucket_ind];


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The scheduler can crash because sinfo->unordered_nodes[ind]->bucket_ind = -1 can be used as a index of sinfo->buckets.

It happened once. I am not sure how to reproduce this error.

#### Describe Your Change
We should test the bucket_ind != -1 before using it.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
