### PR TITLE
TestHookDebugNoCrash is failing due to timeout not being handled

### DIFF
--- a/test/tests/functional/pbs_hook_debug_nocrash.py
+++ b/test/tests/functional/pbs_hook_debug_nocrash.py
@@ -82,7 +82,7 @@ class TestHookDebugNoCrash(TestFunctional):
             self.skipTest(msg)
         TestFunctional.setUp(self)
 
-    @timeout(900)
+    @timeout(1000)
     def test_hook_debug_no_crash(self):
 
         hook_body = """

--- a/test/tests/functional/pbs_hook_debug_nocrash.py
+++ b/test/tests/functional/pbs_hook_debug_nocrash.py
@@ -82,7 +82,7 @@ class TestHookDebugNoCrash(TestFunctional):
             self.skipTest(msg)
         TestFunctional.setUp(self)
 
-    @timeout(400)
+    @timeout(900)
     def test_hook_debug_no_crash(self):
 
         hook_body = """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
TestHookDebugNoCrash.test_hook_debug_no_crash test is getting timedout in tearDown while cleaning up the jobs.  Test is submitting around 1000 Jobs and on slow machines, this takes a while to delete 1000 jobs.

#### Describe Your Change
Increased timeout to 1000 secs for slow machines.

#### Attach Test and Valgrind Logs/Output
[test_hook_debug_no_crash_after_fix.txt](https://github.com/PBSPro/pbspro/files/4248618/test_hook_debug_no_crash_after_fix.txt)
[test_hook_debug_no_crash_before_fix.txt](https://github.com/PBSPro/pbspro/files/4248619/test_hook_debug_no_crash_before_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
