### PR TITLE
unable to create resv from job if flatuid=False AND reject altering of create_resv_from_job if the job is already running

### DIFF
--- a/src/lib/Libattr/master_job_attr_def.xml
+++ b/src/lib/Libattr/master_job_attr_def.xml
@@ -2763,7 +2763,7 @@
       <member_at_free>free_null</member_at_free>
       <member_at_action>NULL_FUNC</member_at_action>
       <member_at_flags>
-         <both>READ_WRITE | ATR_DFLAG_ALTRUN</both>
+         <both>READ_WRITE</both>
       </member_at_flags>
       <member_at_type>
          <both>ATR_TYPE_LONG</both>

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -342,8 +342,11 @@ resc_resv *
 find_resv_by_quename(char *quename)
 {
 	char *pc;
-	resc_resv *presv;
+	resc_resv *presv = NULL;
 	char qname[PBS_MAXQUEUENAME + 1];
+
+	if (quename == NULL || *quename == '\0')
+		return NULL;
 
 	(void)strncpy(qname, quename, PBS_MAXQUEUENAME);
 	qname[PBS_MAXQUEUENAME] = '\0';

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -314,7 +314,7 @@ req_quejob(struct batch_request *preq)
 	resource_def *prdefplc;
 	resource *presc;
 	conn_t *conn;
-	resc_resv *presv;
+	resc_resv *presv = NULL;
 #else
 	mom_hook_input_t  hook_input;
 	mom_hook_output_t hook_output;
@@ -671,12 +671,16 @@ req_quejob(struct batch_request *preq)
 
 		/* decode attribute */
 #ifndef PBS_MOM
-		presv = find_resv_by_quename(qname);
+		if (index == JOB_ATR_create_resv_from_job) {
+			if (qname != NULL && *qname != '\0') {
+				presv = find_resv_by_quename(qname);
 
-		if (index == JOB_ATR_create_resv_from_job && presv) {
-			job_purge(pj);
-			req_reject(PBSE_RESV_FROM_RESVJOB, 0, preq);
-			return;
+				if (presv) {
+					job_purge(pj);
+					req_reject(PBSE_RESV_FROM_RESVJOB, 0, preq);
+					return;
+				}
+			}
 		}
 #endif
 		if ((index == JOB_ATR_resource) && (psatl->al_resc != NULL) &&

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -314,7 +314,6 @@ req_quejob(struct batch_request *preq)
 	resource_def *prdefplc;
 	resource *presc;
 	conn_t *conn;
-	resc_resv *presv = NULL;
 #else
 	mom_hook_input_t  hook_input;
 	mom_hook_output_t hook_output;
@@ -673,6 +672,7 @@ req_quejob(struct batch_request *preq)
 #ifndef PBS_MOM
 		if (index == JOB_ATR_create_resv_from_job) {
 			if (qname != NULL && *qname != '\0') {
+				resc_resv *presv;
 				presv = find_resv_by_quename(qname);
 
 				if (presv) {

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -3441,13 +3441,14 @@ int
 copy_params_from_job(char *jobid, resc_resv *presv)
 {
 	job *pjob;
-	char buf[256];
+	int bufsize;
 	attribute temp;
 	resource *presc;
 	resource_def *prdefsl;
 	resource_def *resc_def;
 	resource *job_resc_entry;
 	resource *resv_resc_entry;
+	char buf[PBS_MAXUSER + PBS_MAXHOSTNAME + 64] = {0};
 
 	int walltime_copied = 0;
 
@@ -3460,7 +3461,12 @@ copy_params_from_job(char *jobid, resc_resv *presv)
 		(pjob->ji_wattr[JOB_ATR_exec_vnode].at_val.at_str == NULL))
 		return PBSE_BADSTATE;
 
-	snprintf(buf, 255, "%s@%s", pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str,
+	bufsize = PBS_MAXUSER + PBS_MAXHOSTNAME + 64 - 1;
+
+	if (strchr(pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str, '@')) {
+		strncpy(buf, pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str, bufsize);
+	} else
+		snprintf(buf, bufsize, "%s@%s", pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str,
 			pjob->ji_wattr[(int)JOB_ATR_submit_host].at_val.at_str);
 
 	set_attr_svr(&presv->ri_wattr[(int)RESV_ATR_resv_owner], &resv_attr_def[(int)RESV_ATR_resv_owner], buf);

--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -241,7 +241,7 @@ j.create_resv_from_job=1
 
     def test_set_attr_when_job_running(self):
         """
-        This test confirms that create_resv_from_job=1 is not allowed to be
+        This test confirms that create_resv_from_job is not allowed to be
         altered when the job is already running.
         """
         j = Job(TEST_USER)

--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -117,7 +117,7 @@ j.create_resv_from_job=1
         self.server.expect(JOB, {ATTR_state: 'R'}, jid)
 
         self.server.log_match("Reject reply code=15095", starttime=now,
-                              interval=2, max_attempts=20, existence=False)
+                              interval=2, max_attempts=10, existence=False)
 
         a = {ATTR_job: jid}
         rid = self.server.status(RESV, a)[0]['id'].split(".")[0]

--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -248,11 +248,10 @@ j.create_resv_from_job=1
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, jid)
 
-        try:
+        msg = "attribute allowed to be modified"
+        with self.assertRaises(PbsAlterError, msg=msg) as c:
             self.server.alterjob(jid, {ATTR_W: 'create_resv_from_job=1'})
-        except PbsAlterError as e:
-            msg = "qalter: Cannot modify attribute while job running  "
-            msg += "create_resv_from_job"
-            self.assertTrue(msg in e.msg[0])
-        else:
-            self.fail("attribute allowed to be modified")
+
+        msg = "qalter: Cannot modify attribute while job running  "
+        msg += "create_resv_from_job"
+        self.assertIn(msg, c.exception.msg[0])

--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -109,10 +109,15 @@ j.create_resv_from_job=1
             s_nodect_before = '0'
             s_ncpus_before = '0'
 
+        now = time.time()
+
         a = {ATTR_W: 'create_resv_from_job=1'}
         job = Job(TEST_USER, a)
         jid = self.server.submit(job)
         self.server.expect(JOB, {ATTR_state: 'R'}, jid)
+
+        self.server.log_match("Reject reply code=15095", starttime=now,
+                              interval=2, max_attempts=20, existence=False)
 
         a = {ATTR_job: jid}
         rid = self.server.status(RESV, a)[0]['id'].split(".")[0]
@@ -225,3 +230,11 @@ j.create_resv_from_job=1
             self.assertTrue(msg in e.msg[0])
         else:
             self.fail("Error message not as expected")
+
+    def test_flatuid_false(self):
+        """
+        This test confirms that a reservation can be created out of a job
+        even when flatuid is set to False.
+        """
+        self.server.manager(MGR_CMD_SET, SERVER, {'flatuid': False})
+        self.test_create_resv_from_job_using_qsub()

--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -238,3 +238,21 @@ j.create_resv_from_job=1
         """
         self.server.manager(MGR_CMD_SET, SERVER, {'flatuid': False})
         self.test_create_resv_from_job_using_qsub()
+
+    def test_set_attr_when_job_running(self):
+        """
+        This test confirms that create_resv_from_job=1 is not allowed to be
+        altered when the job is already running.
+        """
+        j = Job(TEST_USER)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, jid)
+
+        try:
+            self.server.alterjob(jid, {ATTR_W: 'create_resv_from_job=1'})
+        except PbsAlterError as e:
+            msg = "qalter: Cannot modify attribute while job running  "
+            msg += "create_resv_from_job"
+            self.assertTrue(msg in e.msg[0])
+        else:
+            self.fail("attribute allowed to be modified")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When flatuid is set to False, create_resv_from_job does not work.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
**Change 1)** In copy_params_from_job(), the user was being set as below -
snprintf(buf, 255, "%s@%s", pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str,
pjob->ji_wattr[(int)JOB_ATR_submit_host].at_val.at_str);

Now, added a check to see if '@' is already present and copy the owner accordingly.

**Change 2)**
Also, @arungrover reported a crash with the below trace -
(gdb) bt
#0  0x00007f4e01c08ada in __strcmp_sse42 () from /usr/lib64/libc.so.6
#1  0x0000000000458915 in find_resv_by_quename (quename=quename@entry=0x1319088 "") at ../../../src/server/queue_func.c:355
#2  0x0000000000469ca9 in req_quejob (preq=0x1318cf0) at ../../../src/server/req_quejob.c:677
#3  0x00000000004bd0bc in process_socket (sock=sock@entry=15) at ../../../../src/lib/Libnet/net_server.c:512
#4  0x00000000004bd282 in wait_request (waittime=waittime@entry=2, priority_context=<optimized out>) at ../../../../src/lib/Libnet/net_server.c:628
#5  0x000000000042b55b in main (argc=<optimized out>, argv=<optimized out>) at ../../../src/server/pbsd_main.c:1833
(gdb) fr 2
#2  0x0000000000469ca9 in req_quejob (preq=0x1318cf0) at ../../../src/server/req_quejob.c:677
677                                         presv = find_resv_by_quename(qname);
(gdb) p qname
$1 = 0x1319088 ""
(gdb)

Added a NULL check to prevent the crash and also moved this check inside the if where it is relevant.

**Change 3)**
Rejecting attempt to alter create_resv_from_job if the job is running.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
[before-24606.txt](https://github.com/PBSPro/pbspro/files/4419797/before-24606.txt)
[after-24606.txt](https://github.com/PBSPro/pbspro/files/4419798/after-24606.txt)