### PR TITLE
Making log_record async-safe

### DIFF
--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -960,6 +960,8 @@ log_record(int eventtype, int objclass, int sev, const char *objname, const char
 sigunblock:
 #ifndef WIN32
 	sigprocmask(SIG_SETMASK, &old_mask, NULL);
+#else
+	return;
 #endif
 }
 

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -893,15 +893,15 @@ log_record(int eventtype, int objclass, int sev, const char *objname, const char
 			snprintf(microsec_buf, sizeof(microsec_buf), ".%06ld", (long)tp.tv_usec);
 	}
 
-	/* lock the log mutex */
-	if (log_mutex_lock() != 0)
-		goto sigunblock;
-
 #ifdef WIN32
 	ptm = localtime(&now);
 #else
 	ptm = localtime_r(&now, &ltm);
 #endif
+
+	/* lock the log mutex */
+	if (log_mutex_lock() != 0)
+		goto sigunblock;
 
 	/* Do we need to switch the log? */
 	if (log_auto_switch && (ptm->tm_yday != log_open_day)) {

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -960,8 +960,6 @@ log_record(int eventtype, int objclass, int sev, const char *objname, const char
 sigunblock:
 #ifndef WIN32
 	sigprocmask(SIG_SETMASK, &old_mask, NULL);
-#else
-	return;
 #endif
 }
 

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -853,20 +853,20 @@ log_record(int eventtype, int objclass, int sev, const char *objname, const char
 {
 	time_t now = 0;
 	struct tm *ptm;
-#ifndef WIN32
-	struct tm ltm;
-#endif
 	int    rc = 0;
 	FILE  *savlog;
 	char slogbuf[LOG_BUF_SIZE];
 	struct timeval tp;
 	char microsec_buf[8] = {0};
+#ifndef WIN32
+	struct tm ltm;
 	sigset_t block_mask;
 	sigset_t old_mask;
 
 	/* Block all signals to the process to make the function async-safe */
 	sigfillset(&block_mask);
 	sigprocmask(SIG_BLOCK, &block_mask, &old_mask);
+#endif
 
 #if SYSLOG
 	if (syslogopen != 0) {
@@ -958,7 +958,11 @@ log_record(int eventtype, int objclass, int sev, const char *objname, const char
 	}
 
 sigunblock:
+#ifndef WIN32
 	sigprocmask(SIG_SETMASK, &old_mask, NULL);
+#else
+	return;
+#endif
 }
 
 /**

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -260,7 +260,7 @@ typedef struct {
 	stream_t *strm; /* pointer to the stream structure at this slot */
 } stream_slot_t;
 stream_slot_t *strmarray = NULL; /* array of streams */
-pthread_mutex_t strmarray_lock;       /* global lock for the streams array */
+pthread_mutex_t strmarray_lock = PTHREAD_MUTEX_INITIALIZER;       /* global lock for the streams array */
 unsigned int max_strms = 0;           /* total number of streams allocated */
 
 /* the following two variables are used to quickly find out a unused slot */

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -260,7 +260,7 @@ typedef struct {
 	stream_t *strm; /* pointer to the stream structure at this slot */
 } stream_slot_t;
 stream_slot_t *strmarray = NULL; /* array of streams */
-pthread_mutex_t strmarray_lock = PTHREAD_MUTEX_INITIALIZER;       /* global lock for the streams array */
+pthread_mutex_t strmarray_lock;       /* global lock for the streams array */
 unsigned int max_strms = 0;           /* total number of streams allocated */
 
 /* the following two variables are used to quickly find out a unused slot */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
log_record is called, either directly or indirectly via log_event, from various signal handlers in various PBS daemons. log_record is not currently async-safe as it calls system calls like localtime_r() which are not async-safe. So, this PR is to make log_record async-safe by blocking all signals.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added code to block all signals inside log_record()

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
There's no good test for this, this solves a slim race condition, so code inspection might be the only way to analyze the changes + smoke tests to ensure that nothing breaks.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
