### PR TITLE
Modified svr_dyn_res test to work with sudo rules

### DIFF
--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -417,8 +417,9 @@ class TestServerDynRes(TestFunctional):
         self.server.expect(JOB, a, id=jid)
 
         # Change script during job run
-        cmd = ["echo", "\"echo 50gb\"", " > ", filenames[0]]
-        self.du.run_cmd(cmd=cmd, runas=ROOT_USER, as_script=True)
+        tmp_file = self.du.create_temp_file(body="echo 50gb")
+        self.du.run_copy(src=tmp_file, dest=filenames[0], sudo=True,
+                         preserve_permission=False)
 
         # Rerun job
         self.server.rerunjob(jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Addressing a test issue where the test assumes that sudoer rules are lenient enough to allow redirecting an 'echo' command to a server dynamic resource script.
While this works in most cases, the test fails on our internal test systems.


#### Describe Your Change
Modifying the redirection to creating a file and then copying the file over


#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_dyn_res.txt](https://github.com/PBSPro/pbspro/files/4257834/test_dyn_res.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
