### PR TITLE
PTL PBSLogUtils.get_timestamps fails with sudo

### DIFF
--- a/test/fw/ptl/utils/pbs_logutils.py
+++ b/test/fw/ptl/utils/pbs_logutils.py
@@ -327,7 +327,11 @@ class PBSLogUtils(object):
             num_rec += 1
             if num is not None and num_rec > num:
                 break
-            m = tm_tag.match(str(record))
+
+            if type(record) == bytes:
+                record = record.decode("utf-8")
+
+            m = tm_tag.match(record)
             if m:
                 rec_times.append(
                     self.convert_date_time(m.group('datetime')))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When called with sudo=True, the function fails to find any timestamps, even though valid logs exist. The reason why this happens is that when we pass sudo, the function open_log() returns a byte stream, and get_timestamps() was converting bytes into string by simply doing str(), which converts a byte form of b'blah' to "b'blah'" and that fails the regex match for timestamp.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Instead of doing str() on the bytes object, used decode("utf-8") to convert it to a string correctly.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[before_fix.log](https://github.com/PBSPro/pbspro/files/4412065/before_fix.log)
[after_fix.log](https://github.com/PBSPro/pbspro/files/4412066/after_fix.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
