### PR TITLE
Fix tests of TestPbsHookAlarmLargeMultinodeJob

### DIFF
--- a/test/tests/resilience/pbs_hook_alarm_large_multinode_job.py
+++ b/test/tests/resilience/pbs_hook_alarm_large_multinode_job.py
@@ -153,7 +153,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing epilogue hook %s" % (e.hook_name,))
 """
         search_after = int(time.time())
         a = {'event': hook_event, 'enabled': 'True',
-             'alarm': '20'}
+             'alarm': '30'}
         self.server.create_import_hook(hook_name, a, hook_body)
 
         j = Job(TEST_USER)

--- a/test/tests/resilience/pbs_hook_alarm_large_multinode_job.py
+++ b/test/tests/resilience/pbs_hook_alarm_large_multinode_job.py
@@ -64,7 +64,7 @@ class TestPbsHookAlarmLargeMultinodeJob(TestResilience):
         # Restart mom explicitly due to PP-993
         self.mom.restart()
 
-    @timeout(400)
+    @skipOnCpuSet
     def test_begin_hook(self):
         """
         Create an execjob_begin hook, import a hook content with a small
@@ -78,7 +78,7 @@ e=pbs.event()
 pbs.logmsg(pbs.LOG_DEBUG, "executing begin hook %s" % (e.hook_name,))
 """
         a = {'event': hook_event, 'enabled': 'True',
-             'alarm': '20'}
+             'alarm': '30'}
         self.server.create_import_hook(hook_name, a, hook_body)
 
         j = Job(TEST_USER)
@@ -102,7 +102,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing begin hook %s" % (e.hook_name,))
         self.mom.log_match("Job;%s;Started, pid" % (jid,), n=100,
                            max_attempts=5, interval=5, regexp=True)
 
-    @timeout(400)
+    @skipOnCpuSet
     def test_prolo_hook(self):
         """
         Create an execjob_prologue hook, import a hook content with a
@@ -116,7 +116,7 @@ e=pbs.event()
 pbs.logmsg(pbs.LOG_DEBUG, "executing prologue hook %s" % (e.hook_name,))
 """
         a = {'event': hook_event, 'enabled': 'True',
-             'alarm': '20'}
+             'alarm': '30'}
         self.server.create_import_hook(hook_name, a, hook_body)
 
         j = Job(TEST_USER)
@@ -138,7 +138,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing prologue hook %s" % (e.hook_name,))
             "Job;%s;alarm call while running %s hook" % (jid, hook_event),
             n=100, max_attempts=5, interval=5, regexp=True, existence=False)
 
-    @timeout(400)
+    @skipOnCpuSet
     def test_epi_hook(self):
         """
         Create an execjob_epilogue hook, import a hook content with a small
@@ -164,7 +164,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing epilogue hook %s" % (e.hook_name,))
 
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'},
-                           jid, max_attempts=10, interval=2)
+                           jid, max_attempts=20, interval=2)
 
         self.logger.info("Wait 10s for job to finish")
         sleep(10)
@@ -182,7 +182,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing epilogue hook %s" % (e.hook_name,))
         self.mom.log_match("Job;%s;Obit sent" % (jid,), n=100,
                            max_attempts=5, interval=5, regexp=True)
 
-    @timeout(400)
+    @skipOnCpuSet
     def test_end_hook(self):
         """
         Create an execjob_end hook, import a hook content with a small
@@ -197,7 +197,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing end hook %s" % (e.hook_name,))
 """
         search_after = int(time.time())
         a = {'event': hook_event, 'enabled': 'True',
-             'alarm': '15'}
+             'alarm': '20'}
         self.server.create_import_hook(hook_name, a, hook_body)
 
         j = Job(TEST_USER)
@@ -208,7 +208,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing end hook %s" % (e.hook_name,))
 
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'},
-                           jid, max_attempts=15, interval=2)
+                           jid, max_attempts=20, interval=2)
 
         self.logger.info("Wait 10s for job to finish")
         sleep(10)

--- a/test/tests/resilience/pbs_hook_alarm_large_multinode_job.py
+++ b/test/tests/resilience/pbs_hook_alarm_large_multinode_job.py
@@ -78,7 +78,7 @@ e=pbs.event()
 pbs.logmsg(pbs.LOG_DEBUG, "executing begin hook %s" % (e.hook_name,))
 """
         a = {'event': hook_event, 'enabled': 'True',
-             'alarm': '15'}
+             'alarm': '20'}
         self.server.create_import_hook(hook_name, a, hook_body)
 
         j = Job(TEST_USER)
@@ -90,7 +90,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing begin hook %s" % (e.hook_name,))
         jid = self.server.submit(j)
 
         self.server.expect(JOB, {'job_state': 'R'},
-                           jid, max_attempts=15, interval=2)
+                           jid, max_attempts=20, interval=2)
         self.mom.log_match(
             "pbs_python;executing begin hook %s" % (hook_name,), n=100,
             max_attempts=5, interval=5, regexp=True)
@@ -116,7 +116,7 @@ e=pbs.event()
 pbs.logmsg(pbs.LOG_DEBUG, "executing prologue hook %s" % (e.hook_name,))
 """
         a = {'event': hook_event, 'enabled': 'True',
-             'alarm': '15'}
+             'alarm': '20'}
         self.server.create_import_hook(hook_name, a, hook_body)
 
         j = Job(TEST_USER)
@@ -128,7 +128,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing prologue hook %s" % (e.hook_name,))
         jid = self.server.submit(j)
 
         self.server.expect(JOB, {'job_state': 'R'},
-                           jid, max_attempts=15, interval=2)
+                           jid, max_attempts=20, interval=2)
 
         self.mom.log_match(
             "pbs_python;executing prologue hook %s" % (hook_name,), n=100,
@@ -153,7 +153,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing epilogue hook %s" % (e.hook_name,))
 """
         search_after = int(time.time())
         a = {'event': hook_event, 'enabled': 'True',
-             'alarm': '15'}
+             'alarm': '20'}
         self.server.create_import_hook(hook_name, a, hook_body)
 
         j = Job(TEST_USER)
@@ -164,7 +164,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing epilogue hook %s" % (e.hook_name,))
 
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'},
-                           jid, max_attempts=15, interval=2)
+                           jid, max_attempts=10, interval=2)
 
         self.logger.info("Wait 10s for job to finish")
         sleep(10)

--- a/test/tests/resilience/pbs_hook_alarm_large_multinode_job.py
+++ b/test/tests/resilience/pbs_hook_alarm_large_multinode_job.py
@@ -59,7 +59,8 @@ class TestPbsHookAlarmLargeMultinodeJob(TestResilience):
             self.server.create_vnodes(self.mom.shortname, a, 5000, self.mom,
                                       expect=False)
             # Make sure all the nodes are in state free.  We can't let
-            # create_vnodes() do this because it does a pbsnodes -v on each vnode.
+            # create_vnodes() do this because it does
+            # a pbsnodes -v on each vnode.
             # This takes a long time.
             self.server.expect(NODE, {'state=free': (GE, 5000)})
             # Restart mom explicitly due to PP-993
@@ -73,13 +74,15 @@ class TestPbsHookAlarmLargeMultinodeJob(TestResilience):
             vnode_id = vnode_val[0]['id']
             ncpus = vnode_val[0]['resources_available.ncpus']
             del vnode_val[0]
-            a = {'Resource_List.select': '1:ncpus=' + ncpus + ':vnode=' + vnode_id }
+            a = {'Resource_List.select': '1:ncpus=' +
+                 ncpus + ':vnode=' + vnode_id}
             for _vnode in vnode_val:
                 vnode_id = _vnode['id']
                 ncpus = _vnode['resources_available.ncpus']
-                a['Resource_List.select'] += '+1:ncpus=' + ncpus + ':vnode=' + vnode_id
+                a['Resource_List.select'] += '+1:ncpus=' + \
+                    ncpus + ':vnode=' + vnode_id
         else:
-           a['Resource_List.select'] = '5000:ncpus=1:mem=1gb'
+            a['Resource_List.select'] = '5000:ncpus=1:mem=1gb'
         j = Job(TEST_USER)
 
         j.set_attributes(a)
@@ -202,7 +205,6 @@ pbs.logmsg(pbs.LOG_DEBUG, "executing end hook %s" % (e.hook_name,))
         a = {'event': hook_event, 'enabled': 'True',
              'alarm': '20'}
         self.server.create_import_hook(hook_name, a, hook_body)
-
 
         jid = self.submit_job()
         self.server.expect(JOB, {'job_state': 'R'},


### PR DESCRIPTION
#### Describe Bug or Feature
Tests of TestPbsHookAlarmLargeMultinodeJob failed on slow machines due to less alarm value of execjob_* hooks where before Job goes into R state, alarm would trigger and Job gets requeued and test fails with incorrect Job state.

#### Describe Your Change
Since, we are creating large number of vnodes(5000 vnodes) and submitting job on 5000 vnode setup, Job is taking time from changing it's state from Q->R. Increased max attempts to check Job state in R and also increased alarm value from 15 secs to 20 secs.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[TestPbsHookAlarmLargeMultinodeJob_after_fix.txt](https://github.com/PBSPro/pbspro/files/4412783/TestPbsHookAlarmLargeMultinodeJob_after_fix.txt)
[TestPbsHookAlarmLargeMultinodeJob_before_fix.txt](https://github.com/PBSPro/pbspro/files/4412784/TestPbsHookAlarmLargeMultinodeJob_before_fix.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
