### PR TITLE
TestPbsNodeRampDown Tests failing because of jobs not in R state soon after server restart

### DIFF
--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -6040,10 +6040,11 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
         self.server.start()
         self.assertTrue(self.server.isUp())
 
-        # make sure job is now running with assigned resources
+        # make sure job is now running after server restart
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        # make sure job is running with assigned resources
         # from the original request
-        self.server.expect(JOB, {'job_state': 'R',
-                                 'Resource_List.mem': '5gb',
+        self.server.expect(JOB, {'Resource_List.mem': '5gb',
                                  'Resource_List.ncpus': 7,
                                  'Resource_List.nodect': 3,
                                  'Resource_List.select': self.job11x_select,
@@ -6406,10 +6407,12 @@ pbs.logjobmsg(pbs.event().job.id, "epilogue hook executed")
         self.server.start()
         self.assertTrue(self.server.isUp())
 
-        # make sure job is now running with assigned resources
+        # make sure job is now running after server restart
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        # make sure job is running with assigned resources
         # from the original request
-        self.server.expect(JOB, {'job_state': 'R',
-                                 'Resource_List.mem': '5gb',
+        self.server.expect(JOB, {'Resource_List.mem': '5gb',
                                  'Resource_List.ncpus': 7,
                                  'Resource_List.nodect': 3,
                                  'Resource_List.select': self.job11_select,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Soon after server restart nodes are not yet available so job will be in Q state for sometime. Tests are checking assigned resources and R state of the job soon after server restart as assigned resources are not there test fails it does not retrigger sched cycle.


#### Describe Your Change
Check the job for R state first which retriggers scheduling cycle and waits for jobs to run and then check for assigned resources.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[shared_restart.txt](https://github.com/PBSPro/pbspro/files/4347058/shared_restart.txt)
[excl_restart.txt](https://github.com/PBSPro/pbspro/files/4347063/excl_restart.txt)
[pbs_node_ramp_down_19.2.6_logs.txt](https://github.com/PBSPro/pbspro/files/4347111/pbs_node_ramp_down_19.2.6_logs.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
