### PR TITLE
Added sudo=True to pbs_rmget for load test

### DIFF
--- a/test/tests/functional/pbs_sched_load_balancing.py
+++ b/test/tests/functional/pbs_sched_load_balancing.py
@@ -58,7 +58,7 @@ class TestSchedLoadBalancing(TestFunctional):
         cmd = os.path.join(self.server.pbs_conf[
                            'PBS_EXEC'], 'unsupported', 'pbs_rmget')
         cmd += ' -m ' + self.mom.hostname + ' loadave '
-        ret = self.du.run_cmd(self.mom.hostname, cmd)
+        ret = self.du.run_cmd(self.mom.hostname, cmd, sudo=True)
         current_load = float(ret['out'][0].split('=')[1])
         # Considering our job will need 1 cpu
         ideal_load = current_load + 1


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The mom requires RM requests to come from root.  The test TestSchedLoadBalancing did an pbs_rmget as the test user who ran the test.  Unless the test is run by root, the test will fail.

#### Describe Your Change
pass sudo=True to the run_cmd() for pbs_rmget

#### Attach Test and Valgrind Logs/Output
[load-before.log](https://github.com/PBSPro/pbspro/files/4315333/load-before.log)
[load-after.log](https://github.com/PBSPro/pbspro/files/4315332/load-after.log)
