### PR TITLE
Can't alter start time of running resv if jobs finished with history

### DIFF
--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -818,8 +818,7 @@ req_modifyReservation(struct batch_request *preq)
 
 		switch (index) {
 			case RESV_ATR_start:
-				if ((presv->ri_wattr[RESV_ATR_state].at_val.at_long != RESV_RUNNING) ||
-					!(num_jobs)) {
+				if ((presv->ri_wattr[RESV_ATR_state].at_val.at_long != RESV_RUNNING) || !num_jobs) {
 					temp = strtol(psatl->al_value, &end, 10);
 					if ((temp > time(NULL)) &&
 						(temp != presv->ri_wattr[RESV_ATR_start].at_val.at_long)) {

--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -740,6 +740,7 @@ req_modifyReservation(struct batch_request *preq)
 	int		next_occr_start = 0;
 	extern char	*msg_stdg_resv_occr_conflict;
 	resc_resv	*presv;
+	int num_jobs;
 
 	if (preq == NULL)
 		return;
@@ -767,6 +768,12 @@ req_modifyReservation(struct batch_request *preq)
 	if (presv == NULL) {
 		req_reject(PBSE_UNKRESVID, 0, preq);
 		return;
+	}
+
+	num_jobs = presv->ri_qp->qu_numjobs;
+	if (svr_chk_history_conf()) {
+		num_jobs -= (presv->ri_qp->qu_njstate[JOB_STATE_MOVED] + presv->ri_qp->qu_njstate[JOB_STATE_FINISHED] +
+			presv->ri_qp->qu_njstate[JOB_STATE_EXPIRED]);
 	}
 
 	is_standing = presv->ri_wattr[RESV_ATR_resv_standing].at_val.at_long;
@@ -812,7 +819,7 @@ req_modifyReservation(struct batch_request *preq)
 		switch (index) {
 			case RESV_ATR_start:
 				if ((presv->ri_wattr[RESV_ATR_state].at_val.at_long != RESV_RUNNING) ||
-					!(presv->ri_qp->qu_numjobs)) {
+					!(num_jobs)) {
 					temp = strtol(psatl->al_value, &end, 10);
 					if ((temp > time(NULL)) &&
 						(temp != presv->ri_wattr[RESV_ATR_start].at_val.at_long)) {
@@ -832,7 +839,7 @@ req_modifyReservation(struct batch_request *preq)
 						return;
 					}
 				} else {
-					if (presv->ri_qp->qu_numjobs)
+					if (num_jobs)
 						req_reject(PBSE_RESV_NOT_EMPTY, 0, preq);
 					else
 						req_reject(PBSE_BADTSPEC, 0, preq);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If a reservation is empty, you should be able to alter its start time of a running reservation.  If there are history jobs in the reservation, the server thinks it is not empty and rejects the alter request.
 

```
[vstumpf@shecil pbspro]$ qstat -x
Job id Name User Time Use S Queue
---------------- ---------------- ---------------- -------- - -----
1347.shecil STDIN vstumpf 00:00:00 F R1346

[vstumpf@shecil pbspro]$ pbs_ralter -R 1530 R1346
pbs_ralter: Reservation not empty
```

#### Describe Your Change
If job history is enabled, subtract moved, finished, and expired jobs from the number of jobs in the queue.


#### Attach Test and Valgrind Logs/Output
[afte-fix-manual.txt](https://github.com/PBSPro/pbspro/files/4252796/afte-fix-manual.txt)
[after-fix.txt](https://github.com/PBSPro/pbspro/files/4252797/after-fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
