### PR TITLE
Change default rpp_max_pkt_check value from 1024 to 64

### DIFF
--- a/src/include/rpp.h
+++ b/src/include/rpp.h
@@ -57,7 +57,7 @@ extern "C" {
 /*
  * Default number of RPP packets to check every server iteration
  */
-#define RPP_MAX_PKT_CHECK_DEFAULT	1024
+#define RPP_MAX_PKT_CHECK_DEFAULT	64
 
 /* TPP specific definitions and structures */
 #define TPP_DEF_ROUTER_PORT 17001


### PR DESCRIPTION
On busy installations with lots of jobs beginning and ending we have frequently had a need to lower the value of rpp_max_pkt_check as the default 1024 value can cause the client commands to appear sluggish.  Values of 32 or 128 are common, so 64 seems like a good default.

