### PR TITLE
pbs_mom fails to start while mom hook is running.

### DIFF
--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -880,6 +880,7 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 		}
 
 	} else {		/* child */
+                // releasing ports
                 rpp_terminate();
                 net_close(-1);
 		(void)setsid();

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -880,6 +880,8 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 		}
 
 	} else {		/* child */
+                rpp_terminate();
+                net_close(-1);
 		(void)setsid();
 
 		myseq = getpid();

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -880,7 +880,7 @@ run_hook(hook *phook, unsigned int event_type, mom_hook_input_t *hook_input,
 		}
 
 	} else {		/* child */
-                // releasing ports
+                /* releasing ports */
                 rpp_terminate();
                 net_close(-1);
 		(void)setsid();

--- a/test/tests/functional/pbs_hook_execjob_end.py
+++ b/test/tests/functional/pbs_hook_execjob_end.py
@@ -463,15 +463,27 @@ class TestPbsExecjobEnd(TestFunctional):
         Test to restart mom while execjob_end hook is running
         """
         hook_name = "end_hook"
-        attr = {'event': 'execjob_end', 'enabled': 'True', 'alarm': '100'}
-        self.server.create_import_hook(hook_name, attr, self.hook_body)
+        attr = {'event': 'execjob_end', 'enabled': 'True', 'alarm': '40'}
+        hook_body = ("import pbs\n"
+                     "import time\n"
+                     "e = pbs.event()\n"
+                     "pbs.logjobmsg(e.job.id, \
+                                    'execjob_end hook started')\n"
+                     "time.sleep(20)\n"
+                     "pbs.logjobmsg(e.job.id, \
+                                    'execjob_end hook ended')\n"
+                     "e.accept()\n")
+        self.server.create_import_hook(hook_name, attr, hook_body)
         j = Job(TEST_USER)
         j.set_sleep_time(5)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.mom.log_match("Job;%s;executed execjob_end hook" %
+        self.mom.log_match("Job;%s;execjob_end hook started" %
                            jid, n=100, max_attempts=10,
                            interval=2)
         self.mom.restart()
+        self.mom.log_match("Job;%s;execjob_end hook ended" %
+                           jid, n=100, max_attempts=20,
+                           interval=2)
         self.server.log_match(jid + ";Exit_status=0", interval=4,
                               max_attempts=10)

--- a/test/tests/functional/pbs_hook_execjob_end.py
+++ b/test/tests/functional/pbs_hook_execjob_end.py
@@ -34,22 +34,32 @@
 # Use of Altair’s trademarks, including but not limited to "PBS™",
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
+import textwrap
 from tests.functional import *
 from ptl.utils.pbs_logutils import PBSLogUtils
 
-hook_body = """
-import pbs
-import time
-e = pbs.event()
 
-if e.type == pbs.EXECJOB_EPILOGUE:
-    hook_type = "EXECJOB_EPILOGUE"
-elif e.type == pbs.EXECJOB_END:
-    hook_type = "EXECJOB_END"
-pbs.logjobmsg(e.job.id, "starting hook event %s" % (hook_type))
-time.sleep(5)
-pbs.logjobmsg(e.job.id, "ending hook event %s" % (hook_type))
-"""
+def get_hook_body(sleep_time):
+    """
+    method to return hook body
+    :param sleep_time: sleep time added in the hook
+    :type sleep_time: int
+    """
+    hook_body = """
+    import pbs
+    import time
+    e = pbs.event()
+
+    if e.type == pbs.EXECJOB_EPILOGUE:
+        hook_type = "EXECJOB_EPILOGUE"
+    elif e.type == pbs.EXECJOB_END:
+        hook_type = "EXECJOB_END"
+    pbs.logjobmsg(e.job.id, "starting hook event " + hook_type)
+    time.sleep(%s)
+    pbs.logjobmsg(e.job.id, "ending hook event " + hook_type)
+    """ % sleep_time
+    hook_body = textwrap.dedent(hook_body)
+    return hook_body
 
 
 class TestPbsExecjobEnd(TestFunctional):
@@ -357,8 +367,7 @@ class TestPbsExecjobEnd(TestFunctional):
         """
 
         hook_name = "epiend_hook"
-        global hook_body
-
+        hook_body = get_hook_body(5)
         attr = {'event': 'execjob_epilogue,execjob_end', 'enabled': 'True'}
         self.server.create_import_hook(hook_name, attr, hook_body)
         j = Job(TEST_USER)
@@ -426,7 +435,7 @@ class TestPbsExecjobEnd(TestFunctional):
         """
 
         hook_name = "end_hook"
-        global hook_body
+        hook_body = get_hook_body(5)
         attr = {'event': 'execjob_end', 'enabled': 'True', 'alarm': '50'}
         self.server.create_import_hook(hook_name, attr, hook_body)
         attrib = {ATTR_nodefailrq: 30}
@@ -442,7 +451,7 @@ class TestPbsExecjobEnd(TestFunctional):
         """
 
         hook_name = "end_hook"
-        global hook_body
+        hook_body = get_hook_body(5)
         attr = {'event': 'execjob_end', 'enabled': 'True', 'alarm': '50'}
         self.server.create_import_hook(hook_name, attr, hook_body)
         attrib = {ATTR_nodefailrq: 30}
@@ -463,26 +472,18 @@ class TestPbsExecjobEnd(TestFunctional):
         Test to restart mom while execjob_end hook is running
         """
         hook_name = "end_hook"
+        hook_body = get_hook_body(20)
         attr = {'event': 'execjob_end', 'enabled': 'True', 'alarm': '40'}
-        hook_body = ("import pbs\n"
-                     "import time\n"
-                     "e = pbs.event()\n"
-                     "pbs.logjobmsg(e.job.id, \
-                                    'execjob_end hook started')\n"
-                     "time.sleep(20)\n"
-                     "pbs.logjobmsg(e.job.id, \
-                                    'execjob_end hook ended')\n"
-                     "e.accept()\n")
         self.server.create_import_hook(hook_name, attr, hook_body)
         j = Job(TEST_USER)
         j.set_sleep_time(5)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.mom.log_match("Job;%s;execjob_end hook started" %
+        self.mom.log_match("Job;%s;starting hook event EXECJOB_END" %
                            jid, n=100, max_attempts=10,
                            interval=2)
         self.mom.restart()
-        self.mom.log_match("Job;%s;execjob_end hook ended" %
+        self.mom.log_match("Job;%s;ending hook event EXECJOB_END" %
                            jid, n=100, max_attempts=20,
                            interval=2)
         self.server.log_match(jid + ";Exit_status=0", interval=4,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When the hook is running for a long period and if we kill mom and start, then mom fails to start.
PBS Mom fails to restart with network bind issue while the mom hook is running, while trying to bind on 15002:
msg=server port = 15002, errno = 25 pbs_mom startup failed, exit 3 aborting.

While the hook is running, we see:

lsof | grep 15002
pbs_mom    1144          root    5u     IPv4           43046049       0t0        TCP *:15002 (LISTEN)
pbs_mom    1144  1147    root    5u     IPv4           43046049       0t0        TCP *:15002 (LISTEN)
pbs_pytho  1211          root    5u     IPv4           43046049       0t0        TCP *:15002 (LISTEN)

 

ps -ef | grep 1144
root 1144 1 0 Feb21 ? 00:01:09 /opt/pbs/sbin/pbs_mom
root 1211 1144 0 00:35 ? 00:00:00 /opt/pbs/bin/pbs_python --hook -i /var/spool/pbs/mom_priv/hooks/tmp/hook_execjob_end_momhook_1211.in -o /var/spool/pbs/mom_priv/hooks/tmp/hook_execjob_end_momhook_1211.out -L /var/spool/pbs/mom_logs -e 959 /var/spool/pbs/mom_priv/hooks/momhook.PY

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Release the port after fork, in child (hook execution).

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
NA

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_mom_restart_logs_afterfix.txt](https://github.com/PBSPro/pbspro/files/4347313/test_mom_restart_logs_afterfix.txt)
[test_mom_restart_logs_beforefix.txt](https://github.com/PBSPro/pbspro/files/4347314/test_mom_restart_logs_beforefix.txt)
[TestPbsExecjobEnd_logs_afterfix.txt](https://github.com/PBSPro/pbspro/files/4347315/TestPbsExecjobEnd_logs_afterfix.txt)

 Valgrind Logs:
[valgrind.log](https://github.com/PBSPro/pbspro/files/4348764/valgrind.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
