### PR TITLE
Tests of TestServerDynRes are failing while verifying the job's comment

### DIFF
--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -91,11 +91,14 @@ class TestServerDynRes(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         return scripts
 
+    @skipOnCpuSet
     def test_invalid_script_out(self):
         """
         Test that the scheduler handles incorrect output from server_dyn_res
         script correctly
         """
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         # Create a server_dyn_res of type long
         resname = ["mybadres"]
         restype = ["long"]
@@ -227,6 +230,8 @@ class TestServerDynRes(TestFunctional):
         Test multiple dynamic resources specified in resourcedef
         and sched_config
         """
+        a = {'resources_available.ncpus': 3}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         # Create resources of type long
         resname = ["foobar_small", "foobar_medium", "foobar_large"]
         restype = ["long", "long", "long"]
@@ -263,11 +268,14 @@ class TestServerDynRes(TestFunctional):
         a = {'job_state': 'R', 'Resource_List.foobar_large': 18}
         self.server.expect(JOB, a, id=jid)
 
+    @skipOnCpuSet
     def test_res_string(self):
         """
         Test that server_dyn_res accepts a string value returned
         by a script
         """
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         # Create a resource of type string
         resname = ["foobar"]
         restype = ["string"]
@@ -299,11 +307,14 @@ class TestServerDynRes(TestFunctional):
         a = {'job_state': 'Q', 'comment': job_comment}
         self.server.expect(JOB, a, id=jid, attrop=PTL_AND)
 
+    @skipOnCpuSet
     def test_res_string_array(self):
         """
         Test that server_dyn_res accepts string array returned
         by a script
         """
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         # Create a resource of type string_array
         resname = ["foobar"]
         restype = ["string_array"]
@@ -341,6 +352,8 @@ class TestServerDynRes(TestFunctional):
         Test that server_dyn_res accepts type "size" and a "value"
         returned by a script
         """
+        a = {'resources_available.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         # Create a resource of type size
         resname = ["foobar"]
         restype = ["size"]

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -344,8 +344,6 @@ class TestServerDynRes(TestFunctional):
         Test that server_dyn_res accepts type "size" and a "value"
         returned by a script
         """
-        a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         # Create a resource of type size
         resname = ["foobar"]
         restype = ["size"]

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -339,7 +339,6 @@ class TestServerDynRes(TestFunctional):
         a = {'job_state': 'Q', 'comment': job_comment}
         self.server.expect(JOB, a, id=jid, attrop=PTL_AND)
 
-    @skipOnCpuSet
     def test_res_size(self):
         """
         Test that server_dyn_res accepts type "size" and a "value"
@@ -381,18 +380,11 @@ class TestServerDynRes(TestFunctional):
         self.server.deljob(jid2, wait=True, runas=TEST_USER)
 
         # Submit jobs again
-        a = {'Resource_List.foobar': '50gb'}
+        a = {'Resource_List.foobar': '100gb'}
         j1 = Job(TEST_USER, attrs=a)
         jid1 = self.server.submit(j1)
-
-        a = {'Resource_List.foobar': '50gb'}
-        j2 = Job(TEST_USER, attrs=a)
-        jid2 = self.server.submit(j2)
-
-        # Both jobs must run successfully
-        a = {'job_state': 'R', 'Resource_List.foobar': '50gb'}
+        a = {'job_state': 'R', 'Resource_List.foobar': '100gb'}
         self.server.expect(JOB, a, id=jid1)
-        self.server.expect(JOB, a, id=jid2)
 
     @skipOnCpuSet
     def test_res_size_runtime(self):

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -384,7 +384,6 @@ class TestServerDynRes(TestFunctional):
         a = {'job_state': 'R', 'Resource_List.foobar': '100gb'}
         self.server.expect(JOB, a, id=jid1)
 
-    @skipOnCpuSet
     def test_res_size_runtime(self):
         """
         Test that server_dyn_res accepts type "size" and a "value"

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -91,14 +91,11 @@ class TestServerDynRes(TestFunctional):
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         return scripts
 
-    @skipOnCpuSet
     def test_invalid_script_out(self):
         """
         Test that the scheduler handles incorrect output from server_dyn_res
         script correctly
         """
-        a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         # Create a server_dyn_res of type long
         resname = ["mybadres"]
         restype = ["long"]
@@ -109,6 +106,7 @@ class TestServerDynRes(TestFunctional):
 
         # Submit a job
         j = Job(TEST_USER)
+        j.set_sleep_time(1)
         jid = self.server.submit(j)
 
         # Make sure that "Problem with creating server data structure"
@@ -224,14 +222,11 @@ class TestServerDynRes(TestFunctional):
         # Cleanup dynamically created file
         self.du.rm(fpath_out, sudo=True, force=True)
 
-    @skipOnCpuSet
     def test_multiple_res(self):
         """
         Test multiple dynamic resources specified in resourcedef
         and sched_config
         """
-        a = {'resources_available.ncpus': 3}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         # Create resources of type long
         resname = ["foobar_small", "foobar_medium", "foobar_large"]
         restype = ["long", "long", "long"]
@@ -244,6 +239,7 @@ class TestServerDynRes(TestFunctional):
         a = {'Resource_List.foobar_small': '4'}
         # Submit job
         j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(5)
         jid = self.server.submit(j)
 
         # Job must run successfully
@@ -253,6 +249,7 @@ class TestServerDynRes(TestFunctional):
         a = {'Resource_List.foobar_medium': '10'}
         # Submit job
         j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(5)
         jid = self.server.submit(j)
 
         # Job must run successfully
@@ -268,14 +265,11 @@ class TestServerDynRes(TestFunctional):
         a = {'job_state': 'R', 'Resource_List.foobar_large': 18}
         self.server.expect(JOB, a, id=jid)
 
-    @skipOnCpuSet
     def test_res_string(self):
         """
         Test that server_dyn_res accepts a string value returned
         by a script
         """
-        a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         # Create a resource of type string
         resname = ["foobar"]
         restype = ["string"]
@@ -288,6 +282,7 @@ class TestServerDynRes(TestFunctional):
         # Submit job
         a = {'Resource_List.foobar': 'abc'}
         j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(5)
         jid = self.server.submit(j)
 
         # Job must run successfully
@@ -307,14 +302,11 @@ class TestServerDynRes(TestFunctional):
         a = {'job_state': 'Q', 'comment': job_comment}
         self.server.expect(JOB, a, id=jid, attrop=PTL_AND)
 
-    @skipOnCpuSet
     def test_res_string_array(self):
         """
         Test that server_dyn_res accepts string array returned
         by a script
         """
-        a = {'resources_available.ncpus': 2}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         # Create a resource of type string_array
         resname = ["foobar"]
         restype = ["string_array"]
@@ -327,6 +319,7 @@ class TestServerDynRes(TestFunctional):
         # Submit job
         a = {'Resource_List.foobar': 'red'}
         j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(5)
         jid = self.server.submit(j)
 
         # Job must run successfully
@@ -384,8 +377,6 @@ class TestServerDynRes(TestFunctional):
         # The job shouldn't run
         a = {'job_state': 'Q', 'comment': job_comment}
         self.server.expect(JOB, a, id=jid2, attrop=PTL_AND)
-
-        # Delete jobs
         self.server.deljob(jid1, wait=True, runas=TEST_USER)
         self.server.deljob(jid2, wait=True, runas=TEST_USER)
 

--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -356,6 +356,7 @@ class TestServerDynRes(TestFunctional):
         # Submit job
         a = {'Resource_List.foobar': '95gb'}
         j1 = Job(TEST_USER, attrs=a)
+        j1.set_sleep_time(5)
         jid1 = self.server.submit(j1)
 
         # Job must run successfully
@@ -374,7 +375,7 @@ class TestServerDynRes(TestFunctional):
         # The job shouldn't run
         a = {'job_state': 'Q', 'comment': job_comment}
         self.server.expect(JOB, a, id=jid2, attrop=PTL_AND)
-        self.server.deljob(jid1, wait=True, runas=TEST_USER)
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid1)
         self.server.deljob(jid2, wait=True, runas=TEST_USER)
 
         # Submit jobs again


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Tests "test_invalid_script_out, test_multiple_res,test_res_string,test_res_string_array,test_res_size" of TestServerDynRes are failing on certain machines during regression 


#### Describe Your Change

- In the test we are submitting more than 1 job and expecting certain job comment but the default "resources_available.ncpus" on few machines is 1 due to which job's comment differs and hence the test failure.

- Change the tests to not use default job script(sleep of 100s) but use short script(sleep 5) and remove skipOnCpuset decorator from the tests as they can be run on Cpuset machines with the said changes.

- Modiifed test 'test_res_size' to wait  for job1 to complete instead of deleting it, as we are now submitting shortjob and deleting would sometimes race condition. Also updated the third job submission to request foobar=100gb.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_TestServerDynRes_x55_aftr_fix.txt](https://github.com/PBSPro/pbspro/files/4316767/Execution_logs_TestServerDynRes_x55_aftr_fix.txt)

- [Execution_logs_TestServerDynRes_x55_bfr_fix.txt](https://github.com/PBSPro/pbspro/files/4316769/Execution_logs_TestServerDynRes_x55_bfr_fix.txt)

- [Execution_logs_TestServerDynRes_x57_aftr_fix.txt](https://github.com/PBSPro/pbspro/files/4316770/Execution_logs_TestServerDynRes_x57_aftr_fix.txt)

- [Execution_logs_TestServerDynRes_x57_bfr_fix.txt](https://github.com/PBSPro/pbspro/files/4316771/Execution_logs_TestServerDynRes_x57_bfr_fix.txt)

- [Execution_logs_TestServerDynRes_x69_aftr_fix.txt](https://github.com/PBSPro/pbspro/files/4316772/Execution_logs_TestServerDynRes_x69_aftr_fix.txt)

- [Execution_logs_TestServerDynRes_x69_bfr_fix.txt](https://github.com/PBSPro/pbspro/files/4316773/Execution_logs_TestServerDynRes_x69_bfr_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
