### PR TITLE
Updates to MoM class' save_configuration() & load_configuration() for saving mom configurations when option '--use-current-setup' is used in PTL's pbs_benchpress

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4313,7 +4313,6 @@ class PBSService(PBSObject):
                             self.logger.error("Failed to restore "
                                               + "configuration: %s" % k)
                             return False
-                        self.du.rm(path=fn, force=True, sudo=True)
                     except:
                         self.logger.error("Failed to restore "
                                           + "configuration: %s" % k)
@@ -13397,7 +13396,7 @@ class MoM(PBSService):
                 self._save_config_file(conf,
                                        os.path.join(mpriv, 'config.d', f))
         mconf = {self.hostname: conf}
-        if MGR_OBJ_NODE not in self.server.saved_config.keys():
+        if MGR_OBJ_NODE not in self.server.saved_config:
             self.server.saved_config[MGR_OBJ_NODE] = {}
         self.server.saved_config[MGR_OBJ_NODE].update(mconf)
         if outfile is not None:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4294,7 +4294,7 @@ class PBSService(PBSObject):
             elif objtype == MGR_OBJ_SCHED:
                 for k, v in conf.items():
                     fn = self.du.create_temp_file()
-                    if os.path.isfile(fn):
+                    try:
                         rv = self.du.chmod(path=fn, mode=0o644)
                         if not rv:
                             self.logger.error("Failed to restore "
@@ -4314,16 +4314,19 @@ class PBSService(PBSObject):
                                               + "configuration: %s" % k)
                             return False
                         self.du.rm(path=fn, force=True, sudo=True)
-                    else:
+                    except:
                         self.logger.error("Failed to restore "
                                           + "configuration: %s" % k)
                         return False
+                    finally:
+                        if os.path.isfile(fn):
+                            self.du.rm(path=fn, force=True, sudo=True)
                 return True
             elif objtype == MGR_OBJ_NODE:
                 nconf = conf[str(self.hostname)]
                 for k, v in nconf.items():
-                    fn = self.du.create_temp_file()
-                    if os.path.isfile(fn):
+                    try:
+                        fn = self.du.create_temp_file()
                         rv = self.du.chmod(path=fn, mode=0o644)
                         if not rv:
                             self.logger.error("Failed to restore "
@@ -4342,11 +4345,13 @@ class PBSService(PBSObject):
                             self.logger.error("Failed to restore "
                                               + "configuration: %s" % k)
                             return False
-                        self.du.rm(path=fn, force=True, sudo=True)
-                    else:
+                    except:
                         self.logger.error("Failed to restore "
                                           + "configuration: %s" % k)
                         return False
+                    finally:
+                        if os.path.isfile(fn):
+                            self.du.rm(path=fn, force=True, sudo=True)
                 return True
 
     def create_pbsnode(self, node_name, attrs):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4243,6 +4243,7 @@ class PBSService(PBSObject):
                     return False
             conf = sconf[str(objtype)]
             if objtype == MGR_OBJ_SERVER:
+                conf = sconf[str(objtype)]
                 qmgr = os.path.join(self.client_conf['PBS_EXEC'],
                                     'bin', 'qmgr')
                 for k, v in conf.items():
@@ -4292,6 +4293,7 @@ class PBSService(PBSObject):
                             return False
                 return True
             elif objtype == MGR_OBJ_SCHED:
+                conf = sconf[str(objtype)]
                 for k, v in conf.items():
                     try:
                         fn = self.du.create_temp_file()
@@ -4303,11 +4305,41 @@ class PBSService(PBSObject):
                             self.logger.error("Failed to restore "
                                               + "configuration: %s" % k)
                             return False
+                        rv = self.du.chown(path=k, runas=ROOT_USER,
+                                           uid=0, gid=0, sudo=True)
+                        if not rv:
+                            self.logger.error("Failed to restore "
+                                              + "configuration: %s" % k)
+                            return False
                     finally:
                         if os.path.isfile(fn):
-                            self.du.rm(path=fn)
+                            self.du.rm(path=fn, force=True, sudo=True)
                 return True
-        return False
+            elif objtype == MGR_OBJ_NODE:
+                conf = sconf[str(objtype)]
+                nconf = {}
+                nconf = conf[str(self.hostname)]
+                for k, v in nconf.items():
+                    try:
+                        fn = self.du.create_temp_file()
+                        self.du.chmod(path=fn, mode=0o644)
+                        with open(fn, 'w') as fd:
+                            fd.write("\n".join(v))
+                        rv = self.du.run_copy(self.hostname, fn, k, sudo=True)
+                        if rv['rc'] != 0:
+                            self.logger.error("Failed to restore "
+                                              + "configuration: %s" % k)
+                            return False
+                        rv = self.du.chown(path=k, runas=ROOT_USER,
+                                           uid=0, gid=0, sudo=True)
+                        if not rv:
+                            self.logger.error("Failed to restore "
+                                              + "configuration: %s" % k)
+                            return False
+                    finally:
+                        if os.path.isfile(fn):
+                            self.du.rm(path=fn, force=True, sudo=True)
+                return True
 
     def create_pbsnode(self, node_name, attrs):
         """
@@ -13325,12 +13357,13 @@ class MoM(PBSService):
             return self.isUp()
         return True
 
-    def save_configuration(self, outfile, mode='a'):
+    def save_configuration(self, outfile=None, mode='w'):
         """
         Save a MoM ``mom_priv/config``
 
-        :param outfile: the output file to which onfiguration is
-                        saved
+        :param outfile: Optional Path to a file to which configuration
+                        is saved, when not provided, data is saved in
+                        class variable saved_config
         :type outfile: str
         :param mode: the mode in which to open outfile to save
                      configuration.
@@ -13342,7 +13375,6 @@ class MoM(PBSService):
                   should save with mode 'a' or 'a+'. Defaults to a+
         """
         conf = {}
-        mconf = {MGR_OBJ_NODE: conf}
         mpriv = os.path.join(self.pbs_conf['PBS_HOME'], 'mom_priv')
         cf = os.path.join(mpriv, 'config')
         self._save_config_file(conf, cf)
@@ -13351,20 +13383,26 @@ class MoM(PBSService):
             for f in os.listdir(os.path.join(mpriv, 'config.d')):
                 self._save_config_file(conf,
                                        os.path.join(mpriv, 'config.d', f))
-        try:
-            with open(outfile, mode) as f:
-                cPickle.dump(mconf, f)
-        except:
-            self.logger.error('error saving configuration to ' + outfile)
-            return False
-
+        mconf = {self.hostname: conf}
+        if MGR_OBJ_NODE not in self.server.saved_config.keys():
+            self.server.saved_config[MGR_OBJ_NODE] = {}
+        self.server.saved_config[MGR_OBJ_NODE].update(mconf)
+        if outfile is not None:
+            try:
+                with open(outfile, mode) as f:
+                    json.dump(self.server.saved_config, f)
+            except:
+                self.logger.error('error saving configuration to ' + outfile)
+                return False
         return True
 
     def load_configuration(self, infile):
         """
-        load configuration from saved file infile
+        load mom configuration from saved file infile
         """
-        self._load_configuration(infile, MGR_OBJ_NODE)
+        rv = self._load_configuration(infile, MGR_OBJ_NODE)
+        self.signal('-HUP')
+        return rv
 
     def is_cray(self):
         """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -172,6 +172,7 @@ def skipOnCpuSet(function):
     """
     Decorator to skip a test on a CpuSet system
     """
+
     def wrapper(self, *args, **kwargs):
         for mom in self.moms.values():
             if mom.is_cpuset_mom():
@@ -452,6 +453,7 @@ class PBSTestSuite(unittest.TestCase):
         cls.check_users_exist()
         cls.init_servers()
         cls.init_schedulers()
+        cls.init_moms()
         if cls.use_cur_setup:
             _, path = tempfile.mkstemp(prefix="saved_custom_setup",
                                        suffix=".json")
@@ -459,6 +461,11 @@ class PBSTestSuite(unittest.TestCase):
             if not ret:
                 cls.logger.error("Failed to save server's custom setup")
                 raise Exception("Failed to save server's custom setup")
+            for mom in cls.moms.values():
+                ret = mom.save_configuration()
+                if not ret:
+                    cls.logger.error("Failed to save mom's custom setup")
+                    raise Exception("Failed to save mom's custom setup")
             ret = cls.scheduler.save_configuration(path, 'w')
             if ret:
                 cls.saved_file = path
@@ -467,7 +474,6 @@ class PBSTestSuite(unittest.TestCase):
                 raise Exception("Failed to save scheduler's custom setup")
             cls.add_mgrs_opers()
         cls.init_comms()
-        cls.init_moms()
         cls.log_end_setup(True)
 
     def setUp(self):
@@ -482,6 +488,11 @@ class PBSTestSuite(unittest.TestCase):
             if not ret:
                 self.logger.error("Failed to save server's test setup")
                 raise Exception("Failed to save server's test setup")
+            for mom in self.moms.values():
+                ret = mom.save_configuration()
+                if not ret:
+                    cls.logger.error("Failed to save mom's test setup")
+                    raise Exception("Failed to save mom's test setup")
             ret = self.scheduler.save_configuration(path, 'w')
             if ret:
                 self.saved_file = path
@@ -489,17 +500,15 @@ class PBSTestSuite(unittest.TestCase):
                 self.logger.error("Failed to save scheduler's test setup")
                 raise Exception("Failed to save scheduler's test setup")
             PBSTestSuite.config_saved = True
-        # Adding only server and pbs.conf methods in use current
-        # setup block, rest of them to be added to this block
+        # Adding only server, mom & scheduler and pbs.conf methods in use
+        # current setup block, rest of them to be added to this block
         # once save & load configurations are implemented for
-        # comm, mom, scheduler
-        if self.use_cur_setup:
-            self.server.delete_nodes()
-        else:
+        # comm
+        if not self.use_cur_setup:
             self.revert_servers()
             self.revert_pbsconf()
             self.revert_schedulers()
-        self.revert_moms()
+            self.revert_moms()
         self.revert_comms()
         self.log_end_setup()
         self.measurements = []
@@ -1625,6 +1634,10 @@ class PBSTestSuite(unittest.TestCase):
             ret = self.scheduler.load_configuration(self.saved_file)
             if not ret:
                 raise Exception("Failed to load scheduler's test setup")
+            for mom in self.moms.values():
+                ret = mom.load_configuration(self.saved_file)
+                if not ret:
+                    raise Exception("Failed to load mom's test setup")
         self.log_end_teardown()
 
     @classmethod
@@ -1639,5 +1652,9 @@ class PBSTestSuite(unittest.TestCase):
             ret = cls.scheduler.load_configuration(cls.saved_file)
             if not ret:
                 raise Exception("Failed to load scheduler's custom setup")
+            for mom in cls.moms.values():
+                ret = mom.load_configuration(cls.saved_file)
+                if not ret:
+                    raise Exception("Failed to load mom's custom setup")
         if cls.use_cur_setup:
             cls.du.rm(path=cls.saved_file)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
MoM class' save_configuration() & load_configuration() methods were not updated using json, for saving mom configurations when option '--use-current-setup' is used in PTL's pbs_benchpress


#### Describe Your Change
Updated MoM class' save_configuration() & load_configuration() for saving mom configurations when option '--use-current-setup' is used in PTL's pbs_benchpress
Updated below methods to save mom configurations
save_configuration()
load_configuration()
setUpClass()
tearDownClass()
setUp()
tearDown()

#### Link to Design Doc
Design Documentation https://pbspro.atlassian.net/wiki/spaces/PD/pages/557088789/Design+for+a+supported+way+to+change+default+setup+in+PTL


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_steps.txt](https://github.com/PBSPro/pbspro/files/4401833/test_steps.txt)
[check_30mar.out4.txt](https://github.com/PBSPro/pbspro/files/4401834/check_30mar.out4.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
