### PR TITLE
Test_server_periodic_hook.test_alarm_more_than_freq failing due to race condition

### DIFF
--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -83,7 +83,6 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
                                 hook end messages.
         """
         occurance = 0
-        time_expected = int(time.time()) + freq
         # time after which we want to start matching log
         search_after = int(time.time())
         intr = freq
@@ -92,8 +91,11 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
             msg = self.server.log_match(msg_expected,
                                         interval=(intr + 1),
                                         starttime=search_after)
-            time_logged = self.get_timestamp(msg[1])
-            self.assertFalse((time_logged - time_expected) > freq)
+            if occurance == 0:
+                time_expected = time_logged = self.get_timestamp(msg[1])
+            else:
+                time_logged = self.get_timestamp(msg[1])
+                self.assertFalse((time_logged - time_expected) > 1)
 
             if check_for_hook_end is True:
                 time_expected = time_logged + hook_run_time
@@ -104,7 +106,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
                                             interval=(hook_run_time + 1),
                                             starttime=search_after)
                 time_logged = self.get_timestamp(msg[1])
-                self.assertFalse((time_logged - time_expected) > freq)
+                self.assertFalse((time_logged - time_expected) > 1)
 
                 if hook_run_time <= freq:
                     intr = freq - hook_run_time
@@ -119,7 +121,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
             # we just matched hook start/end message, next start message is
             # surely after time_expected.
             search_after = time_expected
-            time_expected = time_expected + intr
+            time_expected = time_logged + intr
             occurance += 1
 
     def test_sp_hook_run(self):

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -93,10 +93,10 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
                                         interval=(intr + 1),
                                         starttime=search_after)
             time_logged = self.get_timestamp(msg[1])
-            self.assertFalse((time_logged - time_expected) > 1)
+            self.assertFalse((time_logged - time_expected) > freq)
 
             if check_for_hook_end is True:
-                time_expected += hook_run_time
+                time_expected = time_logged + hook_run_time
                 # set it to a second before we expect the hook to end
                 search_after = time_expected - 1
                 msg_expected = self.end_msg
@@ -104,7 +104,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
                                             interval=(hook_run_time + 1),
                                             starttime=search_after)
                 time_logged = self.get_timestamp(msg[1])
-                self.assertFalse((time_logged - time_expected) > 1)
+                self.assertFalse((time_logged - time_expected) > freq)
 
                 if hook_run_time <= freq:
                     intr = freq - hook_run_time


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
There are two race conditions
1. sometimes test failed in assertion, test expect that time difference between logged message and expected message should not be greater than 1 sec. sometimes on slower machines message appear, but time difference is more than 1 sec. and test cannot get expected time difference. 
2. sometime test failed due to cannot get hook end message in expected time, there is 1 sec. of time difference between expected time and logged time.

#### Describe Your Change
* first race condition i changed value in assertion from 1 sec. to freq. because expected time is calculating based on current time and on some slower machines it takes more than 1 sec. 
* second race condition, previously code was calculating expected time of end message from expected time of start message. sometime there is 1 sec. of time difference between expected and logged message due to search time got increased by 1 sec. for end message. Expected end message was appeared in server logs, but 1 sec. before search time. I changed code to calculate expected time for end message from logged message. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Before fix:
[before_fix2.txt](https://github.com/PBSPro/pbspro/files/4273978/before_fix2.txt)
[before_fix1.txt](https://github.com/PBSPro/pbspro/files/4273979/before_fix1.txt)

After fix:
[res_after_change2.txt](https://github.com/PBSPro/pbspro/files/4274025/res_after_change2.txt)
[res_after_change3.txt](https://github.com/PBSPro/pbspro/files/4274026/res_after_change3.txt)
[res_after_change4.txt](https://github.com/PBSPro/pbspro/files/4274027/res_after_change4.txt)
[res_after_change5.txt](https://github.com/PBSPro/pbspro/files/4274028/res_after_change5.txt)
[res_after_change6.txt](https://github.com/PBSPro/pbspro/files/4274029/res_after_change6.txt)
[res_after_change7.txt](https://github.com/PBSPro/pbspro/files/4274030/res_after_change7.txt)
[res_after_change8.txt](https://github.com/PBSPro/pbspro/files/4274031/res_after_change8.txt)
[res_after_change9.txt](https://github.com/PBSPro/pbspro/files/4274032/res_after_change9.txt)
[res_after_change10.txt](https://github.com/PBSPro/pbspro/files/4274033/res_after_change10.txt)
[res_after_change11.txt](https://github.com/PBSPro/pbspro/files/4274034/res_after_change11.txt)
[res_after_change12.txt](https://github.com/PBSPro/pbspro/files/4274035/res_after_change12.txt)
[res_after_change13.txt](https://github.com/PBSPro/pbspro/files/4274036/res_after_change13.txt)
[res_after_change14.txt](https://github.com/PBSPro/pbspro/files/4274013/res_after_change14.txt)
[res_after_change15.txt](https://github.com/PBSPro/pbspro/files/4274014/res_after_change15.txt)
[res_after_change16.txt](https://github.com/PBSPro/pbspro/files/4274015/res_after_change16.txt)
[res_after_change17.txt](https://github.com/PBSPro/pbspro/files/4274016/res_after_change17.txt)
[res_after_change18.txt](https://github.com/PBSPro/pbspro/files/4274017/res_after_change18.txt)
[res_after_change19.txt](https://github.com/PBSPro/pbspro/files/4274018/res_after_change19.txt)
[res_after_change20.txt](https://github.com/PBSPro/pbspro/files/4274019/res_after_change20.txt)
[res_after_change21.txt](https://github.com/PBSPro/pbspro/files/4274020/res_after_change21.txt)
[res_after_change22.txt](https://github.com/PBSPro/pbspro/files/4274021/res_after_change22.txt)
[res_after_change23.txt](https://github.com/PBSPro/pbspro/files/4274022/res_after_change23.txt)
[res_after_change24.txt](https://github.com/PBSPro/pbspro/files/4274023/res_after_change24.txt)
[res_after_change25.txt](https://github.com/PBSPro/pbspro/files/4274024/res_after_change25.txt)

Complete Test Suite:
[res_after_change_test_suite1.txt](https://github.com/PBSPro/pbspro/files/4274039/res_after_change_test_suite1.txt)
[res_after_change_test_suite2.txt](https://github.com/PBSPro/pbspro/files/4274040/res_after_change_test_suite2.txt)
[res_after_change_test_suite3.txt](https://github.com/PBSPro/pbspro/files/4274041/res_after_change_test_suite3.txt)
[res_after_change_test_suite4.txt](https://github.com/PBSPro/pbspro/files/4274042/res_after_change_test_suite4.txt)
[res_after_change_test_suite5.txt](https://github.com/PBSPro/pbspro/files/4274043/res_after_change_test_suite5.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
