### PR TITLE
changes to user reliability test to not expect a certain number of ncpus

### DIFF
--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -179,11 +179,17 @@ j.create_resv_from_job=1
         This test confirms that a reservation cannot be created out of an
         array job.
         """
+
+        # Let us not assume the number of ncpus
+        nodes = self.server.status(NODE)
+        ncpus = nodes[0]['resources_available.ncpus']
+        j_range = '1-' + ncpus
+
         j = Job(TEST_USER)
-        j.set_attributes({ATTR_J: '1-3'})
+        j.set_attributes({ATTR_J: j_range})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'B'}, jid)
-        self.server.expect(JOB, {'job_state=R': 3}, count=True,
+        self.server.expect(JOB, {'job_state=R': ncpus}, count=True,
                            id=jid, extend='t')
 
         subjobs = self.server.status(JOB, id=jid, extend='t')

--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -180,17 +180,10 @@ j.create_resv_from_job=1
         array job.
         """
 
-        # Let us not assume the number of ncpus
-        nodes = self.server.status(NODE)
-        ncpus = nodes[0]['resources_available.ncpus']
-        j_range = '1-' + ncpus
-
         j = Job(TEST_USER)
-        j.set_attributes({ATTR_J: j_range})
+        j.set_attributes({ATTR_J: '1-3'})
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'B'}, jid)
-        self.server.expect(JOB, {'job_state=R': ncpus}, count=True,
-                           id=jid, extend='t')
 
         subjobs = self.server.status(JOB, id=jid, extend='t')
         jids1 = subjobs[1]['id']


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The test test_create_resv_from_array_job from Test_user_reliability would fail on machines having ncpus < 3.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Changed the test to not check for all subjobs to be running.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl_24538.txt](https://github.com/PBSPro/pbspro/files/4386372/ptl_24538.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
