### PR TITLE
A new fix for server hooks nonetype object not callable error

### DIFF
--- a/src/lib/Libpython/Makefile.am
+++ b/src/lib/Libpython/Makefile.am
@@ -46,14 +46,23 @@ libpbspython_a_SOURCES = \
 	shared_python_utils.c \
 	common_python_utils.c \
 	pbs_ifl_wrap.c \
-	pbs_python_external.c
+	pbs_python_external.c \
+	pbs_python_svr_external.c \
+	module_pbs_v1.c \
+	pbs_python_svr_internal.c \
+	pbs_python_svr_size_type.c \
+	pbs_python_import_types.c
 
 libpbspython_svr_a_CPPFLAGS = \
+	-DLIBPYTHONSVR \
 	-I$(top_srcdir)/src/include \
 	@PYTHON_INCLUDES@
 
 libpbspython_svr_a_SOURCES = \
 	shared_python_utils.c \
+	common_python_utils.c \
+	pbs_ifl_wrap.c \
+	pbs_python_external.c \
 	pbs_python_svr_external.c \
 	module_pbs_v1.c \
 	pbs_python_svr_internal.c \

--- a/src/lib/Libpython/pbs_python_external.c
+++ b/src/lib/Libpython/pbs_python_external.c
@@ -115,12 +115,6 @@ pbs_python_ext_start_interpreter(struct python_interpreter_data *interp_data)
 	char pbs_python_destlib2[MAXPATHLEN + 1] = {'\0'};
 	int  evtype;
 	int  rc;
-#ifndef WIN32
-	struct sigaction act;
-	struct sigaction oact;
-#else
-	void *oact;
-#endif
 
 	/*
 	 * initialize the convenience global pbs_python_daemon_name, as it is
@@ -188,46 +182,12 @@ pbs_python_ext_start_interpreter(struct python_interpreter_data *interp_data)
 		goto ERROR_EXIT;
 	}
 
-#ifndef WIN32
-	/*
-	 * Temporary set SIGINT to SIG_DFL, so Py_InitializeEx can setup proper SIGINT handler
-	 * see https://github.com/python/cpython/blob/3.6/Modules/signalmodule.c#L1280
-	 * as per above, If SIGINT is not set to SIG_DFL then Python won't register it's SIGINT handler
-	 * which means Python won't raise KeyBoardInterrupt on PyErr_SetInterrupt()
-	 * instead it will throw NoneType object is not callable exception
-	 */
-	sigemptyset(&act.sa_mask);
-	act.sa_flags   = 0;
-	act.sa_handler = SIG_DFL;
-	if (sigaction(SIGINT, &act, &oact) != 0) {
-		log_err(errno, __func__, "Failed to set SIG_DFL on SIGINT");
-		return 1;
-	}
-#else
-	oact = signal(SIGINT, SIG_DFL);
-	if (oact == SIG_ERR) {
-		log_err(errno, __func__, "Failed to set SIG_DFL on SIGINT");
-		return 1;
-	}
-#endif
 	/*
 	 * arg '1' means to not skip init of signals
 	 * we want signals to propagate to the executing
 	 * Python script to be able to interrupt it
 	 */
 	Py_InitializeEx(1);
-
-	/* revert SIGINT to original sig handler */
-#ifndef WIN32
-	if (sigaction(SIGINT, &oact, NULL) != 0)
-#else
-	if (signal(SIGINT, oact) == SIG_ERR)
-#endif
-	{
-		log_err(errno, __func__, "Failed to revert signal handler for SIGINT");
-		return 1;
-	}
-
 
 	if (Py_IsInitialized()) {
 		char *msgbuf;
@@ -278,6 +238,28 @@ pbs_python_ext_start_interpreter(struct python_interpreter_data *interp_data)
 	}
 
 	interp_data->pbs_python_types_loaded = 1; /* just in case */
+
+#if !defined(PBS_PYTHON)
+	PyObject *m, *d, *f, *handler, *sigint;
+    m = PyImport_ImportModule("signal");
+    d = PyModule_GetDict(m);
+    f = PyDict_GetItemString(d, "signal");
+    handler = PyDict_GetItemString(d, "default_int_handler");
+    sigint = PyDict_GetItemString(d, "SIGINT");
+    if (f && PyCallable_Check(f)) {
+        PyObject_CallFunctionObjArgs(f, sigint, handler, NULL);
+    } else {
+        log_err(-1, __func__, "could not set up python signal.default_int_handler");
+        goto ERROR_EXIT;
+    }
+    Py_XDECREF(m);
+    Py_XDECREF(d);
+    Py_XDECREF(f);
+    Py_XDECREF(sigint);
+    Py_XDECREF(handler);
+    log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_INFO, interp_data->daemon_name, "successfully set up signal.default_int_handler");
+#endif
+
 SUCCESS_EXIT:
 	return 0;
 ERROR_EXIT:

--- a/src/lib/Libpython/pbs_python_external.c
+++ b/src/lib/Libpython/pbs_python_external.c
@@ -239,7 +239,7 @@ pbs_python_ext_start_interpreter(struct python_interpreter_data *interp_data)
 
 	interp_data->pbs_python_types_loaded = 1; /* just in case */
 
-#if !defined(PBS_PYTHON)
+#ifdef LIBPYTHONSVR
 	PyObject *m, *d, *f, *handler, *sigint;
     m = PyImport_ImportModule("signal");
     d = PyModule_GetDict(m);

--- a/src/lib/Libpython/pbs_python_external.c
+++ b/src/lib/Libpython/pbs_python_external.c
@@ -253,10 +253,6 @@ pbs_python_ext_start_interpreter(struct python_interpreter_data *interp_data)
         goto ERROR_EXIT;
     }
     Py_XDECREF(m);
-    Py_XDECREF(d);
-    Py_XDECREF(f);
-    Py_XDECREF(sigint);
-    Py_XDECREF(handler);
     log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_INFO, interp_data->daemon_name, "successfully set up signal.default_int_handler");
 #endif
 

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -55,7 +55,6 @@ pbs_server_bin_LDADD = \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
 	$(top_builddir)/src/lib/Libsec/libsec.a \
 	$(top_builddir)/src/lib/Libsite/libsite.a \
-	$(top_builddir)/src/lib/Libpython/libpbspython.a \
 	$(top_builddir)/src/lib/Libpython/libpbspython_svr.a \
 	$(top_builddir)/src/lib/Libdb/libdb.a \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -112,8 +112,6 @@ pbs_python_CPPFLAGS =  \
 	@PYTHON_INCLUDES@ @KRB5_CFLAGS@
 
 pbs_python_LDADD = \
-	$(top_builddir)/src/lib/Libpython/libpbspython.a \
-	$(top_builddir)/src/lib/Libpython/libpbspython_svr.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libattr/libattr.a \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
@@ -126,6 +124,15 @@ pbs_python_LDADD = \
 	@KRB5_LIBS@
 
 pbs_python_SOURCES = \
+	$(top_builddir)/src/lib/Libpython/shared_python_utils.c \
+	$(top_builddir)/src/lib/Libpython/common_python_utils.c \
+	$(top_builddir)/src/lib/Libpython/pbs_ifl_wrap.c \
+	$(top_builddir)/src/lib/Libpython/pbs_python_external.c \
+	$(top_builddir)/src/lib/Libpython/pbs_python_svr_external.c \
+	$(top_builddir)/src/lib/Libpython/module_pbs_v1.c \
+	$(top_builddir)/src/lib/Libpython/pbs_python_svr_internal.c \
+	$(top_builddir)/src/lib/Libpython/pbs_python_svr_size_type.c \
+	$(top_builddir)/src/lib/Libpython/pbs_python_import_types.c \
 	$(top_builddir)/src/lib/Libattr/job_attr_def.c \
 	$(top_builddir)/src/lib/Libattr/node_attr_def.c \
 	$(top_builddir)/src/lib/Libattr/queue_attr_def.c \

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -112,6 +112,7 @@ pbs_python_CPPFLAGS =  \
 	@PYTHON_INCLUDES@ @KRB5_CFLAGS@
 
 pbs_python_LDADD = \
+	$(top_builddir)/src/lib/Libpython/libpbspython.a \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libattr/libattr.a \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
@@ -124,15 +125,6 @@ pbs_python_LDADD = \
 	@KRB5_LIBS@
 
 pbs_python_SOURCES = \
-	$(top_builddir)/src/lib/Libpython/shared_python_utils.c \
-	$(top_builddir)/src/lib/Libpython/common_python_utils.c \
-	$(top_builddir)/src/lib/Libpython/pbs_ifl_wrap.c \
-	$(top_builddir)/src/lib/Libpython/pbs_python_external.c \
-	$(top_builddir)/src/lib/Libpython/pbs_python_svr_external.c \
-	$(top_builddir)/src/lib/Libpython/module_pbs_v1.c \
-	$(top_builddir)/src/lib/Libpython/pbs_python_svr_internal.c \
-	$(top_builddir)/src/lib/Libpython/pbs_python_svr_size_type.c \
-	$(top_builddir)/src/lib/Libpython/pbs_python_import_types.c \
 	$(top_builddir)/src/lib/Libattr/job_attr_def.c \
 	$(top_builddir)/src/lib/Libattr/node_attr_def.c \
 	$(top_builddir)/src/lib/Libattr/queue_attr_def.c \


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
This is a new fix for the problem describe in #1445 .

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Reverted #1445 
* Explicitly import Python's built-int `signal` module and register `signal.default_int_handler`, instead of temporarily set SIGINT handler to SIGDFL and then switch it back. 
* The change above also requires putting a block of code that only executes when the server starts a Python interpreter. So I made pbs_server link to `libpbspython_svr.a` only and compile `libpbspython_svr.a` with a special flag. All other daemons and commands (like pbs_python) still link to `libpbspython.a`. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
<img width="840" alt="Screen Shot 2020-03-02 at 5 56 39 PM" src="https://user-images.githubusercontent.com/6920446/75666556-f73a1600-5cb0-11ea-9e3f-30918e6504b5.png">

[717-ALL.zip](https://github.com/PBSPro/pbspro/files/4274710/717-ALL.zip)

Note: TestPbsExecutePrologue.test_prologue_hook_set_fail_action fails on oss master branch as well so is not caused by this PR. 
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
