### PR TITLE
Reservation queue from default partition fails to recover

### DIFF
--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -2351,6 +2351,9 @@ action_node_partition(attribute *pattr, void *pobj, int actmode)
 
 	pnode = (pbsnode *)pobj;
 
+	if (actmode == ATR_ACTION_RECOV)
+		return PBSE_NONE;
+
 	if (strcmp(pattr->at_val.at_str, DEFAULT_PARTITION) == 0)
 		return PBSE_DEFAULT_PARTITION;
 

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -476,6 +476,9 @@ action_queue_partition(attribute *pattr, void *pobj, int actmode)
 {
 	int i;
 
+	if (actmode == ATR_ACTION_RECOV)
+		return PBSE_NONE;
+
 	if (((pbs_queue *)pobj)->qu_qs.qu_type  == QTYPE_RoutePush)
 		return PBSE_ROUTE_QUE_NO_PARTITION;
 

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -1022,6 +1022,9 @@ action_sched_partition(attribute *pattr, void *pobj, int actmode)
 	pbs_sched* pin_sched;
 	attribute *part_attr;
 
+	if (actmode == ATR_ACTION_RECOV)
+		return PBSE_NONE;
+
 	if (pobj == dflt_scheduler)
 		return PBSE_SCHED_OP_NOT_PERMITTED;
 	pin_sched = (pbs_sched*)pobj;

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2170,14 +2170,14 @@ class TestReservations(TestFunctional):
                                       start=now + 5, end=now + 100)
 
         a = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
-        self.server.status(RESV, a, id=rid)
+        self.server.expect(RESV, a, id=rid)
 
         self.server.restart()
-        self.server.status(RESV, a, id=rid)
+        self.server.expect(RESV, a, id=rid)
 
         resv_queue = rid.split('.')[0]
         a = {'Resource_List.select': '1:ncpus=1', ATTR_queue: resv_queue}
         J = Job(attrs=a)
         jid = self.server.submit(J)
 
-        self.server.status(JOB, {ATTR_state: 'R'}, id=jid)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
After the change made in #1509 PBS Server now disallows queue/scheduler/node to have the partition name set to pbs-default. This default partition is internally assigned to these three objects by the server.
PBS server failed to recover objects (queue & reservation) which had partition set to pbs-default because the action function for this attribute failed.

#### Describe Your Change
Changed the action functions to ignore the validation of attributes when the server is recovering attributes from the database.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_before_fix.txt](https://github.com/PBSPro/pbspro/files/4314768/test_before_fix.txt)
[test_after_fix.txt](https://github.com/PBSPro/pbspro/files/4314769/test_after_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
