### PR TITLE
Fix build error on RHEL 8

### DIFF
--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1989,7 +1989,6 @@ convert_job_to_resv(job *pjob)
 	pbs_list_head *plhed;
 	struct work_task *pwt;
 	struct batch_request *newreq;
-	char owner[PBS_MAXUSER + 1];
 
 	newreq = alloc_br(PBS_BATCH_SubmitResv);
 	if (newreq == NULL) {
@@ -1999,8 +1998,7 @@ convert_job_to_resv(job *pjob)
 	}
 	newreq->rq_type = PBS_BATCH_SubmitResv;
 
-	get_jobowner(pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str, owner);
-	strncpy(newreq->rq_user, owner, PBS_MAXUSER);
+	get_jobowner(pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str, newreq->rq_user);
 
 	strncpy(newreq->rq_host, pjob->ji_wattr[JOB_ATR_submit_host].at_val.at_str, PBS_MAXHOSTNAME);
 	newreq->rq_perm = READ_WRITE | ATR_DFLAG_ALTRUN;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
With PR #1145 merged, there was a build issue on RHEL 8.
pbspro/src/server/req_runjob.c:2003:2: error: \xe2\x80\x98strncpy\xe2\x80\x99 output may be truncated copying 256 bytes from a string of length 256 [-Werror=stringop-truncation]

  **strncpy(newreq->rq_user, owner, PBS_MAXUSER)**;

  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

cc1: all warnings being treated as errors

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Removed the strncpy, copying the username directly to preq->rq_user through get_jobowner().

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl.txt](https://github.com/PBSPro/pbspro/files/4291755/ptl.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
