### PR TITLE
Fix for tcp_recv goes to infinite loop at times when the other party …

### DIFF
--- a/src/lib/Libifl/tcp_dis.c
+++ b/src/lib/Libifl/tcp_dis.c
@@ -153,7 +153,10 @@ tcp_recv(int fd, void *data, int len)
 #else
 		i = CS_read(fd, pb, torecv);
 #endif
-		if (i <= 0) {
+		if (i == 0)
+			return -2;
+
+		if (i < 0) {
 #ifdef WIN32
 			/*
 			 * for WASCONNRESET, treat like no data for winsock
@@ -166,7 +169,7 @@ tcp_recv(int fd, void *data, int len)
 #else
 			if (errno != EINTR)
 #endif
-				return ((i == 0) ? -2 : i);
+				return i;
 		} else {
 			torecv -= i;
 			pb += i;


### PR DESCRIPTION
…shuts down

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
tcp_recv goes to infinite loop at times when the other party closes/shuts down.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Following is the snapshot of backtrace when this issue is observed.

(gdb) bt
#0  0x00007fc73c1e67fd in read () from /lib64/libpthread.so.0
#1  0x00000000004a06e6 in CS_read (sd=10, buf=0x7ffdb32cacfc "", len=1)
    at ../Libsec/cs_standard.c:144
#2  0x00000000004a04c9 in tcp_recv (fd=10, data=0x7ffdb32cacfc, len=1)
    at ../Libifl/tcp_dis.c:154
#3  0x000000000048d87f in transport_recv_pkt (fd=10, type=0x7ffdb32cacfc, 
    data_out=0x7ffdb32cad08, len_out=0x7ffdb32cad00) at ../Libdis/dis_helpers.c:282
#4  0x000000000048df44 in __transport_read (fd=10) at ../Libdis/dis_helpers.c:653
#5  0x000000000048e005 in dis_getc (fd=10) at ../Libdis/dis_helpers.c:692
#6  0x000000000048e7ff in disrsl_ (stream=10, negate=0x7ffdb32caddc, 
    value=0x7ffdb32cadd0, count=1, recursv=1) at ../Libdis/disrsl_.c:79
#7  0x000000000048e67a in disrsl (stream=10, retval=0x7ffdb32cae20)
    at ../Libdis/disrsl.c:98
#8  0x0000000000424265 in get_sched_cmd (sock=10, val=0x7ffdb32caeec, 
    identifier=0x7ffdb32cb3e8) at get_4byte.c:91
#9  0x000000000041e75c in main (argc=5, argv=0x7ffdb32cb798) at pbs_sched.c:1406

Following is a scenario where the issue can be reproduced.

1. Make Server connections persistent at the Scheduler
2. Run the test case test_pbsfs_server_restart from TestMultipleSchedulers test case.
3. As part of the test case Server is restarted that is when the issue happens.

tcp_recv() is not handling the shutdown/closure of the other party properly. Basically it clubs the code for  handling both of the following in a wrong way.
1) When an error happens and errno is set
2) When the other party closes/shuts down.

Separated this functionality and corrected the code to solve the issue in hand.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Attached are the detailed testing logs.
[test_pbsfs_restart_mline.log](https://github.com/PBSPro/pbspro/files/4353577/test_pbsfs_restart_mline.log)
[TestMultipleSchedulers.log](https://github.com/PBSPro/pbspro/files/4353578/TestMultipleSchedulers.log)
[TestSchedulerInterface.log](https://github.com/PBSPro/pbspro/files/4353580/TestSchedulerInterface.log)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
