### PR TITLE
"PTL test_preempt_checkpoint_requeue uses the wrong checkpoint script

### DIFF
--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -190,7 +190,7 @@ exit 1
         """
         Test that when checkpoint fails, a job is correctly requeued
         """
-        self.mom.add_checkpoint_abort_script(body=self.chk_script)
+        self.mom.add_checkpoint_abort_script(body=self.chk_script_fail)
         self.submit_and_preempt_jobs(preempt_order='CR')
 
     @skipOnCpuSet


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
"PTL test_preempt_checkpoint_requeue expects checkpoint should fail and job preempt due to requeue. But job is preempted by checkpoint . So to match the test definition, test should use checkpoint fail script. 


#### Describe Your Change
uses checkpoint fail script so that checkpoint fails and job preempts by requeue.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[checkpoint_requeue.txt](https://github.com/PBSPro/pbspro/files/4305022/checkpoint_requeue.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
