### PR TITLE
changes affecting revert_pbsconf()

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1018,6 +1018,11 @@ class PBSTestSuite(unittest.TestCase):
             # default list
             if len(pbs_conf_val) != len(new_pbsconf):
                 restart_comm = True
+            # Check if existing pbs.conf has correct ownership
+            dest = self.du.get_pbs_conf_file(comm.hostname)
+            (cf_uid, cf_gid) = (os.stat(dest).st_uid, os.stat(dest).st_gid)
+            if cf_uid != 0 or cf_gid > 10:
+                restart_comm = True
 
             if restart_comm:
                 self.du.set_pbs_config(comm.hostname, confs=new_pbsconf)
@@ -1094,6 +1099,11 @@ class PBSTestSuite(unittest.TestCase):
             # Check if existing pbs.conf has more/less entries than the
             # default list
             if len(pbs_conf_val) != len(new_pbsconf):
+                restart_mom = True
+            # Check if existing pbs.conf has correct ownership
+            dest = self.du.get_pbs_conf_file(mom.hostname)
+            (cf_uid, cf_gid) = (os.stat(dest).st_uid, os.stat(dest).st_gid)
+            if cf_uid != 0 or cf_gid > 10:
                 restart_mom = True
 
             if restart_mom:
@@ -1206,6 +1216,11 @@ class PBSTestSuite(unittest.TestCase):
             # default list
             if len(pbs_conf_val) != len(new_pbsconf):
                 restart_pbs = True
+            # Check if existing pbs.conf has correct ownership
+            dest = self.du.get_pbs_conf_file(server.hostname)
+            (cf_uid, cf_gid) = (os.stat(dest).st_uid, os.stat(dest).st_gid)
+            if cf_uid != 0 or cf_gid > 10:
+                restart_pbs = True
 
             if restart_pbs or dmns_to_restart > 0:
                 # Write out the new pbs.conf file
@@ -1260,7 +1275,7 @@ class PBSTestSuite(unittest.TestCase):
 
     def revert_pbsconf(self):
         """
-        Revert contents of the pbs.conf file
+        Revert contents and ownership of the pbs.conf file
         Also start/stop the appropriate daemons
         """
         primary_server = self.server


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
revert_pbsconf() does not revert to correct ownership of PBS config file


#### Describe Your Changes
- Check if config file is owned by root, otherwise change ownership to root.
- chown() now uses the form "chown uid:gid <file>" instead of "chown uid <file>"


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<img width="1582" alt="Screen Shot 2020-03-18 at 10 11 55 AM" src="https://user-images.githubusercontent.com/17935097/76988653-4794b300-6902-11ea-8626-22917094c6c2.png">



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
