### PR TITLE
cgroup pbs.server() timeouts using multiprocessing

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -116,10 +116,19 @@ else:
     import operator
     import fnmatch
     import math
+    import types
     try:
         import json
     except Exception:
         import simplejson as json
+    multiprocessing = None
+    try:
+        # will fail in Python 2.5
+        import multiprocessing
+    except Exception:
+        # but we can use isinstance(multiprocessing, types.ModuleType) later
+        # to find out if it worked
+        pass
     import fcntl
     import pwd
 
@@ -597,6 +606,114 @@ def job_is_running(jobid):
     if 'substate' in jobinfo:
         return jobinfo['substate'] == 42
     return False
+
+
+def fetch_vnode_comments_nomp(vnode_list, timeout=10):
+    comment_dict = {}
+    failure = False
+    pbs.logmsg(pbs.EVENT_DEBUG4,
+               "vnode list in fetch_vnode_comment is %s"
+               % vnode_list)
+    try:
+        with Timeout(timeout, 'Timed out contacting server'):
+            for vn in vnode_list:
+                comment_dict[vn] = pbs.server().vnode(vn).comment
+                pbs.logmsg(pbs.EVENT_DEBUG4,
+                           "comment for vnode %s fetched from server is %s"
+                           % (str(vn), comment_dict[vn]))
+    except TimeoutError:
+        # pbs.server().vnode(xx).comment got stuck, or the timeout
+        # was too short for the number of nodes supplied
+        pbs.logmsg(pbs.EVENT_ERROR,
+                   'Timed out while fetching comments from server, '
+                   'timeout was %s' % str(timeout))
+        failure = True
+    except Exception as exc:
+        # other exception, like e.g. wrong vnode name
+        pbs.logmsg(pbs.EVENT_ERROR,
+                   'Unexpected error in fetch_vnode_comments: %s'
+                   % repr(exc))
+        failure = True
+    # only return a full dictionary if you got the comment for all vnodes
+    if not failure:
+        return (comment_dict, failure)
+    else:
+        return ({}, failure)
+
+
+def fetch_vnode_comments_queue(vnode_list, commq):
+    comment_dict = {}
+    failure = False
+    pbs.logmsg(pbs.EVENT_DEBUG4,
+               "vnode list in fetch_vnode_comment is %s"
+               % vnode_list)
+    try:
+        for vn in vnode_list:
+            comment_dict[vn] = pbs.server().vnode(vn).comment
+            pbs.logmsg(pbs.EVENT_DEBUG4,
+                       "comment for vnode %s fetched from server is %s"
+                       % (str(vn), comment_dict[vn]))
+
+    except Exception as exc:
+        # other exception, like e.g. wrong vnode name
+        pbs.logmsg(pbs.EVENT_ERROR,
+                   'Unexpected error in fetch_vnode_comments: %s'
+                   % repr(exc))
+        failure = True
+    # only return a full dictionary if you got the comment for all vnodes
+    if not failure:
+        commq.put(comment_dict)
+    else:
+        commq.put({})
+    return True
+
+
+def fetch_vnode_comments_mp(vnode_list, timeout=10):
+    worker_comment_dict = {}
+    commq = multiprocessing.Queue()
+    worker = multiprocessing.Process(target=fetch_vnode_comments_queue,
+                                     args=(vnode_list, commq))
+    worker.start()
+    worker.join(timeout)
+    if worker.is_alive():
+        pbs.logmsg(pbs.EVENT_ERROR,
+                   "comment fetcher for %s timed out after %s seconds"
+                   % (str(vnode_list), timeout))
+        # will mess up the commq Queue but we don't care
+        # will send SIGTERM, but it's possible that is masked
+        # while in a SWIG function
+        # we don't really care since unline in threading,
+        # in multiprocessing we can exit and orphan the worker
+        worker.terminate()
+        pbs.logmsg(pbs.EVENT_ERROR,
+                   'Timed out while fetching comments from server,'
+                   'timeout was %s' % str(timeout))
+        return ({}, True)
+    else:
+        pbs.logmsg(pbs.EVENT_DEBUG4,
+                   "comments fetched from server without timeout")
+        comment_dict = {}
+        try:
+            comment_dict = commq.get()
+        except Exception:
+            # Treat failure to get comments dictionary from queue
+            # as a timeout
+            return ({}, True)
+        pbs.logmsg(pbs.EVENT_DEBUG4,
+                   "worker comment_dict is %r" % comment_dict)
+
+        return (comment_dict, False)
+
+
+def fetch_vnode_comments(vnode_list, timeout=10):
+    if not isinstance(multiprocessing, types.ModuleType):
+        pbs.logmsg(pbs.EVENT_DEBUG4, "multiprocessing not available, "
+                   "fetch_vnode_comment will use SIGALRM timeout")
+        return fetch_vnode_comments_nomp(vnode_list, timeout)
+    else:
+        pbs.logmsg(pbs.EVENT_DEBUG4, "multiprocessing available, "
+                   "fetch_vnode_comment will use mp for timeout")
+        return fetch_vnode_comments_mp(vnode_list, timeout)
 
 
 # ============================================================================
@@ -2185,27 +2302,22 @@ class NodeUtils(object):
                        '%s: Too soon since node was offlined' % caller_name())
             return
         # Get comments for vnodes associated with this event
-        vnode_comments = dict()
-        try:
-            with Timeout(self.cfg['server_timeout'],
-                         'Timed out contacting server'):
-                for vnode_name in pbs.event().vnode_list:
-                    vnode_comments[vnode_name] = \
-                        pbs.server().vnode(vnode_name).comment
-        except TimeoutError:
-            pbs.logmsg(pbs.EVENT_DEBUG, '%s: Timed out contacting server' %
-                       caller_name())
-            return
-        except Exception as exc:
-            pbs.logmsg(pbs.EVENT_DEBUG, '%s: Error contacting server: %s' %
-                       (caller_name(), exc))
+        vnl = pbs.event().vnode_list.keys()
+        (vnode_comments, failure) = \
+            fetch_vnode_comments(vnl, timeout=self.cfg['server_timeout'])
+        if failure:
+            pbs.logmsg(pbs.EVENT_ERROR,
+                       '%s: Failed contacting server for vnode comments'
+                       % caller_name())
+            pbs.logmsg(pbs.EVENT_ERROR, '%s: Not bringing vnodes online'
+                       % caller_name())
             return
         # Bring vnodes online that this hook has taken offline
         for vnode_name in vnode_comments:
             if vnode_comments[vnode_name] != self.offline_msg:
-                pbs.logmsg(pbs.EVENT_DEBUG, '%s: Comment for vnode %s '
-                           'was not set by this hook' %
-                           (caller_name(), vnode_name))
+                pbs.logmsg(pbs.EVENT_DEBUG, ('%s: Comment for vnode %s '
+                           + 'was not set by this hook')
+                           % (caller_name(), vnode_name))
                 continue
             vnode = pbs.event().vnode_list[vnode_name]
             vnode.state = pbs.ND_FREE


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The Timeout class is meant to allow long operations to be interrupted so that the cgroup hook abandons what it was doing.

This is currently _only_ used when deciding whether to online vnodes: the hook verifies that the site admin did not change the comment to something else, which would signal that he does not want to online the vnode just yet or that he has other reasons to offline the vnode. The hook ONLY onlines the vnode again if the comment on the vnode is that which was set by the hook.

The server can be unresponsive because it is busy servicing other requests, which can then make the exechost_periodic quasihang. Sadly, it is holding the cgroup lock file, so as a cascading effect this may also make other cgroup operations fail for e.g. excejob_begin, since they may wait for too long and fail to finish before the hook alarm timeout is triggered.

There is a configuration file option "server_timeout" that is meant to interrupt this operation if querying the comments from the server takes too long. But the Timeout class used is relying upon handling of a SIGALRM signal, and sadly the implementation of Python signal handling in Python 2.7 and Python 3.x is such that signals are only checked before the interpreter starts to process a new statement. pbs.server().vnode(XXX).comment is using a PBS IFL C call wrapped in Python using SWIG, so the mechanism to trigger an alarm will not work.

In Python 2.6 and later, multiprocessing can be used to sidestep that limitation. You can fork into two processes (each with their own memory space and Python interpreter) so that a main thread can spawn a worker to fetch the comment and pass it using a multiprocessing queue, and the main thread can abort and kill the child if the child takes too long to exit. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The new hook attempts to import multiprocessing; multiprocessing is set to None if this fails.

A wrapper routine is made to fetch all comments for a list of vnodes; it returns a tuple with a dictionary of comments and a boolean indicating failure (or not). 

If multiprocessing support is detected, it will fork a worker thread to contact the server and pass a dictionary with the relevant comments using a multiprocessing.Queue. If the thread fails to exit within server_timeout seconds, the function will indicate failure and return an empty dictionary. If the worker thread has finished before the timeout expires, it will read the comments dictionary from the queue in which the worker has pushed it, and indicate success.

If no multiprocessing support is detected, then it will call a routine that uses the existing Timeout class to attempt to implement a timeout around the pobs.server().vnode(xxx) calls.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
