### PR TITLE
Put least expensive test first for empty_cores

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -3598,9 +3598,9 @@ class CgroupUtils(object):
                 # Find cores that are fully available
                 empty_cores = set()
                 for corenum in sorted(cores):
-                    if (set(node.cpuinfo['cpu'][corenum]['threads'])
-                            .issubset(set(available['cpus']))
-                            and corenum not in node.cpuinfo['hyperthreads']):
+                    if (corenum not in node.cpuinfo['hyperthreads']
+                            and set(node.cpuinfo['cpu'][corenum]['threads'])
+                            .issubset(set(available['cpus']))):
                         # All hyperthreads available for this core
                         empty_cores.add(corenum)
                 # Assign threads from the empty cores


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
empty_cores is constructed to include only the first thread from all the cores whose list of threads is completely available (we list only the first thread to avoid encountering duplicates, since for these "empty" cores we will always add all threads to the list of assigned threads).

Unfortunately, the two criteria (all siblings of this thread should be available, and the thread should be the lowest numbered sibling) were arranged with the most expensive test first (the one that evaluates whether set A is a subset of set B).

This pull request just interchanges the order of the 'and' operands, so that the issubset need not be performed for threads that are not the first sibling of a core. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Swapped two operands of an "and" expression

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
Functionally identical to existing code -- only faster

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
N/A


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
