### PR TITLE
Updates to Scheduler class' save_configuration() &load_configuration() for saving scheduler configurations when option '--use-current-setup' is used in PTL's pbs_benchpress

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5277,7 +5277,6 @@ class Server(PBSService):
         :returns: True on success, False on error
         """
         conf = {}
-        self.saved_config[MGR_OBJ_SERVER] = {}
         # save pbs.conf file
         cfg_path = self.du.get_pbs_conf_file()
         with open(cfg_path, 'r') as p:
@@ -5336,6 +5335,7 @@ class Server(PBSService):
             try:
                 with open(outfile, mode) as f:
                     json.dump(self.saved_config, f)
+                    self.saved_config[MGR_OBJ_SERVER].clear()
             except:
                 self.logger.error('Error processing file ' + outfile)
                 return False
@@ -6118,7 +6118,6 @@ class Server(PBSService):
                 objid = None
             else:
                 objid = ret['out'][0]
-
             if ret['err'] != ['']:
                 self.last_error = ret['err']
             self.last_rc = rc = ret['rc']
@@ -11570,7 +11569,6 @@ class Scheduler(PBSService):
         :returns: True on success and False otherwise
         """
         conf = {}
-        self.server.saved_config[MGR_OBJ_SCHED] = {}
         if 'sched_priv' in self.attributes:
             sched_priv = self.attributes['sched_priv']
         else:
@@ -11590,6 +11588,7 @@ class Scheduler(PBSService):
             try:
                 with open(outfile, mode) as f:
                     json.dump(self.server.saved_config, f)
+                    self.server.saved_config[MGR_OBJ_SCHED].clear()
             except:
                 self.logger.error('error saving configuration ' + outfile)
                 return False

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -3485,6 +3485,7 @@ class PBSService(PBSObject):
         self._is_local = True
         self.launcher = None
         self.dyn_created_files = []
+        self.saved_config = {}
 
         PBSObject.__init__(self, name, attrs, defaults)
 
@@ -4220,7 +4221,7 @@ class PBSService(PBSObject):
 
     def _load_configuration(self, infile, objtype=None):
         """
-        Load server configuration as was saved in infile
+        Load configuration as was saved in infile
 
         :param infile: the file in which configuration
                        was saved
@@ -4231,61 +4232,80 @@ class PBSService(PBSObject):
         """
         if os.path.isfile(infile):
             conf = {}
+            sconf = {}
             with open(infile, 'r') as f:
                 try:
-                    conf = json.load(f)
+                    sconf = json.load(f)
                 except ValueError:
                     self.logger.info("Error loading JSON file: %s"
                                      % infile)
                     return False
-            qmgr = os.path.join(self.client_conf['PBS_EXEC'],
-                                'bin', 'qmgr')
-            for k, v in conf.items():
-                # Load server configuration
-                if k.startswith('qmgr_'):
-                    fpath = self.du.create_temp_file()
-                    print_svr = '\n'.join(v)
-                    with open(fpath, 'w') as f:
-                        f.write(print_svr)
-                    file_qmgr = open(fpath)
-                    d = self.du.run_cmd(
-                        self.hostname, [qmgr], stdin=file_qmgr, sudo=True,
-                        logerr=False, level=logging.DEBUG)
-                    err_msg = "Failed to load server configurations"
-                    file_qmgr.close()
-                    if d['rc'] != 0:
-                        self.logger.error("%s" % err_msg)
-                        return False
-                # Load pbs.conf file
-                elif k == "pbs_conf":
-                    enc_utf = v.encode('UTF-8')
-                    dec_b64 = base64.b64decode(enc_utf)
-                    cfg_vals = dec_b64.decode('UTF-8')
-                    config = ast.literal_eval(cfg_vals)
-                    self.du.set_pbs_config(self.hostname, confs=config)
-                # Load hooks
-                elif k == "hooks":
-                    fpath = self.du.create_temp_file()
-                    print_hooks = '\n'.join(v['qmgr_print_hook'])
-                    with open(fpath, 'w') as f:
-                        f.write(print_hooks)
-                    file_qmgr = open(fpath)
-                    d = self.du.run_cmd(
-                        self.hostname, [qmgr], stdin=file_qmgr, sudo=True,
-                        level=logging.DEBUG)
-                    file_qmgr.close()
-                    if d['rc'] != 0:
-                        self.logger.error("Failed to load site hooks")
-            if 'pbsnodes' in conf:
-                nodes = conf['pbsnodes']
-                for node in nodes:
-                    node_name = str(node['id'])
-                    nodes_created = self.create_pbsnode(node_name, node)
-                    if not nodes_created:
-                        self.logger.error("Failed to create node: %s"
-                                          % node)
-                        return False
-            return True
+            conf = sconf[str(objtype)]
+            if objtype == MGR_OBJ_SERVER:
+                qmgr = os.path.join(self.client_conf['PBS_EXEC'],
+                                    'bin', 'qmgr')
+                for k, v in conf.items():
+                    # Load server configuration
+                    if k.startswith('qmgr_'):
+                        fpath = self.du.create_temp_file()
+                        print_svr = '\n'.join(v)
+                        with open(fpath, 'w') as f:
+                            f.write(print_svr)
+                        file_qmgr = open(fpath)
+                        d = self.du.run_cmd(
+                            self.hostname, [qmgr], stdin=file_qmgr, sudo=True,
+                            logerr=False, level=logging.DEBUG)
+                        err_msg = "Failed to load server configurations"
+                        file_qmgr.close()
+                        if d['rc'] != 0:
+                            self.logger.error("%s" % err_msg)
+                            return False
+                    # Load pbs.conf file
+                    elif k == "pbs_conf":
+                        enc_utf = v.encode('UTF-8')
+                        dec_b64 = base64.b64decode(enc_utf)
+                        cfg_vals = dec_b64.decode('UTF-8')
+                        config = ast.literal_eval(cfg_vals)
+                        self.du.set_pbs_config(self.hostname, confs=config)
+                    # Load hooks
+                    elif k == "hooks":
+                        fpath = self.du.create_temp_file()
+                        print_hooks = '\n'.join(v['qmgr_print_hook'])
+                        with open(fpath, 'w') as f:
+                            f.write(print_hooks)
+                        file_qmgr = open(fpath)
+                        d = self.du.run_cmd(
+                            self.hostname, [qmgr], stdin=file_qmgr, sudo=True,
+                            level=logging.DEBUG)
+                        file_qmgr.close()
+                        if d['rc'] != 0:
+                            self.logger.error("Failed to load site hooks")
+                if 'pbsnodes' in conf:
+                    nodes = conf['pbsnodes']
+                    for node in nodes:
+                        node_name = str(node['id'])
+                        nodes_created = self.create_pbsnode(node_name, node)
+                        if not nodes_created:
+                            self.logger.error("Failed to create node: %s"
+                                              % node)
+                            return False
+                return True
+            elif objtype == MGR_OBJ_SCHED:
+                for k, v in conf.items():
+                    try:
+                        fn = self.du.create_temp_file()
+                        self.du.chmod(path=fn, mode=0o644)
+                        with open(fn, 'w') as fd:
+                            fd.write("\n".join(v))
+                        rv = self.du.run_copy(self.hostname, fn, k, sudo=True)
+                        if rv['rc'] != 0:
+                            self.logger.error("Failed to restore "
+                                              + "configuration: %s" % k)
+                            return False
+                    finally:
+                        if os.path.isfile(fn):
+                            self.du.rm(path=fn)
+                return True
         return False
 
     def create_pbsnode(self, node_name, attrs):
@@ -5233,7 +5253,7 @@ class Server(PBSService):
             if "Unknown node" not in e.msg[0]:
                 raise
 
-    def save_configuration(self, outfile, mode='a'):
+    def save_configuration(self, outfile=None, mode='w'):
         """
         Save a server configuration, this includes:
 
@@ -5257,7 +5277,7 @@ class Server(PBSService):
         :returns: True on success, False on error
         """
         conf = {}
-        sconf = {MGR_OBJ_SERVER: conf}
+        self.saved_config[MGR_OBJ_SERVER] = {}
         # save pbs.conf file
         cfg_path = self.du.get_pbs_conf_file()
         with open(cfg_path, 'r') as p:
@@ -5311,12 +5331,14 @@ class Server(PBSService):
         else:
             nodes_val = self.utils.convert_to_dictlist(ret['out'])
             conf['pbsnodes'] = nodes_val
-        try:
-            with open(outfile, mode) as f:
-                json.dump(conf, f)
-        except:
-            self.logger.error('Error processing file ' + outfile)
-            return False
+        self.saved_config[MGR_OBJ_SERVER] = conf
+        if outfile is not None:
+            try:
+                with open(outfile, mode) as f:
+                    json.dump(self.saved_config, f)
+            except:
+                self.logger.error('Error processing file ' + outfile)
+                return False
 
         return True
 
@@ -5338,7 +5360,7 @@ class Server(PBSService):
 
     def load_configuration(self, infile):
         """
-        load configuration from saved file ``infile``
+        load server configuration from saved file ``infile``
         """
         rv = self._load_configuration(infile, MGR_OBJ_SERVER)
         return rv
@@ -11534,20 +11556,21 @@ class Scheduler(PBSService):
 
         self.setup_sched_priv(sched_priv=sched_priv_dir)
 
-    def save_configuration(self, outfile, mode='a'):
+    def save_configuration(self, outfile=None, mode='w'):
         """
         Save scheduler configuration
 
-        :param outfile: Path to a file to which configuration
-                        is saved
+        :param outfile: Optional Path to a file to which configuration
+                        is saved, when not provided, data is saved in
+                        class variable saved_config
         :type outfile: str
         :param mode: mode to use to access outfile. Defaults to
-                     append, 'a'.
+                     append, 'w'.
         :type mode: str
         :returns: True on success and False otherwise
         """
         conf = {}
-        sconf = {MGR_OBJ_SCHED: conf}
+        self.server.saved_config[MGR_OBJ_SCHED] = {}
         if 'sched_priv' in self.attributes:
             sched_priv = self.attributes['sched_priv']
         else:
@@ -11562,20 +11585,24 @@ class Scheduler(PBSService):
         hd = os.path.join(sched_priv, 'holidays')
         self._save_config_file(conf, hd)
 
-        try:
-            with open(outfile, mode) as f:
-                cPickle.dump(sconf, f)
-        except:
-            self.logger.error('error saving configuration ' + outfile)
-            return False
+        self.server.saved_config[MGR_OBJ_SCHED] = conf
+        if outfile is not None:
+            try:
+                with open(outfile, mode) as f:
+                    json.dump(self.server.saved_config, f)
+            except:
+                self.logger.error('error saving configuration ' + outfile)
+                return False
 
         return True
 
     def load_configuration(self, infile):
         """
-        load configuration from saved file infile
+        load scheduler configuration from saved file infile
         """
-        self._load_configuration(infile, MGR_OBJ_SCHED)
+        rv = self._load_configuration(infile, MGR_OBJ_SCHED)
+        self.signal('-HUP')
+        return rv
 
     def get_resources(self, exclude=[]):
         """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -455,14 +455,14 @@ class PBSTestSuite(unittest.TestCase):
                                        suffix=".json")
             ret = cls.server.save_configuration()
             if not ret:
-                cls.logger.error("Failed to save custom setup")
-                raise Exception("Failed to save custom setup")
+                cls.logger.error("Failed to save server's custom setup")
+                raise Exception("Failed to save server's custom setup")
             ret = cls.scheduler.save_configuration(path, 'w')
             if ret:
                 cls.saved_file = path
             else:
-                cls.logger.error("Failed to save custom setup")
-                raise Exception("Failed to save custom setup")
+                cls.logger.error("Failed to save scheduler's custom setup")
+                raise Exception("Failed to save scheduler's custom setup")
             cls.add_mgrs_opers()
         cls.init_comms()
         cls.init_moms()
@@ -478,14 +478,14 @@ class PBSTestSuite(unittest.TestCase):
                                        suffix=".json")
             ret = self.server.save_configuration()
             if not ret:
-                self.logger.error("Failed to save test setup")
-                raise Exception("Failed to save test setup")
+                self.logger.error("Failed to save server's test setup")
+                raise Exception("Failed to save server's test setup")
             ret = self.scheduler.save_configuration(path, 'w')
             if ret:
                 self.saved_file = path
             else:
-                self.logger.error("Failed to save test setup")
-                raise Exception("Failed to save test setup")
+                self.logger.error("Failed to save scheduler's test setup")
+                raise Exception("Failed to save scheduler's test setup")
             PBSTestSuite.config_saved = True
         # Adding only server and pbs.conf methods in use current
         # setup block, rest of them to be added to this block
@@ -496,9 +496,9 @@ class PBSTestSuite(unittest.TestCase):
         else:
             self.revert_servers()
             self.revert_pbsconf()
+            self.revert_schedulers()
         self.revert_moms()
         self.revert_comms()
-        self.revert_schedulers()
         self.log_end_setup()
         self.measurements = []
 
@@ -1604,10 +1604,10 @@ class PBSTestSuite(unittest.TestCase):
             self.delete_current_state(self.server, self.moms)
             ret = self.server.load_configuration(self.saved_file)
             if not ret:
-                raise Exception("Failed to load test setup")
+                raise Exception("Failed to load server's test setup")
             ret = self.scheduler.load_configuration(self.saved_file)
             if not ret:
-                raise Exception("Failed to load test setup")
+                raise Exception("Failed to load scheduler's test setup")
         self.log_end_teardown()
 
     @classmethod
@@ -1618,9 +1618,9 @@ class PBSTestSuite(unittest.TestCase):
             PBSTestSuite.config_saved = False
             ret = cls.server.load_configuration(cls.saved_file)
             if not ret:
-                raise Exception("Failed to load custom setup")
+                raise Exception("Failed to load server's custom setup")
             ret = cls.scheduler.load_configuration(cls.saved_file)
             if not ret:
-                raise Exception("Failed to load custom setup")
+                raise Exception("Failed to load scheduler's custom setup")
         if cls.use_cur_setup:
             cls.du.rm(path=cls.saved_file)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
'--use-current-setup' option in PTL currently saves only server configurations. This needs to include scheduler configurations.
This feature is as per design: https://pbspro.atlassian.net/wiki/spaces/PD/pages/557088789/Design+for+a+supported+way+to+change+default+setup+in+PTL

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Updated below methods to save scheduler configurations
save_configuration()
load_configuration() 
setUpClass()
tearDownClass()
setUp()
tearDown()


#### Link to Design Doc
<!--- If there is a design, link to it here: **[Design for a supported way to change default setup in PTL](https://pbspro.atlassian.net/wiki/spaces/PD/pages/557088789/Design+for+a+supported+way+to+change+default+setup+in+PTL)** --> Design for a supported way to change default setup in PTL [https://pbspro.atlassian.net/wiki/spaces/PD/pages/557088789/Design+for+a+supported+way+to+change+default+setup+in+PTL]


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

**AFTER FIX ====================================================**

[root@x105-c7p6-docker saritah]# grep eoe /var/spool/pbs/sched_priv/sched_config;grep 2020 "/var/spool/pbs/sched_priv/dedicated_time";grep Ugadi /var/spool/pbs/sched_priv/holidays
resources: "ncpus, mem, arch, host, vnode, aoe, eoe, **foo**"
**4/15/2020 16:00 4/15/2020 16:40**
**85           Mar 25          Ugadi Festival**
[root@x105-c7p6-docker saritah]# echo "AFTER TEST RUN"                                                                                                                                       AFTER TEST RUN
[root@x105-c7p6-docker grep eoe /var/spool/pbs/sched_priv/sched_config;grep 2020 "/var/spool/pbs/sched_priv/dedicated_time";grep Ugadi /var/spool/pbs/sched_priv/holidays
resources: "ncpus, mem, arch, host, vnode, aoe, eoe, **foo**"
**4/15/2020 16:00 4/15/2020 16:40**
**85           Mar 25          Ugadi Festival**
[root@x105-c7p6-docker saritah]#


**BEFORE FIX ================================**

[root@x105-c7p6-docker grep eoe /var/spool/pbs/sched_priv/sched_config;grep 2020 "/var/spool/pbs/sched_priv/dedicated_time";grep Ugadi /var/spool/pbs/sched_priv/holidays
resources: "ncpus, mem, arch, host, vnode, aoe, eoe, **foo**"
**4/15/2020 16:00 4/15/2020 16:40**
**85           Mar 25          Ugadi Day**
[root@x105-c7p6-docker saritah]# echo "AFTER TEST RUN"                                                                                                                                       AFTER TEST RUN
[root@x105-c7p6-docker saritah]# grep eoe /var/spool/pbs/sched_priv/sched_config;grep 2020 "/var/spool/pbs/sched_priv/dedicated_time";grep Ugadi /var/spool/pbs/sched_priv/holidays
resources: "ncpus, mem, arch, host, vnode, aoe, eoe"
[root@x105-c7p6-docker saritah]# 




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
