### PR TITLE
rpp connection 'server -> mom' can be confused

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1441,6 +1441,7 @@ ping_a_mom_mcast(mominfo_t *pmom, int force_hello, int mtfd_ishello, int mtfd_is
 				 "Failed to add mom at %s:%d to ping mcast", pmom->mi_host, pmom->mi_port);
 		log_err(-1, __func__, log_buffer);
 		rpp_close(psvrmom->msr_stream);
+		tdelete2((u_long)psvrmom->msr_stream, 0, &streams);
 		psvrmom->msr_stream = -1;
 	}
 }

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -692,6 +692,7 @@ conn_to_mom_failed(job *pjob, void(*func)(struct work_task *))
 		svr_disconnect(pjob->ji_momhandle);
 	} else {
 		rpp_close(pjob->ji_momhandle);
+		tdelete2((u_long)pjob->ji_momhandle, 0, &streams);
 	}
 	pjob->ji_momhandle = -1;
 	ptask = set_task(WORK_Immed, 0, func, pjob);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
We experienced vast network issues in our PBS infrastructure. There were a significant packet loss and connection breaks. As a result of the issues, some nodes were confused in the server like this:

It happened that node like:
```
create node node1 Mom=node1.domain
```
was randomly changed to:
```
create node node1 Mom="node1.domain,random-node.domain"
```

The issue seems to be caused by not deleting mom stream from the main tree of streams after rpp_close() in the server. 

tdelete2() should be called after  rpp_close() or  rpp_destroy() (supposing the stream was inserted in the tree of streams). If the tdelete2() is not called and the stream remains in the tree of streams, it can lead to confusing the mom identity.


#### Describe Your Change
 I found two occurrences of rpp_close() with missing tdelete2(). tdelete2() was added here.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
