### PR TITLE
Accounting records for Job Suspend and resume events

### DIFF
--- a/src/include/acct.h
+++ b/src/include/acct.h
@@ -66,6 +66,8 @@ extern "C" {
 #define PBS_ACCT_NEXT	(int)'c'	/* phased job next record */
 #define PBS_ACCT_LAST	(int)'e'	/* phased job last usage record */
 #define PBS_ACCT_ALTER  (int)'a'	/* Job attribute is being altered */
+#define PBS_ACCT_SUSPEND (int)'z'   /* Job is suspended */
+#define PBS_ACCT_RESUME (int)'r'   /* Suspended Job is resumed */
 
 /* for RESERVATION accounting */
 
@@ -95,6 +97,7 @@ extern void account_jobstr2(job *pjob, int type);
 extern void account_job_update(job *pjob, int type);
 extern void account_jobend(job *pjob, char * used, int type);
 extern void log_alter_records_for_attrs(job *pjob, svrattrl *plist);
+extern void log_suspend_resume_record(job *pjob, char *user, char *host, char *signal_type);
 extern void set_job_ProvAcctRcd(job *pjob, long time_se, int type);
 
 extern int concat_rescused_to_buffer(char **buffer, int *buffer_size, svrattrl *patlist, char *delim, job *pjob);

--- a/src/include/acct.h
+++ b/src/include/acct.h
@@ -97,7 +97,7 @@ extern void account_jobstr2(job *pjob, int type);
 extern void account_job_update(job *pjob, int type);
 extern void account_jobend(job *pjob, char * used, int type);
 extern void log_alter_records_for_attrs(job *pjob, svrattrl *plist);
-extern void log_suspend_resume_record(job *pjob, char *user, char *host, char *signal_type);
+extern void log_suspend_resume_record(job *pjob, char *user, char *host, int acct_type);
 extern void set_job_ProvAcctRcd(job *pjob, long time_se, int type);
 
 extern int concat_rescused_to_buffer(char **buffer, int *buffer_size, svrattrl *patlist, char *delim, job *pjob);

--- a/src/include/acct.h
+++ b/src/include/acct.h
@@ -97,7 +97,7 @@ extern void account_jobstr2(job *pjob, int type);
 extern void account_job_update(job *pjob, int type);
 extern void account_jobend(job *pjob, char * used, int type);
 extern void log_alter_records_for_attrs(job *pjob, svrattrl *plist);
-extern void log_suspend_resume_record(job *pjob, char *user, char *host, int acct_type);
+extern void log_suspend_resume_record(job *pjob, int acct_type);
 extern void set_job_ProvAcctRcd(job *pjob, long time_se, int type);
 
 extern int concat_rescused_to_buffer(char **buffer, int *buffer_size, svrattrl *patlist, char *delim, job *pjob);

--- a/src/server/accounting.c
+++ b/src/server/accounting.c
@@ -2298,7 +2298,6 @@ log_suspend_resume_record(job *pjob, char *user, char *host, int acct_type)
 {
 	if (acct_type == PBS_ACCT_SUSPEND) {
 		char *resc_buf;
-		char *resc_released;
 		int resc_buf_size = RESC_USED_BUF_SIZE;
 
 		/* Allocating initial space as required by resc_used. Future space will be allocated by pbs_strcat(). */

--- a/src/server/accounting.c
+++ b/src/server/accounting.c
@@ -2309,19 +2309,18 @@ log_suspend_resume_record(job *pjob, char *user, char *host, int acct_type)
 
 		if (get_resc_used(pjob, resc_buf, resc_buf_size) < 0) {
 			write_account_record(acct_type, pjob->ji_qs.ji_jobid, NULL);
-			goto writeit;
+			goto end;
 		}
 
 		if (pjob->ji_wattr[JOB_ATR_resc_released].at_flags & ATR_VFLAG_SET) {
-			if (pbs_strcat(&resc_buf, &resc_buf_size, " resources_released=") == NULL) {
-				goto writeit;
-			}
-			if (pbs_strcat(&resc_buf, &resc_buf_size, pjob->ji_wattr[JOB_ATR_resc_released].at_val.at_str) == NULL) {
-				goto writeit;
-			}
+			if (pbs_strcat(&resc_buf, &resc_buf_size, " resources_released=") == NULL)
+				goto end;
+
+			if (pbs_strcat(&resc_buf, &resc_buf_size, pjob->ji_wattr[JOB_ATR_resc_released].at_val.at_str) == NULL)
+				goto end;
 		}
 		write_account_record(acct_type, pjob->ji_qs.ji_jobid, resc_buf + 1);
-writeit:
+end:
 	free(resc_buf);
 	return;
 	}

--- a/src/server/accounting.c
+++ b/src/server/accounting.c
@@ -340,6 +340,16 @@ get_resc_used(job *pjob, char *resc_used, int resc_used_size) {
 		&temp_head, job_attr_def[(int) JOB_ATR_resc_used].at_name,
 		NULL, ATR_ENCODE_CLIENT, &patlist);
 
+	/*
+	 * NOTE:
+	 * Following code for constructing resources used information is same as job_obit()
+	 * with minor different that to traverse patlist in this code
+	 * we have to use patlist->al_sister since it is encoded information in job struct
+	 * where in job_obit() we are using GET_NEXT(patlist->al_link) which is part of batch
+	 * request.
+	 * ji_acctrec is lost on server restart.  Recreate it here if needed.
+	 */
+
 	while(patlist) {
 		/* log to accounting_logs only if there's a value */
 		if (strlen(patlist->al_value) > 0) {

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -498,7 +498,7 @@ post_signal_req(struct work_task *pwt)
 				/* update all released resources */
 				svr_setjobstate(pjob, JOB_STATE_RUNNING, ss);
 				rel_resc(pjob); /* release resc and nodes */
-				log_suspend_resume_record(pjob, preq->rq_user, preq->rq_host, PBS_ACCT_SUSPEND);
+				log_suspend_resume_record(pjob, PBS_ACCT_SUSPEND);
 				/* Since our purpose is to put the node in maintenance state if "admin-suspend"
 				 * signal is used, be sure that rel_resc() is called before set_admin_suspend().
 				 * Otherwise, set_admin_suspend will move the node to maintenance state and
@@ -520,7 +520,7 @@ post_signal_req(struct work_task *pwt)
 			pjob->ji_wattr[(int) JOB_ATR_resc_released_list].at_flags &= ~ATR_VFLAG_SET;
 
 			svr_setjobstate(pjob, JOB_STATE_RUNNING, JOB_SUBSTATE_RUNNING);
-			log_suspend_resume_record(pjob, preq->rq_user, preq->rq_host, PBS_ACCT_RESUME);
+			log_suspend_resume_record(pjob, PBS_ACCT_RESUME);
 
 			set_attr_svr(&(pjob->ji_wattr[(int) JOB_ATR_Comment]), &job_attr_def[(int) JOB_ATR_Comment],
 				form_attr_comment("Job run at %s", pjob->ji_wattr[(int) JOB_ATR_exec_vnode].at_val.at_str));

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -71,6 +71,7 @@
 #include "svrfunc.h"
 #include "sched_cmds.h"
 #include "pbs_sched.h"
+#include "acct.h"
 
 
 /* Private Function local to this file */
@@ -497,6 +498,7 @@ post_signal_req(struct work_task *pwt)
 				/* update all released resources */
 				svr_setjobstate(pjob, JOB_STATE_RUNNING, ss);
 				rel_resc(pjob); /* release resc and nodes */
+				log_suspend_resume_record(pjob, preq->rq_user, preq->rq_host, preq->rq_ind.rq_signal.rq_signame);
 				/* Since our purpose is to put the node in maintenance state if "admin-suspend"
 				 * signal is used, be sure that rel_resc() is called before set_admin_suspend().
 				 * Otherwise, set_admin_suspend will move the node to maintenance state and
@@ -518,6 +520,7 @@ post_signal_req(struct work_task *pwt)
 			pjob->ji_wattr[(int) JOB_ATR_resc_released_list].at_flags &= ~ATR_VFLAG_SET;
 
 			svr_setjobstate(pjob, JOB_STATE_RUNNING, JOB_SUBSTATE_RUNNING);
+			log_suspend_resume_record(pjob, preq->rq_user, preq->rq_host, preq->rq_ind.rq_signal.rq_signame);
 
 			set_attr_svr(&(pjob->ji_wattr[(int) JOB_ATR_Comment]), &job_attr_def[(int) JOB_ATR_Comment],
 				form_attr_comment("Job run at %s", pjob->ji_wattr[(int) JOB_ATR_exec_vnode].at_val.at_str));

--- a/src/server/req_signal.c
+++ b/src/server/req_signal.c
@@ -498,7 +498,7 @@ post_signal_req(struct work_task *pwt)
 				/* update all released resources */
 				svr_setjobstate(pjob, JOB_STATE_RUNNING, ss);
 				rel_resc(pjob); /* release resc and nodes */
-				log_suspend_resume_record(pjob, preq->rq_user, preq->rq_host, preq->rq_ind.rq_signal.rq_signame);
+				log_suspend_resume_record(pjob, preq->rq_user, preq->rq_host, PBS_ACCT_SUSPEND);
 				/* Since our purpose is to put the node in maintenance state if "admin-suspend"
 				 * signal is used, be sure that rel_resc() is called before set_admin_suspend().
 				 * Otherwise, set_admin_suspend will move the node to maintenance state and
@@ -520,7 +520,7 @@ post_signal_req(struct work_task *pwt)
 			pjob->ji_wattr[(int) JOB_ATR_resc_released_list].at_flags &= ~ATR_VFLAG_SET;
 
 			svr_setjobstate(pjob, JOB_STATE_RUNNING, JOB_SUBSTATE_RUNNING);
-			log_suspend_resume_record(pjob, preq->rq_user, preq->rq_host, preq->rq_ind.rq_signal.rq_signame);
+			log_suspend_resume_record(pjob, preq->rq_user, preq->rq_host, PBS_ACCT_RESUME);
 
 			set_attr_svr(&(pjob->ji_wattr[(int) JOB_ATR_Comment]), &job_attr_def[(int) JOB_ATR_Comment],
 				form_attr_comment("Job run at %s", pjob->ji_wattr[(int) JOB_ATR_exec_vnode].at_val.at_str));

--- a/test/tests/functional/pbs_suspend_resume_accounting.py
+++ b/test/tests/functional/pbs_suspend_resume_accounting.py
@@ -1,0 +1,355 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+
+from tests.functional import *
+
+
+class TestSuspendResumeAccounting(TestFunctional):
+    """
+    Testsuite for verifying accounting of
+    suspend/resume events of job
+    """
+
+    script = ['#!/bin/bash\nfor ((c=1; c <= 1000000000; c++));']
+    script += ['do']
+    script += ['sleep 1']
+    script += ['done']
+
+    def test_suspend_resume_job_signal(self):
+        """
+        Test case to verify accounting suspend
+        and resume records when the events are
+        triggered by client for one job.
+        """
+        j = Job(TEST_USER)
+        j.create_script(self.script)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+
+        self.server.sigjob(jobid=jid, signal="suspend")
+
+        record = 'z;%s;requestor=%s@%s .*resources_used.' % \
+                 (jid, self.server.current_user, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid, regexp=True)
+
+        self.server.sigjob(jobid=jid, signal="resume")
+        record = 'r;%s;requestor=Scheduler@%s' % \
+                 (jid, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid)
+
+    @skipOnCpuSet
+    def test_suspend_resume_job_array_signal(self):
+        """
+        Test case to verify accounting suspend
+        and resume records when the events are
+        triggered by client for a job array.
+        """
+        a = {ATTR_rescavail + '.ncpus': 2}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        j = Job(TEST_USER)
+        j.create_script(self.script)
+        j.set_attributes({ATTR_J: '1-2'})
+        jid = self.server.submit(j)
+
+        subjobs = self.server.status(JOB, id=jid, extend='t')
+        sub_jid1 = subjobs[1]['id']
+        sub_jid2 = subjobs[2]['id']
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=sub_jid1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=sub_jid2)
+
+        # suspend job
+        self.server.sigjob(jobid=jid, signal="suspend")
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=sub_jid1)
+        self.server.expect(JOB, {ATTR_state: 'S'}, id=sub_jid2)
+
+        record = 'z;%s;requestor=%s@%s resources_used.' % \
+                 (sub_jid1, self.server.current_user, self.server.hostname)
+        self.server.accounting_match(msg=record, id=sub_jid1)
+
+        record = 'z;%s;requestor=%s@%s resources_used.' % \
+                 (sub_jid2, self.server.current_user, self.server.hostname)
+        self.server.accounting_match(msg=record, id=sub_jid2)
+
+        self.server.sigjob(jobid=jid, signal="resume")
+        record = 'r;%s;requestor=Scheduler@%s' % \
+                 (sub_jid1, self.server.hostname)
+        self.server.accounting_match(msg=record, id=sub_jid1)
+
+        record = 'r;%s;requestor=Scheduler@%s' % \
+                 (sub_jid2, self.server.hostname)
+        self.server.accounting_match(msg=record, id=sub_jid2)
+
+    def test_interactive_job_suspend_resume(self):
+        """
+        Test case to verify accounting suspend
+        and resume records when the events are
+        triggered by client for a interactive job.
+        """
+
+        cmd = 'sleep 10'
+        j = Job(TEST_USER, attrs={ATTR_inter: ''})
+        j.interactive_script = [('hostname', '.*'),
+                                (cmd, '.*')]
+
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        self.server.sigjob(jobid=jid, signal="suspend")
+
+        record = 'z;%s;requestor=%s@%s .*resources_used.' % \
+                 (jid, self.server.current_user, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid, regexp=True)
+
+        self.server.sigjob(jobid=jid, signal="resume")
+        record = 'r;%s;requestor=Scheduler@%s' % \
+                 (jid, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid)
+
+    @skipOnCpuSet
+    def test_suspend_resume_job_scheduler(self):
+        """
+        Test case to verify accounting suspend
+        and resume records when the events are
+        triggered by Scheduler.
+        """
+
+        a = {ATTR_rescavail + '.ncpus': 4, ATTR_rescavail + '.mem': '2gb'}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        # Create an express queue
+        b = {ATTR_qtype: 'Execution', ATTR_enable: 'True',
+             ATTR_start: 'True', ATTR_p: '200'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, b, "expressq")
+
+        a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus,mem'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        j1 = Job(TEST_USER)
+        j1.create_script(self.script)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb'})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        j2 = Job(TEST_USER)
+        j2.create_script(self.script)
+        j2.set_attributes(
+            {ATTR_l + '.select': '1:ncpus=2:mem=512mb',
+             ATTR_q: 'expressq'})
+        jid2 = self.server.submit(j2)
+
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'S', ATTR_substate: 45}, id=jid1)
+
+        record = 'z;%s;requestor=Scheduler@%s .*resources_used.' % \
+                 (jid1, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid1, regexp=True)
+
+        self.server.delete(jid2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+        record = 'r;%s;requestor=Scheduler@%s' % \
+                 (jid1, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid1)
+
+    def test_admin_suspend_resume_signal(self):
+        """
+        Test case to verify accounting of admin-suspend
+        and admin-resume records.
+        """
+        j = Job(TEST_USER)
+        j.create_script(self.script)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid)
+
+        self.server.sigjob(jid, 'admin-suspend', runas=ROOT_USER)
+        self.server.expect(JOB, {'job_state': 'S'}, id=jid)
+        self.server.expect(NODE, {'state': 'maintenance'}, id=self.mom.shortname)
+
+        record = 'z;%s;requestor=%s@%s .*resources_used.' % \
+                 (jid, ROOT_USER, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid, regexp=True)
+
+        self.server.sigjob(jid, 'admin-resume', runas=ROOT_USER)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.expect(NODE, {'state': 'free'}, id=self.mom.shortname)
+
+        record = 'r;%s;requestor=%s@%s' % \
+                 (jid, ROOT_USER, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid)
+
+    def test_resc_released_susp_resume(self):
+        """
+        Test case to verify accounting of suspend/resume
+        events with restrict_res_to_release_on_suspend set
+        on server
+        """
+        # Set both ncpus and mem
+        a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus,mem'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        j = Job(TEST_USER)
+        j.create_script(self.script)
+        j.set_attributes({ATTR_l + '.select': '1:ncpus=1:mem=512mb'})
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+        self.server.sigjob(jobid=jid, signal="suspend")
+
+        # check for both ncpus and mem are released
+        record = 'z;%s;requestor=%s@%s ' \
+                 'resources_released=(%s:ncpus=1:mem=524288kb) ' \
+                 'resources_used.' % \
+                 (jid, self.server.current_user,
+                  self.server.hostname, self.server.shortname)
+
+        self.server.accounting_match(msg=record, id=jid)
+
+        self.server.sigjob(jobid=jid, signal="resume")
+        record = 'r;%s;requestor=Scheduler@%s' % \
+                 (jid, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid)
+
+        # Set resources to be released to just ncpus
+        a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        # check if only ncpus is released
+        self.server.sigjob(jobid=jid, signal="suspend")
+        record = 'z;%s;requestor=%s@%s ' \
+                 'resources_released=(%s:ncpus=1) ' \
+                 'resources_used.' % \
+                 (jid, self.server.current_user,
+                  self.server.hostname, self.server.shortname)
+
+        self.server.accounting_match(msg=record, id=jid)
+
+    @skipOnCpuSet
+    def test_resc_released_susp_resume_multi_vnode(self):
+        """
+        Test case to verify accounting of suspend/resume
+        events with restrict_res_to_release_on_suspend set
+        on server for multiple vnodes
+        """
+        # Set restrict_res_to_release_on_suspend server attribute
+        a = {ATTR_restrict_res_to_release_on_suspend: 'ncpus'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+
+        b = {ATTR_qtype: 'Execution', ATTR_enable: 'True',
+             ATTR_start: 'True', ATTR_p: '200'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, b, "expressq")
+
+        vn_attrs = {ATTR_rescavail + '.ncpus': 8,
+                    ATTR_rescavail + '.mem': '1024mb'}
+        self.server.create_vnodes("vnode1", vn_attrs, 1,
+                                  self.mom, fname="vnodedef1")
+        # Append a vnode
+        vn_attrs = {ATTR_rescavail + '.ncpus': 6,
+                    ATTR_rescavail + '.mem': '1024mb'}
+        self.server.create_vnodes("vnode2", vn_attrs, 1,
+                                  self.mom, additive=True, fname="vnodedef2")
+
+        # Submit a low priority job
+        j1 = Job(TEST_USER)
+        j1.create_script(self.script)
+        j1.set_attributes({ATTR_l + '.select':
+                               '1:ncpus=8:mem=512mb+1:ncpus=6:mem=256mb'})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        # Submit a high priority job
+        j2 = Job(TEST_USER)
+        j2.create_script(self.script)
+        j2.set_attributes(
+            {ATTR_l + '.select': '1:ncpus=8:mem=256mb',
+             ATTR_q: 'expressq'})
+        jid2 = self.server.submit(j2)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid2)
+        self.server.expect(JOB, {ATTR_state: 'S', ATTR_substate: 45}, id=jid1)
+
+        record = 'z;%s;requestor=Scheduler@%s ' \
+                 'resources_released=(vnode1[0]:ncpus=8)+' \
+                 '(vnode2[0]:ncpus=6) resources_used.' % \
+                 (jid1, self.server.hostname)
+
+        self.server.accounting_match(msg=record, id=jid1)
+
+    @skipOnCpuSet
+    def test_higher_priority_job_hook_reject(self):
+        """
+        Test case to verify accounting of suspend/resume
+        events of a job which gets suspended by a higher priority
+        job and gets resumed when the runjob hook rejects the
+        higher priority job.
+        """
+        a = {ATTR_rescavail + '.ncpus': 4, ATTR_rescavail + '.mem': '2gb'}
+        self.server.manager(MGR_CMD_SET, NODE, a, self.mom.shortname)
+
+        b = {ATTR_qtype: 'Execution', ATTR_enable: 'True',
+             ATTR_start: 'True', ATTR_p: '200'}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, b, "expressq")
+
+        # Define a runjob hook
+        hook = """
+import pbs
+e = pbs.event()
+e.reject()
+"""
+        j1 = Job(TEST_USER)
+        j1.create_script(self.script)
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=4:mem=512mb'})
+        jid1 = self.server.submit(j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        a = {'event': 'runjob', 'enabled': 'True'}
+        self.server.create_import_hook("sr_hook", a, hook)
+
+        j2 = Job(TEST_USER)
+        j2.create_script(self.script)
+        j2.set_attributes(
+            {ATTR_l + '.select': '1:ncpus=2:mem=512mb',
+             ATTR_q: 'expressq'})
+        jid2 = self.server.submit(j2)
+
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
+
+        record = 'z;%s;requestor=Scheduler@%s .*resources_used.' % \
+                 (jid1, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid1, regexp=True)
+
+        record = 'r;%s;requestor=Scheduler@%s' % \
+                 (jid1, self.server.hostname)
+        self.server.accounting_match(msg=record, id=jid1)

--- a/test/tests/functional/pbs_suspend_resume_accounting.py
+++ b/test/tests/functional/pbs_suspend_resume_accounting.py
@@ -198,7 +198,8 @@ class TestSuspendResumeAccounting(TestFunctional):
 
         self.server.sigjob(jid, 'admin-suspend', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid)
-        self.server.expect(NODE, {'state': 'maintenance'}, id=self.mom.shortname)
+        self.server.expect(NODE, {'state': 'maintenance'},
+                           id=self.mom.shortname)
 
         record = 'z;%s;requestor=%s@%s .*resources_used.' % \
                  (jid, ROOT_USER, self.server.hostname)
@@ -285,8 +286,8 @@ class TestSuspendResumeAccounting(TestFunctional):
         # Submit a low priority job
         j1 = Job(TEST_USER)
         j1.create_script(self.script)
-        j1.set_attributes({ATTR_l + '.select':
-                               '1:ncpus=8:mem=512mb+1:ncpus=6:mem=256mb'})
+        j1.set_attributes({ATTR_l + '.select': '1:ncpus=8:mem=512mb+1'
+                                               ':ncpus=6:mem=256mb'})
         jid1 = self.server.submit(j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid1)
 


### PR DESCRIPTION
#### Describe Bug or Feature
Accounting of suspend and resume events of a job for monitoring resources throughout the job's lifecycle. 

#### Describe Your Change
1. Added a new 'z' record for the suspend event which has few job resources that are not static across other records - requestor, resources_released, resources_used. 
2. Added a new 'r' record for the resume event and accounting the requestor for the same. 

#### Link to Design Doc
[Design document](http://community.pbspro.org/t/new-accounting-record-for-suspend-and-resume-event/1917/2
)

#### Attach Test and Valgrind Logs/Output
[valgrind_logs.txt](https://github.com/PBSPro/pbspro/files/4415019/valgrind_logs.txt)
[automated_test_logs.txt](https://github.com/PBSPro/pbspro/files/4415021/automated_test_logs.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
