### PR TITLE
Fix for premature end of message when auth fails

### DIFF
--- a/src/include/auth.h
+++ b/src/include/auth.h
@@ -146,6 +146,7 @@ typedef struct auth_def {
 enum AUTH_MSG_TYPES {
 	AUTH_CTX_DATA = 1, /* starts from 1, zero means EOF */
 	AUTH_ERR_DATA,
+	AUTH_CTX_OK,
 	AUTH_ENCRYPTED_DATA,
 	AUTH_LAST_MSG
 };

--- a/src/lib/Libauth/munge/munge_supp.c
+++ b/src/lib/Libauth/munge/munge_supp.c
@@ -140,6 +140,9 @@ err:
  * @brief
  *	munge_get_auth_data - Call Munge encode API's to get the authentication data for the current user
  *
+ * @param[in] ebuf - buffer to hold error msg if any
+ * @param[in] ebufsz - size of ebuf
+ *
  * @return char *
  * @retval !NULL - success
  * @retval  NULL - failure
@@ -155,7 +158,14 @@ munge_get_auth_data(char *ebuf, size_t ebufsz)
 	char payload[PBS_MAXUSER + PBS_MAXGRPN + 1] = { '\0' };
 	int munge_err = 0;
 
-	ebuf[0] = '\0';
+	/*
+	 * ebuf passed to this function is initialized with nulls all through
+	 * and ebufsz value passed is sizeof(ebuf) - 1
+	 * So, we don't need to null terminate the last byte in the below
+	 * all snprintf
+	 *
+	 * see pbs_auth_process_handshake_data()
+	 */
 
 	if (munge_dlhandle == NULL) {
 		pthread_once(&munge_init_once, init_munge);
@@ -202,6 +212,8 @@ err:
  *	munge_validate_auth_data - validate given munge authentication data
  *
  * @param[in] auth_data - auth data to be verified
+ * @param[in] ebuf - buffer to hold error msg if any
+ * @param[in] ebufsz - size of ebuf
  *
  * @return int
  * @retval 0 - Success
@@ -221,7 +233,14 @@ munge_validate_auth_data(void *auth_data, char *ebuf, size_t ebufsz)
 	char *p;
 	int rc = -1;
 
-	ebuf[0] = '\0';
+	/*
+	 * ebuf passed to this function is initialized with nulls all through
+	 * and ebufsz value passed is sizeof(ebuf) - 1
+	 * So, we don't need to null terminate the last byte in the below
+	 * all snprintf
+	 *
+	 * see pbs_auth_process_handshake_data()
+	 */
 
 	if (munge_dlhandle == NULL) {
 		pthread_once(&munge_init_once, init_munge);

--- a/src/lib/Libauth/munge/munge_supp.c
+++ b/src/lib/Libauth/munge/munge_supp.c
@@ -71,8 +71,8 @@ static void (*logger)(int type, int objclass, int severity, const char *objname,
 #define MUNGE_LOG_DBG(m) __MUNGE_LOGGER(PBSEVENT_DEBUG|PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER, LOG_DEBUG, m)
 
 static void init_munge(void);
-static char * munge_get_auth_data();
-static int munge_validate_auth_data(void *auth_data);
+static char *munge_get_auth_data(char *, size_t);
+static int munge_validate_auth_data(void *, char *, size_t);
 
 /**
  * @brief
@@ -146,7 +146,7 @@ err:
  *
  */
 static char *
-munge_get_auth_data(void)
+munge_get_auth_data(char *ebuf, size_t ebufsz)
 {
 	char *cred = NULL;
 	uid_t myrealuid;
@@ -154,12 +154,14 @@ munge_get_auth_data(void)
 	struct group *grp;
 	char payload[PBS_MAXUSER + PBS_MAXGRPN + 1] = { '\0' };
 	int munge_err = 0;
-	char ebuf[LOG_BUF_SIZE];
+
+	ebuf[0] = '\0';
 
 	if (munge_dlhandle == NULL) {
 		pthread_once(&munge_init_once, init_munge);
 		if (munge_encode == NULL) {
-			MUNGE_LOG_ERR("Munge lib not loaded");
+			snprintf(ebuf, ebufsz, "Failed to load munge lib");
+			MUNGE_LOG_ERR(ebuf);
 			goto err;
 		}
 	}
@@ -167,14 +169,14 @@ munge_get_auth_data(void)
 	myrealuid = getuid();
 	pwent = getpwuid(myrealuid);
 	if (pwent == NULL) {
-		snprintf(ebuf, sizeof(ebuf) - 1, "Failed to obtain user-info for uid = %d", myrealuid);
+		snprintf(ebuf, ebufsz, "Failed to obtain user-info for uid = %d", myrealuid);
 		MUNGE_LOG_ERR(ebuf);
 		goto err;
 	}
 
 	grp = getgrgid(pwent->pw_gid);
 	if (grp == NULL) {
-		snprintf(ebuf, sizeof(ebuf) - 1, "Failed to obtain group-info for gid=%d", pwent->pw_gid);
+		snprintf(ebuf, ebufsz, "Failed to obtain group-info for gid=%d", pwent->pw_gid);
 		MUNGE_LOG_ERR(ebuf);
 		goto err;
 	}
@@ -183,7 +185,7 @@ munge_get_auth_data(void)
 
 	munge_err = munge_encode(&cred, NULL, payload, strlen(payload));
 	if (munge_err != 0) {
-		snprintf(ebuf, sizeof(ebuf) - 1, "MUNGE user-authentication on encode failed with `%s`", munge_strerror(munge_err));
+		snprintf(ebuf, ebufsz, "MUNGE user-authentication on encode failed with `%s`", munge_strerror(munge_err));
 		MUNGE_LOG_ERR(ebuf);
 		goto err;
 	}
@@ -207,7 +209,7 @@ err:
  *
  */
 static int
-munge_validate_auth_data(void *auth_data)
+munge_validate_auth_data(void *auth_data, char *ebuf, size_t ebufsz)
 {
 	uid_t uid;
 	gid_t gid;
@@ -218,31 +220,33 @@ munge_validate_auth_data(void *auth_data)
 	int munge_err = 0;
 	char *p;
 	int rc = -1;
-	char ebuf[LOG_BUF_SIZE];
+
+	ebuf[0] = '\0';
 
 	if (munge_dlhandle == NULL) {
 		pthread_once(&munge_init_once, init_munge);
 		if (munge_decode == NULL) {
-			MUNGE_LOG_ERR("Munge lib not loaded");
+			snprintf(ebuf, ebufsz, "Failed to load munge lib");
+			MUNGE_LOG_ERR(ebuf);
 			goto err;
 		}
 	}
 
 	munge_err = munge_decode(auth_data, NULL, &recv_payload, &recv_len, &uid, &gid);
 	if (munge_err != 0) {
-		snprintf(ebuf, sizeof(ebuf) - 1, "MUNGE user-authentication on decode failed with `%s`", munge_strerror(munge_err));
+		snprintf(ebuf, ebufsz, "MUNGE user-authentication on decode failed with `%s`", munge_strerror(munge_err));
 		MUNGE_LOG_ERR(ebuf);
 		goto err;
 	}
 
 	if ((pwent = getpwuid(uid)) == NULL) {
-		snprintf(ebuf, sizeof(ebuf) - 1, "Failed to obtain user-info for uid = %d", uid);
+		snprintf(ebuf, ebufsz, "Failed to obtain user-info for uid = %d", uid);
 		MUNGE_LOG_ERR(ebuf);
 		goto err;
 	}
 
 	if ((grp = getgrgid(pwent->pw_gid)) == NULL) {
-		snprintf(ebuf, sizeof(ebuf) - 1, "Failed to obtain group-info for gid=%d", gid);
+		snprintf(ebuf, ebufsz, "Failed to obtain group-info for gid=%d", gid);
 		MUNGE_LOG_ERR(ebuf);
 		goto err;
 	}
@@ -251,8 +255,10 @@ munge_validate_auth_data(void *auth_data)
 
 	if (p && (strncmp(pwent->pw_name, p, PBS_MAXUSER) == 0)) /* inline with current pbs_iff we compare with username only */
 		rc = 0;
-	else
-		MUNGE_LOG_ERR("User credentials do not match");
+	else {
+		snprintf(ebuf, ebufsz, "User credentials do not match");
+		MUNGE_LOG_ERR(ebuf);
+	}
 
 err:
 	if (recv_payload)
@@ -356,6 +362,7 @@ int
 pbs_auth_process_handshake_data(void *ctx, void *data_in, size_t len_in, void **data_out, size_t *len_out, int *is_handshake_done)
 {
 	int rc = -1;
+	char ebuf[LOG_BUF_SIZE] = {'\0'};
 
 	*len_out = 0;
 	*data_out = NULL;
@@ -364,6 +371,9 @@ pbs_auth_process_handshake_data(void *ctx, void *data_in, size_t len_in, void **
 	pthread_once(&munge_init_once, init_munge);
 
 	if (munge_dlhandle == NULL) {
+		*data_out = strdup("Munge lib is not loaded");
+		if (*data_out != NULL)
+			*len_out = strlen(*data_out);
 		return 1;
 	}
 
@@ -371,17 +381,25 @@ pbs_auth_process_handshake_data(void *ctx, void *data_in, size_t len_in, void **
 		char *data = (char *)data_in;
 		/* enforce null char at given length of data */
 		data[len_in] = '\0';
-		rc = munge_validate_auth_data(data);
+		rc = munge_validate_auth_data(data, ebuf, sizeof(ebuf) - 1);
 		if (rc == 0) {
 			*is_handshake_done = 1;
 			return 0;
+		} else if (ebuf[0] != '\0') {
+			*data_out = strdup(ebuf);
+			if (*data_out != NULL)
+				*len_out = strlen(ebuf);
 		}
 	} else {
-		*data_out = (void *)munge_get_auth_data();
+		*data_out = (void *)munge_get_auth_data(ebuf, sizeof(ebuf) - 1);
 		if (*data_out) {
 			*len_out = strlen((char *)*data_out);
 			*is_handshake_done = 1;
 			return 0;
+		} else if (ebuf[0] != '\0') {
+			*data_out = strdup(ebuf);
+			if (*data_out != NULL)
+				*len_out = strlen(ebuf);
 		}
 	}
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* When authentication fails on the server and if the server sends an auth error message back to client still client fails with `Premature end of message (null)`, instead of printing auth error message from the server
* This mostly happens when LibAuth library is not actually doing the handshake, for example, Munge auth lib, on the client, it gets auth data and marks handshake is done (because it doesn't need any data back from server). So, if the auth library says a handshake is done, PBS proceeds further.
* Basically we need a way to say to the client that we have received your data and its valid or not

#### Describe Your Change
* (On server-side) Changed code such a way if auth fails then it sends AUTH_ERR_DATA (existing code) and if auth succeeds then send AUTH_CTX_OK to notify the client auth data is valid
* (On client-side) Always wait for on pkt from the server, which will be either AUTH_CTX_DATA (if handshake needs continuation), AUTH_ERR_DATA (if auth failed on the server) or AUTH_CTX_OK (if auth succeed on the server)
* Modified Munge LibAuth implementation to pass auth error message back to client

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [before-fix.txt](https://github.com/PBSPro/pbspro/files/4386580/before-fix.txt)
* [after-fix.txt](https://github.com/PBSPro/pbspro/files/4386582/after-fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
