### PR TITLE
Adding number of threads info to sched logging

### DIFF
--- a/src/scheduler/multi_threading.c
+++ b/src/scheduler/multi_threading.c
@@ -206,8 +206,8 @@ init_multi_threading(int nthreads)
 		return 1; /* main thread will act as the only worker thread */
 	}
 
-	log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,
-			"", "Launching worker threads");
+	log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG,
+			"", "Launching %d worker threads", num_threads);
 
 	threads = malloc(num_threads * sizeof(pthread_t));
 	if (threads == NULL) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Right now, we log "Launching worker threads" in sched logs, it would be very useful to log the number of threads launched as well.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Just added the number of threads launched to the log message.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
