### PR TITLE
test_attribute_case.TestExpect failed while verifying queue attribute

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1780,7 +1780,7 @@ class BatchUtils(object):
                 m = self.pbsobjattrval_re.match(l)
                 if m:
                     attr = m.group('attribute')
-                    if (attribs is None or str(attr).lower() in attribs
+                    if (attribs is None or attr.lower() in attribs
                             or attr in attribs):
                         if attr in d:
                             d[attr] = d[attr] + "," + m.group('value')

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -1780,7 +1780,8 @@ class BatchUtils(object):
                 m = self.pbsobjattrval_re.match(l)
                 if m:
                     attr = m.group('attribute')
-                    if attribs is None or attr in attribs:
+                    if (attribs is None or str(attr).lower() in attribs
+                            or attr in attribs):
                         if attr in d:
                             d[attr] = d[attr] + "," + m.group('value')
                         else:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Test failed in verifying queue attribute. In test 'expressq' created with priority 150. after creating test try to verify queue attribute, but test cannot get expected output and test got failed. 

Server.except can work with lower cased attribute but Server.status and/or BatchUtils.convert_to_dictlist doesn't understand lower cased attribute name so when Server.expect is called with lower cased attribute name, which internally passed to Server.status->BatchUtils.convert_to_dictlist, but BatchUtils.convert_to_dictlist doesn't incude that attribute from PBS command's response to returned dict.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Function  convert_to_dictlist checks for both lower case and regular attribute while comparing and includes in the same in the dictlist returned.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[test_attribute_case.TestExpect.txt](https://github.com/PBSPro/pbspro/files/4305758/test_attribute_case.TestExpect.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
