### PR TITLE
Buffer overflow corrupts heap in MoM child responsible for file staging

### DIFF
--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -3403,10 +3403,11 @@ req_cpyfile(struct batch_request *preq)
 				if ((pbs_asprintf(&temp_buff, "%s\n", token)) != -1) {
 					log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 						dup_rqcpf_jobid, temp_buff);
-					token = strtok_r(NULL, "\n", &save_ptr);
 					free(temp_buff);
 					temp_buff = NULL;
-				}
+				} else
+					break;
+				token = strtok_r(NULL, "\n", &save_ptr);
 			}
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 					dup_rqcpf_jobid, "---->>>>");
@@ -3572,10 +3573,11 @@ struct batch_request *preq;
 				if ((pbs_asprintf(&temp_buff, "%s\n", token)) != -1) {
 					log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 						preq->rq_ind.rq_cpyfile.rq_jobid, temp_buff);
-					token = strtok_r(NULL, "\n", &save_ptr);
 					free(temp_buff);
 					temp_buff = NULL;
-				}	
+				} else
+					break;
+				token = strtok_r(NULL, "\n", &save_ptr);
 			}
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 				preq->rq_ind.rq_cpyfile.rq_jobid, "---->>>>");	

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -3392,9 +3392,24 @@ req_cpyfile(struct batch_request *preq)
 		}
 	} else {
 		if (stage_inout.bad_files) {
-			sprintf(log_buffer, "Job files not copied: %s", stage_inout.bad_list);
+			char* token; 
+			char* rest = stage_inout.bad_list; 
+			char* save_ptr;
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
-					dup_rqcpf_jobid, log_buffer);
+				dup_rqcpf_jobid, "Job files not copied:---->>>>");
+			token = strtok_r(rest, "\n", &save_ptr);
+			while (token != NULL) {
+				char *temp_buff;
+				if ((pbs_asprintf(&temp_buff, "%s\n", token)) != -1) {
+					log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
+						dup_rqcpf_jobid, temp_buff);
+					token = strtok_r(NULL, "\n", &save_ptr);
+				}
+				free(temp_buff);
+				temp_buff = NULL;
+			}
+			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
+					dup_rqcpf_jobid, "---->>>>");
 		}
 	}
 
@@ -3546,9 +3561,24 @@ struct batch_request *preq;
 		if (!preq->isrpp) {
 			reply_text(preq, rc, bad_list);
 		} else {
-			sprintf(log_buffer, "Job files not deleted: %s", bad_list);
+			char* token;
+			char* save_ptr;
+			char* rest = bad_list;
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
-				preq->rq_ind.rq_cpyfile.rq_jobid, log_buffer);
+				preq->rq_ind.rq_cpyfile.rq_jobid, "Job files not deleted:---->>>>");
+			token = strtok_r(rest, "\n", &save_ptr);
+			while (token != NULL) {
+				char* temp_buff;
+				if ((pbs_asprintf(&temp_buff, "%s\n", token)) != -1) {
+					log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
+						preq->rq_ind.rq_cpyfile.rq_jobid, temp_buff);
+					token = strtok_r(NULL, "\n", &save_ptr);
+				}
+				free(temp_buff);
+				temp_buff = NULL;
+			}
+			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
+				preq->rq_ind.rq_cpyfile.rq_jobid, "---->>>>");	
 		}
 	} else {
 		if (!preq->isrpp)

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -3392,21 +3392,21 @@ req_cpyfile(struct batch_request *preq)
 		}
 	} else {
 		if (stage_inout.bad_files) {
-			char* token; 
-			char* rest = stage_inout.bad_list; 
-			char* save_ptr;
+			char *token = NULL; 
+			char *rest = stage_inout.bad_list; 
+			char *save_ptr = NULL;
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 				dup_rqcpf_jobid, "Job files not copied:---->>>>");
 			token = strtok_r(rest, "\n", &save_ptr);
 			while (token != NULL) {
-				char *temp_buff;
+				char *temp_buff = NULL;
 				if ((pbs_asprintf(&temp_buff, "%s\n", token)) != -1) {
 					log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 						dup_rqcpf_jobid, temp_buff);
 					token = strtok_r(NULL, "\n", &save_ptr);
+					free(temp_buff);
+					temp_buff = NULL;
 				}
-				free(temp_buff);
-				temp_buff = NULL;
 			}
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 					dup_rqcpf_jobid, "---->>>>");
@@ -3561,21 +3561,21 @@ struct batch_request *preq;
 		if (!preq->isrpp) {
 			reply_text(preq, rc, bad_list);
 		} else {
-			char* token;
-			char* save_ptr;
-			char* rest = bad_list;
+			char *token = NULL;
+			char *rest = bad_list;
+			char *save_ptr = NULL;
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 				preq->rq_ind.rq_cpyfile.rq_jobid, "Job files not deleted:---->>>>");
 			token = strtok_r(rest, "\n", &save_ptr);
 			while (token != NULL) {
-				char* temp_buff;
+				char *temp_buff = NULL;
 				if ((pbs_asprintf(&temp_buff, "%s\n", token)) != -1) {
 					log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 						preq->rq_ind.rq_cpyfile.rq_jobid, temp_buff);
 					token = strtok_r(NULL, "\n", &save_ptr);
-				}
-				free(temp_buff);
-				temp_buff = NULL;
+					free(temp_buff);
+					temp_buff = NULL;
+				}	
 			}
 			log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_JOB, LOG_DEBUG,
 				preq->rq_ind.rq_cpyfile.rq_jobid, "---->>>>");	


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Bad_list is a fairly large string that can, amongst others, contain scp verbose logging. Frequently that is a multiline string that is larger than the log buffer.
When the bad_list is too large these will, without fortified source, corrupt the heap (but often of a process about to exit), and with fortified source will immediately make the process abort. That caused some grief  with a fortified source build made to detect an unrelated heap corruption issue.


#### Describe Your Change
Instead of using sprintf() now we are using pbs_asprintf() and also splitting the bad_list on the basis of  \n in the list to avoid the heap corruption. 


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[log_del_buffer_overflow.txt](https://github.com/PBSPro/pbspro/files/4312502/log_del_buffer_overflow.txt)

[stage_buffer_overflow.txt](https://github.com/PBSPro/pbspro/files/4312499/stage_buffer_overflow.txt)

[mom_log_after_changes.txt](https://github.com/PBSPro/pbspro/files/4312503/mom_log_after_changes.txt)

[valgrind_log.txt](https://github.com/PBSPro/pbspro/files/4312511/valgrind_log.txt)





<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
