### PR TITLE
Fixed case where comment could not be set and refactored schd_error

### DIFF
--- a/src/scheduler/buckets.c
+++ b/src/scheduler/buckets.c
@@ -1012,7 +1012,7 @@ find_correct_buckets(status *policy, node_bucket **buckets, resource_resv *resre
 					total += buckets[j]->total * c;
 				} else {
 					if (failerr->status_code == SCHD_UNKWN)
-						copy_schd_error(failerr, err);
+						move_schd_error(failerr, err);
 				}
 				clear_schd_error(err);
 			}

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -2092,10 +2092,10 @@ translate_fail_code(schd_error *err, char *comment_msg, char *log_msg)
 		case INSUFFICIENT_RESOURCE:
 			if (comment_msg != NULL && err->rdef != NULL)
 				snprintf(commentbuf, sizeof(commentbuf), ERR2COMMENT(err->error_code), err->rdef->name,
-					arg1);
+					arg1 == NULL ? "" : arg1);
 			if (log_msg != NULL && err->rdef != NULL)
 				snprintf(log_msg, MAX_LOG_SIZE, ERR2INFO(err->error_code), err->rdef->name,
-					arg1);
+					arg1 == NULL ? "" : arg1);
 			break;
 
 		/* codes using arg1, arg3 and resource definition (in a weird order) */

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -2881,7 +2881,7 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 				else {
 					empty_nspec_array(nsa);
 					if(failerr->status_code == SCHD_UNKWN)
-						copy_schd_error(failerr, err);
+						move_schd_error(failerr, err);
 					clear_schd_error(err);
 
 				}
@@ -2929,7 +2929,7 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 							else {
 								empty_nspec_array(nsa);
 								if (failerr->status_code == SCHD_UNKWN)
-									copy_schd_error(failerr, err);
+									move_schd_error(failerr, err);
 								clear_schd_error(err);
 							}
 						}
@@ -2944,6 +2944,10 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 
 						log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, 
 							resresv->name, "Insufficient host-level resources %s", reason);
+
+						/* don't be so specific in the comment since it's only for a single host */
+						set_schd_error_arg(err, ARG1, NULL);
+
 						if (failerr->status_code == SCHD_UNKWN)
 							move_schd_error(failerr, err);
 						clear_schd_error(err);
@@ -3011,6 +3015,9 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 
 						log_eventf(PBSEVENT_DEBUG3, PBS_EVENTCLASS_JOB, LOG_DEBUG, 
 							resresv->name, "Insufficient host-level resources %s", reason);
+
+						/* don't be so specific in the comment since it's only for a single host */
+						set_schd_error_arg(err, ARG1, NULL);
 
 						if (failerr->status_code == SCHD_UNKWN)
 							move_schd_error(failerr, err);
@@ -3113,13 +3120,13 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 							resresv->name, "Insufficient host-level resources %s", reason);
 #ifdef NAS /* localmod 998 */
 						set_schd_error_codes(err, NOT_RUN, RESOURCES_INSUFFICIENT);
-#else
-						set_schd_error_codes(err, NOT_RUN, SET_TOO_SMALL);
-#endif /* localmod 998 */
 						set_schd_error_arg(err, ARG1, "Host");
 						set_schd_error_arg(err, ARG2, hostsets[i]->name);
+#endif /* localmod 998 */
+						/* don't be so specific in the comment since it's only for a single host */
+						set_schd_error_arg(err, ARG1, NULL);
 
-						if (failerr->status_code != SCHD_UNKWN)
+						if (failerr->status_code == SCHD_UNKWN)
 							move_schd_error(failerr, err);
 						clear_schd_error(err);
 					}
@@ -3631,8 +3638,7 @@ eval_simple_selspec(status *policy, chunk *chk, node_info **pninfo_arr,
 	if (err->status_code == SCHD_UNKWN && failerr->status_code != SCHD_UNKWN)
 		move_schd_error(err, failerr);
 	/* don't be so specific in the comment since it's only for a single node */
-	free(err->arg1);
-	err->arg1 = NULL;
+	set_schd_error_arg(err, ARG1, NULL);
 	return 0;
 }
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
There is a case where the scheduler can set a job comment to 'Not Running:' without a reason.  It happens in free placement when a host-set is too small.

#### Describe Your Change
I fixed the issue and also changed the message (since it never was printed before).  The node search code should return the reason why the job didn't run on one node, but shouldn't specify the node.  I changed the to be the same regardless if we're checking a vnode or a host.

In the process of this, I needed to free/NULL one of the args of the schd_error structure.  There is a setter function for the args, but no way to unset.  I modified the setter to take NULL.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
