### PR TITLE
Better msgs on failures wrt vnode name mismatches

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -1338,25 +1338,22 @@ class JobUtils(object):
                        (caller_name(), hostname, repr(resources)))
             # Return assigned resources for specified host
             return resources
-        # Workaround for systems where node is short hostname
-        pbs.logmsg(pbs.EVENT_DEBUG2,
-                   '%s: No resources assigned to host %s' %
-                   (caller_name(), hostname))
-        try:
-            cmd = ['hostname', '-s']
-            process = subprocess.Popen(cmd, shell=False,
-                                       stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE)
-            out, err = process.communicate()
-        except Exception:
-            pbs.logmsg(pbs.EVENT_DEBUG4, 'Failed to execute: %s' %
-                       " ".join(cmd))
-            return resources
-        shorthostname = out.strip()
-        if shorthostname and shorthostname != hostname:
-            return self._get_assigned_job_resources(hostname=shorthostname)
-        # Return assigned resources for specified host
-        return resources
+        else:
+            pbs.logmsg(pbs.EVENT_JOB_USAGE, "WARNING: job seems "
+                       + "to have no resources assigned to this host.")
+            pbs.logmsg(pbs.EVENT_JOB_USAGE,
+                       "Server and MoM vnode names may not be consistent.")
+            pbs.logmsg(pbs.EVENT_JOB_USAGE,
+                       "Pattern for expected vnode name(s) is %s"
+                       % vnhost_pattern)
+            pbs.logmsg(pbs.EVENT_JOB_USAGE,
+                       "Job exec_vnode is %s" % str(self.job.exec_vnode))
+            pbs.logmsg(pbs.EVENT_JOB_USAGE,
+                       "You may have forgotten to set PBS_MOM_NODE_NAME to "
+                       "the desired matching entry in the exec_vnode string")
+            pbs.logmsg(pbs.EVENT_JOB_USAGE,
+                       "Job will fail or be configured with default ncpus/mem")
+            return {}
 
 
 #
@@ -2035,15 +2032,23 @@ class NodeUtils(object):
                    (caller_name(), self.numa_nodes))
         vnode_name = self.hostname
         # In some cases the hostname and vnode name do not match
+        # admin should fix this!
+        # Give hints
         if vnode_name not in vnode_list:
-            pbs.logmsg(pbs.EVENT_DEBUG,
+            pbs.logmsg(pbs.EVENT_ERROR,
                        "Could not find hostname %s in vnode_list %s"
-                       % (vnode_name, repr(vnode_list)))
-            vnkeys = list(vnode_list.keys())
-            if len(vnkeys) == 1:
-                vnode_name = vnkeys[0]
-            else:
-                raise ProcessingError('Could not identify local vnode')
+                       % (vnode_name, str(vnode_list.keys())))
+            pbs.logmsg(pbs.EVENT_ERROR,
+                       "This error is FATAL. Possible causes:")
+            pbs.logmsg(pbs.EVENT_ERROR, "a) the server's name for "
+                       "the natural node created on the server "
+                       "does not match the output of 'hostname' on the host.")
+            pbs.logmsg(pbs.EVENT_ERROR, "   Please use PBS_MOM_NODE_NAME "
+                       "in /etc/pbs.conf to tell MoM the correct vnode name.")
+            pbs.logmsg(pbs.EVENT_ERROR, "b) v2 config files are used "
+                       "but none mention the natural vnode. Add a line for "
+                       "the natural vnode in one of the v2 config files.")
+            raise ProcessingError('Could not identify local vnode')
         vnode_list[vnode_name] = pbs.vnode(vnode_name)
         host_resc_avail = vnode_list[vnode_name].resources_available
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: host_resc_avail: %s' %
@@ -4526,7 +4531,7 @@ class CgroupUtils(object):
         # Initialize cpuset variables
         cpuset_enabled = 'cpuset' in self.subsystems
         if cpuset_enabled:
-            cpu_limit = 1
+            cpu_limit = 0
             if 'ncpus' in hostresc:
                 cpu_limit = hostresc['ncpus']
             # support weightless jobs in root cpuset


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Right now if the server has used a name that does not match the output of 'hostname' on MoM and PBS_MOM_NODE_NAME is not set correctly, or if v2 config files are present fail to mention the natural vnode, the hook will fail to find "itself" in either the vnode list or the exec_vnode sent over by the server.

That will lead to strange errors, with some messages that are easily overlooked, and offer no hints to the admin on how to fix things. Yes, PBS_MOM_NODE_NAME is documented in the Guides, but not all site admins read these from the first pager to the last ;-).

This pull request makes new log messages visible, and offer hints to the admin on how things probably need to be fixed. Since these are clear errors, these are logged at logging levels that are enabled by default.

When no "ncpus" are found, we also set cpu_limit to 0 by default rather than 1, to prevent the cpuset controller to "eat" single CPUs for "unknown CPU jobs". This is not only a problem when ncpus is "unknown" because of this problem, but also when -lselect=1:mem=500mb is used without specifying ncpus. The server and scheduler will not mark a cpu in resources_assigned, so the cgroup hook should be consistent and not remove a CPU from the pool of available CPUs.



#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
-Changed log messages.

-Removed attempts to 'fix' things by guessing that will only lead to failures later on. We'd rather raise an exception when somethin needs to be addressed by the site admin (sadly we cannot detect server/MoM name discrepancies at exechost_startup since we make an effort not to spam the server at all). One such attempt to fix things did nothing, because as an "alternative" to pbs.get_local_nodename it would use "hostname -s", but by default these are identical.

-Now that 0 cpu jobs are supported, changed the default cpu_limit for "unspecified" ncpus to 0, so that the number of assigned CPUs on server/sched and the cgroup hook will be consistent for 0-cpu jobs (implicit *and* explicit).

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
N/A


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
