### PR TITLE
skip test_systemd since systemctl can't be used

### DIFF
--- a/test/tests/functional/pbs_systemd.py
+++ b/test/tests/functional/pbs_systemd.py
@@ -93,6 +93,7 @@ class Test_systemd(TestFunctional):
             return False
         return True
 
+    @skipOnShasta
     def test_systemd(self):
         """
         Test whether you are able to control pbs using systemd


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The test will fail to run because systemctl doesn't run.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Skip the test on that platform

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
