### PR TITLE
Added a mock run option to pbs_mom for testing

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -1233,6 +1233,13 @@ extern int   set_cpu_licenses_need(job *, char *);
 extern void  allocate_cpu_licenses(job *);
 extern void  deallocate_cpu_licenses(job *);
 extern void  deallocate_cpu_licenses2(job *, int);
+
+extern void del_job_related_file(job *pjob, char *fsuffix);
+#ifdef PBS_MOM
+extern void del_job_dirs(job *pjob);
+extern void del_chkpt_files(job *pjob);
+#endif
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -143,6 +143,8 @@ enum hup_action {
  */
 extern enum hup_action	call_hup;
 
+extern int mock_run;
+
 /* public funtions within MOM */
 
 #ifdef	_PBS_JOB_H
@@ -397,6 +399,8 @@ extern int setcurrentworkdir(char *);
 extern int becomeuser(job *);
 extern int becomeuser_args(char *, uid_t, gid_t, gid_t);
 extern void close_update_pipes(job *);
+extern void mom_set_use_all(void);
+void job_purge_mom(job *pjob);
 
 /* From popen.c */
 extern FILE *pbs_popen(const char *, const char *);

--- a/src/resmom/Makefile.am
+++ b/src/resmom/Makefile.am
@@ -89,6 +89,8 @@ pbs_mom_SOURCES = \
 	${PBS_MACH}/mom_start.c \
 	${PBS_MACH}/pe_input.c \
 	catch_child.c \
+	mock_run.c \
+	mock_run.h \
 	mom_comm.c \
 	mom_hook_func.c \
 	mom_inter.c \

--- a/src/resmom/darwin/mom_mach.c
+++ b/src/resmom/darwin/mom_mach.c
@@ -817,7 +817,6 @@ mom_set_use(job	*pjob)
 
 	assert(pjob != NULL);
 	at = &pjob->ji_wattr[(int)JOB_ATR_resc_used];
-	assert(at->at_type == ATR_TYPE_RESC);
 
 	if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_Suspend) != 0)
 		return (PBSE_NONE);	/* job suspended, don't track it */
@@ -838,7 +837,6 @@ mom_set_use(job	*pjob)
 		 * so the ncpus used can be set to ncpus requested
 		*/
 		at_req = &pjob->ji_wattr[(int)JOB_ATR_resource];
-		assert(at->at_type == ATR_TYPE_RESC);
 
 		pres_req = find_resc_entry(at_req,rd);
 		if ((pres_req != NULL) &&

--- a/src/resmom/darwin/mom_start.c
+++ b/src/resmom/darwin/mom_start.c
@@ -189,13 +189,7 @@ void scan_for_terminated()
 
 	termin_child = 0;
 
-	if (mom_get_sample() == PBSE_NONE) {
-		pjob = (job *)GET_NEXT(svr_alljobs);
-		while (pjob) {
-			mom_set_use(pjob);
-			pjob = (job *)GET_NEXT(pjob->ji_alljobs);
-		}
-	}
+	mom_set_use_all();
 
 	/* Now figure out which task(s) have terminated (are zombies) */
 

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -5554,6 +5554,10 @@ mom_get_sample(void)
 	extern time_t		time_last_sample;
 	char			*stat_str = NULL;
 
+	/* There are no job tasks created in mock run mode, so no need to walk the proc table */
+	if (mock_run)
+		return PBSE_NONE;
+
 	DBPRT(("%s: entered\n", __func__))
 	if (pdir == NULL)
 		return PBSE_INTERNAL;

--- a/src/resmom/linux/mom_start.c
+++ b/src/resmom/linux/mom_start.c
@@ -2436,13 +2436,7 @@ scan_for_terminated(void)
 
 	termin_child = 0;
 
-	if (mom_get_sample() == PBSE_NONE) {
-		pjob = (job *)GET_NEXT(svr_alljobs);
-		while (pjob) {
-			mom_set_use(pjob);
-			pjob = (job *)GET_NEXT(pjob->ji_alljobs);
-		}
-	}
+	mom_set_use_all();
 
 	/* Now figure out which task(s) have terminated (are zombies) */
 

--- a/src/resmom/mock_run.c
+++ b/src/resmom/mock_run.c
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 1994-2020 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * PBS Pro is free software. You can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * For a copy of the commercial license terms and conditions,
+ * go to: (http://www.pbspro.com/UserArea/agreement.html)
+ * or contact the Altair Legal Department.
+ *
+ * Altair’s dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of PBS Pro and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair’s trademarks, including but not limited to "PBS™",
+ * "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+ * trademark licensing policies.
+ *
+ */
+
+#include <pbs_config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <time.h>
+#include <errno.h>
+
+#include "attribute.h"
+#include "batch_request.h"
+#include "job.h"
+#include "log.h"
+#include "mock_run.h"
+#include "mom_func.h"
+#include "pbs_error.h"
+#include "resource.h"
+
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+#include "renew_creds.h"
+#endif
+
+extern time_t time_now;
+extern time_t time_resc_updated;
+extern int min_check_poll;
+extern int next_sample_time;
+
+void
+mock_run_finish_exec(job *pjob)
+{
+	resource_def *rd;
+	attribute *wallt;
+	resource *wall_req;
+	int walltime = 0;
+
+	rd = find_resc_def(svr_resc_def, "walltime", svr_resc_size);
+	wallt = &pjob->ji_wattr[(int)JOB_ATR_resource];
+	wall_req = find_resc_entry(wallt, rd);
+	if (wall_req != NULL) {
+		walltime = wall_req->rs_value.at_val.at_long;
+		start_walltime(pjob);
+	}
+
+	time_now = time(NULL);
+
+	/* Add a work task that runs when the job is supposed to end */
+	set_task(WORK_Timed, time_now + walltime, mock_run_end_job_task, pjob);
+
+	sprintf(log_buffer, "Started mock run of job");
+	log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB,
+		LOG_INFO, pjob->ji_qs.ji_jobid, log_buffer);
+
+	mock_run_record_finish_exec(pjob);
+
+	return;
+}
+
+void
+mock_run_record_finish_exec(job *pjob)
+{
+	pjob->ji_qs.ji_state = JOB_STATE_RUNNING;
+	pjob->ji_qs.ji_substate = JOB_SUBSTATE_RUNNING;
+	job_save(pjob, SAVEJOB_QUICK);
+
+	pjob->ji_wattr[(int)JOB_ATR_state].at_val.at_long = JOB_STATE_RUNNING;
+	pjob->ji_wattr[(int)JOB_ATR_state].at_val.at_char = 'R';
+	pjob->ji_wattr[(int)JOB_ATR_substate].at_val.at_long = JOB_SUBSTATE_RUNNING;
+	pjob->ji_wattr[(int)JOB_ATR_state].at_flags |= ATR_VFLAG_MODIFY;
+	pjob->ji_wattr[(int)JOB_ATR_substate].at_flags |= ATR_VFLAG_MODIFY;
+
+	time_resc_updated = time_now;
+	mock_run_mom_set_use(pjob);
+
+	update_ajob_status(pjob);
+	next_sample_time = min_check_poll;
+
+	return;
+
+}
+
+/**
+ * @brief	work task handler for end of a job in mock run mode
+ *
+ * @param[in]	ptask - pointer to the work task
+ *
+ * @return void
+ */
+void
+mock_run_end_job_task(struct work_task *ptask)
+{
+	job *pjob;
+
+	if (ptask == NULL)
+		return;
+
+	pjob = ptask->wt_parm1;
+
+	pjob->ji_qs.ji_substate = JOB_SUBSTATE_EXITING;
+	pjob->ji_qs.ji_state = JOB_STATE_EXITING;
+	pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_OK;
+
+	scan_for_exiting();
+}
+
+
+/**
+ * @brief
+ * 	Update the resources used.<attributes> of a job when in mock run mode
+ *
+ * @param[in]	pjob - job in question.
+ *
+ *
+ * @return int
+ * @retval PBSE_NONE	for success.
+ */
+int
+mock_run_mom_set_use(job *pjob)
+{
+	int i;
+	resource *pres;
+	resource *pres_req;
+	attribute *at;
+	attribute *at_req;
+	resource_def *rdefp;
+	long val_req = 0;
+	static resource_def	**rd = NULL;
+	static resource_def *vmemd = NULL;
+	int memval = 0;
+	unsigned int mem_atsv_shift = 10;
+	unsigned int mem_atsv_units = ATR_SV_BYTESZ;
+
+	assert(pjob != NULL);
+	at = &pjob->ji_wattr[(int)JOB_ATR_resc_used];
+	at->at_flags |= (ATR_VFLAG_MODIFY|ATR_VFLAG_SET);
+
+	if (rd == NULL) {
+		rd = malloc(5 * sizeof(resource_def *));
+		if (rd  == NULL)
+			return PBSE_SYSTEM;
+
+		rd[0] = find_resc_def(svr_resc_def, "ncpus", svr_resc_size);
+		rd[1] = find_resc_def(svr_resc_def, "mem", svr_resc_size);
+		rd[2] = find_resc_def(svr_resc_def, "cput", svr_resc_size);
+		rd[3] = find_resc_def(svr_resc_def, "cpupercent", svr_resc_size);
+		rd[4] = NULL;
+	}
+	if (vmemd == NULL) {
+		vmemd = find_resc_def(svr_resc_def, "vmem", svr_resc_size);
+		assert(vmemd != NULL);
+	}
+
+	for (i = 0; rd[i] != NULL; i++) {
+		rdefp = rd[i];
+		pres = find_resc_entry(at, rdefp);
+		if (pres == NULL) {
+			pres = add_resource_entry(at, rdefp);
+			pres->rs_value.at_flags |= ATR_VFLAG_SET;
+			pres->rs_value.at_type = rd[i]->rs_type;
+
+			/*
+			 * get pointer to list of resources *requested* for the job
+			 * so the res used can be set to res requested
+			 */
+			at_req = &pjob->ji_wattr[(int)JOB_ATR_resource];
+
+			pres_req = find_resc_entry(at_req, rdefp);
+			if (pres_req != NULL &&
+				(val_req = pres_req->rs_value.at_val.at_long) != 0)
+				pres->rs_value.at_val.at_long = val_req;
+			else
+				pres->rs_value.at_val.at_long = 0;
+
+			if (rd[i]->rs_type == ATR_TYPE_SIZE) {
+				if (pres_req != NULL) {
+					memval = val_req;
+					mem_atsv_shift = pres_req->rs_value.at_val.at_size.atsv_shift;
+					mem_atsv_units = pres_req->rs_value.at_val.at_size.atsv_units;
+					pres->rs_value.at_val.at_size.atsv_shift = mem_atsv_shift;
+					pres->rs_value.at_val.at_size.atsv_units = mem_atsv_units;
+				} else {
+					pres->rs_value.at_val.at_size.atsv_shift = 10; /* KB */
+					pres->rs_value.at_val.at_size.atsv_units = ATR_SV_BYTESZ;
+				}
+			}
+		}
+	}
+
+	/* Set vmem equal to the value of mem */
+	pres = find_resc_entry(at, vmemd);
+	if (pres == NULL) {
+		pres = add_resource_entry(at, vmemd);
+		pres->rs_value.at_flags |= ATR_VFLAG_SET;
+		pres->rs_value.at_type = ATR_TYPE_LONG;
+		pres->rs_value.at_val.at_long = memval;
+		pres->rs_value.at_val.at_size.atsv_shift = mem_atsv_shift;
+		pres->rs_value.at_val.at_size.atsv_units = mem_atsv_units;
+	}
+
+	pjob->ji_sampletim = time(NULL);
+
+	/* update walltime usage */
+	update_walltime(pjob);
+
+	return (PBSE_NONE);
+}
+
+/**
+ * @brief	job_purge for mock run mode
+ *
+ * @param[in,out]	pjob - the job being purged
+ *
+ * @return	void
+ */
+void
+mock_run_job_purge(job *pjob)
+{
+	delete_link(&pjob->ji_jobque);
+	delete_link(&pjob->ji_alljobs);
+	delete_link(&pjob->ji_unlicjobs);
+
+#ifdef PBS_MOM
+	if (pjob->ji_preq != NULL) {
+		log_joberr(PBSE_INTERNAL, __func__, "request outstanding",
+			pjob->ji_qs.ji_jobid);
+		reply_text(pjob->ji_preq, PBSE_INTERNAL, "job deleted");
+		pjob->ji_preq = NULL;
+	}
+#endif
+
+	/* delete script file */
+	del_job_related_file(pjob, JOB_SCRIPT_SUFFIX);
+
+	del_job_dirs(pjob);
+
+	/* delete job file */
+	del_job_related_file(pjob, JOB_FILE_SUFFIX);
+
+	del_chkpt_files(pjob);
+
+#if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
+	delete_cred(pjob->ji_qs.ji_jobid);
+#endif
+	del_job_related_file(pjob, JOB_CRED_SUFFIX);
+
+	job_free(pjob);
+}

--- a/src/resmom/mock_run.h
+++ b/src/resmom/mock_run.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 1994-2020 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * PBS Pro is free software. You can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * For a copy of the commercial license terms and conditions,
+ * go to: (http://www.pbspro.com/UserArea/agreement.html)
+ * or contact the Altair Legal Department.
+ *
+ * Altair’s dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of PBS Pro and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair’s trademarks, including but not limited to "PBS™",
+ * "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+ * trademark licensing policies.
+ *
+ */
+
+#ifndef	_MOCK_RUN_H
+#define	_MOCK_RUN_H
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+#include "work_task.h"
+#include "job.h"
+
+void mock_run_finish_exec(job *pjob);
+
+void mock_run_record_finish_exec(job *pjob);
+
+void mock_run_end_job_task(struct work_task *ptask);
+
+int mock_run_mom_set_use(job *pjob);
+
+void mock_run_job_purge(job *pjob);
+
+#ifdef	__cplusplus
+}
+#endif
+#endif /* _MOCK_RUN_H */

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -3203,7 +3203,7 @@ im_request(int stream, int version)
 			}
 			free_attrlist(&lhead);
 			if (errcode != 0) {
-				(void)job_purge(pjob);
+				(void)job_purge_mom(pjob);
 				SEND_ERR(errcode)
 				goto done;
 			}

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3440,7 +3440,7 @@ void reply_hook_bg(job *pjob)
 
 		del_job_resc(pjob);	/* rm tmpdir, cpusets, etc */
 		pjob->ji_hook_running_bg_on = BG_NONE;
-		job_purge(pjob);
+		job_purge_mom(pjob);
 		dorestrict_user();
 
 		if ((ret = is_compose(server_stream, IS_DISCARD_DONE)) != DIS_SUCCESS)
@@ -3483,7 +3483,7 @@ void reply_hook_bg(job *pjob)
 							req_reject(PBSE_SISCOMM, 0, preq); /* sis down */
 #endif
 					pjob->ji_hook_running_bg_on = BG_NONE;
-					job_purge(pjob);
+					job_purge_mom(pjob);
 				}
 				/*
 				* otherwise, job_purge() and dorestrict_user() are called in

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -159,7 +159,7 @@ volatile pbs_mutex      *pbs_commit_ptr = &pbs_commit_mtx;
 #endif
 
 /* Global Data Items */
-
+int mock_run = 0;
 enum hup_action	call_hup = HUP_CLEAR;
 static int      update_state_flag = 0;
 double		cputfactor = 1.00;
@@ -8373,11 +8373,22 @@ main(int argc, char *argv[])
 	}
 
 	errflg = 0;
-	getopt_str = "d:c:M:NS:R:lL:a:xC:prs:n:Q:-:";
+	getopt_str = "d:c:M:mNS:R:lL:a:xC:prs:n:Q:-:";
 	while ((c = getopt(argc, argv, getopt_str)) != -1) {
 		switch (c) {
 			case 'N':	/* stand alone (win), no fork (others) */
 				stalone = 1;
+				break;
+			case 'm':
+#ifdef WIN32
+				fprintf(stderr, "-m option not supported for Windows\n");
+				g_dwCurrentState = SERVICE_STOPPED;
+				ss.dwCurrentState = g_dwCurrentState;
+				ss.dwWin32ExitCode = ERROR_INVALID_PARAMETER;
+				if (g_ssHandle != 0) SetServiceStatus(g_ssHandle, &ss);
+				return 1;
+#endif
+				mock_run = 1;
 				break;
 			case 'd':	/* directory */
 				if (pbs_conf.pbs_home_path != NULL)
@@ -9362,7 +9373,8 @@ main(int argc, char *argv[])
 	}
 
 #ifndef	WIN32
-	mom_nice();
+	if (!mock_run)
+		mom_nice();
 #endif
 	/*
 	 * Recover the hooks.
@@ -9763,7 +9775,7 @@ main(int argc, char *argv[])
 			 * no harm anyway.
 			 */
 			(void)kill_job(pjob, SIGKILL);
-			job_purge(pjob);
+			job_purge_mom(pjob);
 			++i;
 		}
 		if (i > 0)
@@ -9869,7 +9881,7 @@ main(int argc, char *argv[])
 					req_reject(PBSE_SISCOMM, 0, pjob->ji_preq);
 					pjob->ji_preq = NULL;
 				}
-				job_purge(pjob);
+				job_purge_mom(pjob);
 				dorestrict_user();
 				continue;
 			}
@@ -10096,7 +10108,7 @@ main(int argc, char *argv[])
 	/* Have we any jobs that can be purged before we go away? */
 
 	while ((pjob = (job *)GET_NEXT(mom_deadjobs)) != NULL) {
-		job_purge(pjob);
+		job_purge_mom(pjob);
 	}
 
 	{

--- a/src/resmom/mom_walltime.c
+++ b/src/resmom/mom_walltime.c
@@ -59,7 +59,8 @@ double			wallfactor = 1.00;
  * @par MT-safe: No
  */
 void
-start_walltime(job *pjob) {
+start_walltime(job *pjob)
+{
     if (NULL == pjob)
         return;
     /* 
@@ -86,7 +87,8 @@ start_walltime(job *pjob) {
  * @par MT-safe: No
  */
 void
-update_walltime(job *pjob) {
+update_walltime(job *pjob)
+{
     attribute       *resources_used;
     resource_def    *walltime_def;
     resource        *used_walltime;
@@ -129,7 +131,8 @@ update_walltime(job *pjob) {
  * @par MT-safe: No
  */
 void
-stop_walltime(job *pjob) {
+stop_walltime(job *pjob)
+{
     if (NULL == pjob)
         return;
     /* 
@@ -156,7 +159,8 @@ stop_walltime(job *pjob) {
  * @par MT-safe: No
  */
 void
-recover_walltime(job *pjob) {
+recover_walltime(job *pjob)
+{
     attribute       *resources_used;
     resource_def    *walltime_def;
     resource        *used_walltime;

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -99,6 +99,8 @@
 
 #include "renew_creds.h"
 
+#include "mock_run.h"
+
 #define	PIPE_READ_TIMEOUT	5
 #define EXTRA_ENV_PTRS	       32
 
@@ -6132,6 +6134,16 @@ start_exec(job *pjob)
 
 	if (do_tolerate_node_failures(pjob))
 		reliable_job_node_add(&pjob->ji_node_list, mom_host);
+
+	if (mock_run) {
+		   pjob->ji_ports[0] = -1;
+		   pjob->ji_ports[1] = -1;
+		   pjob->ji_stdout = -1;
+		   pjob->ji_stderr = -1;
+
+		   mock_run_finish_exec(pjob);
+		   return;
+	}
 
 	if (nodenum > 1) {
 		attribute *pattr;

--- a/src/resmom_win/start_exec.c
+++ b/src/resmom_win/start_exec.c
@@ -4157,6 +4157,7 @@ start_exec(job *pjob)
 		exec_bail(pjob, JOB_EXEC_RETRY, NULL);
 		return;
 	}
+
 	pjob->ji_nodeid = 0;		/* I'm MS */
 	nodenum = pjob->ji_numnodes;
 	if (do_tolerate_node_failures(pjob))

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -170,13 +170,16 @@ extern char *pbs_server_name;
 extern pbs_list_head svr_newjobs;
 extern pbs_list_head svr_alljobs;
 extern int is_called_by_job_purge;
+extern char *msg_err_purgejob;
 
 #ifdef PBS_MOM
 #include "mom_func.h"
 
-extern void  rmtmpdir(char *);
+extern void rmtmpdir(char *);
 void nodes_free(job *);
-extern char* std_file_name(job *pjob, enum job_file which, int *keeping);
+extern char *std_file_name(job *pjob, enum job_file which, int *keeping);
+extern char *path_checkpoint;
+
 /**
  * @brief
  * 		free up the tasks from the list of tasks associated with particular job, delete links and close connection.
@@ -655,7 +658,8 @@ job_init_wattr(job *pj)
  * @return  void
  */
 void
-spool_filename(job *pjob, char *namebuf, char *suffix) {
+spool_filename(job *pjob, char *namebuf, char *suffix)
+{
     if (*pjob->ji_qs.ji_fileprefix != '\0')
         (void) strcat(namebuf, pjob->ji_qs.ji_fileprefix);
     else
@@ -673,9 +677,9 @@ spool_filename(job *pjob, char *namebuf, char *suffix) {
  * @return	void
  */
 void
-remove_stdouterr_files(job *pjob, char *suffix) {
+remove_stdouterr_files(job *pjob, char *suffix)
+{
 	char namebuf[MAXPATHLEN + 1];
-	extern char *msg_err_purgejob;
 
 	(void) strcpy(namebuf, path_spool);
 	spool_filename(pjob, namebuf, suffix);
@@ -695,7 +699,8 @@ remove_stdouterr_files(job *pjob, char *suffix) {
  * @retval 1 : direct write is requested by the job.
  * @retval 0 : direct write is not requested by the job.
  */
-int direct_write_requested(job *pjob) {
+int direct_write_requested(job *pjob)
+{
 	char *pj_attrk = NULL;
 	if ((pjob->ji_wattr[(int)JOB_ATR_keep].at_flags & ATR_VFLAG_SET)) {
 		pj_attrk = pjob->ji_wattr[(int)JOB_ATR_keep].at_val.at_str;
@@ -705,6 +710,102 @@ int direct_write_requested(job *pjob) {
 	return 0;
 }
 
+/**
+ * @brief	Convenience function to delete job related files for a job being purged
+ *
+ * @param[in]	pjob - the job being purged
+ * @param[in]	fsuffix - suffix of the file to delete
+ *
+ * @return	void
+ */
+void
+del_job_related_file(job *pjob, char *fsuffix)
+{
+	char namebuf[MAXPATHLEN + 1] = {'\0'};
+
+	strcpy(namebuf, path_jobs);
+	if (*pjob->ji_qs.ji_fileprefix != '\0')
+		strcat(namebuf, pjob->ji_qs.ji_fileprefix);
+	else
+		strcat(namebuf, pjob->ji_qs.ji_jobid);
+	strcat(namebuf, fsuffix);
+	if (unlink(namebuf) < 0) {
+		if (errno != ENOENT) {
+			log_joberr(errno, __func__, msg_err_purgejob,
+				pjob->ji_qs.ji_jobid);
+		}
+	}
+}
+
+#ifdef PBS_MOM
+
+/**
+ * @brief	Convenience function to delete directories associated with a job being purged
+ *
+ * @param[in]	pjob - the job being purged
+ *
+ * @return	void
+ */
+void
+del_job_dirs(job *pjob)
+{
+	char namebuf[MAXPATHLEN + 1] = {'\0'};
+
+	strcpy(namebuf, path_jobs);      /* job directory path */
+	if (*pjob->ji_qs.ji_fileprefix != '\0')
+		strcat(namebuf, pjob->ji_qs.ji_fileprefix);
+	else
+		strcat(namebuf, pjob->ji_qs.ji_jobid);
+	strcat(namebuf, JOB_TASKDIR_SUFFIX);
+	remtree(namebuf);
+
+	rmtmpdir(pjob->ji_qs.ji_jobid);		/* remove tmpdir */
+
+	/* remove the staging and execution directory when sandbox=PRIVATE
+	 ** and there are no stage-out errors
+	 */
+	if ((pjob->ji_wattr[(int)JOB_ATR_sandbox].at_flags & ATR_VFLAG_SET) &&
+		(strcasecmp(pjob->ji_wattr[JOB_ATR_sandbox].at_val.at_str, "PRIVATE") == 0)) {
+		if (!(pjob->ji_qs.ji_svrflags & JOB_SVFLG_StgoFal)) {
+			if (pjob->ji_grpcache != NULL)
+				rmjobdir(pjob->ji_qs.ji_jobid,
+					jobdirname(pjob->ji_qs.ji_jobid, pjob->ji_grpcache->gc_homedir),
+					pjob->ji_grpcache->gc_uid,
+					pjob->ji_grpcache->gc_gid);
+			else
+				rmjobdir(pjob->ji_qs.ji_jobid,
+					jobdirname(pjob->ji_qs.ji_jobid, NULL),
+					0,
+					0);
+		}
+	}
+}
+
+/**
+ * @brief	Convenience function to delete checkpoint files for a job being purged
+ *
+ * @param[in]	pjob - job being purged
+ *
+ * @return void
+ */
+void
+del_chkpt_files(job *pjob)
+{
+	char namebuf[MAXPATHLEN + 1] = {'\0'};
+
+	if (path_checkpoint != NULL) {	/* delete checkpoint files */
+		(void)strcpy(namebuf, path_checkpoint);
+		if (*pjob->ji_qs.ji_fileprefix != '\0')
+			(void)strcat(namebuf, pjob->ji_qs.ji_fileprefix);
+		else
+			(void)strcat(namebuf, pjob->ji_qs.ji_jobid);
+		(void)strcat(namebuf, JOB_CKPT_SUFFIX);
+		(void)remtree(namebuf);
+		(void)strcat(namebuf, ".old");
+		(void)remtree(namebuf);
+	}
+}
+#endif
 
 /**
  * @brief
@@ -726,7 +827,6 @@ job_purge(job *pjob)
 	char		namebuf[MAXPATHLEN + 1] = {'\0'};
 	extern	char	*msg_err_purgejob;
 #ifdef	PBS_MOM
-	extern	char	*path_checkpoint;
 	int keeping = 0;
 	attribute *jrpattr = NULL;
 
@@ -767,6 +867,7 @@ job_purge(job *pjob)
 		pjob->ji_preq = NULL;
 	}
 #ifndef WIN32
+
 	if (pjob->ji_momsubt != 0) {	/* child running */
 		(void)kill(pjob->ji_momsubt, SIGKILL);
 		pjob->ji_momsubt = 0;
@@ -858,63 +959,17 @@ job_purge(job *pjob)
 	}
 	/* Parent Mom process will continue the job cleanup itself, if call to fork is failed */
 #endif
-	(void)strcpy(namebuf, path_jobs);	/* delete script file */
-	if (*pjob->ji_qs.ji_fileprefix != '\0')
-		(void)strcat(namebuf, pjob->ji_qs.ji_fileprefix);
-	else
-		(void)strcat(namebuf, pjob->ji_qs.ji_jobid);
-	(void)strcat(namebuf, JOB_SCRIPT_SUFFIX);
-	if (unlink(namebuf) < 0) {
-		if (errno != ENOENT) {
-			log_joberr(errno, __func__, msg_err_purgejob,
-				pjob->ji_qs.ji_jobid);
-		}
-	}
+	/* delete script file */
+	del_job_related_file(pjob, JOB_SCRIPT_SUFFIX);
 
 	if (pjob->ji_preq != NULL) {
 		req_reject(PBSE_MOMREJECT, 0, pjob->ji_preq);
 		pjob->ji_preq = NULL;
 	}
-	(void)strcpy(namebuf, path_jobs);      /* job directory path */
-	if (*pjob->ji_qs.ji_fileprefix != '\0')
-		(void)strcat(namebuf, pjob->ji_qs.ji_fileprefix);
-	else
-		(void)strcat(namebuf, pjob->ji_qs.ji_jobid);
-	(void)strcat(namebuf, JOB_TASKDIR_SUFFIX);
-	(void)remtree(namebuf);
 
-	rmtmpdir(pjob->ji_qs.ji_jobid);		/* remove tmpdir */
+	del_job_dirs(pjob);
 
-	/* remove the staging and execution directory when sandbox=PRIVATE
-	 ** and there are no stage-out errors
-	 */
-	if ((pjob->ji_wattr[(int)JOB_ATR_sandbox].at_flags & ATR_VFLAG_SET) &&
-		(strcasecmp(pjob->ji_wattr[JOB_ATR_sandbox].at_val.at_str, "PRIVATE") == 0)) {
-		if (!(pjob->ji_qs.ji_svrflags & JOB_SVFLG_StgoFal)) {
-			if (pjob->ji_grpcache != NULL)
-				rmjobdir(pjob->ji_qs.ji_jobid,
-					jobdirname(pjob->ji_qs.ji_jobid, pjob->ji_grpcache->gc_homedir),
-					pjob->ji_grpcache->gc_uid,
-					pjob->ji_grpcache->gc_gid);
-			else
-				rmjobdir(pjob->ji_qs.ji_jobid,
-					jobdirname(pjob->ji_qs.ji_jobid, NULL),
-					0,
-					0);
-		}
-	}
-
-	if (path_checkpoint != NULL) {	/* delete checkpoint files */
-		(void)strcpy(namebuf, path_checkpoint);
-		if (*pjob->ji_qs.ji_fileprefix != '\0')
-			(void)strcat(namebuf, pjob->ji_qs.ji_fileprefix);
-		else
-			(void)strcat(namebuf, pjob->ji_qs.ji_jobid);
-		(void)strcat(namebuf, JOB_CKPT_SUFFIX);
-		(void)remtree(namebuf);
-		(void)strcat(namebuf, ".old");
-		(void)remtree(namebuf);
-	}
+	del_chkpt_files(pjob);
 
 	jrpattr = &pjob->ji_wattr[(int) JOB_ATR_remove];
 	/* remove stdout/err files if remove_files is set. */
@@ -958,18 +1013,8 @@ job_purge(job *pjob)
 #endif	/* PBS_MOM */
 
 #ifdef PBS_MOM
-	(void)strcpy(namebuf, path_jobs);	/* delete job file */
-	if (*pjob->ji_qs.ji_fileprefix != '\0')
-		(void)strcat(namebuf, pjob->ji_qs.ji_fileprefix);
-	else
-		(void)strcat(namebuf, pjob->ji_qs.ji_jobid);
-	(void)strcat(namebuf, JOB_FILE_SUFFIX);
-	if (unlink(namebuf) < 0) {
-		if (errno != ENOENT) {
-			log_joberr(errno, __func__, msg_err_purgejob,
-				pjob->ji_qs.ji_jobid);
-		}
-	}
+	/* delete job file */
+	del_job_related_file(pjob, JOB_FILE_SUFFIX);
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 	delete_cred(pjob->ji_qs.ji_jobid);
@@ -1015,18 +1060,7 @@ job_purge(job *pjob)
 	}
 #endif
 
-	(void)strcpy(namebuf, path_jobs);	/* delete cred file */
-	if (*pjob->ji_qs.ji_fileprefix != '\0')
-		(void)strcat(namebuf, pjob->ji_qs.ji_fileprefix);
-	else
-		(void)strcat(namebuf, pjob->ji_qs.ji_jobid);
-	(void)strcat(namebuf, JOB_CRED_SUFFIX);
-	if (unlink(namebuf) < 0) {
-		if (errno != ENOENT) {
-			log_joberr(errno, __func__, msg_err_purgejob,
-				pjob->ji_qs.ji_jobid);
-		}
-	}
+	del_job_related_file(pjob, JOB_CRED_SUFFIX);
 
 	/* Clearing purge job info from svr_newjobs list */
 	if (pjob == (job *) GET_NEXT(svr_newjobs))

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -824,9 +824,9 @@ del_chkpt_files(job *pjob)
 void
 job_purge(job *pjob)
 {
-	char		namebuf[MAXPATHLEN + 1] = {'\0'};
 	extern	char	*msg_err_purgejob;
 #ifdef	PBS_MOM
+	char namebuf[MAXPATHLEN + 1] = {'\0'};
 	int keeping = 0;
 	attribute *jrpattr = NULL;
 

--- a/test/tests/functional/pbs_mom_mock_run.py
+++ b/test/tests/functional/pbs_mom_mock_run.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestMomMockRun(TestFunctional):
+    def test_rsc_used(self):
+        """
+        Test that resources_used are set correctly by mom under mock run
+        """
+        # Kill the existing mom process
+        self.mom.stop()
+
+        # Start mom in mock run mode
+        mompath = os.path.join(self.server.pbs_conf["PBS_EXEC"], "sbin",
+                               "pbs_mom")
+        cmd = [mompath, "-m"]
+        self.du.run_cmd(cmd=cmd, sudo=True)
+
+        # Submit a job requesting ncpus, mem and walltime
+        attr = {ATTR_l + ".select": "1:ncpus=1:mem=5mb",
+                ATTR_l + ".walltime": "00:00:05"}
+        j = Job(attrs=attr)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        # This job should end in 5 seconds, let's sleep
+        time.sleep(7)
+
+        # Check accounting record for this job
+        used_ncpus = "resources_used.ncpus=1"
+        self.server.accounting_match(msg=used_ncpus, id=jid)
+        used_mem = "resources_used.mem=5mb"
+        self.server.accounting_match(msg=used_mem, id=jid)
+        used_walltime = "resources_used.walltime=00:00:05"
+        self.server.accounting_match(msg=used_walltime, id=jid)

--- a/win_configure/projects/include.vcxproj
+++ b/win_configure/projects/include.vcxproj
@@ -128,6 +128,7 @@
     <ClInclude Include="..\..\src\include\win.h" />
     <ClInclude Include="..\..\src\include\win_remote_shell.h" />
     <ClInclude Include="..\..\src\include\work_task.h" />
+    <ClInclude Include="..\..\src\resmom\mock_run.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\include\include.dsp" />

--- a/win_configure/projects/pbs_mom.vcxproj
+++ b/win_configure/projects/pbs_mom.vcxproj
@@ -202,6 +202,11 @@
       <BasicRuntimeChecks Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">EnableFastChecks</BasicRuntimeChecks>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
     </ClCompile>
+    <ClCompile Include="..\..\src\resmom\mock_run.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Disabled</Optimization>
+      <BasicRuntimeChecks Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">EnableFastChecks</BasicRuntimeChecks>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+    </ClCompile>
     <ClCompile Include="..\..\src\resmom_win\start_exec.c">
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Disabled</Optimization>
       <BasicRuntimeChecks Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">EnableFastChecks</BasicRuntimeChecks>


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Often while testing, especially for performance profiling, devs have the need to run thousands of jobs to tax scheduler and server enough to find bottlenecks. In such scenarios, pbs_mom becomes a bottleneck instead when the testing is being done on a single machine, not an actual cluster. Major reasons why this happens:

- pbs_mom forks off a separate process for each job that it runs. If we create a system with 10k vnodes, which are able to run 100k jobs at once, imagine pbs_mom(s) forking off 100k processes for these jobs at the same time. This overloads the system.

- pbs_mom also walks through the entire proc table on the system on a regular basis. This again compounds the problem in bullet 1 as there are hundreds of thousands of processes.

- pbs_mom also sets a high nice value for its process, which means that the kernel gives it preference over other processes like the scheduler or server which are running on the same machine.

So, for testing/performance profiling scheduler or server, it would be immensely useful to add an option to pbs_mom which makes it lightweight and not burden the system, while still maintaining similar server communication so that server and sched don’t see any difference and work the same way that they would in a real cluster.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added a new option to pbs_mom "-m" which will make it execute in mock run mode. For more details, please refer to the design document. This PR doesn't implement the change that's needed to update cput and cpupercent to something more accurate than 0, this can be taken up in a later enhancement.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1555726337/Add+a+mock+run+option+to+pbs+mom+for+testing

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_mock_rsc_used.log](https://github.com/PBSPro/pbspro/files/4338664/test_mock_rsc_used.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
