### PR TITLE
TestMomWalltime.test_suspend_time_not_counted_in_walltime: Job ends before suspend/resume signal is sent to it on Ubuntu

### DIFF
--- a/test/tests/functional/pbs_mom_walltime.py
+++ b/test/tests/functional/pbs_mom_walltime.py
@@ -116,6 +116,7 @@ class TestMomWalltime(TestFunctional):
         a = {'Resource_List.ncpus': 1}
 
         script_content = (
+            '#!/bin/bash\n'
             'for i in {1..30}\n'
             'do\n'
             '\techo "time wait"\n'


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestMomWalltime.test_suspend_time_not_counted_in_walltime test case was failing with error: 'qsig: Job has finished'

#### Describe Your Change
In test case, Job was submitted with script and on Ubuntu platforms, it was failing because shebang line was missing in script. Added shebang line at the start of the script.

#### Attach Test and Valgrind Logs/Output
[test_suspend_time_not_counted_in_walltime_after_fix.txt](https://github.com/PBSPro/pbspro/files/4230581/test_suspend_time_not_counted_in_walltime_after_fix.txt)
[test_suspend_time_not_counted_in_walltime_before_fix.txt](https://github.com/PBSPro/pbspro/files/4230582/test_suspend_time_not_counted_in_walltime_before_fix.txt)
[test_suspend_time_not_counted_in_walltime_non_ubuntu_after_fix.txt](https://github.com/PBSPro/pbspro/files/4230583/test_suspend_time_not_counted_in_walltime_non_ubuntu_after_fix.txt)

