### PR TITLE
TestServerDynRes.test_invalid_script_out test case failing with sched log match error

### DIFF
--- a/test/tests/functional/pbs_svr_dyn_res.py
+++ b/test/tests/functional/pbs_svr_dyn_res.py
@@ -101,6 +101,7 @@ class TestServerDynRes(TestFunctional):
         restype = ["long"]
         script_body = ['echo abc']
 
+        start_time = time.time()
         # Add it as a server_dyn_res that returns a string output
         filenames = self.setup_dyn_res(resname, restype, script_body)
 
@@ -112,7 +113,8 @@ class TestServerDynRes(TestFunctional):
         # Make sure that "Problem with creating server data structure"
         # is not logged in sched_logs
         self.scheduler.log_match("Problem with creating server data structure",
-                                 existence=False, max_attempts=10)
+                                 existence=False, max_attempts=10,
+                                 starttime=start_time)
 
         # Also check that "<script> returned bad output"
         # is in the logs


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test is expecting message "Problem with creating server data structure" not be there in sched logs but test case is failing with message found in sched_logs. Reason is when we run test case with fresh installation, nodes list will be empty and when server is restarted with no nodes created, we get above error message in sched logs:

Sched_logs:
02/23/2020 15:02:11.533351;0040;pbs_sched;Node;;Error getting nodes: Server has no node list
02/23/2020 15:02:11.539033;0002;pbs_sched;Svr;;Problem with creating server data structure

#### Describe Your Change
Send starttime from the time test case has started while searching for log match.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->

#### Attach Test and Valgrind Logs/Output
[test_invalid_script_out_after_fix.txt](https://github.com/PBSPro/pbspro/files/4328354/test_invalid_script_out_after_fix.txt)
[test_invalid_script_out_before_fix.txt](https://github.com/PBSPro/pbspro/files/4328355/test_invalid_script_out_before_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
