### PR TITLE
TestSupportLinuxHookEventPhase1_2 test suite failing on cpuset machines

### DIFF
--- a/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
+++ b/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
@@ -89,7 +89,7 @@ else:
                  (self.hostA, self.hostB)]
         test += ['%s -j $PBS_JOBID /bin/sleep 30\n' % self.pbs_attach]
         test += ['%s %s.pbspro.com %s /bin/sleep 30\n' %
-                 (self.pbs_tmrsh, self.hostB, self.pbs_attach)]
+                 (self.pbs_tmrsh, self.momB.shortname, self.pbs_attach)]
 
         # Submit a job
         j = Job(TEST_USER)
@@ -176,7 +176,7 @@ e.accept()
                  (self.hostA, self.hostB)]
         test += ['%s -j $PBS_JOBID /bin/sleep 30\n' % self.pbs_attach]
         test += ['%s %s.pbspro.com %s /bin/sleep 30\n' %
-                 (self.pbs_tmrsh, self.hostB, self.pbs_attach)]
+                 (self.pbs_tmrsh, self.momB.shortname, self.pbs_attach)]
 
         # Submit a job
         j = Job(TEST_USER)
@@ -193,7 +193,7 @@ e.accept()
                     "---------------------->",
                     "Hook;pbs_python;Event is: EXECJOB_ATTACH",
                     "Hook;pbs_python;Requestor is: pbs_mom",
-                    "Hook;pbs_python;Requestor_host is: %s" % self.hostB,
+                    "Hook;pbs_python;Requestor_host is: %s" % self.momB.shortname,
                     "Hook;pbs_python;Vnode: [%s]-------------->" % self.hostA,
                     "Hook;pbs_python;Vnode: [%s]-------------->" % self.hostB,
                     "pbs_python;Job;%s;PID =" % jid,

--- a/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
+++ b/test/tests/functional/pbs_support_linux_hook_event_phase1_2.py
@@ -189,15 +189,20 @@ e.accept()
         time.sleep(31)
 
         # Check log msgs on sister mom
-        log_msgB = ["Hook;pbs_python;printing pbs.event() values " +
-                    "---------------------->",
-                    "Hook;pbs_python;Event is: EXECJOB_ATTACH",
-                    "Hook;pbs_python;Requestor is: pbs_mom",
-                    "Hook;pbs_python;Requestor_host is: %s" % self.momB.shortname,
-                    "Hook;pbs_python;Vnode: [%s]-------------->" % self.hostA,
-                    "Hook;pbs_python;Vnode: [%s]-------------->" % self.hostB,
-                    "pbs_python;Job;%s;PID =" % jid,
-                    "Hook;pbs_python;job is NOT in_ms_mom"]
+        log_msgB = [
+            "Hook;pbs_python;printing pbs.event() values " +
+            "---------------------->",
+            "Hook;pbs_python;Event is: EXECJOB_ATTACH",
+            "Hook;pbs_python;Requestor is: pbs_mom",
+            "Hook;pbs_python;Requestor_host is: %s" %
+            self.momB.shortname,
+            "Hook;pbs_python;Vnode: [%s]-------------->" %
+            self.hostA,
+            "Hook;pbs_python;Vnode: [%s]-------------->" %
+            self.hostB,
+            "pbs_python;Job;%s;PID =" %
+            jid,
+            "Hook;pbs_python;job is NOT in_ms_mom"]
 
         for msg in log_msgB:
             rc = self.momB.log_match(msg, starttime=check_after,


### PR DESCRIPTION
#### Describe Bug or Feature
TestSupportLinuxHookEventPhase1_2  test suite was failing with EXECJOB_ATTACH log message not found in cpuset moms.

#### Describe Your Change
Both tests in TestSupportLinuxHookEventPhase1_2 test suite were submitting a Job with pbs_tmrsh command executing on a vnode instead of hostname. Job was exiting with status "1". 
Replaced vnode name with hostname in Job script.


#### Link to Design Doc
[TestSupportLinuxHookEventPhase1_2_before_fix_logs.txt](https://github.com/PBSPro/pbspro/files/4443376/TestSupportLinuxHookEventPhase1_2_before_fix_logs.txt)

[TestSupportLinuxHookEventPhase1_2_logs.txt](https://github.com/PBSPro/pbspro/files/4443357/TestSupportLinuxHookEventPhase1_2_logs.txt)


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
