### PR TITLE
Hup mom to run exechost_startup hook

### DIFF
--- a/test/tests/functional/pbs_resc_custom_perm.py
+++ b/test/tests/functional/pbs_resc_custom_perm.py
@@ -82,8 +82,8 @@ e.vnode_list[localnode].resources_available['foo_strh'] = "str_hook"
             startup_hook_body,
             overwrite=True)
 
-        # Restart the MoM so that exechost_startup hook can run.
-        self.momA.restart()
+        # HUP the MoM so that exechost_startup hook can run.
+        self.momA.signal("-HUP")
 
         # Give the moms a chance to receive the updated resource.
         # Ensure the new resource is seen by all moms.


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
custom resource is not set by the execjob_startup hook


#### Describe Your Change
HUP the mom to run execjob_startup hook


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[custom_res.txt](https://github.com/PBSPro/pbspro/files/4306951/custom_res.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
