### PR TITLE
ralter resv runs across placement sets

### DIFF
--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1536,18 +1536,6 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 			return NULL;
 	}
 
-	/* For a reservation alter, if the reservation has not started running
-	 * note that alternate nodes (that do not belong to the reservation)
-	 * should also be looked at if the alter cannot be confirmed on the
-	 * nodes belonging to the reservation.
-	 */
-	if (resresv->is_resv && resresv->resv &&
-		resresv->resv->resv_state == RESV_BEING_ALTERED &&
-		resresv->resv->resv_substate == RESV_CONFIRMED) {
-
-		resresv->resv->check_alternate_nodes = 1;
-	}
-
 	/* Sets of nodes:
 	   * 1. job is in a reservation - use reservation nodes
 	   * 2. job or reservation has nodes -- use them
@@ -1565,10 +1553,7 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 		ninfo_arr = resresv->job->resv->resv->resv_nodes;
 		nodepart = NULL;
 	}
-	else if (resresv->is_resv && resresv->resv && resresv->resv->check_alternate_nodes) {
-		ninfo_arr = sinfo->unassoc_nodes;
-		nodepart = NULL;
-	}
+
 	/* if we have nodes, use them
 	 * don't care about node grouping because nodes are already assigned
 	 * to the job.  We won't need to search for them.
@@ -1997,8 +1982,7 @@ void get_resresv_spec(resource_resv *resresv, selspec **spec, place **pl)
 			*spec = resresv->select;
 		}
 	} else if (resresv->is_resv && resresv->resv != NULL) {
-		if ((resresv->resv->resv_state == RESV_BEING_ALTERED || resresv->resv->resv_state == RESV_RUNNING) && 
-				!resresv->resv->check_alternate_nodes)
+		if (resresv->resv->resv_state == RESV_BEING_ALTERED || resresv->resv->resv_state == RESV_RUNNING)
 			*spec = resresv->execselect;
 		else
 			*spec = resresv->select;

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -726,10 +726,6 @@ struct node_info
 struct resv_info
 {
 	unsigned 	 is_standing:1;			/* set to 1 for a standing reservation */
-	unsigned 	 check_alternate_nodes:1;	/* set to 1 while altering a reservation if
-							 * the request can be confirmed on nodes other
-							 * than the ones currently assigned to it.
-							 */
 	char		 *queuename;			/* the name of the queue */
 	char		 *rrule;			/* recurrence rule for standing reservations */
 	char		 *execvnodes_seq;		/* sequence of execvnodes for standing resvs */

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -2793,8 +2793,7 @@ eval_placement(status *policy, selspec *spec, node_info **ninfo_arr, place *pl,
 	 *         a ptr to a reordered static array
 	 */
 	if ((pl->pack && spec->total_chunks == 1) ||
-		(conf.provision_policy == AVOID_PROVISION && resresv->aoename != NULL) ||
-		(resresv->is_resv && resresv->resv != NULL && resresv->resv->check_alternate_nodes))
+		(conf.provision_policy == AVOID_PROVISION && resresv->aoename != NULL))
 		nptr = reorder_nodes(ninfo_arr, resresv);
 
 	if (nptr == NULL)
@@ -4244,8 +4243,7 @@ check_resources_for_node(resource_req *resreq, node_info *ninfo,
 
 					if (is_excl(resc_resv->place_spec, ninfo->sharing) || resresv_excl) {
 						min_chunks = 0;
-					}
-					else {
+					} else {
 						cur_res = nres;
 						while (cur_res != NULL) {
 							if (cur_res->type.is_consumable) {
@@ -5093,21 +5091,6 @@ reorder_nodes(node_info **nodes, resource_resv *resresv)
 		snprintf(last_node_name, sizeof(last_node_name), "%s", nodes[0]->name);
 
 	if (resresv != NULL) {
-		if (resresv->is_resv && resresv->resv != NULL && resresv->resv->check_alternate_nodes) {
-			int		i = 0;
-			node_info	*temp = NULL;
-
-			memcpy(nptr, nodes, (nsize + 1) * sizeof(node_info *));
-			for (i = 0; nptr[i] != NULL; i++) {
-				temp = find_node_by_rank(resresv->ninfo_arr, nptr[i]->rank);
-				if (temp != NULL)
-					nptr[i]->nscr.to_be_sorted = 0;
-				else
-					nptr[i]->nscr.to_be_sorted = 1;
-			}
-			qsort(nptr, i, sizeof(node_info*), cmp_nodes_sort);
-			return nptr;
-		}
 		if (resresv->aoename != NULL && conf.provision_policy == AVOID_PROVISION) {
 			memcpy(nptr, nodes, (nsize+1) * sizeof(node_info *));
 

--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -881,9 +881,6 @@ create_events(server_info *sinfo)
 	qsort(all, count_array((void **)all), sizeof(resource_resv *), cmp_events);
 
 	for (i = 0; all[i] != NULL && is_timed(all[i]); i++) {
-		if (all[i]->is_resv && all[i]->resv != NULL &&
-			all[i]->resv->resv_state == RESV_BEING_ALTERED)
-			continue;
 		/* only add a run event for a job or reservation if they're
 		 * in a runnable state (i.e. don't add it if they're running)
 		 */
@@ -910,7 +907,7 @@ create_events(server_info *sinfo)
 
 	/* for nodes that are in state=sleep add a timed event */
 	for (i = 0; sinfo->nodes[i] != NULL; i++) {
-	        node_info *node = sinfo->nodes[i];
+		node_info *node = sinfo->nodes[i];
 		if (node->is_sleeping) {
 			te = create_event(TIMED_NODE_UP_EVENT, sinfo->server_time + PROVISION_DURATION,
 					(event_ptr_t *) node, (event_func_t) node_up_event, NULL);

--- a/src/scheduler/sort.c
+++ b/src/scheduler/sort.c
@@ -1209,33 +1209,6 @@ cmp_starving_jobs(const void *j1, const void *j2)
 
 /**
  * @brief
- * cmp_nodes_sort	- compare nodes based on to_be_sorted's
- * 			  value in the node scratch area.
- *
- * @param[in] n1	- node to compare.
- * @param[in] n2	- node to compare.
- *
- * @return - int
- * @retval  1: If n2's to_be_sorted is set and n1's is not.
- *          0: If both the nodes have to_be_sorted equal.
- *         -1: If n1's to_be_sorted is set and n2's is not.
- */
-int
-cmp_nodes_sort(const void *n1, const void *n2)
-{
-	int n1_sort = (*(node_info **)n1)->nscr.to_be_sorted;
-	int n2_sort = (*(node_info **)n2)->nscr.to_be_sorted;
-
-	if (n1_sort && !n2_sort)
-		return 1;
-	if (!n1_sort && n2_sort)
-		return -1;
-	else
-		return 0;
-}
-
-/**
- * @brief
  * cmp_resv_state	- compare reservation state with RESV_BEING_ALTERED.
  *
  * @param[in] r1	- reservation to compare.

--- a/src/scheduler/sort.h
+++ b/src/scheduler/sort.h
@@ -189,11 +189,6 @@ int cmp_preemption(resource_resv *r1, resource_resv *r2);
 int cmp_starving_jobs(const void *j1, const void *j2);
 
 /*
- * cmp_nodes_sort - compare based on to_be_sorted in node scratch area.
- */
-int cmp_nodes_sort(const void *n1, const void *n2);
-
-/*
  * cmp_resv_state - compare based on resv_state
  */
 int cmp_resv_state(const void *r1, const void *r2);

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -541,6 +541,7 @@ req_confirmresv(struct batch_request *preq)
 	char *tmp_buf = NULL;
 	size_t tmp_buf_size = 0;
 	char buf[PBS_MAXQRESVNAME+PBS_MAXHOSTNAME + 256] = {0}; /* FQDN resvID+text */
+	char *partition_name = NULL;
 
 	if ((preq->rq_perm & (ATR_DFLAG_MGWR | ATR_DFLAG_OPWR)) == 0) {
 		req_reject(PBSE_PERM, 0, preq);

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -540,8 +540,7 @@ req_confirmresv(struct batch_request *preq)
 	int is_being_altered = 0;
 	char *tmp_buf = NULL;
 	size_t tmp_buf_size = 0;
-	char buf[PBS_MAXQRESVNAME+PBS_MAXHOSTNAME+256] = {0}; /* FQDN resvID+text */
-	char *partition_name = NULL;
+	char buf[PBS_MAXQRESVNAME+PBS_MAXHOSTNAME + 256] = {0}; /* FQDN resvID+text */
 
 	if ((preq->rq_perm & (ATR_DFLAG_MGWR | ATR_DFLAG_OPWR)) == 0) {
 		req_reject(PBSE_PERM, 0, preq);

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1427,3 +1427,91 @@ class TestPbsResvAlter(TestFunctional):
 
         self.server.expect(RESV, attr, op=UNSET, id=rid, max_attempts=5)
         self.server.expect(QUEUE, attr2, op=UNSET, id=qid, max_attempts=5)
+
+    @skipOnCpuSet
+    def test_ralter_psets(self):
+        """
+        Test that PBS will not place a job across placement sets after
+        successfully being altered
+        """
+        duration = 120
+        offset1 = 30
+        offset2 = 180
+
+        a = {'type': 'string', 'flag': 'h'}
+        self.server.manager(MGR_CMD_CREATE, RSC, a, id='color')
+
+        a = {'resources_available.ncpus': 4, 'resources_available.mem': '4gb'}
+        self.server.create_vnodes('vn', a, 3, self.mom)
+
+        a = {'resources_available.color': 'red'}
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vn[0]')
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vn[1]')
+        a = {'resources_available.color': 'green'}
+        self.server.manager(MGR_CMD_SET, NODE, a, id='vn[2]')
+
+        a = {'node_group_key': 'color', 'node_group_enable': True}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        rid1, start1, end1 = self.submit_and_confirm_reservation(
+            offset1, duration, select="2:ncpus=4")
+
+        self.server.status(RESV)
+        nodes = self.server.reservations[rid1].get_vnodes()
+
+        rid2, start2, end2 = self.submit_and_confirm_reservation(
+            offset2, duration, select="1:ncpus=4:vnode=" + nodes[0])
+
+        c = 'resources_available.color'
+        color1 = self.server.status(NODE, c, id=nodes[0])[0][c]
+        color2 = self.server.status(NODE, c, id=nodes[1])[0][c]
+        self.assertEqual(color1, color2)
+
+        self.alter_a_reservation(rid1, start1, end1, shift=300,
+                                 alter_e=True, whichMessage=3)
+
+        t = start1 - int(time.time())
+        self.logger.info('Sleeping until reservation starts')
+        self.server.expect(RESV, {'reserve_state': (MATCH_RE, 'RESV_RUNNING')},
+                           id=rid1, offset=t)
+
+        # sequence=2 because we'll get one message from the last alter attempt
+        # and one message from this alter attempt
+        self.alter_a_reservation(rid1, start1, end1, shift=300,
+                                 alter_e=True, sequence=2, whichMessage=3)
+
+    @skipOnCpuSet
+    def test_failed_ralter(self):
+        """
+        Test that a failed ralter does not allow jobs to interfere with
+        that reservation.
+        """
+        self.skipTest('Skipped due to ralter reservation/job overlap bug')
+        duration = 120
+        offset1 = 30
+        offset2 = 180
+
+        rid1, start1, end1 = self.submit_and_confirm_reservation(
+            offset1, duration, select="2:ncpus=4")
+
+        j = Job(attrs={'Resource_List.walltime': 100})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'Q',
+                                 'comment': (MATCH_RE, 'Not Running')}, id=jid)
+
+        rid2, start2, end2 = self.submit_and_confirm_reservation(
+            offset2, duration, select="2:ncpus=4")
+
+        self.alter_a_reservation(rid1, start1, end1, shift=300,
+                                 alter_e=True, whichMessage=3)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+
+        self.logger.info('Sleeping until reservation starts')
+        t = start1 - int(time.time())
+        self.server.expect(RESV, {'reserve_state':
+                                  (MATCH_RE, 'RESV_RUNNING|5')},
+                           offset=t, id=rid1)
+
+        self.alter_a_reservation(rid1, start1, end1, shift=300,
+                                 alter_e=True, whichMessage=3)
+        self.server.expect(JOB, {'job_state': 'Q'}, id=jid)

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1472,7 +1472,8 @@ class TestPbsResvAlter(TestFunctional):
 
         t = start1 - int(time.time())
         self.logger.info('Sleeping until reservation starts')
-        self.server.expect(RESV, {'reserve_state': (MATCH_RE, 'RESV_RUNNING')},
+        self.server.expect(RESV,
+                           {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')},
                            id=rid1, offset=t)
 
         # sequence=2 because we'll get one message from the last alter attempt


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a reservation is submitted it will  only run within a placement set.  This is not true for when it is altered.  It can run in multiple placement sets.

This was due to how the reservation ralter code worked.  It attempted to keep as many of the original nodes on the reservation as possible.  To this end, it ignored placement sets.

#### Describe Your Change
I made reconfirming an alter request much closer to how reconfirming a degraded reservation works.  Instead of going out of our way to keep as many of the original nodes as possible, we will reconfirm on any nodes matching our select spec (when the reservation is confirmed).

The fix was to remove the code which tried to keep all the same nodes it could and then tell the node searching code to use the placement sets (which previously it didn't).   Trying to keep the code where we attempt to keep as many nodes as possible is messy.  The first problem is we'll confirm in the first placement that the reservation fits.  This might be on completely different nodes.  The next problem is if we have overlapping placement sets.  We'll keep some nodes but replace others even if the ones we replaced are free.  Since the reservation isn't running yet, any node matching the select spec is as good as any other.  There is no reason to for the added complexity to attempt to keep the same ones.

Since a running reservation is required to stay on the same nodes, this issue didn't exist for them.

I encountered a different bug when fixing this where a job could overlap with a reservation when an ralter fails.   I filed the ticket.  I wrote a test for it and skipped it.  The test can be unskipped when the issue is fixed.

#### Attach Test and Valgrind Logs/Output
[ralter_before.log](https://github.com/PBSPro/pbspro/files/4295604/ralter_before.log)
[ralter_after.log](https://github.com/PBSPro/pbspro/files/4295616/ralter_after.log)

I ran a valgrind run on TH3 and found nothing of note.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
