### PR TITLE
Jobs dependent on finished jobs stay in held state

### DIFF
--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -301,6 +301,7 @@ extern "C" {
 #define PBSE_SVR_SCHED_JSF_INCOMPAT 15226	/* Server's job_sort_formula is incompatible with sched's */
 #define PBSE_NODE_BUSY	15227		 /* Node is busy */
 #define PBSE_DEFAULT_PARTITION 15228	/* Default partition name is not allowed */
+#define PBSE_HISTDEPEND  15229		/* Finished job did not satisfy dependency */
 
 /* the following structure is used to tie error number      */
 /* with text to be returned to a client, see svr_messages.c */

--- a/src/lib/Liblog/pbs_messages.c
+++ b/src/lib/Liblog/pbs_messages.c
@@ -423,6 +423,7 @@ char *msg_softwt_stf = "soft_walltime is not supported with Shrink to Fit jobs";
 char *msg_node_busy = "Node is busy";
 char *msg_default_partition = "Default partition name is not allowed";
 char *msg_depend_runone = "Job deleted, a dependent job ran";
+char *msg_histdepend = "Finished job did not satisfy dependency";
 
 /*
  * The following table connects error numbers with text
@@ -607,6 +608,7 @@ struct pbs_err_to_txt pbs_err_to_txt[] = {
 	{PBSE_SVR_SCHED_JSF_INCOMPAT, &msg_jsf_incompatible},
 	{PBSE_NODE_BUSY, &msg_node_busy},
 	{PBSE_DEFAULT_PARTITION, &msg_default_partition},
+	{PBSE_HISTDEPEND, &msg_histdepend},
 	{ 0, NULL }		/* MUST be the last entry */
 };
 

--- a/src/server/req_register.c
+++ b/src/server/req_register.c
@@ -356,7 +356,7 @@ req_register(struct batch_request *preq)
 						rc = PBSE_PERM;		/* not same user */
 					} else {
 						/* ok owner, see if job has "on" */
-							pdep = find_depend(JOB_DEPEND_TYPE_ON, pattr);
+						pdep = find_depend(JOB_DEPEND_TYPE_ON, pattr);
 						if (pdep == 0) {
 							/* on "on", see if child already registered */
 							revtype = type ^ (JOB_DEPEND_TYPE_BEFORESTART -
@@ -364,7 +364,7 @@ req_register(struct batch_request *preq)
 							pdep = find_depend(revtype, pattr);
 							if (pdep == 0) {
 								/* no "on" and no prior - return error */
-							rc = PBSE_BADDEPEND;
+								rc = PBSE_BADDEPEND;
 							} else {
 								pdj = find_dependjob(pdep,
 									preq->rq_ind.rq_register.rq_child);
@@ -372,7 +372,7 @@ req_register(struct batch_request *preq)
 									/* has prior register, update it */
 									(void)strcpy(pdj->dc_svr,
 										preq->rq_ind.rq_register.rq_svr);
-									}
+								}
 							}
 						} else if ((rc=register_dep(pattr, preq, type, &made)) == 0) {
 							if (made) {	/* first time registered */
@@ -565,10 +565,9 @@ post_doq(struct work_task *pwt)
 		else if (preq->rq_reply.brp_code == PBSE_HISTDEPEND)
 			log_eventf(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO, jobid,
 				   "%s %s", preq->rq_ind.rq_register.rq_parent, msg_histdepend);
-		else {
+		else
 			log_eventf(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO, jobid,
 				   "%s%s", msg_regrej, preq->rq_ind.rq_register.rq_parent);
-		}
 
 		pjob = find_job(jobid);
 		if ((msg = pbse_to_txt(preq->rq_reply.brp_code)) != NULL) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
If a job is dependent on a job that has already finished by the time dependent job enters the system, it stays in "H" state for the rest of its life.
This change addresses this issue and releases the dependency if it meets the dependency criteria.

#### Describe Your Change
When job history is enabled and PBS server is able to find the finished job, it checks that the exit status of the finished job satisfies the dependency criteria, if it does then no dependency is added on the submitted job and it stays in 'Q' state. If the criteria is not met then the submitted job is simply rejected (the same way it is rejected when job history is not enabled and PBS is unable to find the parent job).

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
[test.txt](https://github.com/PBSPro/pbspro/files/4417711/test.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
