### PR TITLE
unable to create resv from a job if flatuid is false

### DIFF
--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -3460,7 +3460,10 @@ copy_params_from_job(char *jobid, resc_resv *presv)
 		(pjob->ji_wattr[JOB_ATR_exec_vnode].at_val.at_str == NULL))
 		return PBSE_BADSTATE;
 
-	snprintf(buf, 255, "%s@%s", pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str,
+	if (strchr(pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str, '@')) {
+		strncpy(buf, pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str, 255);
+	} else
+		snprintf(buf, 255, "%s@%s", pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str,
 			pjob->ji_wattr[(int)JOB_ATR_submit_host].at_val.at_str);
 
 	set_attr_svr(&presv->ri_wattr[(int)RESV_ATR_resv_owner], &resv_attr_def[(int)RESV_ATR_resv_owner], buf);

--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -109,10 +109,15 @@ j.create_resv_from_job=1
             s_nodect_before = '0'
             s_ncpus_before = '0'
 
+        now = time.time()
+
         a = {ATTR_W: 'create_resv_from_job=1'}
         job = Job(TEST_USER, a)
         jid = self.server.submit(job)
         self.server.expect(JOB, {ATTR_state: 'R'}, jid)
+
+        self.server.log_match("Reject reply code=15095", starttime=now,
+                              interval=2, max_attempts=20, existence=False)
 
         a = {ATTR_job: jid}
         rid = self.server.status(RESV, a)[0]['id'].split(".")[0]
@@ -225,3 +230,11 @@ j.create_resv_from_job=1
             self.assertTrue(msg in e.msg[0])
         else:
             self.fail("Error message not as expected")
+
+    def test_flatuid_false(self):
+        """
+        This test confirms that a reservation can be created out of a job
+        even when flatuid is set to False.
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {'flatuid': False})
+        self.test_create_resv_from_job_using_qsub()


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When flatuid is set to False, create_resv_from_job does not work.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
In copy_params_from_job(), the user was being set as below -
snprintf(buf, 255, "%s@%s", pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str,
pjob->ji_wattr[(int)JOB_ATR_submit_host].at_val.at_str);

Now, added a check to see if '@' is already present and copy the owner accordingly.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
[before-24606.txt](https://github.com/PBSPro/pbspro/files/4419742/before-24606.txt)
[after-24606.txt](https://github.com/PBSPro/pbspro/files/4419744/after-24606.txt)
