### PR TITLE
Test "test_prologue_internal_error_offline_vnodes" of PbsExecutePrologue is failing while verifying vnode attributes on cpuset mom

### DIFF
--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -115,6 +115,7 @@ class TestPbsExecutePrologue(TestFunctional):
 
         self.server.expect(NODE, {'state': 'free'}, id=self.hostA, offset=1)
 
+    @skipOnCpuSet
     def test_prologue_internal_error_offline_vnodes(self):
         """
         Test a prologue hook with an internal error and
@@ -122,10 +123,8 @@ class TestPbsExecutePrologue(TestFunctional):
         """
         attr = {'resources_available.mem': '2gb',
                 'resources_available.ncpus': '1'}
-        if not self.momC.is_cpuset_mom():
-            self.server.create_vnodes(self.hostC, attr, 3, self.momC,
-                                      delall=True, usenatvnode=True)
-
+        self.server.create_vnodes(self.hostC, attr, 3, self.momC,
+                                  delall=True, usenatvnode=True)
         hook_name = "prologue_exception"
         hook_body = ("import pbs\n"
                      "e = pbs.event()\n"

--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -122,8 +122,9 @@ class TestPbsExecutePrologue(TestFunctional):
         """
         attr = {'resources_available.mem': '2gb',
                 'resources_available.ncpus': '1'}
-        self.server.create_vnodes(self.hostC, attr, 3, self.momC, delall=True,
-                                  usenatvnode=True)
+        if not self.momC.is_cpuset_mom():
+            self.server.create_vnodes(self.hostC, attr, 3, self.momC,
+                                      delall=True, usenatvnode=True)
 
         hook_name = "prologue_exception"
         hook_body = ("import pbs\n"


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test "test_prologue_internal_error_offline_vnodes" of PbsExecutePrologue is failing while verifying vnode attributes on cpuset mom


#### Describe Your Change

- Existing test will fail when cpuset machine is part of cluster. In the test we are creating vnodes, so need to update the test so that if the hostC is cpuset mom then use the existing vnodes of that host instead of creating vnodes.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_aftr_fix.txt](https://github.com/PBSPro/pbspro/files/4407630/Execution_logs_aftr_fix.txt)

- [Execution_logs_aftr_fix_non_UV.txt](https://github.com/PBSPro/pbspro/files/4407631/Execution_logs_aftr_fix_non_UV.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
