### PR TITLE
Remove typecasting starttime/endtime to int while searching for log messages

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -3323,7 +3323,7 @@ class PBSObject(object):
         self.dflt_attributes = defaults
         self.attropl = None
         self.custom_attrs = OrderedDict()
-        self.ctime = int(time.time())
+        self.ctime = time.time()
 
         self.set_attributes(attrs)
 
@@ -3895,7 +3895,7 @@ class PBSService(PBSObject):
         lines = []
         sudo = False
         if endtime is None:
-            endtime = int(time.time())
+            endtime = time.time()
         if starttime is None:
             starttime = self.ctime
         try:
@@ -8542,7 +8542,7 @@ class Server(PBSService):
                         runas=ROOT_USER, wait=False)
         except PbsDeljobError:
             pass
-        st = int(time.time())
+        st = time.time()
         if len(job_ids) > 100:
             for host, pids in host_pid_map.items():
                 chunks = [pids[i:i + 5000] for i in range(0, len(pids), 5000)]
@@ -11307,7 +11307,7 @@ class Scheduler(PBSService):
         if len(config) == 0:
             return True
 
-        reconfig_time = int(time.time())
+        reconfig_time = time.time()
         try:
             fn = self.du.create_temp_file()
             with open(fn, "w", encoding="utf-8") as fd:
@@ -12695,7 +12695,7 @@ class Scheduler(PBSService):
                 self.hostname, self.resource_group_file)
         if isinstance(name, PbsUser):
             name = str(name)
-        reconfig_time = int(time.time())
+        reconfig_time = time.time()
         rc = self.resource_group.create_node(name, fairshare_id,
                                              parent_name=parent,
                                              nshares=nshares)

--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -1276,7 +1276,7 @@ class PBSSchedulerLog(PBSLogAnalyzer):
 
         cycles = []
         if end is None:
-            end = int(time.time())
+            end = time.time()
         for c in self.cycles:
             if c.start >= start and c.end < end:
                 cycles.append(c)


### PR DESCRIPTION
#### Describe Bug or Feature
Currently, most of the PTL tests are failing either due to log msgs found or not found in sched/server logs. Few of the tests are expecting non-existence of log msg in sched logs but the msg has appeared before the test case has started. 
This issue is observed when time stamp(HH:MM:SS) of log message which has appeared is same as the time test case is looking for log message.
Currently functions(log_lines, apply_config etc) are type casting starttime and endtime to int which truncates the microseconds from time stamps due to which the tests are able to find the logs msgs in sched logs 

#### Describe Your Change
Remove type casting time to int so that we will be searching logs with microseconds time stamp.

#### Attach Test and Valgrind Logs/Output
[log_match_after_fix.txt](https://github.com/PBSPro/pbspro/files/4328677/log_match_after_fix.txt)
[log_match_before_fix.txt](https://github.com/PBSPro/pbspro/files/4328678/log_match_before_fix.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
