### PR TITLE
PTl should mark test as skip if hardware requirement doesn't met

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -503,10 +503,6 @@ class PbsResvAlterError(PtlException):
     pass
 
 
-class PbsHardwareMonitorError(PtlException):
-    pass
-
-
 class PbsTypeSize(str):
 
     """

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -845,7 +845,7 @@ class PTLTestRunner(Plugin):
                 _msg += ", disk cleanup is recommended."
                 self.logger.warning(_msg)
             elif used_disk_percent >= 95:
-                _msg = hostname + ":disk usage > 95%, skiping the test(s)"
+                _msg = hostname + ":disk usage > 95%, skipping the test(s)"
                 self.hardware_report_timer.cancel()
                 raise SkipTest(_msg)
             # checks for core files

--- a/test/fw/ptl/utils/plugins/ptl_test_runner.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_runner.py
@@ -60,7 +60,6 @@ from nose.util import isclass
 
 import ptl
 from ptl.lib.pbs_testlib import PBSInitServices
-from ptl.lib.pbs_testlib import PbsHardwareMonitorError
 from ptl.utils.pbs_covutils import LcovUtils
 from ptl.utils.pbs_dshutils import DshUtils
 from ptl.utils.pbs_dshutils import TimeOut
@@ -838,19 +837,17 @@ class PTLTestRunner(Plugin):
             if used_disk_percent is None:
                 _msg = hostname
                 _msg += ": unable to get disk info"
-                self.logger.error(_msg)
                 self.hardware_report_timer.cancel()
-                raise PbsHardwareMonitorError(msg=_msg)
+                raise SkipTest(_msg)
             elif 70 <= used_disk_percent < 95:
                 _msg = hostname + ": disk usage is at "
                 _msg += str(used_disk_percent) + "%"
                 _msg += ", disk cleanup is recommended."
                 self.logger.warning(_msg)
             elif used_disk_percent >= 95:
-                _msg = hostname + ":disk usage > 95%, stopping the test(s)"
-                self.logger.error(_msg)
+                _msg = hostname + ":disk usage > 95%, skiping the test(s)"
                 self.hardware_report_timer.cancel()
-                raise PbsHardwareMonitorError(msg=_msg)
+                raise SkipTest(_msg)
             # checks for core files
             pbs_conf = du.parse_pbs_config(hostname)
             mom_priv_path = os.path.join(pbs_conf["PBS_HOME"], "mom_priv")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
"PbsHardwareMonitorError" error occurs if  hardware requirement doesn't met. So PTL  should marks test as skip with a relevant skipping message if hardware requirement doesn't met.

#### Describe Your Change
PTL marks the test as skip with a relevant skipping message If hardware requirement doesn't met. No more requirement of  error "PbsHardwareMonitorError" because we are not sending any error message at the time of hardware monitoring. we are just skipping the test with a relevant skipping message if hardware requirement doesn't met.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[hardware_status_before_changes.txt](https://github.com/PBSPro/pbspro/files/4393414/hardware_status_before_changes.txt)
[hardware_status_after_changes.txt](https://github.com/PBSPro/pbspro/files/4393415/hardware_status_after_changes.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
