### PR TITLE
Server won't unset the resources_assigned attribute during resource unset anymore, if present

### DIFF
--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1120,26 +1120,6 @@ mgr_unset_attr(attribute *pattr, attribute_def *pdef, int limit, svrattrl *plist
 								pobj, ptype);
 							do_indirect_check = 1;
 					}
-					else {
-						/* If resources_available is unset, also unset associated resources assigned */
-						if (strcasecmp(plist->al_name, ATTR_rescavail) == 0) {
-							int i = find_attr(pdef, ATTR_rescassn, limit);
-							if (i >= 0) {
-								if ((pattr+i)->at_flags & ATR_VFLAG_SET) {
-									resource *nresc;
-									if ((nresc = find_resc_entry((pattr+i), prsdef)) != NULL) {
-										nresc->rs_defin->rs_free(&nresc->rs_value);
-										delete_link(&nresc->rs_link);
-										free(nresc);
-										nresc = (resource *)GET_NEXT((pattr+i)->at_val.at_list);
-										if (nresc == NULL)
-											(pattr+i)->at_flags &= ~ATR_VFLAG_SET;
-										(pattr+i)->at_flags |= ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
-									}
-								}
-							}
-						}
-					}
 					prsdef->rs_free(&presc->rs_value);
 				}
 				delete_link(&presc->rs_link);

--- a/test/tests/functional/pbs_que_resc_usage.py
+++ b/test/tests/functional/pbs_que_resc_usage.py
@@ -1,0 +1,169 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+from tests.functional import *
+
+
+class TestQueRescUsage(TestFunctional):
+    """
+    Test resource behavior after set/unset/assign/release resource on the queue
+    """
+    err_msg = 'Failed to get the expected resource value'
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        self.server.manager(MGR_CMD_SET, NODE, {
+                            'resources_available.ncpus': 10},
+                            self.mom.shortname)
+
+    @skipOnCpuSet
+    def test_resc_assigned_set_unset(self):
+        """
+        Test "resources_assigned" attribute of the resource and it's behavior
+        during set/unset
+        """
+
+        # set a resource and unset it without using
+        a = {'resources_available.ncpus': 4}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq')
+        q_status = self.server.status(QUEUE, id='workq')
+        self.assertEqual(
+            int(q_status[0]['resources_available.ncpus']), 4, self.err_msg)
+        self.assertNotIn('resources_assigned.ncpus',
+                         q_status[0].keys(), self.err_msg)
+        self.server.manager(MGR_CMD_UNSET, QUEUE,
+                            'resources_available.ncpus', id='workq')
+        q_status = self.server.status(QUEUE, id='workq')
+        self.assertNotIn('resources_available.ncpus',
+                         q_status[0].keys(), self.err_msg)
+
+        # set the resource and unset it after using
+        a = {'resources_available.ncpus': 8}
+        self.server.manager(MGR_CMD_SET, QUEUE, a, id='workq')
+        q_status = self.server.status(QUEUE, id='workq')
+        self.assertEqual(
+            int(q_status[0]['resources_available.ncpus']), 8, self.err_msg)
+        # job submission
+        j_attr = {ATTR_queue: 'workq', 'Resource_List.select': '1:ncpus=3'}
+        j1 = Job(TEST_USER, j_attr)
+        j1.set_sleep_time(30)
+        jid_1 = self.server.submit(j1)
+        j2 = Job(TEST_USER, j_attr)
+        j2.set_sleep_time(30)
+        jid_2 = self.server.submit(j2)
+        self.server.expect(JOB, {'job_state': 'R'}, jid_1)
+        self.server.expect(JOB, {'job_state': 'R'}, jid_2)
+        q_status = self.server.status(
+            QUEUE, 'resources_assigned.ncpus', id='workq')
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.ncpus']), 6, self.err_msg)
+        self.server.manager(MGR_CMD_UNSET, QUEUE,
+                            'resources_available.ncpus', id='workq')
+        q_status = self.server.status(QUEUE, id='workq')
+        self.assertNotIn('resources_available.ncpus',
+                         q_status[0].keys(), self.err_msg)
+        self.assertIn('resources_assigned.ncpus',
+                      q_status[0].keys(), self.err_msg)
+
+        # Restart the server() and check "resources_assigned" value when
+        # resource is not set but still some jobs are running in the system
+        # and using the same resource.
+        self.server.restart()
+        q_status = self.server.status(QUEUE, id='workq')
+        self.assertNotIn('resources_available.ncpus',
+                         q_status[0].keys(), self.err_msg)
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.ncpus']), 6, self.err_msg)
+        # If no jobs are running at the time of restart the server
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid_1)
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid_2)
+        self.server.restart()
+        q_status = self.server.status(QUEUE, id='workq')
+        self.assertNotIn('resources_available.ncpus',
+                         q_status[0].keys(), self.err_msg)
+        self.assertNotIn('resources_assigned.ncpus',
+                         q_status[0].keys(), self.err_msg)
+
+    @skipOnCpuSet
+    def test_resources_assigned_with_zero_val(self):
+        """
+        In PBS we can request +ve or -ve values so sometimes resources_assigned
+        becomes zero despite some jobs are still using the same resource.
+        In this case resources_assigned shouldn't be unset if jobs are there
+        in the system or else unset it.
+        """
+
+        # create a custom resource
+        self.server.manager(MGR_CMD_CREATE, RSC, {
+                            'type': 'long', 'flag': 'q'}, id='foo')
+        self.scheduler.add_resource('foo')
+        self.server.manager(MGR_CMD_SET, QUEUE, {
+                            'resources_available.foo': 6}, id='workq')
+        q_status = self.server.status(QUEUE, id='workq')
+        self.assertEqual(
+            int(q_status[0]['resources_available.foo']), 6, self.err_msg)
+
+        # resources_assigned is zero but still jobs are in the system
+        j1_attr = {ATTR_queue: 'workq',
+                   'Resource_List.select': '1', 'Resource_List.foo': '3'}
+        j1 = Job(TEST_USER, j1_attr)
+        j1.set_sleep_time(30)
+        jid_1 = self.server.submit(j1)
+        # requesting negative resource here
+        j2_attr = {ATTR_queue: 'workq',
+                   'Resource_List.select': '1', 'Resource_List.foo': '-3'}
+        j2 = Job(TEST_USER, j2_attr)
+        j2.set_sleep_time(30)
+        jid_2 = self.server.submit(j2)
+        self.server.expect(JOB, {'job_state': 'R'}, jid_1)
+        self.server.expect(JOB, {'job_state': 'R'}, jid_2)
+        q_status = self.server.status(QUEUE, id='workq')
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.foo']), 0, self.err_msg)
+        self.server.manager(MGR_CMD_UNSET, QUEUE,
+                            'resources_available.foo', id='workq')
+        self.server.restart()
+        q_status = self.server.status(QUEUE, id='workq')
+        self.assertEqual(
+            int(q_status[0]['resources_assigned.foo']), 0, self.err_msg)
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid_1)
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid_2)
+        # jobs are finished now, resources_assigned should unset this time
+        self.server.restart()
+        q_status = self.server.status(QUEUE, id='workq')
+        self.assertNotIn('resources_assigned.foo',
+                         q_status[0].keys(), self.err_msg)


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Queue resources_assigned goes negative because we unset a resource which is already been occupied by the job.
**Steps to reproduce:**
   1.  set q <queue_name> resources_available.ncpus=<value>
   2.  run a job
   3. unset q <qeueu_name> resources_available.ncpus
   4. qdel the job
   5. qstat -Qf <queue_name> and see "resources_assigned" value

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
As per the new changes, If we unset the resource then will remove only resources_available.<resc_name> attribute  and leave resources_assigned.<resc_name> attribute as it is with its original value((could be zero as well) if present. Resources_assigned.<resc_name> will be there in the system forever, until the resource is deleted or server can also unset this attribute if didn't find any jobs related to that particular resource in the system at the time of restart.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

PTL logs:- [ptl_que_resc_usage.txt](https://github.com/PBSPro/pbspro/files/4386420/ptl_que_resc_usage.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
