### PR TITLE
Let scheduler accept connections from PBS_LEAF_NAME

### DIFF
--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -1147,6 +1147,9 @@ main(int argc, char *argv[])
 		/* Failover is not configured, but PBS_SERVER_HOST_NAME is. */
 		addclient(pbs_conf.pbs_server_host_name);
 	}
+	if (pbs_conf.pbs_leaf_name) {
+		addclient(pbs_conf.pbs_leaf_name);
+	}
 
 	if (configfile) {
 		if (read_config(configfile) != 0)

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -1139,6 +1139,8 @@ main(int argc, char *argv[])
 	}
 	addclient("localhost");   /* who has permission to call MOM */
 	addclient(host);
+	if (pbs_conf.pbs_server_name)
+		addclient(pbs_conf.pbs_server_name);
 	if (pbs_conf.pbs_primary && pbs_conf.pbs_secondary) {
 		/* Failover is configured when both primary and secondary are set. */
 		addclient(pbs_conf.pbs_primary);
@@ -1147,9 +1149,8 @@ main(int argc, char *argv[])
 		/* Failover is not configured, but PBS_SERVER_HOST_NAME is. */
 		addclient(pbs_conf.pbs_server_host_name);
 	}
-	if (pbs_conf.pbs_leaf_name) {
+	if (pbs_conf.pbs_leaf_name)
 		addclient(pbs_conf.pbs_leaf_name);
-	}
 
 	if (configfile) {
 		if (read_config(configfile) != 0)


### PR DESCRIPTION
#### Describe Bug or Feature
If a server has PBS_LEAF_NAME set, the server will use that interface for outgoing connections.
The scheduler whitelists hosts for incoming connections. PBS_LEAF_NAME was not in this whitelist.


#### Describe Your Change
Add the value of PBS_LEAF_NAME to the whitelist.



#### Attach Test and Valgrind Logs/Output
Manual test, as it requires multiple network interfaces and PTL shouldn't really have to support that.
[after-fix.txt](https://github.com/PBSPro/pbspro/files/4390350/after-fix.txt)
[before-fix.txt](https://github.com/PBSPro/pbspro/files/4390351/before-fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
