### PR TITLE
customize TPP mcast packet for target comms

### DIFF
--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -3656,7 +3656,7 @@ add_part_packet(stream_t *strm, void *data, int sz)
 	pkt = strm->part_recv_pkt;
 	TPP_DBPRT(("*** pkt=%p, sd=%u, sz=%d, totlen=%d, cmprsd_len=%u", (void *) pkt, strm->sd, sz, totlen, cmprsd_len));
 	if (!pkt) {
-		/* some rare cases, compresses size can be larger than orig size, hence use the larger value */
+		/* some rare cases, compressed size can be larger than orig size, hence use the larger value */
 		pkt = tpp_cr_pkt(NULL, totlen > sz ? totlen : sz, 1);
 		if (!pkt)
 			return NULL;

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -1223,7 +1223,7 @@ tpp_send(int sd, void *data, int len)
 
 	TPP_DBPRT(("Sending: sd=%d, len=%d", sd, len));
 
-	if ((tpp_conf->compress == 1) && (len > TPP_SEND_SIZE)) {
+	if ((tpp_conf->compress == 1) && (len > TPP_COMPR_SIZE)) {
 		void *outbuf;
 
 		outbuf = tpp_deflate(data, len, &cmprsd_len);
@@ -2326,7 +2326,7 @@ tpp_mcast_send(int mtfd, void *data, unsigned int len, unsigned int full_len, un
 	chunks[0].len = sizeof(tpp_mcast_pkt_hdr_t);
 	totlen = chunks[0].len;
 
-	if (tpp_conf->compress == 1 && minfo_len > TPP_SEND_SIZE) {
+	if (tpp_conf->compress == 1 && minfo_len > TPP_COMPR_SIZE) {
 		def_ctx = tpp_multi_deflate_init(minfo_len);
 		if (def_ctx == NULL)
 			goto err;
@@ -3656,7 +3656,8 @@ add_part_packet(stream_t *strm, void *data, int sz)
 	pkt = strm->part_recv_pkt;
 	TPP_DBPRT(("*** pkt=%p, sd=%u, sz=%d, totlen=%d, cmprsd_len=%u", (void *) pkt, strm->sd, sz, totlen, cmprsd_len));
 	if (!pkt) {
-		pkt = tpp_cr_pkt(NULL, totlen, 1);
+		/* some rare cases, compresses size can be larger than orig size, hence use the larger value */
+		pkt = tpp_cr_pkt(NULL, totlen > sz ? totlen : sz, 1);
 		if (!pkt)
 			return NULL;
 		TPP_DBPRT(("Total length = %d, sz=%d", totlen, sz));

--- a/src/lib/Libtpp/tpp_common.h
+++ b/src/lib/Libtpp/tpp_common.h
@@ -273,7 +273,7 @@ enum TPP_MSG_TYPES {
 #define TPP_STRM_TIMEOUT        600
 #define TPP_MIN_WAIT            2
 #define TPP_SEND_SIZE           8192
-#define TPP_COMPR_SIZE			8192
+#define TPP_COMPR_SIZE          8192
 
 /* tpp cmds used internally by the layer to notify messages between threads */
 #define TPP_CMD_SEND            1

--- a/src/lib/Libtpp/tpp_common.h
+++ b/src/lib/Libtpp/tpp_common.h
@@ -273,6 +273,7 @@ enum TPP_MSG_TYPES {
 #define TPP_STRM_TIMEOUT        600
 #define TPP_MIN_WAIT            2
 #define TPP_SEND_SIZE           8192
+#define TPP_COMPR_SIZE			8192
 
 /* tpp cmds used internally by the layer to notify messages between threads */
 #define TPP_CMD_SEND            1

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -1950,18 +1950,18 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 			int i, k;
 			tpp_addr_t *src_host;
 			typedef struct {
-				char *router_name;
 				int target_fd; /* target comm fd */
+				int num_streams; /* actual number of destination streams */ 
+				char *router_name;
 				void *cmpr_ctx;
 				void *minfo_buf; /* allocate size for total members */
-				int num_streams; /* actual number of destination streams */ 
 			} target_comm_struct_t;
 
 			target_comm_struct_t *rlist = NULL;
 			int rsize = 0;
 			int csize = 0;
 			void *tmp;
-			tpp_chunk_t mchunks[3];
+			tpp_chunk_t mchunks[3]; /* mcast packet has 3 chunks */
 
 			/* find the fd to forward to via the associated router */
 			tpp_mcast_pkt_hdr_t *mhdr = (tpp_mcast_pkt_hdr_t *) data;
@@ -2072,7 +2072,7 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 					memcpy(&shdr.dest_addr, &minfo->dest_addr, sizeof(tpp_addr_t));
 
 					TPP_DBPRT(("Send mcast indiv packet to %s", tpp_netaddr(&shdr.dest_addr)));
-					
+
 					if (tpp_transport_vsend(target_fd, chunks, 2) != 0) {
 						tpp_log_func(LOG_ERR, __func__, "Failed to send mcast indiv pkt");
 						tpp_transport_close(target_fd);
@@ -2087,8 +2087,8 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 				} else if (orig_hop == 0) {
 					/* add this to list of routers to whom we need to send */
 					/**
-					 * now check list backwards if router already added to
-					 * rational for checking backwards is that the last router
+					 * now walk list backwards checking if router was already added.
+					 * Rationale for checking backwards is that the last router
 					 * that we added data to, is probably the one that the next
 					 * few nodes are attached to as well.
 					 * Might be able to use a hash here for faster search

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -1949,10 +1949,19 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 		case TPP_MCAST_DATA: {
 			int i, k;
 			tpp_addr_t *src_host;
-			int *rlist = NULL;
+			typedef struct {
+				char *router_name;
+				int target_fd; /* target comm fd */
+				void *cmpr_ctx;
+				void *minfo_buf; /* allocate size for total members */
+				int num_streams; /* actual number of destination streams */ 
+			} target_comm_struct_t;
+
+			target_comm_struct_t *rlist = NULL;
 			int rsize = 0;
 			int csize = 0;
 			void *tmp;
+			tpp_chunk_t mchunks[3];
 
 			/* find the fd to forward to via the associated router */
 			tpp_mcast_pkt_hdr_t *mhdr = (tpp_mcast_pkt_hdr_t *) data;
@@ -1966,8 +1975,6 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 			unsigned int cmprsd_len = ntohl(mhdr->info_cmprsd_len);
 			unsigned int num_streams = ntohl(mhdr->num_streams);
 			unsigned int info_len = ntohl(mhdr->info_len);
-			tpp_chunk_t mchunks[1];
-			int already_sent;
 
 			if (cmprsd_len > 0) {
 				payload_len = len - sizeof(tpp_mcast_pkt_hdr_t) - cmprsd_len;
@@ -2011,8 +2018,9 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 #endif
 
 			mhdr->hop = 1; /* set hop=1 to forward, use orig_hop for checking */
-			mchunks[0].data = data;
-			mchunks[0].len = len;
+
+			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Total mcast member streams=%d", num_streams);
+			tpp_log_func(LOG_INFO, __func__, tpp_get_logbuf());
 
 			/*
 			 * go backwards in an attempt to distribute mcast packet
@@ -2064,7 +2072,7 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 					memcpy(&shdr.dest_addr, &minfo->dest_addr, sizeof(tpp_addr_t));
 
 					TPP_DBPRT(("Send mcast indiv packet to %s", tpp_netaddr(&shdr.dest_addr)));
-
+					
 					if (tpp_transport_vsend(target_fd, chunks, 2) != 0) {
 						tpp_log_func(LOG_ERR, __func__, "Failed to send mcast indiv pkt");
 						tpp_transport_close(target_fd);
@@ -2077,74 +2085,131 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 						return 0;
 					}
 				} else if (orig_hop == 0) {
-					/* this to list of routers to whom we need to send */
-					if (!rlist) {
-						/* first element */
-						rsize = RLIST_INC;
-						rlist = malloc(sizeof(int) * rsize);
-						if (!rlist) {
-							if (cmprsd_len > 0)
-								free(minfo_base);
-							snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating pbs_comm list of %lu bytes",
-								(unsigned long)(sizeof(int) * rsize));
-							tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-							if (data_out)
-								free(data_out);
-							return -1;
-						}
-						csize = 0;
-					}
-
+					/* add this to list of routers to whom we need to send */
 					/**
-					 * now check list backwards if router already sent to
+					 * now check list backwards if router already added to
 					 * rational for checking backwards is that the last router
-					 * that we sent data to, is probably the one that the next
+					 * that we added data to, is probably the one that the next
 					 * few nodes are attached to as well.
+					 * Might be able to use a hash here for faster search
 					 **/
-					already_sent = 0;
+					int found = -1;
 					for (i = csize - 1; i >= 0; i--) {
-						if (rlist[i] == target_fd) {
-							already_sent = 1;
+						if (rlist[i].target_fd == target_fd) {
+							found = i;
 							break;
 						}
 					}
-					if (already_sent == 1)
-						continue;
 
-					if (csize == rsize) {
-						/* got to add, but no space */
-						tmp = realloc(rlist, sizeof(int) * (rsize + RLIST_INC));
-						if (!tmp) {
-							free(rlist);
-							if (cmprsd_len > 0)
-								free(minfo_base);
-							snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory resizing pbs_comm list to %lu bytes",
-								(unsigned long)(sizeof(int) * rsize));
-							tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
-							if (data_out)
-								free(data_out);
-							return -1;
+					if (found == -1) {
+						int c_minfo_len;
+						if (csize == rsize) {
+							/* got to add, but no space */
+							tmp = realloc(rlist, sizeof(target_comm_struct_t) * (rsize + RLIST_INC));
+							if (!tmp) {
+								snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, 
+									"Out of memory resizing pbs_comm list to %lu bytes", (unsigned long)(sizeof(int) * rsize));
+								tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+								goto mcast_err;
+							}
+							rsize += RLIST_INC;
+							rlist = tmp;
 						}
-						rsize += RLIST_INC;
-						rlist = tmp;
+						found = csize++; /* the last index, and increment post */
+						memset(&rlist[found], 0, sizeof(target_comm_struct_t));
+						rlist[found].target_fd = target_fd; /* add this fd to the list of fds to send to */
+						rlist[found].router_name = target_router->router_name; /* keep a pointer to the router name */
+
+						/* allocate minfo_buf for this target comm */
+						c_minfo_len = sizeof(tpp_mcast_pkt_info_t) * num_streams;
+						if (tpp_conf->compress == 1 && c_minfo_len > TPP_COMPR_SIZE) {
+							rlist[found].cmpr_ctx = tpp_multi_deflate_init(c_minfo_len);
+							if (rlist[found].cmpr_ctx == NULL)
+								goto mcast_err;
+						} else {
+							rlist[found].minfo_buf = malloc(c_minfo_len);
+							if (!rlist[found].minfo_buf) {
+								snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating mcast buffer of %d bytes", c_minfo_len);
+								tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());
+								goto mcast_err;
+							}
+						}
+					} /* if entry not found */
+
+					/* at this point to have the entry particular target comm */
+					/* copy (or compress) the minfo for the target leaf */
+					if (rlist[found].cmpr_ctx == NULL) { /* no compression */
+						tpp_mcast_pkt_info_t *c_minfo = 
+							(tpp_mcast_pkt_info_t *)((char *) rlist[found].minfo_buf + (rlist[found].num_streams * sizeof(tpp_mcast_pkt_info_t)));
+						memcpy(c_minfo, minfo, sizeof(tpp_mcast_pkt_info_t));
+					} else {
+						if (tpp_multi_deflate_do(rlist[found].cmpr_ctx, 0, minfo, sizeof(tpp_mcast_pkt_info_t)) != 0)
+							goto mcast_err;
 					}
-					TPP_DBPRT(("Forwarding MCAST to %s", target_router->router_name));
-					if (tpp_transport_vsend(target_fd, mchunks, 1) != 0) {
+
+					rlist[found].num_streams++;
+				}
+			} /* for k streams */
+
+			if (csize > 0) {
+				tpp_mcast_pkt_hdr_t t_mhdr;
+				/* header data */
+				memcpy(&t_mhdr, mhdr, sizeof(tpp_mcast_pkt_hdr_t)); /* only to satisfy valgrind */
+				t_mhdr.hop = 1;
+
+				/* set the header chunk and data chunk one time for all target comms */ 
+				mchunks[0].data = &t_mhdr;
+				mchunks[0].len = sizeof(tpp_mcast_pkt_hdr_t);
+
+				mchunks[2].data = payload;
+				mchunks[2].len = payload_len;
+
+				snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Total target comms=%d", csize);
+				tpp_log_func(LOG_INFO, __func__, tpp_get_logbuf());
+
+				/* finish up the MCAST packets for each target comm and send */
+				for(k = 0; k < csize; k++) {
+					void *t_minfo_buf = NULL;
+					unsigned int t_minfo_len = 0;
+
+					t_mhdr.num_streams = htonl(rlist[k].num_streams);
+					t_minfo_len = rlist[k].num_streams * sizeof(tpp_mcast_pkt_info_t);
+					t_mhdr.info_len = htonl(t_minfo_len);
+
+					/* the router information has been collected in rlist[k] */
+					if (rlist[k].cmpr_ctx != NULL) {
+						if (tpp_multi_deflate_do(rlist[k].cmpr_ctx, 1, NULL, 0) != 0) /* finish the compression */
+							goto mcast_err;
+						t_minfo_buf = tpp_multi_deflate_done(rlist[k].cmpr_ctx, &t_minfo_len);
+						if (t_minfo_buf == NULL)
+							goto mcast_err;
+						t_mhdr.info_cmprsd_len = htonl(t_minfo_len);
+						rlist[k].cmpr_ctx = NULL; /* done with compression */
+					} else {
+						t_minfo_buf = rlist[k].minfo_buf;
+						t_mhdr.info_cmprsd_len = 0;
+					}
+
+					mchunks[1].data = t_minfo_buf;
+					mchunks[1].len = t_minfo_len;
+					
+					snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Sending MCAST packet to %s, num_streams=%d", rlist[k].router_name, rlist[k].num_streams);
+					tpp_log_func(LOG_INFO, __func__, tpp_get_logbuf());
+					if (tpp_transport_vsend(rlist[k].target_fd, mchunks, 3) != 0) {
 						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "send failed: errno = %d", errno);
 						tpp_log_func(LOG_ERR, __func__, tpp_get_logbuf());
-
-						tpp_log_func(LOG_ERR, __func__, "Failed to send TPP_MCAST_DATA");
-						tpp_transport_close(target_fd);
 					}
-					/* add this fd to the list of fds already sent to */
-					rlist[csize++] = target_fd;
 				}
 			}
+mcast_err:
 			if (cmprsd_len > 0)
 				free(minfo_base);
 
-			if (rlist)
+			if (rlist) {
+				for (k = 0; k < csize; k++)
+					free(rlist[k].minfo_buf);
 				free(rlist);
+			}
 
 			tpp_log_func(LOG_INFO, NULL, "mcast done");
 

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -1730,7 +1730,11 @@ tpp_inflate(void *inbuf, unsigned int inlen, unsigned int totlen)
 	z_stream strm;
 	void *outbuf = NULL;
 
-	outbuf = malloc(totlen);
+	/* 
+	 * in some rare cases totlen < compressed_len (inlen)
+	 * so safer to malloc the larger of the two values
+	 */
+	outbuf = malloc(totlen > inlen ? totlen:inlen);
 	if (!outbuf) {
 		snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Out of memory allocating inflate buffer %d bytes", totlen);
 		tpp_log_func(LOG_CRIT, __func__, tpp_get_logbuf());


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
In typical large setups, it is often the case that leafs (recipients) are attached to different comm routers.
A sender leaf sends an MCAST packet to the comm router to which it is connected to, and that router forwards the packet, unchanged, to several target routers. The fact that it sends the packet without customizing (or changing) it to the downstream comm routers, poses the following issues:

1. The downstream routers often have only a small subset of the total list of leafs attached to them (that they manage). However, since the MCAST packet contains target leaf entries that do not belong to this downstream comm router, the router wastes time in processing those entries by making avltree lookups  (which is quite fast, but nevertheless wasteful) only to find that the entry is not a leaf attached to itself and thus discards that entry.

2. Some sites do not connect all the comm routers to each other. They rather like to maintain islands of leafs (moms/nodes) that are isolated in groups. Thus the comm router in one island has no knowledge of leafs attached to a different comm router in another node island. Thus when the above MCAST packet arrives, the comm router fails to find some leafs - and without knowing whether it is a deliberate configuration or a network error (that is a leaf actually went down), the only thing it can do, safely, is to reject the whole MCAST packet - which results in the job aborting at startup.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The proposed fix customizes the MCAST packet before it forwards it to downstream comm routers. Specifically, it only fills in the entries for leafs that are connected to a particular downstream comm router. This way, both the above listed issues are mitigated.


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Test steps and results (Thanks to @saritakh ) : 
[tpp_fix_tests.txt](https://github.com/PBSPro/pbspro/files/4353620/tpp_fix_tests.txt)
[tpp_fix_valgrind.txt](https://github.com/PBSPro/pbspro/files/4353824/tpp_fix_valgrind.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
