### PR TITLE
Test "test_sched_unknown_node_state" of "TestSchedBadstate" is failing while verifying the node attributes

### DIFF
--- a/test/tests/functional/pbs_sched_badstate.py
+++ b/test/tests/functional/pbs_sched_badstate.py
@@ -35,6 +35,7 @@
 # "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
 # trademark licensing policies.
 
+import copy
 from tests.functional import *
 
 
@@ -76,49 +77,59 @@ class TestSchedBadstate(TestFunctional):
                                  interval=1)
         self.server.delete(j1id)
 
-    @skipOnCpuSet
     def test_sched_unknown_node_state(self):
         """
         Test to see if the scheduler reports node states as 'Unknown'
         """
         self.server.manager(MGR_CMD_SET, SCHED, {'log_events': 2047})
-        a = {'resources_available.ncpus': 1}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
 
         # free is when all ncpus are free
         self.server.expect(NODE, {'state': 'free'}, id=self.mom.shortname)
         self.scheduler.log_match("Unknown Node State",
                                  existence=False, max_attempts=2)
-
-        # job-busy is when all ncpus are assigned
-        J = Job()
+        ncpus = self.server.status(NODE)[0]['resources_available.ncpus']
+        a = {'Resource_List.select': '1:ncpus=' + ncpus}
+        if self.mom.is_cpuset_mom():
+            vnode_id = self.server.status(NODE)[1]['id']
+            vnode_val = 'vnode=' + vnode_id
+            ncpus = self.server.status(NODE)[1]['resources_available.ncpus']
+            a['Resource_List.select'] = vnode_val + ":ncpus=" + ncpus
+        b = a.copy()
+        J = Job(attrs=a)
         jid1 = self.server.submit(J)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
-
-        self.server.expect(NODE, {'state': 'job-busy'}, id=self.mom.shortname)
+        if self.mom.is_cpuset_mom():
+            self.server.expect(VNODE, {'state': 'job-exclusive'}, id=vnode_id)
+        else:
+            self.server.expect(NODE, {'state': 'job-busy'},
+                               id=self.mom.shortname)
         self.scheduler.log_match("Unknown Node State",
                                  existence=False, max_attempts=2)
 
         # maintenance is when a job is has been admin-suspended
         self.server.sigjob(jid1, 'admin-suspend')
         self.server.expect(JOB, {'job_state': 'S'}, id=jid1)
-
-        self.server.expect(NODE, {'state': 'maintenance'},
-                           id=self.mom.shortname)
+        if self.mom.is_cpuset_mom():
+            self.server.expect(VNODE, {'state': 'maintenance'}, id=vnode_id)
+        else:
+            self.server.expect(NODE, {'state': 'maintenance'},
+                               id=self.mom.shortname)
         self.scheduler.log_match("Unknown Node State",
                                  existence=False, max_attempts=2)
 
         self.server.delete(jid1, wait=True)
 
         # job-exclusive is when a job requests place=excl
-        a = {'Resource_List.select': '1:ncpus=1',
-             'Resource_List.place': 'excl'}
-        J = Job(attrs=a)
+        b['Resource_List.place'] = 'excl'
+        J = Job(attrs=b)
         jid2 = self.server.submit(J)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid2)
 
-        self.server.expect(NODE, {'state': 'job-exclusive'},
-                           id=self.mom.shortname)
+        if self.mom.is_cpuset_mom():
+            self.server.expect(VNODE, {'state': 'job-exclusive'}, id=vnode_id)
+        else:
+            self.server.expect(NODE, {'state': 'job-exclusive'},
+                               id=self.mom.shortname)
         self.scheduler.log_match("Unknown Node State",
                                  existence=False, max_attempts=2)
 
@@ -127,28 +138,36 @@ class TestSchedBadstate(TestFunctional):
         # resv-exclusive is when a reservation requersts -lplace=excl
         st = time.time() + 30
         et = st + 30
-        a = {'Resource_List.select': '1:ncpus=1',
-             'Resource_List.place': 'excl',
-             'reserve_start': st, 'reserve_end': et}
-        R = Reservation(attrs=a)
+        b['reserve_start'] = st
+        b['reserve_end'] = et
+        R = Reservation(attrs=b)
         rid = self.server.submit(R)
         self.server.expect(RESV, {'reserve_state':
                                   (MATCH_RE, 'RESV_CONFIRMED|2')}, id=rid)
 
         self.server.expect(RESV, {'reserve_state':
-                                  (MATCH_RE, 'RESV_RUNNING|5')}, id=rid)
+                                  (MATCH_RE, 'RESV_RUNNING|5')},
+                           id=rid, offset=30)
 
-        self.server.expect(NODE, {'state': 'resv-exclusive'},
-                           id=self.mom.shortname)
+        if self.mom.is_cpuset_mom():
+            self.server.expect(VNODE, {'state': 'resv-exclusive'}, id=vnode_id)
+        else:
+            self.server.expect(NODE, {'state': 'resv-exclusive'},
+                               id=self.mom.shortname)
         self.scheduler.log_match("Unknown Node State",
                                  existence=False, max_attempts=2)
         self.server.delete(rid)
 
         # Multiple node states eg: down + job-busy
-        J = Job()
+        J = Job(attrs=a)
         jid3 = self.server.submit(J)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid3)
         self.mom.signal('-KILL')
-        self.server.expect(NODE, {'state': 'down,job-busy'},
-                           id=self.mom.shortname)
+        if self.mom.is_cpuset_mom():
+            self.server.expect(VNODE, {'state': 'down,job-exclusive'},
+                               id=vnode_id)
+        else:
+            self.server.expect(NODE, {'state': 'down,job-busy'},
+                               id=self.mom.shortname)
         self.scheduler.log_match("Unknown Node State",
                                  existence=False, max_attempts=2)

--- a/test/tests/functional/pbs_sched_badstate.py
+++ b/test/tests/functional/pbs_sched_badstate.py
@@ -88,12 +88,13 @@ class TestSchedBadstate(TestFunctional):
         self.scheduler.log_match("Unknown Node State",
                                  existence=False, max_attempts=2)
         ncpus = self.server.status(NODE)[0]['resources_available.ncpus']
-        a = {'Resource_List.select': '1:ncpus=' + ncpus}
         if self.mom.is_cpuset_mom():
             vnode_id = self.server.status(NODE)[1]['id']
             vnode_val = 'vnode=' + vnode_id
             ncpus = self.server.status(NODE)[1]['resources_available.ncpus']
-            a['Resource_List.select'] = vnode_val + ":ncpus=" + ncpus
+            a = {'Resource_List.select': vnode_val + ':ncpus=' + ncpus}
+        else:
+            a = {'Resource_List.select': '1:ncpus=' + ncpus}
         b = a.copy()
         J = Job(attrs=a)
         jid1 = self.server.submit(J)


### PR DESCRIPTION
#### Describe Bug or Feature

- Test "test_sched_unknown_node_state" of "TestSchedBadstate" is failing while verifying the node attributes


#### Describe Your Change

- The test is submitting a job, killing mom and then verifying node state to be "down,job busy" but observed node state is "down". This is because job is not scheduled on the node. 

- After the job is submitted, check for job to be in R state(to ensure that the job has been scheduled on a node) and then kill pbs_mom and check for node state to be "down,job busy"

- Also update the test accordingly so that it runs on cpuset machines as well

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_TestSchedBadstate_bfr_fix_nonuv.txt](https://github.com/PBSPro/pbspro/files/4408848/Execution_logs_TestSchedBadstate_bfr_fix_nonuv.txt)

- [Execution_logs_TestSchedBadstate_aftr_fix_nonuv.txt](https://github.com/PBSPro/pbspro/files/4408839/Execution_logs_TestSchedBadstate_aftr_fix_nonuv.txt)

- [Execution_logs_TestSchedBadstate_aftr_fix_uv.txt](https://github.com/PBSPro/pbspro/files/4408840/Execution_logs_TestSchedBadstate_aftr_fix_uv.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
