### PR TITLE
Round of the microsecond value of the time parsed from logs

### DIFF
--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -1293,6 +1293,7 @@ class PBSSchedulerLog(PBSLogAnalyzer):
         m = self.tm_tag.match(rec)
         if m:
             tm = self.logutils.convert_date_time(m.group('datetime'))
+            tm = round(tm, 0)
             self.record_tm.append(tm)
             if self.logutils.in_range(tm, start, end):
                 rv = self._parse_line(rec)


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Time passed to in_range function to return log lines was in microseconds because of that condition tm<=endtime (ex: 55.234 <= 55)  would fail and was not returning the log lines.


#### Describe Your Change
Rounded of the time parsed to 0th decimal. So that would match the end time to return the log lines,


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[buggy_output_sched_logs.txt](https://github.com/PBSPro/pbspro/files/4296331/buggy_output_sched_logs.txt)
[buggy_output.txt](https://github.com/PBSPro/pbspro/files/4296332/buggy_output.txt)
[fixed_output_sched_logs.txt](https://github.com/PBSPro/pbspro/files/4296333/fixed_output_sched_logs.txt)
[fixed_output.txt](https://github.com/PBSPro/pbspro/files/4296334/fixed_output.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
