### PR TITLE
Modified get_log_files to consider the borderline timestamps

### DIFF
--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -542,11 +542,11 @@ class PBSLogUtils(object):
                     d1 = time.strftime("%Y%m%d", time.localtime(tm[0]))
                     if start is not None:
                         d2 = time.strftime("%Y%m%d", time.localtime(start))
-                        if d1 < d2:
+                        if d1 <= d2:
                             continue
                     if end is not None:
                         d2 = time.strftime("%Y%m%d", time.localtime(end))
-                        if d1 > d2:
+                        if d1 >= d2:
                             continue
                 paths.append(f)
         elif self.du.isfile(hostname, path, sudo=sudo):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Tests checking for political order were intermittently failing as scheduler analyze does not consider the end time passed in the test case.


#### Describe Your Change
Modified get_log_files to consider the borderline timestamps to parse the logs for analysis.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[Buggy_log.txt](https://github.com/PBSPro/pbspro/files/4292736/Buggy_log.txt)
[fixed_logs.txt](https://github.com/PBSPro/pbspro/files/4292737/fixed_logs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
