### PR TITLE
qsub crashes if environment variables contain backslashes

### DIFF
--- a/src/cmds/qsub.c
+++ b/src/cmds/qsub.c
@@ -480,7 +480,7 @@ copy_env_value(char *dest, char *pv, int quote_flg)
 			case ESC_CHAR: /* backslash in value, escape it */
 				*dest++ = *pv;
 				if (*(pv + 1) != ',') /* do not escape if ESC_CHAR already escapes */
-					*dest++ = *++pv;
+					*dest++ = *pv;
 				break;
 
 			case ',':
@@ -537,10 +537,12 @@ expand_varlist(char *varlist)
 	char *vv = NULL;
 	char *p1, *p2, *p;
 	char *ev;
+	char *ev2;
 	int v_value1_sz=0;
 	char *pc;
 	int special_char_cnt = 0;
 	int len = 0;
+	int esc_char_cnt = 0;
 
 	/*
 	 * count special characters as they are escaped with '\' in copy_env_value function
@@ -587,8 +589,16 @@ expand_varlist(char *varlist)
 				fprintf(stderr, "qsub: cannot send environment with the job\n");
 				goto expand_varlist_err;
 			}
+			/* count escape characters as they are escaped with '\'*/
+			ev2 = ev;
+			len = 0;
+			for (; *ev2; ev2++) {
+				if ((*ev2 == ESC_CHAR))
+					esc_char_cnt++;
 
-			v_value1_sz = v_value1_sz + strlen(ev) + 1; /* include '=' */
+				len++;
+			}
+			v_value1_sz = v_value1_sz + len + esc_char_cnt + 1; /* include '=' */
 			p = realloc(v_value1, v_value1_sz);
 			if (p == NULL) {
 				fprintf(stderr, "qsub: out of memory\n");

--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -183,11 +183,7 @@ foo\n
         self.server.expect(JOB, {'Variable_List': (MATCH_RE,
                                                    'SET_IN_SUBMISSION=false')},
                            id=jid1)
-<<<<<<< HEAD
     
-=======
-
->>>>>>> 5e617dc... Done commit signature changes
     def test_passing_env_special_char_via_qsub(self):
         """
         Submit a job with -v ENV_TEST=N:\\aa\\bb\\cc\\dd\\ee\\ff\\gg\\hh\\ii

--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -183,7 +183,11 @@ foo\n
         self.server.expect(JOB, {'Variable_List': (MATCH_RE,
                                                    'SET_IN_SUBMISSION=false')},
                            id=jid1)
+<<<<<<< HEAD
+    
+=======
 
+>>>>>>> 5e617dc... Done commit signature changes
     def test_passing_env_special_char_via_qsub(self):
         """
         Submit a job with -v ENV_TEST=N:\\aa\\bb\\cc\\dd\\ee\\ff\\gg\\hh\\ii
@@ -201,6 +205,6 @@ foo\n
         qstat = self.server.status(JOB, ATTR_v, id=jid2)
         job_outfile = qstat[0]['Variable_List']
         var_list = job_outfile.split(",")
-        exp_string = "ENV_TEST=N:\\\\aa\\\\bb\\\\cc\\\\dd"
-        exp_string += "\\\\ee\\\\ff\\\\gg\\\\hh\\\\ii"
+        exp_string = 'ENV_TEST=N:\\\\\\\\aa\\\\\\\\bb\\\\\\\\cc\\\\\\\\dd'
+        exp_string += '\\\\\\\\ee\\\\\\\\ff\\\\\\\\gg\\\\\\\\hh\\\\\\\\ii'
         self.assertIn(exp_string, var_list)

--- a/test/tests/functional/pbs_passing_environment_variable.py
+++ b/test/tests/functional/pbs_passing_environment_variable.py
@@ -183,7 +183,7 @@ foo\n
         self.server.expect(JOB, {'Variable_List': (MATCH_RE,
                                                    'SET_IN_SUBMISSION=false')},
                            id=jid1)
-    
+
     def test_passing_env_special_char_via_qsub(self):
         """
         Submit a job with -v ENV_TEST=N:\\aa\\bb\\cc\\dd\\ee\\ff\\gg\\hh\\ii


### PR DESCRIPTION
#### Issue-ID

- PBS-23201

#### Describe Bug or Feature

- qsub crashes if environment variables contain backslashes 

#### Describe Your Change

- qsub crashes if environment variables contain backslashes because it does not have enough memory allocated for the exported environmental variable. 

- Earlier, when we copy an environment variable value,  "copy_env_value" was adding extra special characters. we were not accommodating for those characters. With this code change we are allocating memory for extra characters.

[Before_fix.txt](https://github.com/PBSPro/pbspro/files/4328485/Before_fix.txt)
[After_fix.txt](https://github.com/PBSPro/pbspro/files/4328486/After_fix.txt)

[ptl_test_log.txt](https://github.com/PBSPro/pbspro/files/4328494/ptl_test_log.txt)
