### PR TITLE
Run one job out of all dependent jobs

### DIFF
--- a/src/include/job.h
+++ b/src/include/job.h
@@ -57,7 +57,7 @@ extern "C" {
 #ifndef	_SERVER_LIMITS_H
 #include "server_limits.h"
 #endif
-
+#include "work_task.h"
 /*
  * Dependent Job Structures
  *
@@ -76,6 +76,7 @@ struct depend {
 	short	  dp_numexp;	/* num jobs expected (on or syncct only) */
 	short	  dp_numreg;	/* num jobs registered (syncct only)     */
 	short	  dp_released;	/* This job released to run (syncwith)   */
+	short	  dp_numrun;    /* num jobs supposed to run		 */
 	pbs_list_head dp_jobs;	/* list of related jobs  (all)           */
 };
 
@@ -105,6 +106,7 @@ struct depend_job {
 #define JOB_DEPEND_TYPE_BEFORENOTOK	 6
 #define JOB_DEPEND_TYPE_BEFOREANY	 7
 #define JOB_DEPEND_TYPE_ON		 8
+#define JOB_DEPEND_TYPE_RUN_ONE		 9
 #define JOB_DEPEND_NUMBER_TYPES		11
 
 #define JOB_DEPEND_OP_REGISTER		1
@@ -1112,7 +1114,14 @@ task_find	(job		*pjob,
 extern void  add_dest(job *);
 extern int   depend_on_que(attribute *, void *, int);
 extern int   depend_on_exec(job *);
+extern int   depend_run_one_remove_dependency(job *);
+extern int   depend_run_one_hold_all(job *);
+extern int   depend_run_one_release_all(job *);
 extern int   depend_on_term(job *);
+extern struct depend *find_depend(int type, attribute *pattr);
+extern struct depend_job *find_dependjob(struct depend *pdep, char *name);
+extern int send_depend_req(job *pjob, struct depend_job *pparent, int type, int op, int schedhint, void (*postfunc)(struct work_task *));
+extern void post_run_one(struct work_task *pwt);
 extern job  *find_job(char *);
 extern char *get_egroup(job *);
 extern char *get_variable(job *, char *);

--- a/src/include/job.h
+++ b/src/include/job.h
@@ -106,7 +106,7 @@ struct depend_job {
 #define JOB_DEPEND_TYPE_BEFORENOTOK	 6
 #define JOB_DEPEND_TYPE_BEFOREANY	 7
 #define JOB_DEPEND_TYPE_ON		 8
-#define JOB_DEPEND_TYPE_RUN_ONE		 9
+#define JOB_DEPEND_TYPE_RUNONE		 9
 #define JOB_DEPEND_NUMBER_TYPES		11
 
 #define JOB_DEPEND_OP_REGISTER		1
@@ -1114,14 +1114,14 @@ task_find	(job		*pjob,
 extern void  add_dest(job *);
 extern int   depend_on_que(attribute *, void *, int);
 extern int   depend_on_exec(job *);
-extern int   depend_run_one_remove_dependency(job *);
-extern int   depend_run_one_hold_all(job *);
-extern int   depend_run_one_release_all(job *);
+extern int   depend_runone_remove_dependency(job *);
+extern int   depend_runone_hold_all(job *);
+extern int   depend_runone_release_all(job *);
 extern int   depend_on_term(job *);
 extern struct depend *find_depend(int type, attribute *pattr);
 extern struct depend_job *find_dependjob(struct depend *pdep, char *name);
 extern int send_depend_req(job *pjob, struct depend_job *pparent, int type, int op, int schedhint, void (*postfunc)(struct work_task *));
-extern void post_run_one(struct work_task *pwt);
+extern void post_runone(struct work_task *pwt);
 extern job  *find_job(char *);
 extern char *get_egroup(job *);
 extern char *get_variable(job *, char *);

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -61,6 +61,10 @@ extern "C" {
 #include "pbs_sched.h"
 #include "server_limits.h"
 
+#define SYNC_SCHED_HINT_NULL	0
+#define SYNC_SCHED_HINT_FIRST	1
+#define SYNC_SCHED_HINT_OTHER	2
+
 enum srv_atr {
 	SRV_ATR_State,
 	SRV_ATR_SvrHost,

--- a/src/lib/Libcmds/parse_depend.c
+++ b/src/lib/Libcmds/parse_depend.c
@@ -56,6 +56,7 @@ static char *deptypes[] = {
 	"beforenotok",
 	"beforeany",
 	"syncwith",
+	"runone",
 	NULL
 };
 

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -422,6 +422,8 @@ char *msg_alps_switch_err = "Switching ALPS reservation failed";
 char *msg_softwt_stf = "soft_walltime is not supported with Shrink to Fit jobs";
 char *msg_node_busy = "Node is busy";
 char *msg_default_partition = "Default partition name is not allowed";
+char *msg_depend_run_one = "Job deleted, a dependent job ran";
+
 /*
  * The following table connects error numbers with text
  * to be returned to the client.  Each is guaranteed to be pure text.

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -422,7 +422,7 @@ char *msg_alps_switch_err = "Switching ALPS reservation failed";
 char *msg_softwt_stf = "soft_walltime is not supported with Shrink to Fit jobs";
 char *msg_node_busy = "Node is busy";
 char *msg_default_partition = "Default partition name is not allowed";
-char *msg_depend_run_one = "Job deleted, a dependent job ran";
+char *msg_depend_runone = "Job deleted, a dependent job ran";
 
 /*
  * The following table connects error numbers with text

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -589,6 +589,8 @@ struct job_info
 	float formula_value;		/* evaluated job sort formula value */
 	nspec **resreleased;		/* list of resources released by the job on each node */
 	resource_req *resreq_rel;	/* list of resources released */
+	char *depend_job_str;		/* dependent jobs in a ':' separated string */
+	resource_resv **dependent_jobs; /* dependent jobs with runone depenency */
 
 #ifdef NAS
 	/* localmod 045 */

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -129,8 +129,10 @@
 #include "site_queue.h"
 #endif
 
-
 extern char *pbse_to_txt(int err);
+
+/* assuming that in most cases there won't be more than 10 dependent runone jobs */
+#define DEFAULT_RUNONE_JOBS 10
 
 /**
  *	This table contains job comment and information messages that correspond
@@ -5382,7 +5384,8 @@ resource_resv **filter_preemptable_jobs(resource_resv **arr, resource_resv *job,
 static char **parse_runone_job_list(char *depend_val) {
 	char *start;
 	const char *depend_type = "runone";
-	int i, len = 10;
+	int i;
+	int len = DEFAULT_RUNONE_JOBS;
 	char *p, q;
 	char *r;
 	char *tok;
@@ -5411,16 +5414,16 @@ static char **parse_runone_job_list(char *depend_val) {
 		return NULL;
 	}
 	for (tok = strtok_r(r, ":", &p1); tok != NULL; tok = strtok_r(NULL, ":", &p1), i++) {
-		if (i == len-1) {
+		if (i == len - 1) {
 			char **tmp;
-			tmp = realloc(ret, (len + 10)*sizeof(char *));
+			tmp = realloc(ret, (len + DEFAULT_RUNONE_JOBS) * sizeof(char *));
 			if (tmp == NULL) {
 				free_ptr_array((void **)ret);
 				free(depend_str);
 				return NULL;
 			}
 			ret = tmp;
-			len += 10;
+			len += DEFAULT_RUNONE_JOBS;
 		}
 		tok = strtok_r(tok, "@", &p2);
 		ret[i] = string_dup(tok);

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -5383,10 +5383,9 @@ resource_resv **filter_preemptable_jobs(resource_resv **arr, resource_resv *job,
  */
 static char **parse_runone_job_list(char *depend_val) {
 	char *start;
-	const char *depend_type = "runone";
+	const char *depend_type = "runone:";
 	int i;
 	int len = DEFAULT_RUNONE_JOBS;
-	char *p, q;
 	char *r;
 	char *tok;
 	char **ret = NULL;
@@ -5401,18 +5400,15 @@ static char **parse_runone_job_list(char *depend_val) {
 	start = strstr(depend_str, depend_type);
 	if (start == NULL)
 		return NULL;
-	for (i = 0; start[i] != ',' &&  start[i] != '\0'; i++)
-		;
-	q = start[i];
-	p  = &start[i];
-	*p = '\0';
+
 	r = start + strlen(depend_type);
 	i = 0;
 	ret = calloc(len, sizeof(char *));
 	if (ret == NULL) {
-		*p = q;
+		free(depend_str);
 		return NULL;
 	}
+
 	for (tok = strtok_r(r, ":", &p1); tok != NULL; tok = strtok_r(NULL, ":", &p1), i++) {
 		if (i == len - 1) {
 			char **tmp;

--- a/src/scheduler/job_info.h
+++ b/src/scheduler/job_info.h
@@ -404,6 +404,8 @@ long extend_soft_walltime(resource_resv *resresv, time_t server_time);
 /* Returns a list of preemptable candidates */
 resource_resv **filter_preemptable_jobs(resource_resv **arr, resource_resv *job, schd_error *err);
 
+void associate_dependent_jobs(server_info *sinfo);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -1612,16 +1612,19 @@ res_to_str_re(void *p, enum resource_fields fld, char **buf,
 /*
  * @brief   helper function to free an array of pointers
  *
- * @param[in] arr - array of pointers
+ * @param[in] inp - array of pointers
  * @return void
  */
 void
-free_ptr_array(void **arr)
+free_ptr_array(void *inp)
 {
 	int i;
+	void **arr;
 
-	if (arr == NULL)
+	if (inp == NULL)
 		return;
+
+	arr = (void **)inp;
 
 	for (i = 0; arr[i] != NULL; i++)
 		free(arr[i]);

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -1609,3 +1609,21 @@ res_to_str_re(void *p, enum resource_fields fld, char **buf,
 	return *buf;
 }
 
+/*
+ * @brief   helper function to free an array of pointers
+ *
+ * @param[in] arr - array of pointers
+ * @return void
+ */
+void
+free_ptr_array(void **arr)
+{
+	int i;
+
+	if (arr == NULL)
+		return;
+
+	for (i = 0; arr[i] != NULL; i++)
+		free(arr[i]);
+	free(arr);
+}

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -277,6 +277,11 @@ add_str_to_array(char ***str_arr, char *str);
 int
 add_str_to_unique_array(char ***str_arr, char *str);
 
+/*
+ * helper function to free an array of pointers
+ */
+void free_ptr_array (void **arr);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -280,7 +280,7 @@ add_str_to_unique_array(char ***str_arr, char *str);
 /*
  * helper function to free an array of pointers
  */
-void free_ptr_array (void **arr);
+void free_ptr_array (void *inp);
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -1645,6 +1645,12 @@ update_resresv_on_run(resource_resv *resresv, nspec **nspec_arr)
 				free(selectspec);
 			}
 		}
+		if (resresv->job->dependent_jobs != NULL) {
+			for (i = 0; resresv->job->dependent_jobs[i] != NULL; i++) {
+				/* Mark all run one dependent jobs as "can not run" */
+				resresv->job->dependent_jobs[i]->can_not_run = 1;
+			}
+		}
 	}
 	else if (resresv->is_resv && resresv->resv !=NULL) {
 		resresv->resv->resv_state = RESV_RUNNING;

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -1647,7 +1647,7 @@ update_resresv_on_run(resource_resv *resresv, nspec **nspec_arr)
 		}
 		if (resresv->job->dependent_jobs != NULL) {
 			for (i = 0; resresv->job->dependent_jobs[i] != NULL; i++) {
-				/* Mark all run one dependent jobs as "can not run" */
+				/* Mark all runone jobs as "can not run" */
 				resresv->job->dependent_jobs[i]->can_not_run = 1;
 			}
 		}

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -349,6 +349,7 @@ query_server(status *pol, int pbs_sd)
 		return NULL;
 	}
 #endif /* localmod 050 */
+	associate_dependent_jobs(sinfo);
 
 	/* create res_to_check arrays based on current jobs/resvs */
 	policy->resdef_to_check = collect_resources_from_requests(sinfo->all_resresv);

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -2488,6 +2488,10 @@ dup_server_info(server_info *osinfo)
 			nsinfo->nodes[i]->node_events = dup_te_lists(osinfo->nodes[i]->node_events, nsinfo->calendar->next_event);
 	}
 	nsinfo->buckets = dup_node_bucket_array(osinfo->buckets, nsinfo);
+	/* Now that all job information has been created, time to associate
+	 * jobs to each other if they have runone dependency
+	 */
+	associate_dependent_jobs(nsinfo);
 
 	return nsinfo;
 }

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -260,6 +260,8 @@ job_abt(job *pjob, char *text)
 	int	old_substate;
 	int	rc = 0;
 
+	if (pjob == NULL)
+		return 0; /* nothing to do */
 	/* save old state and update state to Exiting */
 
 	old_state = pjob->ji_qs.ji_state;

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -616,6 +616,7 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 	struct batch_request *temp_preq = NULL;
 	int rc;
 	int is_mgr = 0;
+	int jt;
 
 	/* + 2 is for the '@' in user@host and for the null termination byte. */
 	char by_user[PBS_MAXUSER + PBS_MAXHOSTNAME + 2] = {'\0'};
@@ -632,6 +633,8 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 	/* See if the request is coming from a manager */
 	if (preq->rq_perm & (ATR_DFLAG_MGRD | ATR_DFLAG_MGWR))
 		is_mgr = 1;
+
+	jt = is_job_array(pjob->ji_qs.ji_jobid);
 
 	if (pjob->ji_qs.ji_state == JOB_STATE_TRANSIT) {
 
@@ -694,6 +697,13 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 		}
 
 		return;
+	} else if (((jt != IS_ARRAY_Range) && (jt != IS_ARRAY_Single)) &&
+		   ((pjob->ji_qs.ji_state == JOB_STATE_QUEUED) ||
+		    (pjob->ji_qs.ji_state == JOB_STATE_HELD))) {
+		struct depend *dp;
+		dp = find_depend(JOB_DEPEND_TYPE_RUN_ONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
+		if (dp != NULL)
+			depend_run_one_remove_dependency(pjob);
 	}
 
 	if (is_mgr && forcedel) {

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -701,9 +701,9 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 		   ((pjob->ji_qs.ji_state == JOB_STATE_QUEUED) ||
 		    (pjob->ji_qs.ji_state == JOB_STATE_HELD))) {
 		struct depend *dp;
-		dp = find_depend(JOB_DEPEND_TYPE_RUN_ONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
+		dp = find_depend(JOB_DEPEND_TYPE_RUNONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
 		if (dp != NULL)
-			depend_run_one_remove_dependency(pjob);
+			depend_runone_remove_dependency(pjob);
 	}
 
 	if (is_mgr && forcedel) {

--- a/src/server/req_register.c
+++ b/src/server/req_register.c
@@ -179,7 +179,7 @@ static void update_runone_depend(job *pjob, char *d_jobid, char *d_svr, int op)
 		if (dp == NULL) {
 			dp = make_depend(JOB_DEPEND_TYPE_RUNONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
 			if (dp == NULL)
-			        return;
+				return;
 		}
 		dpj = find_dependjob(dp, d_jobid);
 		if (dpj)
@@ -888,7 +888,7 @@ int depend_runone_remove_dependency(job *pjob)
 				temp_pdj = find_dependjob(find_depend(JOB_DEPEND_TYPE_RUNONE, &d_pjob->ji_wattr[(int)JOB_ATR_depend]),
 					                  pjob->ji_qs.ji_jobid);
 				if (temp_pdj) {
-				        del_depend_job(temp_pdj);
+					del_depend_job(temp_pdj);
 					d_pjob->ji_wattr[(int)JOB_ATR_depend].at_flags |= ATR_VFLAG_MODIFY|ATR_VFLAG_MODCACHE;
 				}
 			}
@@ -925,7 +925,7 @@ int depend_runone_hold_all(job *pjob)
 			d_pjob = find_job(pdj->dc_child);
 			if (d_pjob) {
 				d_pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long |= HOLD_s;
-		                d_pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+				d_pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
 				(void)svr_setjobstate(d_pjob, JOB_STATE_HELD, JOB_SUBSTATE_HELD);
 			}
 		}
@@ -964,7 +964,7 @@ int depend_runone_release_all(job *pjob)
 			d_pjob = find_job(pdj->dc_child);
 			if (d_pjob) {
 				d_pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long &= ~HOLD_s;
-		                d_pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		                d_pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_MODCACHE;
 				svr_evaljobstate(d_pjob, &newstate, &newsub, 0);
 				(void)svr_setjobstate(d_pjob, newstate, newsub); /* saves job */
 			}

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -100,6 +100,7 @@ post_rerun(struct work_task *pwt)
 {
 	job	*pjob;
 	struct batch_request *preq;
+	struct depend *pdep;
 
 	preq = (struct batch_request *)pwt->wt_parm1;
 
@@ -114,6 +115,12 @@ post_rerun(struct work_task *pwt)
 
 			if (pjob->ji_pmt_preq != NULL)
 				reply_preempt_jobs_request(preq->rq_reply.brp_code, PREEMPT_METHOD_REQUEUE, pjob);
+		}
+		else {
+			/* mom acknowledged to rerun the job, release depend hold on run-one dependency */
+			pdep = find_depend(JOB_DEPEND_TYPE_RUN_ONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
+			if (pdep != NULL)
+				depend_run_one_release_all(pjob);
 		}
 	}
 
@@ -409,6 +416,7 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 	struct  work_task *ptask;
 	time_t  rerun_to;
 	conn_t	*conn;
+	struct depend *pdep;
 	int rc;
 
 	if (preq->rq_extend && (strcmp(preq->rq_extend, "force") == 0))
@@ -457,7 +465,6 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 	 * then deleted from mom as well.
 	 */
 	if (force == 1) {
-
 		/* Mom is down and issue signal failed or
 		 * request is from a manager and "force" is on,
 		 * force the requeue */
@@ -471,6 +478,9 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 		 * force_reque will be called in post_discard_job,
 		 * after receiving IS_DISCARD_DONE from the MOM.
 		 */
+		pdep = find_depend(JOB_DEPEND_TYPE_RUN_ONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
+		if (pdep != NULL)
+			depend_run_one_release_all(pjob);
 		reply_ack(preq);
 		return;
 

--- a/src/server/req_rerun.c
+++ b/src/server/req_rerun.c
@@ -118,9 +118,9 @@ post_rerun(struct work_task *pwt)
 		}
 		else {
 			/* mom acknowledged to rerun the job, release depend hold on run-one dependency */
-			pdep = find_depend(JOB_DEPEND_TYPE_RUN_ONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
+			pdep = find_depend(JOB_DEPEND_TYPE_RUNONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
 			if (pdep != NULL)
-				depend_run_one_release_all(pjob);
+				depend_runone_release_all(pjob);
 		}
 	}
 
@@ -478,9 +478,9 @@ req_rerunjob2(struct batch_request *preq, job *pjob)
 		 * force_reque will be called in post_discard_job,
 		 * after receiving IS_DISCARD_DONE from the MOM.
 		 */
-		pdep = find_depend(JOB_DEPEND_TYPE_RUN_ONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
+		pdep = find_depend(JOB_DEPEND_TYPE_RUNONE, &pjob->ji_wattr[(int)JOB_ATR_depend]);
 		if (pdep != NULL)
-			depend_run_one_release_all(pjob);
+			depend_runone_release_all(pjob);
 		reply_ack(preq);
 		return;
 

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1130,9 +1130,9 @@ svr_strtjob2(job *pjob, struct batch_request *preq)
 			if (base_job != NULL &&
 			    base_job->ji_wattr[(int)JOB_ATR_depend].at_flags & ATR_VFLAG_SET) {
 				struct depend *pdep;
-				pdep = find_depend(JOB_DEPEND_TYPE_RUN_ONE, &base_job->ji_wattr[(int)JOB_ATR_depend]);
+				pdep = find_depend(JOB_DEPEND_TYPE_RUNONE, &base_job->ji_wattr[(int)JOB_ATR_depend]);
 				if (pdep != NULL)
-					depend_run_one_hold_all(base_job);
+					depend_runone_hold_all(base_job);
 			}
 		}
 		return (0);

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1117,8 +1117,23 @@ svr_strtjob2(job *pjob, struct batch_request *preq)
 		 * in
 		 */
 		if (preq == NULL || (preq->rq_type == PBS_BATCH_AsyrunJob)) {
-			if (pjob->ji_qs.ji_substate == JOB_SUBSTATE_PRERUN)
+			job *base_job = NULL;
+			if (pjob->ji_qs.ji_substate == JOB_SUBSTATE_PRERUN){
 				set_resc_assigned((void *)pjob, 0, INCR);
+				/* Just update dependencies for the first subjob that runs */
+				if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) &&
+				    pjob->ji_parentaj->ji_wattr[(int)JOB_ATR_state].at_val.at_long != JOB_STATE_BEGUN)
+					base_job = pjob->ji_parentaj;
+				else
+					base_job = pjob;
+			}
+			if (base_job != NULL &&
+			    base_job->ji_wattr[(int)JOB_ATR_depend].at_flags & ATR_VFLAG_SET) {
+				struct depend *pdep;
+				pdep = find_depend(JOB_DEPEND_TYPE_RUN_ONE, &base_job->ji_wattr[(int)JOB_ATR_depend]);
+				if (pdep != NULL)
+					depend_run_one_hold_all(base_job);
+			}
 		}
 		return (0);
 	} else {

--- a/test/tests/functional/pbs_job_dependency.py
+++ b/test/tests/functional/pbs_job_dependency.py
@@ -1,0 +1,287 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestJobDependency(TestFunctional):
+
+    """
+    Test suite to test different job dependencies
+    """
+    hook_body = """
+import pbs
+e = pbs.event()
+j = e.job
+if ('DEPENDENT_JOB' in j.Variable_List):
+    j.depend = pbs.depend("runone:" + str(j.Variable_List['DEPENDENT_JOB']))
+e.accept()
+"""
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        attr = {ATTR_RESC_TYPE: 'string', ATTR_RESC_FLAG: 'h'}
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id='NewRes')
+        rv = self.scheduler.add_resource('NewRes', apply=True)
+        self.assertTrue(rv)
+        a = {ATTR_rescavail + '.ncpus': 0}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+    def create_vnodes(self):
+        attr = {'resources_available.ncpus': 1}
+        self.server.create_vnodes('vnode', attr, 6, mom=self.mom)
+        for i in range(6):
+            res_str = "ver" + str(i)
+            attr = {'resources_available.NewRes': res_str}
+            vnode = 'vnode[' + str(i) + ']'
+            self.server.manager(MGR_CMD_SET, NODE, attr, vnode)
+
+    def assert_dependency(self, *jobs):
+        dl = []
+        num = len(jobs)
+        for ind, _ in enumerate(jobs):
+            temp = self.server.status(JOB, id=jobs[ind])[0][ATTR_depend]
+            dl.append([i.split('@')[0] for i in temp.split(':')[1:]])
+            self.assertEqual(num-1, len(dl[ind]))
+
+        for ind, job in enumerate(jobs):
+            # make a list of dependency list that does not contain the
+            # enumerated job
+            check_dl = dl[:ind] + dl[ind + 1:]
+            for job_list in check_dl:
+                    self.assertIn(job, job_list)
+
+    def test_runone_depend_basic(self):
+        """
+        Test basic runone dependency tests
+        1 - Submit a job that runs and then submit a job having "runone"
+        dependency on the first job. Check that second job is deleted as
+        soon as it is submitted.
+        2 - Submit a can never run job and submit a second job having "runone"
+        dependency on the first job. Check that first job is deleted when
+        second job runs.
+        """
+
+        self.create_vnodes()
+        job = Job(attrs={'Resource_List.select': '1:NewRes=ver3'})
+        job.set_sleep_time(2)
+        j1 = self.server.submit(job)
+        d_job = Job(attrs={'Resource_List.select': '2:ncpus=1',
+                           ATTR_depend: 'runone:' + j1})
+        j1_2 = self.server.submit(d_job)
+        self.server.expect(JOB, {'job_state': 'R'}, id=j1)
+        self.server.accounting_match("Job deleted as result of dependency",
+                                     id=j1_2)
+
+        job = Job(attrs={'Resource_List.select': '1:ncpus=4:NewRes=ver3'})
+        job.set_sleep_time(2)
+        j2 = self.server.submit(job)
+        d_job = Job(attrs={'Resource_List.select': '2:ncpus=1',
+                           ATTR_depend: 'runone:' + j2})
+        j2_2 = self.server.submit(d_job)
+        self.server.expect(JOB, {'job_state': 'R'}, id=j2_2)
+        self.server.accounting_match("Job deleted as result of dependency",
+                                     id=j2)
+
+    def test_runone_dependency_on_running_job(self):
+        """
+        Submit a job putting runone dependency on an already running job
+        check to see that the second job is put on system hold as soon
+        as it is submitted.
+        """
+        self.create_vnodes()
+        job = Job()
+        j1 = self.server.submit(job)
+        a = {ATTR_state: 'R'}
+        self.server.expect(JOB, a, id=j1)
+
+        a = {ATTR_depend: 'runone:' + j1}
+        job2 = Job(attrs=a)
+        j2 = self.server.submit(job2)
+        a = {ATTR_state: 'H', ATTR_h: 's'}
+        self.server.expect(JOB, a, id=j2)
+
+        self.assert_dependency(j1, j2)
+
+    def test_runone_dependency_on_already_held_job(self):
+        """
+        Submit a job putting runone dependency on an already running job
+        check to see that the second job is put on system hold as soon
+        as it is submitted, then submit another job dependent on the
+        second held job and see if that gets held as well.
+        Also test that all jobs have dependency on other two jobs.
+        """
+        self.create_vnodes()
+        job = Job(TEST_USER)
+        j1 = self.server.submit(job)
+        a = {ATTR_state: 'R'}
+        self.server.expect(JOB, a, id=j1)
+
+        a = {ATTR_depend: 'runone:' + j1}
+        job2 = Job(TEST_USER, attrs=a)
+        j2 = self.server.submit(job2)
+        a = {ATTR_state: 'H', ATTR_h: 's'}
+        self.server.expect(JOB, a, id=j2)
+
+        a = {ATTR_depend: 'runone:' + j2}
+        job3 = Job(TEST_USER, attrs=a)
+        j3 = self.server.submit(job3)
+        a = {ATTR_state: 'H', ATTR_h: 's'}
+        self.server.expect(JOB, a, id=j3)
+
+        self.assert_dependency(j1, j2, j3)
+
+    def test_runone_depend_basic_on_job_array(self):
+        """
+        Test basic runone dependency tests on job arrays
+        1 - Submit a job array that runs and then submit a job having "runone"
+        dependency on the parent job array. Check that second job is deleted as
+        soon as it is submitted.
+        2 - Submit a can never run array job and submit a second job having
+        "runone" dependency on the array parent. Check that first job is
+        deleted when second job runs.
+        3 - Submit a runone dependency on an array subjob and check if job
+        submission fails in this case.
+        """
+
+        self.create_vnodes()
+        job = Job(attrs={'Resource_List.select': '1:ncpus=1',
+                         ATTR_J: '1-3'})
+        job.set_sleep_time(5)
+        j1 = self.server.submit(job)
+        d_job = Job(attrs={'Resource_List.select': '2:ncpus=1',
+                           ATTR_depend: 'runone:' + j1})
+        j1_2 = self.server.submit(d_job)
+        self.server.expect(JOB, {'job_state': 'B'}, id=j1)
+        self.server.expect(JOB, {'job_state': 'H'}, id=j1_2)
+        self.server.accounting_match("Job deleted as result of dependency",
+                                     id=j1_2)
+
+        job = Job(attrs={'Resource_List.select': '1:ncpus=4:NewRes=ver3',
+                         ATTR_J: '1-3'})
+        job.set_sleep_time(2)
+        j2 = self.server.submit(job)
+        d_job = Job(attrs={'Resource_List.select': '2:ncpus=1',
+                           ATTR_depend: 'runone:' + j2})
+        j2_1 = self.server.submit(d_job)
+        self.server.expect(JOB, {'job_state': 'R'}, id=j2_1)
+        self.server.expect(JOB, {'job_state': 'H'}, id=j2)
+        self.server.accounting_match("Job deleted as result of dependency",
+                                     id=j2)
+
+        job = Job(attrs={'Resource_List.select': '1:ncpus=1',
+                         ATTR_J: '1-3'})
+        job.set_sleep_time(2)
+        j3 = self.server.submit(job)
+        j3_1 = j3.split('[')[0] + '1' + j3.split('[')[1]
+        d_job = Job(attrs={'Resource_List.select': '2:ncpus=1',
+                           ATTR_depend: 'runone:' + j3_1})
+        with self.assertRaises(PbsSubmitError) as e:
+            self.server.submit(d_job)
+
+    def test_runone_queuejob_hook(self):
+        """
+        Check to see that a queue job hook can set runone job
+        dependency.
+        """
+        self.create_vnodes()
+        a = {'event': 'queuejob', 'enabled': 'True'}
+        self.server.create_import_hook('h1', a, self.hook_body)
+        job = Job()
+        j1 = self.server.submit(job)
+        a = {ATTR_state: 'R'}
+        self.server.expect(JOB, a, id=j1)
+
+        a = {ATTR_v: 'DEPENDENT_JOB=' + j1}
+        job2 = Job(attrs=a)
+        j2 = self.server.submit(job2)
+        a = {ATTR_state: 'H', ATTR_h: 's'}
+        self.server.expect(JOB, a, id=j2)
+
+        self.assert_dependency(j1, j2)
+
+    def test_runone_runjob_hook(self):
+        """
+        Check to see that a run job hook cannot set runone job
+        dependency.
+        """
+        self.create_vnodes()
+        a = {'event': 'runjob', 'enabled': 'True'}
+        self.server.create_import_hook('h1', a, self.hook_body)
+        job = Job()
+        j1 = self.server.submit(job)
+        a = {ATTR_state: 'R'}
+        self.server.expect(JOB, a, id=j1)
+
+        a = {ATTR_v: 'DEPENDENT_JOB=' + j1}
+        job2 = Job(attrs=a)
+        j2 = self.server.submit(job2)
+        logmsg = "cannot modify job after runjob request has been accepted"
+        self.server.log_match(logmsg)
+
+    def test_deleting_one_runone_dependency_job(self):
+        """
+        Submit a job putting runone dependency on an already running job
+        check to see that the second job is put on system hold as soon
+        as it is submitted, then submit another job dependent on the
+        second held job and see if that gets held as well.
+        Then test that deleting second job updates dependencies on
+        other two jobs.
+        """
+        self.create_vnodes()
+        job = Job(TEST_USER)
+        j1 = self.server.submit(job)
+        a = {ATTR_state: 'R'}
+        self.server.expect(JOB, a, id=j1)
+
+        a = {ATTR_depend: 'runone:' + j1}
+        job2 = Job(TEST_USER, attrs=a)
+        j2 = self.server.submit(job2)
+        a = {ATTR_state: 'H', ATTR_h: 's'}
+        self.server.expect(JOB, a, id=j2)
+
+        a = {ATTR_depend: 'runone:' + j2}
+        job3 = Job(TEST_USER, attrs=a)
+        j3 = self.server.submit(job3)
+        a = {ATTR_state: 'H', ATTR_h: 's'}
+        self.server.expect(JOB, a, id=j3)
+
+        self.assert_dependency(j1, j2, j3)
+
+        self.server.delete(j2)
+        self.assert_dependency(j1, j3)

--- a/test/tests/functional/pbs_job_dependency.py
+++ b/test/tests/functional/pbs_job_dependency.py
@@ -58,17 +58,14 @@ e.accept()
         attr = {ATTR_RESC_TYPE: 'string', ATTR_RESC_FLAG: 'h'}
         self.server.manager(MGR_CMD_CREATE, RSC, attr, id='NewRes')
         self.scheduler.add_resource('NewRes', apply=True)
-        self.create_vnodes()
+        attr = {'resources_available.ncpus': 1}
+        self.server.create_vnodes('vnode', attr, 6, mom=self.mom,
+                                  attrfunc=self.cust_attr, usenatvnode=False)
 
     def cust_attr(self, name, totnodes, numnode, attrib):
         res_str = "ver" + str(numnode)
         attr = {'resources_available.NewRes': res_str}
         return {**attrib, **attr}
-
-    def create_vnodes(self):
-        attr = {'resources_available.ncpus': 1}
-        self.server.create_vnodes('vnode', attr, 6, mom=self.mom,
-                                  attrfunc=self.cust_attr)
 
     def assert_dependency(self, *jobs):
         dl = []
@@ -187,7 +184,7 @@ e.accept()
         j3_1 = job.create_subjob_id(j3, 1)
         d_job = Job(attrs={'Resource_List.select': '2:ncpus=1',
                            ATTR_depend: 'runone:' + j3_1})
-        with self.assertRaises(PbsSubmitError) as e:
+        with self.assertRaises(PbsSubmitError):
             self.server.submit(d_job)
 
     def test_runone_queuejob_hook(self):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
New dependency that allows PBS to run only of the dependent jobs and delete the rest when the job that ran, finishes.


#### Describe Your Change
#### Link to Design Doc
Design discussion - http://community.pbspro.org/t/new-runone-job-dependency/1988
Design proposal - https://pbspro.atlassian.net/wiki/spaces/PD/pages/1507033177/runone+job+dependency


#### Attach Test and Valgrind Logs/Output
[test.txt](https://github.com/PBSPro/pbspro/files/4346235/test.txt)
[server_valgrind_log.txt](https://github.com/PBSPro/pbspro/files/4346236/server_valgrind_log.txt)


#### Raising this pull for early review, I'll be running regression tests in the meantime.