### PR TITLE
use sizeof instead of PBS_MAXSVRJOBID

### DIFF
--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3531,7 +3531,7 @@ void reply_hook_bg(job *pjob)
 				 * been deleted already.
 				 */
 				if ((pjob2 = job_alloc()) != NULL) {
-					(void)snprintf(pjob2->ji_qs.ji_jobid, PBS_MAXSVRJOBID, "%s", jobid);
+					(void)snprintf(pjob2->ji_qs.ji_jobid, sizeof(pjob2->ji_qs.ji_jobid), "%s", jobid);
 					pjob2->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long =
 							runver;
 					pjob2->ji_wattr[(int)JOB_ATR_run_version].at_flags |= ATR_VFLAG_SET;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
There is a compiler error:
/home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/mom_hook_func.c: In function â€˜reply_hook_bgâ€™:
/home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/mom_hook_func.c:3534:64: error: â€˜snprintfâ€™ output may be truncated before the last format character [-Werror=format-truncation=]
      (void)snprintf(pjob2->ji_qs.ji_jobid, PBS_MAXSVRJOBID, "%s", jobid);
                                                                ^
/home/pbsbuild/ramdisk/workspace/build/pbspro/src/resmom/mom_hook_func.c:3534:12: note: â€˜snprintfâ€™ output between 1 and 274 bytes into a destination of size 273
      (void)snprintf(pjob2->ji_qs.ji_jobid, PBS_MAXSVRJOBID, "%s", jobid);
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Instead of using the defined value of PBS_MAXSVRJOBID, use the size of the buffer about to be copied into.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
