### PR TITLE
TestPBSSnapshot.test_multisched_support failing with error 'NoneType'object is not iterable

### DIFF
--- a/test/tests/functional/pbs_snapshot_unittest.py
+++ b/test/tests/functional/pbs_snapshot_unittest.py
@@ -112,7 +112,6 @@ class TestPBSSnapshot(TestFunctional):
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'scheduling': 'True'}, id=sched_id)
 
-    @skipOnCpuSet
     def setup_queues_nodes(self, num_partitions):
         """
         Given a no. of partitions, create equal no. of associated queues


### PR DESCRIPTION
#### Describe Bug or Feature
As part of PR https://github.com/PBSPro/pbspro/pull/1510 @skipOnCpuSet decorator added on function 'setup_queues_nodes', due to function return None value and test got failed.


#### Describe Your Change
remove @skipOnCpuSet decorator on function setup_queues_nodes.

#### Attach Test and Valgrind Logs/Output
before_fix:
[before_fix.txt](https://github.com/PBSPro/pbspro/files/4407091/before_fix.txt)

after_fix:
[after_fix.txt](https://github.com/PBSPro/pbspro/files/4407092/after_fix.txt)
[cpuset_machine.txt](https://github.com/PBSPro/pbspro/files/4407090/cpuset_machine.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
