### PR TITLE
pbs_benchpress --use-current-setup needs manager and operator privileges

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5295,6 +5295,11 @@ class Server(PBSService):
             return False
         else:
             conf['qmgr_print_sched'] = ret['out']
+
+        # sudo=True is added while running "pbsnodes -av", to make
+        # sure that all the node attributes are preserved in
+        # save_configuration. If this command is run without sudo,
+        # some of the node attributes like port, version is not listed.
         ret = self.du.run_cmd(self.hostname, [pbsnodes, '-av'],
                               logerr=False, level=logging.DEBUG, sudo=True)
         err_msg = "Server has no node list"

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5205,7 +5205,7 @@ class Server(PBSService):
                 pass
             self.manager(MGR_CMD_DELETE, QUEUE, id=queues)
 
-    def delete_sched_config(self, sudo=False):
+    def delete_sched_config(self):
         """
         Delete sched_priv & sched_log files
         """
@@ -5221,7 +5221,7 @@ class Server(PBSService):
                            recursive=True, force=True)
                 self.du.rm(path=sched_priv, sudo=True,
                            recursive=True, force=True)
-                self.manager(MGR_CMD_DELETE, SCHED, id=name, sudo=sudo)
+                self.manager(MGR_CMD_DELETE, SCHED, id=name)
 
     def delete_nodes(self):
         """

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5151,7 +5151,7 @@ class Server(PBSService):
                 self.manager(MGR_CMD_DELETE, RSC, id=rescs)
         return True
 
-    def unset_svr_attrib(self, server_stat=None, sudo=False):
+    def unset_svr_attrib(self, server_stat=None):
         """
         Unset server attributes
         """
@@ -5173,9 +5173,9 @@ class Server(PBSService):
             else:
                 unsetlist.append(k)
         if len(unsetlist) != 0:
-            self.manager(MGR_CMD_UNSET, MGR_OBJ_SERVER, unsetlist, sudo=sudo)
+            self.manager(MGR_CMD_UNSET, MGR_OBJ_SERVER, unsetlist)
 
-    def delete_site_hooks(self, sudo=False):
+    def delete_site_hooks(self):
         """
         Delete site hooks from PBS
         """
@@ -5186,9 +5186,9 @@ class Server(PBSService):
             if h in hooks:
                 hooks.remove(h)
         if len(hooks) > 0:
-            self.manager(MGR_CMD_DELETE, HOOK, id=hooks, sudo=sudo)
+            self.manager(MGR_CMD_DELETE, HOOK, id=hooks)
 
-    def delete_queues(self, sudo=False):
+    def delete_queues(self):
         """
         Delete queues
         """
@@ -5203,7 +5203,7 @@ class Server(PBSService):
                                      node['id'])
             except:
                 pass
-            self.manager(MGR_CMD_DELETE, QUEUE, id=queues, sudo=sudo)
+            self.manager(MGR_CMD_DELETE, QUEUE, id=queues)
 
     def delete_sched_config(self, sudo=False):
         """
@@ -5223,12 +5223,12 @@ class Server(PBSService):
                            recursive=True, force=True)
                 self.manager(MGR_CMD_DELETE, SCHED, id=name, sudo=sudo)
 
-    def delete_nodes(self, sudo=False):
+    def delete_nodes(self):
         """
         Remove all the nodes from PBS
         """
         try:
-            self.manager(MGR_CMD_DELETE, VNODE, id="@default", sudo=sudo)
+            self.manager(MGR_CMD_DELETE, VNODE, id="@default")
         except PbsManagerError as e:
             if "Unknown node" not in e.msg[0]:
                 raise
@@ -13214,7 +13214,7 @@ class MoM(PBSService):
 
         return self.version
 
-    def delete_vnodes(self, sudo=False):
+    def delete_vnodes(self):
         rah = ATTR_rescavail + '.host'
         rav = ATTR_rescavail + '.vnode'
         a = {rah: self.hostname, rav: None}
@@ -13235,7 +13235,7 @@ class MoM(PBSService):
             if v[rav].split('.')[0] != v[rah].split('.')[0]:
                 vs.append(v['id'])
         if len(vs) > 0:
-            self.server.manager(MGR_CMD_DELETE, VNODE, id=vs, sudo=sudo)
+            self.server.manager(MGR_CMD_DELETE, VNODE, id=vs)
 
     def revert_to_defaults(self, delvnodedefs=True):
         """

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5151,7 +5151,7 @@ class Server(PBSService):
                 self.manager(MGR_CMD_DELETE, RSC, id=rescs)
         return True
 
-    def unset_svr_attrib(self, server_stat=None):
+    def unset_svr_attrib(self, server_stat=None, sudo=False):
         """
         Unset server attributes
         """
@@ -5173,9 +5173,9 @@ class Server(PBSService):
             else:
                 unsetlist.append(k)
         if len(unsetlist) != 0:
-            self.manager(MGR_CMD_UNSET, MGR_OBJ_SERVER, unsetlist)
+            self.manager(MGR_CMD_UNSET, MGR_OBJ_SERVER, unsetlist, sudo=sudo)
 
-    def delete_site_hooks(self):
+    def delete_site_hooks(self, sudo=False):
         """
         Delete site hooks from PBS
         """
@@ -5186,9 +5186,9 @@ class Server(PBSService):
             if h in hooks:
                 hooks.remove(h)
         if len(hooks) > 0:
-            self.manager(MGR_CMD_DELETE, HOOK, id=hooks)
+            self.manager(MGR_CMD_DELETE, HOOK, id=hooks, sudo=sudo)
 
-    def delete_queues(self):
+    def delete_queues(self, sudo=False):
         """
         Delete queues
         """
@@ -5203,9 +5203,9 @@ class Server(PBSService):
                                      node['id'])
             except:
                 pass
-            self.manager(MGR_CMD_DELETE, QUEUE, id=queues)
+            self.manager(MGR_CMD_DELETE, QUEUE, id=queues, sudo=sudo)
 
-    def delete_sched_config(self):
+    def delete_sched_config(self, sudo=False):
         """
         Delete sched_priv & sched_log files
         """
@@ -5221,14 +5221,14 @@ class Server(PBSService):
                            recursive=True, force=True)
                 self.du.rm(path=sched_priv, sudo=True,
                            recursive=True, force=True)
-                self.manager(MGR_CMD_DELETE, SCHED, id=name)
+                self.manager(MGR_CMD_DELETE, SCHED, id=name, sudo=sudo)
 
-    def delete_nodes(self):
+    def delete_nodes(self, sudo=False):
         """
         Remove all the nodes from PBS
         """
         try:
-            self.manager(MGR_CMD_DELETE, VNODE, id="@default")
+            self.manager(MGR_CMD_DELETE, VNODE, id="@default", sudo=sudo)
         except PbsManagerError as e:
             if "Unknown node" not in e.msg[0]:
                 raise
@@ -5296,7 +5296,7 @@ class Server(PBSService):
         else:
             conf['qmgr_print_sched'] = ret['out']
         ret = self.du.run_cmd(self.hostname, [pbsnodes, '-av'],
-                              logerr=False, level=logging.DEBUG)
+                              logerr=False, level=logging.DEBUG, sudo=True)
         err_msg = "Server has no node list"
         # pbsnodes -av returns a non zero exit code when there are
         # no nodes in cluster
@@ -13214,7 +13214,7 @@ class MoM(PBSService):
 
         return self.version
 
-    def delete_vnodes(self):
+    def delete_vnodes(self, sudo=False):
         rah = ATTR_rescavail + '.host'
         rav = ATTR_rescavail + '.vnode'
         a = {rah: self.hostname, rav: None}
@@ -13235,7 +13235,7 @@ class MoM(PBSService):
             if v[rav].split('.')[0] != v[rah].split('.')[0]:
                 vs.append(v['id'])
         if len(vs) > 0:
-            self.server.manager(MGR_CMD_DELETE, VNODE, id=vs)
+            self.server.manager(MGR_CMD_DELETE, VNODE, id=vs, sudo=sudo)
 
     def revert_to_defaults(self, delvnodedefs=True):
         """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1317,9 +1317,11 @@ class PBSTestSuite(unittest.TestCase):
         if not cls.use_cur_setup:
             try:
                 # Unset managers list
-                cls.server.manager(MGR_CMD_UNSET, SERVER, 'managers', sudo=True)
+                cls.server.manager(MGR_CMD_UNSET, SERVER, 'managers',
+                                   sudo=True)
                 # Unset operators list
-                cls.server.manager(MGR_CMD_UNSET, SERVER, 'operators', sudo=True)
+                cls.server.manager(MGR_CMD_UNSET, SERVER, 'operators',
+                                   sudo=True)
             except PbsManagerError as e:
                 self.logger.error(e.msg)
         attr = {}


### PR DESCRIPTION
#### Describe Bug or Feature
`pbs_benchpress` has an option `--use-current-setup` which runs a testsuite with the current state of PBS. After doing a fresh installation of PBS, when `pbs_benchpress` is run with --use-current-setup, an error **Unauthorized request** is observed while running a `qmgr` command in the test case. 

#### Describe Your Change
Since the test execution user needs manager privileges for creating resources in PBS Server, Added the test execution user as manager role at the testsuite level. Giving `MGR_USER` and `MGR_OPER` as manager and operator roles respectively similar to the default roles assigned without `--use-current-setup`

#### Attach Test and Valgrind Logs/Output
[after_fix.txt](https://github.com/PBSPro/pbspro/files/4243013/after_fix.txt)
[before_fix.txt](https://github.com/PBSPro/pbspro/files/4243014/before_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
