### PR TITLE
Allow root jobs to pbs_attach.

### DIFF
--- a/test/tests/functional/pbs_root_owned_script.py
+++ b/test/tests/functional/pbs_root_owned_script.py
@@ -37,6 +37,7 @@
 
 from tests.functional import *
 
+
 class Test_RootOwnedScript(TestFunctional):
     """
     Test suite to test whether the root owned script is getting rejected

--- a/test/tests/functional/pbs_root_owned_script.py
+++ b/test/tests/functional/pbs_root_owned_script.py
@@ -48,7 +48,7 @@ class Test_RootOwnedScript(TestFunctional):
         """
         Set up the parameters required for Test_RootOwnedScript
         """
-        if os.getuid() != 0:
+        if os.getuid() != 0 or sys.platform in ('cygwin', 'win32'):
             self.skipTest("Test need to run as root")
         TestFunctional.setUp(self)
         mom_conf_attr = {'$reject_root_scripts': 'true'}

--- a/test/tests/functional/pbs_root_owned_script.py
+++ b/test/tests/functional/pbs_root_owned_script.py
@@ -37,7 +37,6 @@
 
 from tests.functional import *
 
-
 class Test_RootOwnedScript(TestFunctional):
     """
     Test suite to test whether the root owned script is getting rejected
@@ -63,8 +62,7 @@ class Test_RootOwnedScript(TestFunctional):
             self.server.pbs_conf['PBS_EXEC'], 'bin', 'qsub')
         # Make sure local mom is ready to run jobs
         a = {'state': 'free', 'resources_available.ncpus': (GE, 1)}
-        self.server.expect(VNODE, a, count=True,
-                           max_attempts=10, interval=2)
+        self.server.expect(VNODE, a, max_attempts=10, interval=2)
 
     def test_root_owned_script(self):
         """
@@ -156,3 +154,29 @@ class Test_RootOwnedScript(TestFunctional):
         ja_comment = "Job Array Held, too many failed attempts to run subjob"
         self.server.expect(JOB, {ATTR_state: "H", ATTR_comment: (MATCH_RE,
                            ja_comment)}, attrop=PTL_AND, id=jid)
+
+    def test_root_owned_job_pbs_attach(self):
+        """
+        submit a job as root and test pbs_attach feature.
+        """
+        mom_conf_attr = {'$reject_root_scripts': 'false'}
+        self.mom.add_config(mom_conf_attr)
+        self.mom.restart()
+        qmgr_attr = {'acl_roots': ROOT_USER}
+        self.server.manager(MGR_CMD_SET, SERVER, qmgr_attr)
+        pbs_attach = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                  'bin', 'pbs_attach')
+
+        # Job script
+        test = []
+        test += ['#PBS -l select=ncpus=1\n']
+        test += ['%s -j $PBS_JOBID -P -s /bin/sleep 30\n' % pbs_attach]
+
+        # Submit a job
+        j = Job(ROOT_USER)
+        j.create_script(body=test)
+        jid = self.server.submit(j)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+
+        msg_expected = ".+%s;pid.+attached as task.+" % jid
+        s = self.mom.log_match(msg_expected, regexp=True, max_attempts=10)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
With PR #1625 fix in place, root jobs could not do a pbs_attach, as the TM_ATTACH request is dependent on the proc_info table, where root processes are no longer tracked.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fix is when pbs_mom receives the TM_ATTACH request, and the pid being attached is not found in the proc_info table, then obtain the pid process info directly from /proc/\<pid> file.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[ptl.test_root_owned_job_pbs_attach.FAIL.txt](https://github.com/PBSPro/pbspro/files/4439419/ptl.test_root_owned_job_pbs_attach.FAIL.txt)
[ptl.test_root_owned_job_pbs_attach.PASS.txt](https://github.com/PBSPro/pbspro/files/4439424/ptl.test_root_owned_job_pbs_attach.PASS.txt)
[ptl.root_owned_script.txt](https://github.com/PBSPro/pbspro/files/4439427/ptl.root_owned_script.txt)
[valgrind.mom.withoutfix.txt](https://github.com/PBSPro/pbspro/files/4439433/valgrind.mom.withoutfix.txt)
[valgrind.mom.withfix.txt](https://github.com/PBSPro/pbspro/files/4439435/valgrind.mom.withfix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
