### PR TITLE
Support building with hwloc version 2.x

### DIFF
--- a/pbspro.spec
+++ b/pbspro.spec
@@ -102,7 +102,7 @@ BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool
 BuildRequires: libtool-ltdl-devel
-BuildRequires: hwloc-devel < 2.0
+BuildRequires: hwloc-devel
 BuildRequires: libX11-devel
 BuildRequires: libXt-devel
 BuildRequires: libedit-devel

--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -102,7 +102,7 @@ BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool
 BuildRequires: libtool-ltdl-devel
-BuildRequires: hwloc-devel < 2.0
+BuildRequires: hwloc-devel
 BuildRequires: libX11-devel
 BuildRequires: libXt-devel
 BuildRequires: libedit-devel


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PBS Pro would not build under OpenSUSE 15.2 because hwloc has been upgrated to version 2.x

#### Describe Your Change
Add cpp macros to handle hwloc versions 1.x and 2.x.

#### Link to Design Doc
N/A

#### Attach Test and Valgrind Logs/Output
[BUILD.LOG](https://github.com/PBSPro/pbspro/files/4423013/BUILD.LOG)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
