### PR TITLE
realpath() usage fix when used with -D_FORTIFY_SOURCE

### DIFF
--- a/src/lib/Liblog/chk_file_sec.c
+++ b/src/lib/Liblog/chk_file_sec.c
@@ -41,10 +41,10 @@
  */
 #include <errno.h>
 #include <stdio.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <limits.h>
 #include <assert.h>
 #include <sys/param.h>
 #include <sys/types.h>

--- a/src/resmom/stage_func.c
+++ b/src/resmom/stage_func.c
@@ -43,6 +43,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -167,8 +168,14 @@ is_child_path(char *dir, char *path)
 		snprintf(fullpath, sizeof(fullpath), "%s", path);
 	}
 
+#ifdef WIN32
 	dir_real = malloc(sizeof(char) * (MAXPATHLEN + 1));
 	fullpath_real = malloc(sizeof(char) * (2 * MAXPATHLEN + 2));
+#else
+	dir_real = realpath(dir, NULL);
+	fullpath_real = realpath(fullpath, NULL);
+#endif
+
 	if (dir_real == NULL || fullpath_real == NULL) {
 		return_value = -1;
 		goto error_exit;
@@ -181,11 +188,7 @@ is_child_path(char *dir, char *path)
 	forward2back_slash(fullpath);
 	strncpy(dir_real, lpath2short(dir), MAXPATHLEN);
 	strncpy(fullpath_real, lpath2short(fullpath), 2 * MAXPATHLEN + 1);
-#else
-	realpath(dir, dir_real);
-	realpath(fullpath, fullpath_real);
 #endif
-
 	/* check that fullpath_real begins with dir_real */
 	if (strlen(dir_real) && strlen(fullpath_real)) {
 		pos = strstr(fullpath_real, dir_real);

--- a/src/tools/pbs_probe.c
+++ b/src/tools/pbs_probe.c
@@ -83,10 +83,10 @@
 #include <sys/utsname.h>
 #include <fcntl.h>
 #include <pwd.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <errno.h>
-#include <limits.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>


### PR DESCRIPTION
#### Describe Bug or Feature
The invocation of realpath at certain places is not with NULL real pointer. While compiling the source with -D_FORTIFY_SOURCE, the realpath() invocation fails, because the resolved length MAXPATHLEN is less than PATH_MAX. 

#### Describe Your Change
1. Fixing the realpath usage by passing NULL real pointer
2. Fixing the order of header files. 

#### Attach Test and Valgrind Logs/Output
[valgrind_logs_after_fix.txt](https://github.com/PBSPro/pbspro/files/4305831/valgrind_logs.txt)
[before_fix.txt](https://github.com/PBSPro/pbspro/files/4305833/before_fix.txt)
[after_fix.txt](https://github.com/PBSPro/pbspro/files/4306521/after_fix.txt)


<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
