### PR TITLE
set ncpus for user reliability tests

### DIFF
--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -41,6 +41,11 @@ import re
 
 class Test_user_reliability(TestFunctional):
 
+    def setUp(self):
+        TestFunctional.setUp(self)
+        a = {'resources_available.ncpus': 4}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
     """
     This test suite is for testing the user reliability workflow feature.
     """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
My assumption in PR #1145 that the machine will have at least 4 ncpus is incorrect, so the tests will fail on machines with less than 3 ncpus as the job demands for that many ncpus, and would not start running.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added setUp() to set ncpus.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl_before.txt](https://github.com/PBSPro/pbspro/files/4298729/ptl_before.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
