### PR TITLE
Fixing user reliability test cases

### DIFF
--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -71,8 +71,7 @@ j.create_resv_from_job=1
             s_nodect_before = '0'
             s_ncpus_before = '0'
 
-        a = {'Resource_List.select': '1:ncpus=3',
-             'Resource_List.walltime': 9999}
+        a = {'Resource_List.walltime': 9999}
         job = Job(TEST_USER, a)
         jid = self.server.submit(job)
         self.server.expect(JOB, {ATTR_state: 'R'}, jid)
@@ -81,7 +80,6 @@ j.create_resv_from_job=1
         rid = self.server.status(RESV, a)[0]['id'].split(".")[0]
 
         a = {ATTR_job: jid, 'reserve_state': (MATCH_RE, 'RESV_RUNNING|5'),
-             'Resource_List.select': '1:ncpus=3',
              'Resource_List.walltime': 9999}
         self.server.expect(RESV, a, id=rid)
 
@@ -148,8 +146,7 @@ j.create_resv_from_job=1
             s_nodect_before = '0'
             s_ncpus_before = '0'
 
-        a = {'Resource_List.select': '1:ncpus=3',
-             'Resource_List.walltime': 9999}
+        a = {'Resource_List.walltime': 9999}
         job = Job(TEST_USER, a)
         jid = self.server.submit(job)
         self.server.expect(JOB, {ATTR_state: 'R'}, jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
My assumption in PR #1145 that the machine will have at least 4 ncpus is incorrect, so the tests will fail on machines with less than 3 ncpus as the job demands for that many ncpus, and would not start running.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Removed the select for 3 ncpus.
If we set ncpus, the test cases cannot be run on cpuset machines.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl_th.txt](https://github.com/PBSPro/pbspro/files/4319392/ptl_th.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
