### PR TITLE
Use snprintf to fix RHEL8 compiler error

### DIFF
--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3531,7 +3531,7 @@ void reply_hook_bg(job *pjob)
 				 * been deleted already.
 				 */
 				if ((pjob2 = job_alloc()) != NULL) {
-					(void)strncpy(pjob2->ji_qs.ji_jobid, jobid, PBS_MAXSVRJOBID);
+					(void)snprintf(pjob2->ji_qs.ji_jobid, PBS_MAXSVRJOBID, jobid);
 					pjob2->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long =
 							runver;
 					pjob2->ji_wattr[(int)JOB_ATR_run_version].at_flags |= ATR_VFLAG_SET;

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3531,7 +3531,7 @@ void reply_hook_bg(job *pjob)
 				 * been deleted already.
 				 */
 				if ((pjob2 = job_alloc()) != NULL) {
-					(void)snprintf(pjob2->ji_qs.ji_jobid, PBS_MAXSVRJOBID, jobid);
+					(void)snprintf(pjob2->ji_qs.ji_jobid, PBS_MAXSVRJOBID, "%s", jobid);
 					pjob2->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long =
 							runver;
 					pjob2->ji_wattr[(int)JOB_ATR_run_version].at_flags |= ATR_VFLAG_SET;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Compiling on RHEL8 gave this error:
+ make
/home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/mom_hook_func.c: In function ‘reply_hook_bg’:
/home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/mom_hook_func.c:3534:12: error: ‘strncpy’ output may be truncated copying 273 bytes from a string of length 273 [-Werror=stringop-truncation]
(void)strncpy(pjob2->ji_qs.ji_jobid, jobid, PBS_MAXSVRJOBID);
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:998: pbs_mom-mom_hook_func.o] Error 1
make[1]: *** [Makefile:510: all-recursive] Error 1
make: *** [Makefile:546: all-recursive] Error 1
+ echo 'Build failed!'
+ exit 1



#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I used snprintf instead of strncpy.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
N/A

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
