### PR TITLE
test_hostname_add uses local hostname instead of mom name

### DIFF
--- a/test/tests/functional/pbs_verify_log_output.py
+++ b/test/tests/functional/pbs_verify_log_output.py
@@ -84,6 +84,7 @@ class TestVerifyLogOutput(TestFunctional):
         Test for hostname presence in log files
         """
         log_val = socket.gethostname()
+        momname = self.moms.values()[0].shortname
         self.scheduler.log_match(
             log_val,
             regexp=False,
@@ -97,7 +98,7 @@ class TestVerifyLogOutput(TestFunctional):
             max_attempts=5,
             interval=2)
         self.mom.log_match(
-            log_val,
+            momname,
             regexp=False,
             starttime=self.server.ctime,
             max_attempts=5,

--- a/test/tests/functional/pbs_verify_log_output.py
+++ b/test/tests/functional/pbs_verify_log_output.py
@@ -84,7 +84,7 @@ class TestVerifyLogOutput(TestFunctional):
         Test for hostname presence in log files
         """
         log_val = socket.gethostname()
-        momname = self.moms.values()[0].shortname
+        momname = self.mom.shortname
         self.scheduler.log_match(
             log_val,
             regexp=False,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The TestVerifyLogOutput.test_hostname_add test is testing for the hostname presence in the logs.  However, the test assumes the mom is on the same node as the server.  If the mom is on a separate node, then this test fails.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Changed the test to use the mom name when searching the logs for a match.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[hostbefore.txt](https://github.com/PBSPro/pbspro/files/4405674/hostbefore.txt)
[hostafter.txt](https://github.com/PBSPro/pbspro/files/4405675/hostafter.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
