### PR TITLE
dup_timed_event() wasn't duping the disabled bit

### DIFF
--- a/src/scheduler/simulate.c
+++ b/src/scheduler/simulate.c
@@ -1099,6 +1099,7 @@ dup_timed_event(timed_event *ote, server_info *nsinfo)
 		return NULL;
 
 	nte = create_event(ote->event_type, ote->event_time, event_ptr, ote->event_func, ote->event_func_arg);
+	set_timed_event_disabled(nte, ote->disabled);
 
 	return nte;
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The function dup_timed_event() wasn't copying over the disabled bit.  This means when the universe was dup'd, the disabled events would be performed.  This could cause top jobs to be scheduled too soon.  This really only affected preemption with sched_preempt_enforce_resumption on.  This was the only place timed events would be marked disabled and then the universe was dup'd.  It would only affect the cycle jobs are preempted.  Future cycles would be fine.

#### Describe Your Change
In dup_timed_event(), copy over the disabled bit.

#### Attach Test and Valgrind Logs/Output
There really isn't any bang for our buck for writing a test.  It only affects a small corner case, and the outcome wasn't that bad.