### PR TITLE
Atom hook should offline all vnodes reported by a mom

### DIFF
--- a/src/modules/python/pbs_hooks/PBS_cray_atom.HK
+++ b/src/modules/python/pbs_hooks/PBS_cray_atom.HK
@@ -4,3 +4,4 @@ user=pbsadmin
 event=execjob_begin,execjob_end
 order=100
 alarm=300
+fail_action=offline_vnodes

--- a/src/modules/python/pbs_hooks/PBS_cray_atom.PY
+++ b/src/modules/python/pbs_hooks/PBS_cray_atom.PY
@@ -50,11 +50,14 @@ import json as JSON
 import urllib
 import site
 site.main()
-import requests
-import requests_unixsocket
-import pbs
-import pwd
-import copy
+
+# to be PEP-8 compliant, the imports must be indented
+if True:
+    import requests
+    import requests_unixsocket
+    import pbs
+    import pwd
+    import copy
 
 requests_unixsocket.monkeypatch()
 
@@ -67,7 +70,9 @@ class OfflineError(Exception):
     """
     Exception that will offline the node and reject the event
     """
-    pass
+
+    def __init__(self, msg):
+        super().__init__(pbs.event().job.id + ': ' + msg)
 
 
 class RejectError(Exception):
@@ -401,11 +406,7 @@ if __name__ == 'builtins':
     try:
         main()
     except OfflineError as e:
-        for v in pbs.event().vnode_list.keys():
-            vnode = pbs.event().vnode_list[v]
-            vnode.state = pbs.ND_OFFLINE
-            vnode.comment = '%s: vnode set to offline: %s' % (
-                pbs.event().hook_name, e.message)
-        pbs.event().reject()
+        # the fail_action will offline the vnodes
+        raise
     except RejectError:
         pbs.event().reject()


### PR DESCRIPTION
#### Describe Bug or Feature
The cray atom hook was not offlining vnodes, and raising an exception for an improper use of 'e.message'


#### Describe Your Change
Use fail_action = offline_vnodes hook attribute.


#### Attach Test and Valgrind Logs/Output
Manual test:
[after-fix.txt](https://github.com/PBSPro/pbspro/files/4384377/after-fix.txt)
[after-fix-multivnode.txt](https://github.com/PBSPro/pbspro/files/4390787/after-fix-multivnode.txt)



#### Design
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1086029883/PBS+Design+Changes+for+Shasta

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
