### PR TITLE
Test "test_comm_with_mom" of TestTPP is failing while verifying reservation state

### DIFF
--- a/test/tests/functional/pbs_test_tpp.py
+++ b/test/tests/functional/pbs_test_tpp.py
@@ -127,6 +127,7 @@ class TestTPP(TestFunctional):
                       ATTR_l + '.place': 'scatter'}
         jid = self.submit_job(set_attrib, exp_attrib={'job_state': 'R'},
                               interactive=True)
+        self.server.expect(JOB, 'queue', id=jid, op=UNSET)
         # Submit reservation
         set_attrib = {'Resource_List.select': '2:ncpus=1',
                       ATTR_l + '.place': 'scatter',


### PR DESCRIPTION
#### Describe Bug or Feature

- Test "test_comm_with_mom" of TestTPP is failing while verifying reservation state


#### Describe Your Change

- The reservation is being deleted by the time test is checking for reservation status to be confirmed. This is because of the resource unavailability.

- In the test we are submitting interactive job that runs on 2 nodes using 1 ncpus.The test is then submitting resv that spans on 2 nodes using 1 ncpus each but as the resources are not available on certain machines the resv is getting deleted.

- Before submitting reservation make sure the interactive job submitted is completed.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [execution_logs_TestTpp_after_fix.txt](https://github.com/PBSPro/pbspro/files/4407507/execution_logs_TestTpp_after_fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
