### PR TITLE
PTL test: Fixing test_obfuscate_resv_user_groups

### DIFF
--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -446,7 +446,7 @@ class TestPBSSnapshot(TestFunctional):
         # Let's submit a reservation with Authorized_Users and
         # Authorized_Groups set
         attribs = {ATTR_auth_u: TEST_USER1, ATTR_auth_g: TSTGRP0,
-                   ATTR_l + ".ncpus": 2, 'reserve_start': now + 25,
+                   ATTR_l + ".ncpus": 1, 'reserve_start': now + 25,
                    'reserve_end': now + 45}
         resv_obj = Reservation(attrs=attribs)
         resv_id = self.server.submit(resv_obj)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The test was failing on single core machines because it was expecting  a reservation requesting 2 ncpus to be confirmed without checking that there were 2 ncpus available.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Changed the ncpus requested from 2 to 1, there's no reason to request 2 ncpus in this test.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[after.log](https://github.com/PBSPro/pbspro/files/4288687/after.log)
[before.log](https://github.com/PBSPro/pbspro/files/4288688/before.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
