### PR TITLE
Adding new option -D to ralter

### DIFF
--- a/src/cmds/pbs_ralter.c
+++ b/src/cmds/pbs_ralter.c
@@ -65,14 +65,17 @@ int
 process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 {
 	int	c = 0;
+	
 	int	errflg = 0;
 	time_t	t;
 
 	char	time_buf[80] = {0};
 	char	*endptr = NULL;
 	long	temp = 0;
+	char dur_buf[800];
+	int i = 0;
 
-	while ((c = getopt(argc, argv, "E:I:m:M:N:R:q:U:G:")) != EOF) {
+	while ((c = getopt(argc, argv, "E:I:m:M:N:R:q:U:G:D:")) != EOF) {
 		switch (c) {
 			case 'E':
 				t = cvtdate(optarg);
@@ -137,6 +140,14 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 				set_attr_error_exit(&attrib, ATTR_auth_g, optarg);
 				break;
 
+			case 'D':
+				sprintf(dur_buf, "%s", optarg);
+				i = set_attr(&attrib, ATTR_resv_duration, dur_buf);
+				if (i != 0) {
+					fprintf(stderr, "pbs_ralter: illegal -D time value\n");
+					errflg++;
+				}
+				break;				
 			default:
 				/* pbs_ralter option not recognized */
 				errflg++;
@@ -161,7 +172,7 @@ print_usage()
 	"                [-N reservation_name] [-R start_time] [-E end_time]\n"
 	"                [-U (+/-)username[,(+/-)username]...]\n"
 	"                [-G [(+/-)group[,(+/-)group]...]]\n"
-	"                resv_id\n";
+	"                [-D durationn] resv_id\n";
 	fprintf(stderr, "%s", usage);
 	fprintf(stderr, "%s", usag2);
 }
@@ -201,6 +212,8 @@ handle_attribute_errors(struct ecl_attribute_errors *err_list)
 			opt = "R";
 		else if (strcmp(attribute->name, ATTR_auth_u) == 0)
 			opt = "U";
+		else if (strcmp(attribute->name, ATTR_resv_duration) == 0)
+			opt = "D";
 		else
 			return ;
 

--- a/src/cmds/pbs_ralter.c
+++ b/src/cmds/pbs_ralter.c
@@ -73,7 +73,6 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 	char	*endptr = NULL;
 	long	temp = 0;
 	char dur_buf[800];
-	int i = 0;
 
 	while ((c = getopt(argc, argv, "E:I:m:M:N:R:q:U:G:D:")) != EOF) {
 		switch (c) {
@@ -141,12 +140,8 @@ process_opts(int argc, char **argv, struct attrl **attrp, char *dest)
 				break;
 
 			case 'D':
-				sprintf(dur_buf, "%s", optarg);
-				i = set_attr(&attrib, ATTR_resv_duration, dur_buf);
-				if (i != 0) {
-					fprintf(stderr, "pbs_ralter: illegal -D time value\n");
-					errflg++;
-				}
+				snprintf(dur_buf, sizeof(dur_buf), "%s", optarg);
+				set_attr_error_exit(&attrib, ATTR_resv_duration, dur_buf);
 				break;				
 			default:
 				/* pbs_ralter option not recognized */
@@ -172,7 +167,8 @@ print_usage()
 	"                [-N reservation_name] [-R start_time] [-E end_time]\n"
 	"                [-U (+/-)username[,(+/-)username]...]\n"
 	"                [-G [(+/-)group[,(+/-)group]...]]\n"
-	"                [-D durationn] resv_id\n";
+	"                [-D duration]\n"
+	"                resv_id\n";
 	fprintf(stderr, "%s", usage);
 	fprintf(stderr, "%s", usag2);
 }
@@ -196,7 +192,9 @@ handle_attribute_errors(struct ecl_attribute_errors *err_list)
 
 	for (i = 0; i < err_list->ecl_numerrors; i++) {
 		attribute = err_list->ecl_attrerr[i].ecl_attribute;
-		if (strcmp(attribute->name, ATTR_resv_end) == 0)
+		if (strcmp(attribute->name, ATTR_resv_duration) == 0)
+			opt = "D";
+		else if (strcmp(attribute->name, ATTR_resv_end) == 0)
 			opt = "E";
 		else if (strcmp(attribute->name, ATTR_auth_g) == 0)
 			opt = "G";
@@ -212,8 +210,6 @@ handle_attribute_errors(struct ecl_attribute_errors *err_list)
 			opt = "R";
 		else if (strcmp(attribute->name, ATTR_auth_u) == 0)
 			opt = "U";
-		else if (strcmp(attribute->name, ATTR_resv_duration) == 0)
-			opt = "D";
 		else
 			return ;
 

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -63,7 +63,7 @@ extern "C" {
 
 #define RESV_START_TIME_MODIFIED	0x1
 #define RESV_END_TIME_MODIFIED		0x2
-#define RESV_DURATION_MODIFIED		0x3
+#define RESV_DURATION_MODIFIED		0x4
 
 
 /*

--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -63,6 +63,8 @@ extern "C" {
 
 #define RESV_START_TIME_MODIFIED	0x1
 #define RESV_END_TIME_MODIFIED		0x2
+#define RESV_DURATION_MODIFIED		0x3
+
 
 /*
  * The following resv_atr enum provide an index into the array of

--- a/src/lib/Libattr/master_resv_attr_def.xml
+++ b/src/lib/Libattr/master_resv_attr_def.xml
@@ -238,7 +238,7 @@
    <attributes>
    /*RESV_ATR_duration*/
 	<member_name><both>ATTR_resv_duration</both></member_name>	<!--  "reserve_duration" -->
-	<member_at_decode>decode_l</member_at_decode>
+	<member_at_decode>decode_time</member_at_decode>
 	<member_at_encode>encode_l</member_at_encode>
 	<member_at_set>set_l</member_at_set>
 	<member_at_comp>comp_l</member_at_comp>
@@ -248,7 +248,7 @@
 	<member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_RESV</member_at_parent>
 	<member_verify_function>
-	<ECL>verify_datatype_long</ECL>
+	<ECL>verify_datatype_time</ECL>
 	<ECL>NULL_VERIFY_VALUE_FUNC</ECL>
 	</member_verify_function>
    </attributes>

--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -829,8 +829,6 @@ req_modifyReservation(struct batch_request *preq)
 							send_to_scheduler = RESV_START_TIME_MODIFIED;
 							presv->ri_alter_stime = presv->ri_wattr[RESV_ATR_start].at_val.at_long;
 							presv->ri_alter_flags |= RESV_START_TIME_MODIFIED;
-							pdef->at_decode(&presv->ri_wattr[RESV_ATR_start], 
-							psatl->al_name, psatl->al_resc, psatl->al_value);
 							r = 1;
 						} else {
 							snprintf(log_buffer, sizeof(log_buffer), "%s", msg_stdg_resv_occr_conflict);
@@ -851,7 +849,7 @@ req_modifyReservation(struct batch_request *preq)
 					return;
 				}
 				
-				if (d==1) {
+				if (d == 1) {
 					presv->ri_alter_etime = presv->ri_wattr[RESV_ATR_end].at_val.at_long;
 					presv->ri_wattr[RESV_ATR_end].at_flags &= ~ATR_VFLAG_SET;
 				}
@@ -871,17 +869,17 @@ req_modifyReservation(struct batch_request *preq)
 					return;
 				}
 				e = 1;
-				if (d==1) {
+				if (d == 1) {
 					presv->ri_alter_stime = presv->ri_wattr[RESV_ATR_start].at_val.at_long;
 					presv->ri_wattr[RESV_ATR_start].at_flags &= ~ATR_VFLAG_SET;
 				}
 
 				break;
 			case RESV_ATR_duration:
-				if (r==1) {
+				if (r == 1) {
 					presv->ri_alter_etime = presv->ri_wattr[RESV_ATR_end].at_val.at_long;
 					presv->ri_wattr[RESV_ATR_end].at_flags &= ~ATR_VFLAG_SET;
-				} else if (e==1) {
+				} else if (e == 1) {
 					presv->ri_alter_stime = presv->ri_wattr[RESV_ATR_start].at_val.at_long;
 					presv->ri_wattr[RESV_ATR_start].at_flags &= ~ATR_VFLAG_SET;
 				}
@@ -897,11 +895,10 @@ req_modifyReservation(struct batch_request *preq)
 				break;
 		}
 
-		if (d == 0) {
+		if (d == 0) 
 			presv->ri_wattr[RESV_ATR_duration].at_flags &= ~ATR_VFLAG_SET;
-		}
 
-		if (d==1 && r==1 && e==1) {
+		if (d == 1 && r == 1 && e == 1) {
 			req_reject(PBSE_BADTSPEC, 0, preq);
 			resv_revert_alter_times(presv);
 			return;

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -1001,6 +1001,22 @@ resv_revert_alter_times(resc_resv *presv)
 		|= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
 		presv->ri_alter_etime = 0;
 	}
+	if (presv->ri_alter_flags & RESV_DURATION_MODIFIED) {
+		if (presv->ri_alter_etime != 0) {
+			presv->ri_qs.ri_etime = presv->ri_alter_etime;
+			presv->ri_wattr[RESV_ATR_end].at_val.at_long = presv->ri_alter_etime;
+			presv->ri_wattr[RESV_ATR_end].at_flags
+			|= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+			presv->ri_alter_etime = 0;
+		}
+		if (presv->ri_alter_stime != 0) {
+			presv->ri_qs.ri_stime = presv->ri_alter_stime;
+			presv->ri_wattr[RESV_ATR_start].at_val.at_long = presv->ri_alter_stime;
+			presv->ri_wattr[RESV_ATR_start].at_flags
+			|= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+			presv->ri_alter_stime = 0;
+		}
+	}
 	
 	presv->ri_qs.ri_duration = presv->ri_qs.ri_etime - presv->ri_qs.ri_stime;
 	presv->ri_wattr[RESV_ATR_duration].at_val.at_long = presv->ri_qs.ri_duration;

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -1001,24 +1001,7 @@ resv_revert_alter_times(resc_resv *presv)
 		|= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
 		presv->ri_alter_etime = 0;
 	}
-	if (presv->ri_alter_flags & RESV_DURATION_MODIFIED) {
-		if (presv->ri_alter_stime != 0) {
-			presv->ri_qs.ri_stime = presv->ri_alter_stime;
-			presv->ri_wattr[RESV_ATR_start].at_val.at_long = presv->ri_alter_stime;
-			presv->ri_wattr[RESV_ATR_start].at_flags
-			|= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
-			presv->ri_alter_stime = 0;
-		} 
-		else {
-			if (presv->ri_alter_etime != 0){
-				presv->ri_qs.ri_etime = presv->ri_alter_etime;
-				presv->ri_wattr[RESV_ATR_end].at_val.at_long = presv->ri_alter_etime;
-				presv->ri_wattr[RESV_ATR_end].at_flags
-				|= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
-				presv->ri_alter_etime = 0;
-			}
-		}		
-	}
+	
 	presv->ri_qs.ri_duration = presv->ri_qs.ri_etime - presv->ri_qs.ri_stime;
 	presv->ri_wattr[RESV_ATR_duration].at_val.at_long = presv->ri_qs.ri_duration;
 	presv->ri_wattr[RESV_ATR_duration].at_flags

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -1001,6 +1001,24 @@ resv_revert_alter_times(resc_resv *presv)
 		|= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
 		presv->ri_alter_etime = 0;
 	}
+	if (presv->ri_alter_flags & RESV_DURATION_MODIFIED) {
+		if (presv->ri_alter_stime != 0) {
+			presv->ri_qs.ri_stime = presv->ri_alter_stime;
+			presv->ri_wattr[RESV_ATR_start].at_val.at_long = presv->ri_alter_stime;
+			presv->ri_wattr[RESV_ATR_start].at_flags
+			|= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+			presv->ri_alter_stime = 0;
+		} 
+		else {
+			if (presv->ri_alter_etime != 0){
+				presv->ri_qs.ri_etime = presv->ri_alter_etime;
+				presv->ri_wattr[RESV_ATR_end].at_val.at_long = presv->ri_alter_etime;
+				presv->ri_wattr[RESV_ATR_end].at_flags
+				|= ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;
+				presv->ri_alter_etime = 0;
+			}
+		}		
+	}
 	presv->ri_qs.ri_duration = presv->ri_qs.ri_etime - presv->ri_qs.ri_stime;
 	presv->ri_wattr[RESV_ATR_duration].at_val.at_long = presv->ri_qs.ri_duration;
 	presv->ri_wattr[RESV_ATR_duration].at_flags

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4603,11 +4603,11 @@ start_end_dur_wall(void *pobj, int objtype)
 			return (-1);
 	} else {
 		if (presv->ri_alter_flags & RESV_DURATION_MODIFIED) 
-			swcode +=4;
+			swcode += 4;
 		if (presv->ri_alter_flags & RESV_END_TIME_MODIFIED)
 			swcode += 2; /*calcualte start time*/
 		if (presv->ri_alter_flags & RESV_START_TIME_MODIFIED)
-			swcode += 1; /*calculate end time*/;
+			swcode += 1; /*calculate end time*/
 		if (presv->ri_alter_flags == RESV_START_TIME_MODIFIED || presv->ri_alter_flags == RESV_END_TIME_MODIFIED) {
 			swcode = 3;
 		}

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4601,21 +4601,20 @@ start_end_dur_wall(void *pobj, int objtype)
 			swcode += 8;			/*have walltime*/
 		else if (!(prsc = add_resource_entry(pattr, rscdef)))
 			return (-1);
-	}
-	else {
-		if (presv->ri_alter_flags & RESV_DURATION_MODIFIED) 
-				swcode += 4;
-		if (presv->ri_alter_flags & RESV_END_TIME_MODIFIED)
-				swcode += 2; /*calcualte start time*/
-		if (presv->ri_alter_flags & RESV_START_TIME_MODIFIED)
-				swcode += 1; /*calculate end time*/;
+	} else {
+		swcode = 3;
+		if (presv->ri_alter_flags & RESV_DURATION_MODIFIED) {
+			swcode +=1;
+			if (presv->ri_alter_flags & RESV_END_TIME_MODIFIED)
+					swcode += 2; /*calcualte start time*/
+			if (presv->ri_alter_flags & RESV_START_TIME_MODIFIED)
+					swcode += 1; /*calculate end time*/;
+		}
 	}
 
 	atemp.at_flags = ATR_VFLAG_SET;
 	atemp.at_type = ATR_TYPE_LONG;
 	switch (swcode) {
-		case  1:
-		case  2:
 		case  3:	/*start, end*/
 			if (((check_start && (pstime->at_val.at_long < time_now)) && (pstate != RESV_BEING_ALTERED)) ||
 				(petime->at_val.at_long <= pstime->at_val.at_long))

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4602,13 +4602,14 @@ start_end_dur_wall(void *pobj, int objtype)
 		else if (!(prsc = add_resource_entry(pattr, rscdef)))
 			return (-1);
 	} else {
-		swcode = 3;
-		if (presv->ri_alter_flags & RESV_DURATION_MODIFIED) {
-			swcode +=1;
-			if (presv->ri_alter_flags & RESV_END_TIME_MODIFIED)
-					swcode += 2; /*calcualte start time*/
-			if (presv->ri_alter_flags & RESV_START_TIME_MODIFIED)
-					swcode += 1; /*calculate end time*/;
+		if (presv->ri_alter_flags & RESV_DURATION_MODIFIED) 
+			swcode +=4;
+		if (presv->ri_alter_flags & RESV_END_TIME_MODIFIED)
+			swcode += 2; /*calcualte start time*/
+		if (presv->ri_alter_flags & RESV_START_TIME_MODIFIED)
+			swcode += 1; /*calculate end time*/;
+		if (presv->ri_alter_flags == RESV_START_TIME_MODIFIED || presv->ri_alter_flags == RESV_END_TIME_MODIFIED) {
+			swcode = 3;
 		}
 	}
 

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4603,22 +4603,19 @@ start_end_dur_wall(void *pobj, int objtype)
 			return (-1);
 	}
 	else {
-		if (presv->ri_alter_flags & RESV_DURATION_MODIFIED) {
-			if (presv->ri_alter_flags & RESV_END_TIME_MODIFIED)
-				swcode += 6; /*calcualte start time*/
-			if (presv->ri_alter_flags & RESV_START_TIME_MODIFIED)
-				swcode += 5; /*calculate end time*/;
-			if (swcode == 11)
-				return (-1);
-		}
-		else {
-			swcode = 3; /*start, end*/
-		}
+		if (presv->ri_alter_flags & RESV_DURATION_MODIFIED) 
+				swcode += 4;
+		if (presv->ri_alter_flags & RESV_END_TIME_MODIFIED)
+				swcode += 2; /*calcualte start time*/
+		if (presv->ri_alter_flags & RESV_START_TIME_MODIFIED)
+				swcode += 1; /*calculate end time*/;
 	}
 
 	atemp.at_flags = ATR_VFLAG_SET;
 	atemp.at_type = ATR_TYPE_LONG;
 	switch (swcode) {
+		case  1:
+		case  2:
 		case  3:	/*start, end*/
 			if (((check_start && (pstime->at_val.at_long < time_now)) && (pstate != RESV_BEING_ALTERED)) ||
 				(petime->at_val.at_long <= pstime->at_val.at_long))
@@ -4631,6 +4628,7 @@ start_end_dur_wall(void *pobj, int objtype)
 			}
 			break;
 
+		case  4:
 		case  5:	/*start, duration*/
 			if (((check_start && pstime->at_val.at_long < time_now) && (pstate != RESV_BEING_ALTERED)) ||
 				(pduration->at_val.at_long <= 0))

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -4596,10 +4596,8 @@ start_end_dur_wall(void *pobj, int objtype)
 		swcode += 2;			/*have end  */
 	if (pduration->at_flags & ATR_VFLAG_SET)
 		swcode += 4;			/*have duration*/
-	if (prsc)
+	if (prsc && pstate != RESV_BEING_ALTERED)
 		swcode += 8;			/*have walltime*/
-	if(pstate == RESV_BEING_ALTERED)
-		swcode -= 8;			/*remove walltime in case of altering reservation*/
 	else if (!(prsc = add_resource_entry(pattr, rscdef)))
 		return (-1);
 
@@ -4607,7 +4605,7 @@ start_end_dur_wall(void *pobj, int objtype)
 	atemp.at_type = ATR_TYPE_LONG;
 	switch (swcode) {
 		case  3:	/*start, end*/
-			if ((((check_start) && (pstime->at_val.at_long < time_now)) && (pstate != RESV_BEING_ALTERED)) ||
+			if (((check_start && (pstime->at_val.at_long < time_now)) && (pstate != RESV_BEING_ALTERED)) ||
 				(petime->at_val.at_long <= pstime->at_val.at_long))
 				rc = -1;
 			else {
@@ -4621,7 +4619,7 @@ start_end_dur_wall(void *pobj, int objtype)
 			break;
 
 		case  5:	/*start, duration*/
-			if ((((check_start) && pstime->at_val.at_long < time_now) && ((pstate != RESV_BEING_ALTERED) && (!presv->ri_qp->qu_numjobs))) ||
+			if (((check_start && pstime->at_val.at_long < time_now) && (pstate != RESV_BEING_ALTERED)) ||
 				(pduration->at_val.at_long <= 0))
 				rc = -1;
 			else {
@@ -4638,8 +4636,8 @@ start_end_dur_wall(void *pobj, int objtype)
 			else {
 				atemp.at_val.at_long = (petime->at_val.at_long -
 					pstime->at_val.at_long);
-				(void)pddef->at_set(pduration, &atemp, SET);
-				(void)rscdef->rs_set(&prsc->rs_value, &atemp, SET);
+				pddef->at_set(pduration, &atemp, SET);
+				rscdef->rs_set(&prsc->rs_value, &atemp, SET);
 			}
 
 		case  7:	/*start, end, duration*/

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1698,17 +1698,15 @@ class TestPbsResvAlter(TestFunctional):
         rid, start, end = self.submit_and_confirm_reservation(offset, duration)
         new_start = self.bu.convert_seconds_to_datetime(start + shift)
         new_end = self.bu.convert_seconds_to_datetime(end + shift)
-        new_duration = self.bu.convert_seconds_to_datetime(new_duration)
 
         with self.assertRaises(PbsResvAlterError) as e:
             attr = {'reserve_start': new_start, 'reserve_end': new_end,
                     'reserve_duration': new_duration}
-            m = self.server.alterresv(rid, attr)
+            self.server.alterresv(rid, attr)
         self.assertIn('pbs_ralter: Bad time specification(s)',
                       e.exception.msg[0])
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
-        print(str(self.server.status(RESV, id=rid)))
         self.assertEqual(int(t_start), start)
         self.assertEqual(int(t_duration), duration)
         self.assertEqual(int(t_end), end)
@@ -1736,8 +1734,6 @@ class TestPbsResvAlter(TestFunctional):
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
         self.assertEqual(t_duration, new_duration)
-        print("new Start is " + str(t_start))
-        print("new End is " + str(t_end))
 
         # Wait for the reservation to start running.
         self.check_resv_running(rid, offset - shift)

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1566,7 +1566,7 @@ class TestPbsResvAlter(TestFunctional):
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
 
-        self.assertEqual(t_end, end+10)
+        self.assertEqual(t_end, end+shift)
         self.assertEqual(t_start, start)
         self.assertEqual(t_duration, new_duration)
 
@@ -1576,13 +1576,14 @@ class TestPbsResvAlter(TestFunctional):
         temp_end = t_end
         temp_start = t_start
 
+        new_duration2 = new_duration + 10
         self.alter_a_reservation(rid, temp_start, temp_end, sequence=2,
-                                 a_duration=new_duration+10, check_log=False)
+                                 a_duration=new_duration2, check_log=False)
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
-        self.assertEqual(t_end, temp_end+10)
+        self.assertEqual(t_end, temp_end+shift)
         self.assertEqual(t_start, temp_start)
-        self.assertEqual(t_duration, new_duration+10)
+        self.assertEqual(t_duration, new_duration2)
 
     def test_adv_resv_dur_and_endtime_before_start(self):
         """
@@ -1602,8 +1603,8 @@ class TestPbsResvAlter(TestFunctional):
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
 
-        self.assertEqual(t_end, end+10)
-        self.assertEqual(t_start, start-10)
+        self.assertEqual(t_end, end+shift)
+        self.assertEqual(t_start, t_end-t_duration)
         self.assertEqual(t_duration, new_duration)
 
         # Submit a job to the reservation and change its start time.
@@ -1611,13 +1612,14 @@ class TestPbsResvAlter(TestFunctional):
         temp_end = t_end
         temp_start = t_start
 
+        new_duration2 = new_duration + 10
         self.alter_a_reservation(rid, temp_start, temp_end, shift=shift,
                                  alter_e=True, sequence=2,
-                                 a_duration=new_duration+10, check_log=False)
+                                 a_duration=new_duration2, check_log=False)
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
-        self.assertEqual(t_end, temp_end+10)
-        self.assertEqual(t_start, temp_start)
-        self.assertEqual(t_duration, new_duration+10)
+        self.assertEqual(t_end, temp_end+shift)
+        self.assertEqual(t_start, t_end-t_duration)
+        self.assertEqual(t_duration, new_duration2)
 
     def test_adv_resv_dur_and_starttime_before_start(self):
         """
@@ -1637,8 +1639,8 @@ class TestPbsResvAlter(TestFunctional):
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
 
-        self.assertEqual(t_end, end+20)
-        self.assertEqual(t_start, start+10)
+        self.assertEqual(t_end, t_start+t_duration)
+        self.assertEqual(t_start, start+shift)
         self.assertEqual(t_duration, new_duration)
 
         # Submit a job to the reservation and change its start time.
@@ -1646,13 +1648,14 @@ class TestPbsResvAlter(TestFunctional):
         temp_end = t_end
         temp_start = t_start
 
+        new_duration2 = new_duration + 10
         self.alter_a_reservation(rid, temp_start, temp_end, shift=shift,
                                  alter_s=True, sequence=2,
-                                 a_duration=new_duration+10, check_log=False)
+                                 a_duration=new_duration2, check_log=False)
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
-        self.assertEqual(t_end, temp_end+20)
-        self.assertEqual(t_start, temp_start+10)
-        self.assertEqual(t_duration, new_duration+10)
+        self.assertEqual(t_end, t_start+t_duration)
+        self.assertEqual(t_start, temp_start+shift)
+        self.assertEqual(t_duration, new_duration2)
 
     def test_adv_res_dur_after_start(self):
         """
@@ -1759,8 +1762,8 @@ class TestPbsResvAlter(TestFunctional):
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
         self.assertEqual(t_duration, new_duration)
-        self.assertEqual(t_end, end+15)
-        self.assertEqual(t_start, start+5)
+        self.assertEqual(t_end, end+shift)
+        self.assertEqual(t_start, t_end-t_duration)
 
         # Wait for the reservation to start running.
         self.check_resv_running(rid, offset - shift)
@@ -1795,8 +1798,8 @@ class TestPbsResvAlter(TestFunctional):
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
         self.assertEqual(t_duration, new_duration)
-        self.assertEqual(t_end, end+25)
-        self.assertEqual(t_start, start+15)
+        self.assertEqual(t_end, t_start+t_duration)
+        self.assertEqual(t_start, start+shift)
 
         # Wait for the reservation to start running.
         self.check_resv_running(rid, offset - shift)

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -340,9 +340,10 @@ class TestPbsResvAlter(TestFunctional):
             else:
                 msg = "pbs_ralter: " + r + " ALTER REQUESTED"
 
-            print(str(attrs))
             self.server.alterresv(r, attrs)
 
+            print(str(msg))
+            print(str(self.server.last_out))
             self.assertEqual(msg, self.server.last_out[0])
             self.logger.info(msg + " displayed")
 
@@ -1549,6 +1550,7 @@ class TestPbsResvAlter(TestFunctional):
         self.alter_a_reservation(rid1, start1, end1, shift=300,
                                  alter_e=True, whichMessage=3)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+
     def test_adv_resv_duration_before_start(self):
         """
         Test duration of reservation can be changed. In this case end

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -261,7 +261,7 @@ class TestPbsResvAlter(TestFunctional):
         :type  start: int.
 
         :param end: End time of the reservation.
-        :type  end: int.
+        :type  end: int
 
         :param shift: Time in seconds the reservation times will be moved.
         :type  shift: int.
@@ -342,8 +342,6 @@ class TestPbsResvAlter(TestFunctional):
 
             self.server.alterresv(r, attrs)
 
-            print(str(msg))
-            print(str(self.server.last_out))
             self.assertEqual(msg, self.server.last_out[0])
             self.logger.info(msg + " displayed")
 
@@ -1559,17 +1557,18 @@ class TestPbsResvAlter(TestFunctional):
 
         offset = 20
         duration = 20
+        new_duration = 30
         shift = 10
         rid, start, end = self.submit_and_confirm_reservation(offset, duration)
 
-        self.alter_a_reservation(rid, start, end, a_duration=30,
+        self.alter_a_reservation(rid, start, end, a_duration=new_duration,
                                  check_log=False)
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
 
         self.assertEqual(t_end, end+10)
         self.assertEqual(t_start, start)
-        self.assertEqual(t_duration, 30)
+        self.assertEqual(t_duration, new_duration)
 
         # Submit a job to the reservation and change its duration.
         self.submit_job_to_resv(rid)
@@ -1578,12 +1577,12 @@ class TestPbsResvAlter(TestFunctional):
         temp_start = t_start
 
         self.alter_a_reservation(rid, temp_start, temp_end, sequence=2,
-                                 a_duration=40, check_log=False)
+                                 a_duration=new_duration+10, check_log=False)
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
         self.assertEqual(t_end, temp_end+10)
         self.assertEqual(t_start, temp_start)
-        self.assertEqual(t_duration, 40)
+        self.assertEqual(t_duration, new_duration+10)
 
     def test_adv_resv_dur_and_endtime_before_start(self):
         """
@@ -1593,17 +1592,19 @@ class TestPbsResvAlter(TestFunctional):
 
         offset = 20
         duration = 20
+        new_duration = 40
         shift = 10
         rid, start, end = self.submit_and_confirm_reservation(offset, duration)
 
         self.alter_a_reservation(rid, start, end, shift=shift,
-                                 alter_e=True, a_duration=40, check_log=False)
+                                 alter_e=True, a_duration=new_duration,
+                                 check_log=False)
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
 
         self.assertEqual(t_end, end+10)
         self.assertEqual(t_start, start-10)
-        self.assertEqual(t_duration, 40)
+        self.assertEqual(t_duration, new_duration)
 
         # Submit a job to the reservation and change its start time.
         self.submit_job_to_resv(rid)
@@ -1612,11 +1613,11 @@ class TestPbsResvAlter(TestFunctional):
 
         self.alter_a_reservation(rid, temp_start, temp_end, shift=shift,
                                  alter_e=True, sequence=2,
-                                 a_duration=50, check_log=False)
+                                 a_duration=new_duration+10, check_log=False)
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
         self.assertEqual(t_end, temp_end+10)
         self.assertEqual(t_start, temp_start)
-        self.assertEqual(t_duration, 50)
+        self.assertEqual(t_duration, new_duration+10)
 
     def test_adv_resv_dur_and_starttime_before_start(self):
         """
@@ -1626,17 +1627,19 @@ class TestPbsResvAlter(TestFunctional):
 
         offset = 60
         duration = 20
+        new_duration = 30
         shift = 10
         rid, start, end = self.submit_and_confirm_reservation(offset, duration)
 
         self.alter_a_reservation(rid, start, end, shift=shift,
-                                 alter_s=True, a_duration=30, check_log=False)
+                                 alter_s=True, a_duration=new_duration,
+                                 check_log=False)
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
 
         self.assertEqual(t_end, end+20)
         self.assertEqual(t_start, start+10)
-        self.assertEqual(t_duration, 30)
+        self.assertEqual(t_duration, new_duration)
 
         # Submit a job to the reservation and change its start time.
         self.submit_job_to_resv(rid)
@@ -1645,11 +1648,11 @@ class TestPbsResvAlter(TestFunctional):
 
         self.alter_a_reservation(rid, temp_start, temp_end, shift=shift,
                                  alter_s=True, sequence=2,
-                                 a_duration=40, check_log=False)
+                                 a_duration=new_duration+10, check_log=False)
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
         self.assertEqual(t_end, temp_end+20)
         self.assertEqual(t_start, temp_start+10)
-        self.assertEqual(t_duration, 40)
+        self.assertEqual(t_duration, new_duration+10)
 
     def test_adv_res_dur_after_start(self):
         """
@@ -1659,16 +1662,17 @@ class TestPbsResvAlter(TestFunctional):
         """
         offset = 10
         duration = 20
+        new_duration = 30
         shift = 10
         rid, start, end = self.submit_and_confirm_reservation(offset, duration)
 
         self.check_resv_running(rid, offset)
 
-        self.alter_a_reservation(rid, start, end, a_duration=30,
+        self.alter_a_reservation(rid, start, end, a_duration=new_duration,
                                  confirm=False, check_log=False)
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
-        self.assertEqual(t_duration, 30)
+        self.assertEqual(t_duration, new_duration)
 
         time.sleep(5)
         attr = {'reserve_duration': 5}
@@ -1681,23 +1685,22 @@ class TestPbsResvAlter(TestFunctional):
 
     def test_adv_resv_endtime_starttime_dur_together(self):
         """
-        Test that all three end, start and duration can be changed together
+        Test that all three end, start and duration cannot be changed together
         """
         offset = 20
         duration = 20
+        new_duration = 30
         shift = 10
         rid, start, end = self.submit_and_confirm_reservation(offset, duration)
         new_start = self.bu.convert_seconds_to_datetime(start + shift)
         new_end = self.bu.convert_seconds_to_datetime(end + shift)
-        new_duration = self.bu.convert_seconds_to_datetime(duration + 10)
+        new_duration = self.bu.convert_seconds_to_datetime(new_duration)
 
-        try:
+        with self.assertRaises(PbsResvAlterError) as e:
             attr = {'reserve_start': new_start, 'reserve_end': new_end,
                     'reserve_duration': new_duration}
             self.server.alterresv(rid, attr)
-        except PbsResvAlterError as e:
-            self.assertTrue("pbs_ralter: Bad time specification(s)" in
-                            e.msg[0])
+            self.assertIn('pbs_ralter: Bad time specification(s)', e.msg[0])
 
     def test_standing_resv_duration(self):
         """
@@ -1711,16 +1714,17 @@ class TestPbsResvAlter(TestFunctional):
         """
         offset = 20
         duration = 20
+        new_duration = 30
         shift = 15
         rid, start, end = self.submit_and_confirm_reservation(offset,
                                                               duration,
                                                               standing=True)
 
         self.alter_a_reservation(rid, start, end, shift=shift,
-                                 a_duration=30, check_log=False)
+                                 a_duration=new_duration, check_log=False)
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
-        self.assertEqual(t_duration, 30)
+        self.assertEqual(t_duration, new_duration)
 
         # Wait for the reservation to start running.
         self.check_resv_running(rid, offset - shift)
@@ -1744,16 +1748,17 @@ class TestPbsResvAlter(TestFunctional):
         """
         offset = 20
         duration = 20
+        new_duration = 30
         shift = 15
         rid, start, end = self.submit_and_confirm_reservation(offset,
                                                               duration,
                                                               standing=True)
 
         self.alter_a_reservation(rid, start, end, shift=shift, alter_e=True,
-                                 a_duration=30, check_log=False)
+                                 a_duration=new_duration, check_log=False)
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
-        self.assertEqual(t_duration, 30)
+        self.assertEqual(t_duration, new_duration)
         self.assertEqual(t_end, end+15)
         self.assertEqual(t_start, start+5)
 
@@ -1779,16 +1784,17 @@ class TestPbsResvAlter(TestFunctional):
         """
         offset = 20
         duration = 20
+        new_duration = 30
         shift = 15
         rid, start, end = self.submit_and_confirm_reservation(offset,
                                                               duration,
                                                               standing=True)
 
         self.alter_a_reservation(rid, start, end, shift=shift, alter_s=True,
-                                 a_duration=30, check_log=False)
+                                 a_duration=new_duration, check_log=False)
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
-        self.assertEqual(t_duration, 30)
+        self.assertEqual(t_duration, new_duration)
         self.assertEqual(t_end, end+25)
         self.assertEqual(t_start, start+15)
 

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1628,7 +1628,7 @@ class TestPbsResvAlter(TestFunctional):
         In this case the endtime will change accordingly
         """
 
-        offset = 60
+        offset = 20
         duration = 20
         new_duration = 30
         shift = 10
@@ -1689,27 +1689,25 @@ class TestPbsResvAlter(TestFunctional):
 
     def test_adv_resv_endtime_starttime_dur_together(self):
         """
-        Test that all three end, start and duration cannot be changed together
+        Test that all three end, start and duration can be changed together
         """
         offset = 20
         duration = 20
-        new_duration = 30
-        shift = 10
+        new_duration = 25
+        shift_start = 10
+        shift_end = 15
         rid, start, end = self.submit_and_confirm_reservation(offset, duration)
-        new_start = self.bu.convert_seconds_to_datetime(start + shift)
-        new_end = self.bu.convert_seconds_to_datetime(end + shift)
+        new_start = self.bu.convert_seconds_to_datetime(start + shift_start)
+        new_end = self.bu.convert_seconds_to_datetime(end + shift_end)
 
-        with self.assertRaises(PbsResvAlterError) as e:
-            attr = {'reserve_start': new_start, 'reserve_end': new_end,
-                    'reserve_duration': new_duration}
-            self.server.alterresv(rid, attr)
-        self.assertIn('pbs_ralter: Bad time specification(s)',
-                      e.exception.msg[0])
+        attr = {'reserve_start': new_start, 'reserve_end': new_end,
+                'reserve_duration': new_duration}
+        self.server.alterresv(rid, attr)
 
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
-        self.assertEqual(int(t_start), start)
-        self.assertEqual(int(t_duration), duration)
-        self.assertEqual(int(t_end), end)
+        self.assertEqual(int(t_start), start + shift_start)
+        self.assertEqual(int(t_duration), new_duration)
+        self.assertEqual(int(t_end), end + shift_end)
 
     def test_standing_resv_duration(self):
         """
@@ -1722,7 +1720,7 @@ class TestPbsResvAlter(TestFunctional):
         All the above operations are expected to be successful.
         """
         offset = 20
-        duration = 60
+        duration = 30
         new_duration = 90
         shift = 15
         rid, start, end = self.submit_and_confirm_reservation(offset,

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -245,10 +245,11 @@ class TestPbsResvAlter(TestFunctional):
         jid = self.server.submit(j)
         return jid
 
-    def alter_a_reservation(self, r, start, end, shift,
+    def alter_a_reservation(self, r, start, end, shift=0,
                             alter_s=False, alter_e=False,
-                            whichMessage=1, confirm=True,
-                            interactive=0, sequence=1):
+                            whichMessage=1, confirm=True, check_log=True,
+                            interactive=0, sequence=1, alter_d=False,
+                            a_duration=None):
         """
         Helper method for altering a reservation.
         This method also checks for the server and accounting logs.
@@ -314,7 +315,17 @@ class TestPbsResvAlter(TestFunctional):
         if interactive > 0:
             attrs['interactive'] = interactive
 
-        new_duration = new_end - new_start
+        if a_duration:
+            if isinstance(a_duration, str) and ':' in a_duration:
+                new_duration_conv = self.bu.convert_duration(a_duration)
+            else:
+                new_duration_conv = a_duration
+        else:
+            new_duration_conv = new_end - new_start
+
+        if a_duration:
+            attrs['reserve_duration'] = new_duration_conv
+
         if whichMessage:
             msg = ['']
             acct_msg = ['']
@@ -329,26 +340,30 @@ class TestPbsResvAlter(TestFunctional):
             else:
                 msg = "pbs_ralter: " + r + " ALTER REQUESTED"
 
+            print(str(attrs))
             self.server.alterresv(r, attrs)
 
             self.assertEqual(msg, self.server.last_out[0])
             self.logger.info(msg + " displayed")
 
-            msg = "Resv;" + r + ";Attempting to modify reservation "
-            if alter_s:
-                msg += "start="
-                msg += time.strftime(self.fmt, time.localtime(int(new_start)))
-
-            if alter_e:
+            if check_log:
+                msg = "Resv;" + r + ";Attempting to modify reservation "
                 if alter_s:
-                    msg += " "
-                    acct_msg += " "
-                msg += "end="
-                msg += time.strftime(self.fmt, time.localtime(int(new_end)))
-                acct_msg += "end="
-                acct_msg += str(new_end)
+                    msg += "start="
+                    msg += time.strftime(self.fmt,
+                                         time.localtime(int(new_start)))
 
-            self.server.log_match(msg, interval=2, max_attempts=30)
+                if alter_e:
+                    if alter_s:
+                        msg += " "
+                        acct_msg += " "
+                    msg += "end="
+                    msg += time.strftime(self.fmt,
+                                         time.localtime(int(new_end)))
+                    acct_msg += "end="
+                    acct_msg += str(new_end)
+
+                self.server.log_match(msg, interval=2, max_attempts=30)
 
             if whichMessage == 1:
                 if alter_s:
@@ -361,7 +376,8 @@ class TestPbsResvAlter(TestFunctional):
                         new_end, self.fmt)
                     attrs['reserve_end'] = new_end_conv
 
-                attrs['reserve_duration'] = new_duration
+                if a_duration:
+                    attrs['reserve_duration'] = new_duration_conv
 
                 if confirm:
                     attrs['reserve_state'] = (MATCH_RE, 'RESV_CONFIRMED|2')
@@ -369,20 +385,23 @@ class TestPbsResvAlter(TestFunctional):
                     attrs['reserve_state'] = (MATCH_RE, 'RESV_RUNNING|5')
 
                 self.server.expect(RESV, attrs, id=r)
-                acct_msg = "Y;" + r + ";requestor=Scheduler@.*" + " start="
-                acct_msg += str(new_start) + " end=" + str(new_end)
-                self.server.status(RESV, 'resv_nodes', id=r)
-                acct_msg += " nodes="
-                acct_msg += re.escape(self.server.reservations[r].resvnodes())
+                if check_log:
+                    acct_msg = "Y;" + r + ";requestor=Scheduler@.*" + " start="
+                    acct_msg += str(new_start) + " end=" + str(new_end)
+                    self.server.status(RESV, 'resv_nodes', id=r)
+                    acct_msg += " nodes="
+                    acct_msg += re.escape(self.server.reservations[r].
+                                          resvnodes())
 
-                if r[0] == 'S':
-                    self.server.status(RESV, 'reserve_count', id=r)
-                    count = self.server.reservations[r].attributes[
-                        'reserve_count']
-                    acct_msg += " count=" + count
+                    if r[0] == 'S':
+                        self.server.status(RESV, 'reserve_count', id=r)
+                        count = self.server.reservations[r].attributes[
+                            'reserve_count']
+                        acct_msg += " count=" + count
 
-                self.server.accounting_match(acct_msg, regexp=True, interval=2,
-                                             max_attempts=30, n='ALL')
+                    self.server.accounting_match(acct_msg, regexp=True,
+                                                 interval=2,
+                                                 max_attempts=30, n='ALL')
 
                 # Check if reservation reports new start time
                 # and updated duration.
@@ -430,6 +449,20 @@ class TestPbsResvAlter(TestFunctional):
             else:
                 self.assertFalse("Reservation alter allowed when it should" +
                                  "not be.")
+
+    def get_resv_time_info(self, rid):
+        """
+        Get the start time, end time and duration of a reservation
+        in seconds
+        :param rid: reservation id
+        :type  rid: string
+        """
+        resv_data = self.server.status(RESV, id=rid)
+        t_duration = int(resv_data[0]['reserve_duration'])
+        t_end = self.bu.convert_stime_to_seconds(resv_data[0]['reserve_end'])
+        t_start = self.bu.convert_stime_to_seconds(resv_data[0]
+                                                   ['reserve_start'])
+        return t_duration, t_start, t_end
 
     @skipOnCpuSet
     def test_alter_advance_resv_start_time_before_run(self):
@@ -566,7 +599,7 @@ class TestPbsResvAlter(TestFunctional):
 
         All the above operations are expected to be successful.
         """
-        offset = 40
+        offset = 30
         duration = 20
         shift = 10
         rid, start, end = self.submit_and_confirm_reservation(offset, duration)
@@ -598,7 +631,7 @@ class TestPbsResvAlter(TestFunctional):
         Only operation 1 should be successful, operation 2 should fail.
         """
         offset = 10
-        duration = 20
+        duration = 200
         shift = 10
         rid, start, end = self.submit_and_confirm_reservation(offset, duration)
 
@@ -1516,3 +1549,253 @@ class TestPbsResvAlter(TestFunctional):
         self.alter_a_reservation(rid1, start1, end1, shift=300,
                                  alter_e=True, whichMessage=3)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
+    def test_adv_resv_duration_before_start(self):
+        """
+        Test duration of reservation can be changed. In this case end
+        time changes, and start time remains the same.
+        """
+
+        offset = 20
+        duration = 20
+        shift = 10
+        rid, start, end = self.submit_and_confirm_reservation(offset, duration)
+
+        self.alter_a_reservation(rid, start, end, a_duration=30,
+                                 check_log=False)
+
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+
+        self.assertEqual(t_end, end+10)
+        self.assertEqual(t_start, start)
+        self.assertEqual(t_duration, 30)
+
+        # Submit a job to the reservation and change its duration.
+        self.submit_job_to_resv(rid)
+
+        temp_end = t_end
+        temp_start = t_start
+
+        self.alter_a_reservation(rid, temp_start, temp_end, sequence=2,
+                                 a_duration=40, check_log=False)
+
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+        self.assertEqual(t_end, temp_end+10)
+        self.assertEqual(t_start, temp_start)
+        self.assertEqual(t_duration, 40)
+
+    def test_adv_resv_dur_and_endtime_before_start(self):
+        """
+        Test that duration and end time of reservation can be changed together.
+        In this case the start time of reservation may also change.
+        """
+
+        offset = 20
+        duration = 20
+        shift = 10
+        rid, start, end = self.submit_and_confirm_reservation(offset, duration)
+
+        self.alter_a_reservation(rid, start, end, shift=shift,
+                                 alter_e=True, a_duration=40, check_log=False)
+
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+
+        self.assertEqual(t_end, end+10)
+        self.assertEqual(t_start, start-10)
+        self.assertEqual(t_duration, 40)
+
+        # Submit a job to the reservation and change its start time.
+        self.submit_job_to_resv(rid)
+        temp_end = t_end
+        temp_start = t_start
+
+        self.alter_a_reservation(rid, temp_start, temp_end, shift=shift,
+                                 alter_e=True, sequence=2,
+                                 a_duration=50, check_log=False)
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+        self.assertEqual(t_end, temp_end+10)
+        self.assertEqual(t_start, temp_start)
+        self.assertEqual(t_duration, 50)
+
+    def test_adv_resv_dur_and_starttime_before_start(self):
+        """
+        Test duration and starttime of reservation can be changed together.
+        In this case the endtime will change accordingly
+        """
+
+        offset = 60
+        duration = 20
+        shift = 10
+        rid, start, end = self.submit_and_confirm_reservation(offset, duration)
+
+        self.alter_a_reservation(rid, start, end, shift=shift,
+                                 alter_s=True, a_duration=30, check_log=False)
+
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+
+        self.assertEqual(t_end, end+20)
+        self.assertEqual(t_start, start+10)
+        self.assertEqual(t_duration, 30)
+
+        # Submit a job to the reservation and change its start time.
+        self.submit_job_to_resv(rid)
+        temp_end = t_end
+        temp_start = t_start
+
+        self.alter_a_reservation(rid, temp_start, temp_end, shift=shift,
+                                 alter_s=True, sequence=2,
+                                 a_duration=40, check_log=False)
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+        self.assertEqual(t_end, temp_end+20)
+        self.assertEqual(t_start, temp_start+10)
+        self.assertEqual(t_duration, 40)
+
+    def test_adv_res_dur_after_start(self):
+        """
+        Test that duration can be changed after the reservation starts.
+        Test that if the duration changes endtime of the reservation to an
+        already passed time, the reservation is deleted
+        """
+        offset = 10
+        duration = 20
+        shift = 10
+        rid, start, end = self.submit_and_confirm_reservation(offset, duration)
+
+        self.check_resv_running(rid, offset)
+
+        self.alter_a_reservation(rid, start, end, a_duration=30,
+                                 confirm=False, check_log=False)
+
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+        self.assertEqual(t_duration, 30)
+
+        time.sleep(5)
+        attr = {'reserve_duration': 5}
+        self.server.alterresv(rid, attr)
+        self.server.log_match(rid + ";Reservation alter denied",
+                              id=rid, interval=2)
+        rid = rid.split('.')[0]
+        self.server.log_match(rid + ";deleted at request of pbs_server",
+                              id=rid, interval=2)
+
+    def test_adv_resv_endtime_starttime_dur_together(self):
+        """
+        Test that all three end, start and duration can be changed together
+        """
+        offset = 20
+        duration = 20
+        shift = 10
+        rid, start, end = self.submit_and_confirm_reservation(offset, duration)
+        new_start = self.bu.convert_seconds_to_datetime(start + shift)
+        new_end = self.bu.convert_seconds_to_datetime(end + shift)
+        new_duration = self.bu.convert_seconds_to_datetime(duration + 10)
+
+        try:
+            attr = {'reserve_start': new_start, 'reserve_end': new_end,
+                    'reserve_duration': new_duration}
+            self.server.alterresv(rid, attr)
+        except PbsResvAlterError as e:
+            self.assertTrue("pbs_ralter: Bad time specification(s)" in
+                            e.msg[0])
+
+    def test_standing_resv_duration(self):
+        """
+        This test case covers the below scenarios for a standing reservation.
+
+        1. Change duration of standing reservation occurance
+        2. After the first occurrence of the reservation finishes, verify that
+           the start and end time of the second occurrence have not changed.
+
+        All the above operations are expected to be successful.
+        """
+        offset = 20
+        duration = 20
+        shift = 15
+        rid, start, end = self.submit_and_confirm_reservation(offset,
+                                                              duration,
+                                                              standing=True)
+
+        self.alter_a_reservation(rid, start, end, shift=shift,
+                                 a_duration=30, check_log=False)
+
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+        self.assertEqual(t_duration, 30)
+
+        # Wait for the reservation to start running.
+        self.check_resv_running(rid, offset - shift)
+
+        # Wait for the reservation occurrence to finish.
+        new_duration = t_end - t_start
+        self.check_occr_finish(rid, new_duration)
+
+        # Check that duration of the second occurrence is not altered.
+        self.check_standing_resv_second_occurrence(rid, start, end)
+
+    def test_standing_resv_duration_and_endtime(self):
+        """
+        This test case covers the below scenarios for a standing reservation.
+
+        1. Change duration and endtime of standing reservation
+        2. After the first occurrence of the reservation finishes, verify that
+           the start and end time of the second occurrence have not changed.
+
+        All the above operations are expected to be successful.
+        """
+        offset = 20
+        duration = 20
+        shift = 15
+        rid, start, end = self.submit_and_confirm_reservation(offset,
+                                                              duration,
+                                                              standing=True)
+
+        self.alter_a_reservation(rid, start, end, shift=shift, alter_e=True,
+                                 a_duration=30, check_log=False)
+
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+        self.assertEqual(t_duration, 30)
+        self.assertEqual(t_end, end+15)
+        self.assertEqual(t_start, start+5)
+
+        # Wait for the reservation to start running.
+        self.check_resv_running(rid, offset - shift)
+
+        # Wait for the reservation occurrence to finish.
+        new_duration = t_end - t_start
+        self.check_occr_finish(rid, new_duration)
+
+        # Check that duration of the second occurrence is not altered.
+        self.check_standing_resv_second_occurrence(rid, start, end)
+
+    def test_standing_resv_duration_and_starttime(self):
+        """
+        This test case covers the below scenarios for a standing reservation.
+
+        1. Change duration and endtime of standing reservation
+        2. After the first occurrence of the reservation finishes, verify that
+           the start and end time of the second occurrence have not changed.
+
+        All the above operations are expected to be successful.
+        """
+        offset = 20
+        duration = 20
+        shift = 15
+        rid, start, end = self.submit_and_confirm_reservation(offset,
+                                                              duration,
+                                                              standing=True)
+
+        self.alter_a_reservation(rid, start, end, shift=shift, alter_s=True,
+                                 a_duration=30, check_log=False)
+
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+        self.assertEqual(t_duration, 30)
+        self.assertEqual(t_end, end+25)
+        self.assertEqual(t_start, start+15)
+
+        # Wait for the reservation to start running.
+        self.check_resv_running(rid, offset - shift)
+
+        # Wait for the reservation occurrence to finish.
+        new_duration = t_end - t_start
+        self.check_occr_finish(rid, new_duration)
+
+        # Check that duration of the second occurrence is not altered.
+        self.check_standing_resv_second_occurrence(rid, start, end)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Currently we can change the start time and the end time of the reservation. With this new option '-D' the user has the option to change the duration of the reservation.

#### Link to Design Doc
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1551400989/New+option+-D+in+pbs+ralter+to+change+duration+of+a+reservation

#### Attach Test and Valgrind Logs/Output
[ralter_fix9.txt](https://github.com/PBSPro/pbspro/files/4430458/ralter_fix9.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->

