### PR TITLE
pbs_snapshot obfuscate sometimes fails at shutil.move() for different fs

### DIFF
--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -425,7 +425,7 @@ class ObfuscateSnapshot(object):
             self.logger.info("Total bad records found: " +
                              str(self.num_bad_acct_records))
 
-    def _replace_str_in_file(self, key, val, fpath):
+    def _replace_str_in_file(self, key, val, fpath, sudo=False):
         """
         Helper function to replace a given string (key) with another (val)
 
@@ -442,6 +442,8 @@ class ObfuscateSnapshot(object):
             alltext = fd.read()
             otext = re.sub(r'\b' + key + r'\b', val, alltext)
             fdout.write(otext)
+
+        self.du.rm(path=fpath, sudo=sudo)
         shutil.move(fout, fpath)
 
     def obfuscate_snapshot(self, snap_dir, map_file, sudo_val):
@@ -554,7 +556,7 @@ class ObfuscateSnapshot(object):
 
                 # Obfuscate values from val_obf_map
                 for key, val in self.val_obf_map.items():
-                    self._replace_str_in_file(key, val, fpath)
+                    self._replace_str_in_file(key, val, fpath, sudo=sudo_val)
                     if key in fname:
                         new_fname = fname.replace(key, val)
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Sometimes, pbs_snapshot fails with --obfuscate at shutil.move(), as follows:
**Traceback (most recent call last):
  File "/opt/pbs/python/lib/python3.6/shutil.py", line 550, in move
    os.rename(src, real_dst)
OSError: [Errno 18] Invalid cross-device link: '/tmp/PtlPbshqvvsx7e' -> '/home/ragrawal/snapshot_20200406_21_34_05/server_priv/topology/a03'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/pbs/python/lib/python3.6/shutil.py", line 564, in move
    copy_function(src, real_dst)
  File "/opt/pbs/python/lib/python3.6/shutil.py", line 263, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/opt/pbs/python/lib/python3.6/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/PtlPbshqvvsx7e'**

#### Analysis
shutil.move() is actually supposed to do copy+delete when the file is being moved between different file systems, as opposed to using os.rename(). But looking at shutil.move()'s source code:
https://github.com/python/cpython/blob/master/Lib/shutil.py#L802
It actually seems to first try a os.rename(), and only call copy_function() if it fails, even when it knows that the fs is different. That's the exception that we see in the call stack, it's expected to happen when the fs is different. The main issue is that copy_function() fails because of permission issue as we are trying to replace a root owned file. So, the issue should go away if we just delete the root owned file first before calling shutil.move()

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added code to remove the root owned file before calling shutil.move(), we are replacing the file anyways so it should be perfectly fine to delete it first.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
There's no good automated test for this. I was able to manually capture the same snapshot successfully after making this change.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
