### PR TITLE
Windows build: Replace hard code 7z in all bat files with env variable ENV_7Z_BIN

### DIFF
--- a/.appveyor/build_libedit.bat
+++ b/.appveyor/build_libedit.bat
@@ -66,7 +66,7 @@ if not exist "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip" (
 )
 
 2>nul rd /S /Q "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%"
-7z x -y "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip" -o"%BINARIESDIR%"
+"%7Z_BIN%" x -y "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip"
     exit /b 1

--- a/.appveyor/build_libedit.bat
+++ b/.appveyor/build_libedit.bat
@@ -67,7 +67,6 @@ if not exist "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip" (
 
 2>nul rd /S /Q "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%"
 
-REM Use the ENV_7Z_BIN environment variable
 "%ENV_7Z_BIN%" x -y "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip"

--- a/.appveyor/build_libedit.bat
+++ b/.appveyor/build_libedit.bat
@@ -66,6 +66,8 @@ if not exist "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip" (
 )
 
 2>nul rd /S /Q "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%"
+
+REM Use the 7Z_BIN environment variable
 "%7Z_BIN%" x -y "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip"

--- a/.appveyor/build_libedit.bat
+++ b/.appveyor/build_libedit.bat
@@ -67,8 +67,8 @@ if not exist "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip" (
 
 2>nul rd /S /Q "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%"
 
-REM Use the 7Z_BIN environment variable
-"%7Z_BIN%" x -y "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip" -o"%BINARIESDIR%"
+REM Use the ENV_7Z_BIN environment variable
+"%ENV_7Z_BIN%" x -y "%BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\wineditline-%LIBEDIT_VERSION%.zip"
     exit /b 1

--- a/.appveyor/build_python.bat
+++ b/.appveyor/build_python.bat
@@ -56,7 +56,6 @@ if exist C:\Python36 (
         exit /b 1
     )
 ) else if exist "%BINARIESDIR%\python.zip" (
-    REM Use the ENV_7Z_BIN environment variable
     "%ENV_7Z_BIN%" x -y "%BINARIESDIR%\python.zip" -o"%BINARIESDIR%"
     if not %ERRORLEVEL% == 0 (
         echo "Failed to extract %BINARIESDIR%\python.zip"
@@ -119,7 +118,6 @@ if exist C:\Python36-x64 (
         exit /b 1
     )
 ) else if exist "%BINARIESDIR%\python_x64.zip" (
-    REM Use the ENV_7Z_BIN environment variable
     "%ENV_7Z_BIN%" x -y "%BINARIESDIR%\python_x64.zip" -o"%BINARIESDIR%"
     if not %ERRORLEVEL% == 0 (
         echo "Failed to extract %BINARIESDIR%\python_x64.zip"
@@ -183,7 +181,6 @@ if not exist "%BINARIESDIR%\cpython-%PYTHON_VERSION%.zip" (
 )
 2>nul rd /S /Q "%BINARIESDIR%\cpython-%PYTHON_VERSION%"
 
-REM Use the ENV_7Z_BIN environment variable
 "%ENV_7Z_BIN%" x -y "%BINARIESDIR%\cpython-%PYTHON_VERSION%.zip" -o"%BINARIESDIR%"
 cd "%BINARIESDIR%\cpython-%PYTHON_VERSION%"
 

--- a/.appveyor/build_python.bat
+++ b/.appveyor/build_python.bat
@@ -56,7 +56,7 @@ if exist C:\Python36 (
         exit /b 1
     )
 ) else if exist "%BINARIESDIR%\python.zip" (
-    7z x -y "%BINARIESDIR%\python.zip" -o"%BINARIESDIR%"
+    "%7Z_BIN%" x -y "%BINARIESDIR%\python.zip" -o"%BINARIESDIR%"
     if not %ERRORLEVEL% == 0 (
         echo "Failed to extract %BINARIESDIR%\python.zip"
         exit /b 1
@@ -118,7 +118,7 @@ if exist C:\Python36-x64 (
         exit /b 1
     )
 ) else if exist "%BINARIESDIR%\python_x64.zip" (
-    7z x -y "%BINARIESDIR%\python_x64.zip" -o"%BINARIESDIR%"
+    "%7Z_BIN%" x -y "%BINARIESDIR%\python_x64.zip" -o"%BINARIESDIR%"
     if not %ERRORLEVEL% == 0 (
         echo "Failed to extract %BINARIESDIR%\python_x64.zip"
         exit /b 1
@@ -180,7 +180,7 @@ if not exist "%BINARIESDIR%\cpython-%PYTHON_VERSION%.zip" (
     )
 )
 2>nul rd /S /Q "%BINARIESDIR%\cpython-%PYTHON_VERSION%"
-7z x -y "%BINARIESDIR%\cpython-%PYTHON_VERSION%.zip" -o"%BINARIESDIR%"
+"%7Z_BIN%" x -y "%BINARIESDIR%\cpython-%PYTHON_VERSION%.zip" -o"%BINARIESDIR%"
 cd "%BINARIESDIR%\cpython-%PYTHON_VERSION%"
 
 REM dirty hack to make python build faster as we only want pythoncore project's output

--- a/.appveyor/build_python.bat
+++ b/.appveyor/build_python.bat
@@ -56,6 +56,7 @@ if exist C:\Python36 (
         exit /b 1
     )
 ) else if exist "%BINARIESDIR%\python.zip" (
+    REM Use the 7Z_BIN environment variable
     "%7Z_BIN%" x -y "%BINARIESDIR%\python.zip" -o"%BINARIESDIR%"
     if not %ERRORLEVEL% == 0 (
         echo "Failed to extract %BINARIESDIR%\python.zip"
@@ -118,6 +119,7 @@ if exist C:\Python36-x64 (
         exit /b 1
     )
 ) else if exist "%BINARIESDIR%\python_x64.zip" (
+    REM Use the 7Z_BIN environment variable
     "%7Z_BIN%" x -y "%BINARIESDIR%\python_x64.zip" -o"%BINARIESDIR%"
     if not %ERRORLEVEL% == 0 (
         echo "Failed to extract %BINARIESDIR%\python_x64.zip"
@@ -180,6 +182,8 @@ if not exist "%BINARIESDIR%\cpython-%PYTHON_VERSION%.zip" (
     )
 )
 2>nul rd /S /Q "%BINARIESDIR%\cpython-%PYTHON_VERSION%"
+
+REM Use the 7Z_BIN environment variable
 "%7Z_BIN%" x -y "%BINARIESDIR%\cpython-%PYTHON_VERSION%.zip" -o"%BINARIESDIR%"
 cd "%BINARIESDIR%\cpython-%PYTHON_VERSION%"
 

--- a/.appveyor/build_python.bat
+++ b/.appveyor/build_python.bat
@@ -56,8 +56,8 @@ if exist C:\Python36 (
         exit /b 1
     )
 ) else if exist "%BINARIESDIR%\python.zip" (
-    REM Use the 7Z_BIN environment variable
-    "%7Z_BIN%" x -y "%BINARIESDIR%\python.zip" -o"%BINARIESDIR%"
+    REM Use the ENV_7Z_BIN environment variable
+    "%ENV_7Z_BIN%" x -y "%BINARIESDIR%\python.zip" -o"%BINARIESDIR%"
     if not %ERRORLEVEL% == 0 (
         echo "Failed to extract %BINARIESDIR%\python.zip"
         exit /b 1
@@ -119,8 +119,8 @@ if exist C:\Python36-x64 (
         exit /b 1
     )
 ) else if exist "%BINARIESDIR%\python_x64.zip" (
-    REM Use the 7Z_BIN environment variable
-    "%7Z_BIN%" x -y "%BINARIESDIR%\python_x64.zip" -o"%BINARIESDIR%"
+    REM Use the ENV_7Z_BIN environment variable
+    "%ENV_7Z_BIN%" x -y "%BINARIESDIR%\python_x64.zip" -o"%BINARIESDIR%"
     if not %ERRORLEVEL% == 0 (
         echo "Failed to extract %BINARIESDIR%\python_x64.zip"
         exit /b 1
@@ -183,8 +183,8 @@ if not exist "%BINARIESDIR%\cpython-%PYTHON_VERSION%.zip" (
 )
 2>nul rd /S /Q "%BINARIESDIR%\cpython-%PYTHON_VERSION%"
 
-REM Use the 7Z_BIN environment variable
-"%7Z_BIN%" x -y "%BINARIESDIR%\cpython-%PYTHON_VERSION%.zip" -o"%BINARIESDIR%"
+REM Use the ENV_7Z_BIN environment variable
+"%ENV_7Z_BIN%" x -y "%BINARIESDIR%\cpython-%PYTHON_VERSION%.zip" -o"%BINARIESDIR%"
 cd "%BINARIESDIR%\cpython-%PYTHON_VERSION%"
 
 REM dirty hack to make python build faster as we only want pythoncore project's output

--- a/.appveyor/build_ssl.bat
+++ b/.appveyor/build_ssl.bat
@@ -65,7 +65,6 @@ if not exist "%BINARIESDIR%\OpenSSL_%OPENSSL_VERSION%.zip" (
 
 2>nul rd /S /Q "%BINARIESDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"
 
-REM Use the ENV_7Z_BIN environment variable
 "%ENV_7Z_BIN%" x -y "%BINARIESDIR%\OpenSSL_%OPENSSL_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"

--- a/.appveyor/build_ssl.bat
+++ b/.appveyor/build_ssl.bat
@@ -65,8 +65,8 @@ if not exist "%BINARIESDIR%\OpenSSL_%OPENSSL_VERSION%.zip" (
 
 2>nul rd /S /Q "%BINARIESDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"
 
-REM Use the 7Z_BIN environment variable
-"%7Z_BIN%" x -y "%BINARIESDIR%\OpenSSL_%OPENSSL_VERSION%.zip" -o"%BINARIESDIR%"
+REM Use the ENV_7Z_BIN environment variable
+"%ENV_7Z_BIN%" x -y "%BINARIESDIR%\OpenSSL_%OPENSSL_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"
     exit /b 1

--- a/.appveyor/build_ssl.bat
+++ b/.appveyor/build_ssl.bat
@@ -64,7 +64,7 @@ if not exist "%BINARIESDIR%\OpenSSL_%OPENSSL_VERSION%.zip" (
 )
 
 2>nul rd /S /Q "%BINARIESDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"
-7z x -y "%BINARIESDIR%\OpenSSL_%OPENSSL_VERSION%.zip" -o"%BINARIESDIR%"
+"%7Z_BIN%" x -y "%BINARIESDIR%\OpenSSL_%OPENSSL_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"
     exit /b 1

--- a/.appveyor/build_ssl.bat
+++ b/.appveyor/build_ssl.bat
@@ -64,6 +64,8 @@ if not exist "%BINARIESDIR%\OpenSSL_%OPENSSL_VERSION%.zip" (
 )
 
 2>nul rd /S /Q "%BINARIESDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"
+
+REM Use the 7Z_BIN environment variable
 "%7Z_BIN%" x -y "%BINARIESDIR%\OpenSSL_%OPENSSL_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\openssl-OpenSSL_%OPENSSL_VERSION%"

--- a/.appveyor/build_swig.bat
+++ b/.appveyor/build_swig.bat
@@ -59,6 +59,8 @@ if not exist "%BINARIESDIR%\swigwin-%SWIG_VERSION%.zip" (
 )
 
 2>nul rd /S /Q "%BINARIESDIR%\swigwin-%SWIG_VERSION%"
+
+REM Use the 7Z_BIN environment variable
 "%7Z_BIN%" x -y "%BINARIESDIR%\swigwin-%SWIG_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\swigwin-%SWIG_VERSION%.zip"

--- a/.appveyor/build_swig.bat
+++ b/.appveyor/build_swig.bat
@@ -59,7 +59,7 @@ if not exist "%BINARIESDIR%\swigwin-%SWIG_VERSION%.zip" (
 )
 
 2>nul rd /S /Q "%BINARIESDIR%\swigwin-%SWIG_VERSION%"
-7z x -y "%BINARIESDIR%\swigwin-%SWIG_VERSION%.zip" -o"%BINARIESDIR%"
+"%7Z_BIN%" x -y "%BINARIESDIR%\swigwin-%SWIG_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\swigwin-%SWIG_VERSION%.zip"
     exit /b 1

--- a/.appveyor/build_swig.bat
+++ b/.appveyor/build_swig.bat
@@ -60,7 +60,6 @@ if not exist "%BINARIESDIR%\swigwin-%SWIG_VERSION%.zip" (
 
 2>nul rd /S /Q "%BINARIESDIR%\swigwin-%SWIG_VERSION%"
 
-REM Use the ENV_7Z_BIN environment variable
 "%ENV_7Z_BIN%" x -y "%BINARIESDIR%\swigwin-%SWIG_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\swigwin-%SWIG_VERSION%.zip"

--- a/.appveyor/build_swig.bat
+++ b/.appveyor/build_swig.bat
@@ -60,8 +60,8 @@ if not exist "%BINARIESDIR%\swigwin-%SWIG_VERSION%.zip" (
 
 2>nul rd /S /Q "%BINARIESDIR%\swigwin-%SWIG_VERSION%"
 
-REM Use the 7Z_BIN environment variable
-"%7Z_BIN%" x -y "%BINARIESDIR%\swigwin-%SWIG_VERSION%.zip" -o"%BINARIESDIR%"
+REM Use the ENV_7Z_BIN environment variable
+"%ENV_7Z_BIN%" x -y "%BINARIESDIR%\swigwin-%SWIG_VERSION%.zip" -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\swigwin-%SWIG_VERSION%.zip"
     exit /b 1

--- a/.appveyor/build_zlib.bat
+++ b/.appveyor/build_zlib.bat
@@ -60,7 +60,6 @@ if not exist "%BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz" (
 
 2>nul rd /S /Q "%BINARIESDIR%\zlib-%ZLIB_VERSION%"
 
-REM Use the ENV_7Z_BIN environment variable
 "%ENV_7Z_BIN%" x -y "%BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz" -so | "%ENV_7Z_BIN%" x -y -aoa -si -ttar -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz"

--- a/.appveyor/build_zlib.bat
+++ b/.appveyor/build_zlib.bat
@@ -59,7 +59,7 @@ if not exist "%BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz" (
 )
 
 2>nul rd /S /Q "%BINARIESDIR%\zlib-%ZLIB_VERSION%"
-7z x -y "%BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz" -so | 7z x -y -aoa -si -ttar -o"%BINARIESDIR%"
+"%7Z_BIN%" x -y "%BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz" -so | "%7Z_BIN%" x -y -aoa -si -ttar -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz"
     exit /b 1

--- a/.appveyor/build_zlib.bat
+++ b/.appveyor/build_zlib.bat
@@ -60,8 +60,8 @@ if not exist "%BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz" (
 
 2>nul rd /S /Q "%BINARIESDIR%\zlib-%ZLIB_VERSION%"
 
-REM Use the 7Z_BIN environment variable
-"%7Z_BIN%" x -y "%BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz" -so | "%7Z_BIN%" x -y -aoa -si -ttar -o"%BINARIESDIR%"
+REM Use the ENV_7Z_BIN environment variable
+"%ENV_7Z_BIN%" x -y "%BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz" -so | "%ENV_7Z_BIN%" x -y -aoa -si -ttar -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz"
     exit /b 1

--- a/.appveyor/build_zlib.bat
+++ b/.appveyor/build_zlib.bat
@@ -59,6 +59,8 @@ if not exist "%BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz" (
 )
 
 2>nul rd /S /Q "%BINARIESDIR%\zlib-%ZLIB_VERSION%"
+
+REM Use the 7Z_BIN environment variable
 "%7Z_BIN%" x -y "%BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz" -so | "%7Z_BIN%" x -y -aoa -si -ttar -o"%BINARIESDIR%"
 if not %ERRORLEVEL% == 0 (
     echo "Failed to extract %BINARIESDIR%\zlib-%ZLIB_VERSION%.tar.gz"

--- a/.appveyor/set_paths.bat
+++ b/.appveyor/set_paths.bat
@@ -47,9 +47,9 @@ if not defined CMAKE_BIN (
     set CMAKE_BIN=cmake
 )
 
-REM Define the 7Z_BIN environment variable if not
-if not defined 7Z_BIN (
-    set 7Z_BIN=7z
+REM Define the ENV_7Z_BIN environment variable if not
+if not defined ENV_7Z_BIN (
+    set ENV_7Z_BIN=7z
 )
 
 if not defined __BINARIESDIR (

--- a/.appveyor/set_paths.bat
+++ b/.appveyor/set_paths.bat
@@ -47,6 +47,7 @@ if not defined CMAKE_BIN (
     set CMAKE_BIN=cmake
 )
 
+REM Define the 7Z_BIN environment variable if not
 if not defined 7Z_BIN (
     set 7Z_BIN=7z
 )
@@ -68,7 +69,7 @@ if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional" (
 )
 
 if not exist "%VS150COMNTOOLS%" (
-    echo "Could not fine VS2017 common tools"
+    echo "Could not find VS2017 common tools"
     exit 1
 )
 

--- a/.appveyor/set_paths.bat
+++ b/.appveyor/set_paths.bat
@@ -47,6 +47,10 @@ if not defined CMAKE_BIN (
     set CMAKE_BIN=cmake
 )
 
+if not defined 7Z_BIN (
+    set 7Z_BIN=7z
+)
+
 if not defined __BINARIESDIR (
     set __BINARIESDIR=%CD%\binaries
 )

--- a/.appveyor/set_paths.bat
+++ b/.appveyor/set_paths.bat
@@ -47,7 +47,6 @@ if not defined CMAKE_BIN (
     set CMAKE_BIN=cmake
 )
 
-REM Define the ENV_7Z_BIN environment variable if not
 if not defined ENV_7Z_BIN (
     set ENV_7Z_BIN=7z
 )


### PR DESCRIPTION
#### Describe Bug
The 7z command is written in bat files with hard code mode. It has no benificial to maintainance and also infexible for user to customize the command when build it.

#### Describe Your Change
Provide one env variable %ENV_7Z_BIN% in set_paths.bat to define the 7z. Use this env variable in bat files.

Best regards
Cherrysx