### PR TITLE
Fix memory leaks for some of obj_save_db functions in case of db save…

### DIFF
--- a/src/server/attr_recov_db.c
+++ b/src/server/attr_recov_db.c
@@ -172,6 +172,7 @@ encode_attr_db(struct attribute_def *padef, struct attribute *pattr, int numattr
 	pbs_db_attr_info_t *attrs = NULL;
 
 	attr_list->attr_count = 0;
+	attr_list->attributes = NULL;
 
 	/* encode each attribute which has a value (not non-set) */
 	CLEAR_HEAD(lhead);

--- a/src/server/node_recov_db.c
+++ b/src/server/node_recov_db.c
@@ -329,9 +329,10 @@ node_save_db(struct pbsnode *pnode)
 	pbs_db_obj_info_t obj;
 	pbs_db_conn_t *conn = (pbs_db_conn_t *) svr_db_conn;
 
-	svr_to_db_node(pnode, &dbnode);
 	obj.pbs_db_obj_type = PBS_DB_NODE;
 	obj.pbs_db_un.pbs_db_node = &dbnode;
+
+	svr_to_db_node(pnode, &dbnode);
 
 	if (pbs_db_save_obj(conn, &obj, PBS_UPDATE_DB_FULL) != 0) {
 		if (pbs_db_save_obj(conn, &obj, PBS_INSERT_DB) != 0) {
@@ -343,6 +344,7 @@ node_save_db(struct pbsnode *pnode)
 
 	return (0);
 db_err:
+	pbs_db_reset_obj(&obj);
 	strcpy(log_buffer, "node_save failed ");
 	if (conn->conn_db_err != NULL)
 		strncat(log_buffer, conn->conn_db_err, LOG_BUF_SIZE - strlen(log_buffer) - 1);

--- a/src/server/queue_recov_db.c
+++ b/src/server/queue_recov_db.c
@@ -167,11 +167,11 @@ que_save_db(pbs_queue *pque, int mode)
 	pbs_db_conn_t		*conn = (pbs_db_conn_t *) svr_db_conn;
 	int savetype = PBS_UPDATE_DB_FULL;
 
-	if (svr_to_db_que(pque, &dbque, savetype) != 0)
-		goto db_err;
-
 	obj.pbs_db_obj_type = PBS_DB_QUEUE;
 	obj.pbs_db_un.pbs_db_que = &dbque;
+
+	if (svr_to_db_que(pque, &dbque, savetype) != 0)
+		goto db_err;
 
 	if (mode == QUE_SAVE_NEW)
 		savetype = PBS_INSERT_DB;
@@ -185,7 +185,7 @@ que_save_db(pbs_queue *pque, int mode)
 
 db_err:
 	/* free the attribute list allocated by encode_attrs */
-	free(dbque.attr_list.attributes);
+	pbs_db_reset_obj(&obj);
 
 	strcpy(log_buffer, "que_save failed ");
 	if (conn->conn_db_err != NULL)

--- a/src/server/svr_recov_db.c
+++ b/src/server/svr_recov_db.c
@@ -333,11 +333,11 @@ svr_save_db(struct server *ps, int mode)
 	else
 		savetype = PBS_INSERT_DB;
 
-	if (svr_to_db_svr(ps, &dbsvr, savetype) != 0)
-		goto db_err;
-
 	obj.pbs_db_obj_type = PBS_DB_SVR;
 	obj.pbs_db_un.pbs_db_svr = &dbsvr;
+
+	if (svr_to_db_svr(ps, &dbsvr, savetype) != 0)
+		goto db_err;
 
 	rc = pbs_db_save_obj(conn, &obj, savetype);
 	if (rc != 0) {
@@ -353,6 +353,7 @@ svr_save_db(struct server *ps, int mode)
 	return (0);
 
 db_err:
+	pbs_db_reset_obj(&obj);
 	strcpy(log_buffer, msg_svdbnosv);
 	if (conn->conn_db_err != NULL)
 		strncat(log_buffer, conn->conn_db_err, LOG_BUF_SIZE - strlen(log_buffer) - 1);
@@ -457,11 +458,11 @@ sched_save_db(pbs_sched *ps, int mode)
 	else
 		savetype = PBS_INSERT_DB;
 
-	if (svr_to_db_sched(ps, &dbsched, savetype) != 0)
-		goto db_err;
-
 	obj.pbs_db_obj_type = PBS_DB_SCHED;
 	obj.pbs_db_un.pbs_db_sched = &dbsched;
+
+	if (svr_to_db_sched(ps, &dbsched, savetype) != 0)
+		goto db_err;
 
 
 	rc = pbs_db_save_obj(conn, &obj, savetype);
@@ -479,6 +480,7 @@ sched_save_db(pbs_sched *ps, int mode)
 	return (0);
 
 db_err:
+	pbs_db_reset_obj(&obj);
 	strcpy(log_buffer, schedemsg);
 	if (conn->conn_db_err != NULL)
 		strncat(log_buffer, conn->conn_db_err, LOG_BUF_SIZE - strlen(log_buffer) - 1);


### PR DESCRIPTION
… failures

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

When database failures like object recovery or save fails some of the obj_save_db functions memory leak.
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Following is the backtrace when the issue happens.
76 bytes in 7 blocks are definitely lost in loss record 249 of 1,365
   at 0x4C2A433: malloc (vg_replace_malloc.c:309)
   by 0x6A9BC79: strdup (in /lib64/libc-2.22.so)
   by 0x46B73D: encode_attr_db (attr_recov_db.c:221)
   by 0x4AF652: svr_to_db_que (queue_recov_db.c:114)
   by 0x4AF748: que_save_db (queue_recov_db.c:170)
   by 0x4BACD4: mgr_queue_create (req_manager.c:1238)
   by 0x4C2E5A: req_manager (req_manager.c:4745)
   by 0x4AD98F: dispatch_request (process_request.c:797)
   by 0x483397: issue_Drequest (issue_request.c:446)
   by 0x4CD081: get_queue_for_reservation (req_quejob.c:3138)
   by 0x4CC03F: req_resvSub (req_quejob.c:2713)
   by 0x4AD8F4: dispatch_request (process_request.c:766)

We could not reproduce the issue either in our dev or test environment at present. Fixed the code with the help of backtrace and code inspection.

It looks like these leaks happen when a database recovery or save fails during which case the control reaches to the label db_err in most of the object save/recovery functions.  Here in some of the places we are not calling pbs_db_reset_obj() which actually frees db attributes. However at the end of this label we call panic_stop_db() which stops db as well as PBS Server from which time the memory gets freed anyways. But if tomorrow if we handle db errors without calling panic_stop_db() then these will occupy lot of memory of the Server host and hence the fix.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
![image](https://user-images.githubusercontent.com/17923736/77414628-6229c900-6de7-11ea-97e5-e296d4187321.png)
Attached are entire regression logs.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
