### PR TITLE
Fix for authentication mismatch error in TPP

### DIFF
--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -4480,7 +4480,6 @@ leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra)
 		conn_auth_t *authdata = (conn_auth_t *)extra;
 		auth_def_t *authdef = NULL;
 		void *authctx = NULL;
-		char *method = NULL;
 
 		if (authdata == NULL) {
 			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, No auth data found", tfd);
@@ -4489,17 +4488,6 @@ leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra)
 		}
 
 		memcpy(&ahdr, data, sizeof(tpp_auth_pkt_hdr_t));
-		if (ahdr.for_encrypt == FOR_AUTH) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Authentication method mismatch in connection", tfd);
-			method = tpp_conf->auth_config->auth_method;
-		} else {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, Encryption method mismatch in connection", tfd);
-			method = tpp_conf->auth_config->encrypt_method;
-		}
-		if (strcmp(ahdr.auth_type, method) != 0) {
-			tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-			return -1;
-		}
 		len_in = (size_t)len - sizeof(tpp_auth_pkt_hdr_t);
 		data_in = calloc(1, len_in);
 		if (data_in == NULL) {

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -1321,23 +1321,13 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 		conn_auth_t *authdata = (conn_auth_t *)extra;
 		auth_def_t *authdef = NULL;
 		void *authctx = NULL;
-		char *method = NULL;
 
 		memcpy(&ahdr, data, sizeof(tpp_auth_pkt_hdr_t));
 
-		if (ahdr.for_encrypt == FOR_AUTH)
-			method = tpp_conf->auth_config->auth_method;
-		else
-			method = tpp_conf->auth_config->encrypt_method;
-		if (strcmp(ahdr.auth_type, method) != 0) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, %s method mismatch in connection %s", tfd, ahdr.for_encrypt == FOR_AUTH ? "Authentication" : "Encryption", tpp_netaddr(&connected_host));
-			tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-			tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
-			return 0; /* let connection be alive, so we can send error */
-		}
-
 		if ((authdef = get_auth(ahdr.auth_type)) == NULL) {
-			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, %s method not supported in connection %s", tfd, ahdr.for_encrypt == FOR_AUTH ? "Authentication" : "Encryption", tpp_netaddr(&connected_host));
+			snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "tfd=%d, %s method not supported in connection %s",
+				tfd, ahdr.for_encrypt == FOR_AUTH ? "Authentication" : "Encryption",
+				tpp_netaddr(&connected_host));
 			tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
 			tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
 			return 0; /* let connection be alive, so we can send error */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* MoM (aka comm leaf) fails to authenticate with comm router when both are using the different authentication method, but by design, the router should allow any leaf to use any supported auth methods


#### Describe Your Change
* Fixed code such a way router allows the leaf to use different auth method


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[before-fix.txt](https://github.com/PBSPro/pbspro/files/4369973/before-fix.txt)
[after-fix.txt](https://github.com/PBSPro/pbspro/files/4369974/after-fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
