### PR TITLE
Hugepagesize updates to test_cgroup_offline_node_vnpernuma

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1754,6 +1754,9 @@ if %s e.job.in_ms_mom():
         the cgroup and brought back online once the cgroup is cleaned up.
         vnode_per_numa_node = true
         """
+        with open('/proc/meminfo', 'r') as desc:
+            if 'Hugepagesize' not in desc:
+                self.skipTest('Hugepagesize not in meminfo')
         name = 'CGROUP7.2'
         vn_per_numa = 'true'
         rv = self.cgroup_offline_node(name, vn_per_numa)

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1754,7 +1754,8 @@ if %s e.job.in_ms_mom():
         the cgroup and brought back online once the cgroup is cleaned up.
         vnode_per_numa_node = true
         """
-        meminfo = open(os.path.join(os.sep, 'proc', 'meminfo'), 'r').read()
+        with open(os.path.join(os.sep, 'proc', 'meminfo'), 'r') as fd:
+            meminfo = fd.read()
         if 'Hugepagesize' not in meminfo:
                 self.skipTest('Hugepagesize not in meminfo')
         name = 'CGROUP7.2'

--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -1754,8 +1754,8 @@ if %s e.job.in_ms_mom():
         the cgroup and brought back online once the cgroup is cleaned up.
         vnode_per_numa_node = true
         """
-        with open('/proc/meminfo', 'r') as desc:
-            if 'Hugepagesize' not in desc:
+        meminfo = open(os.path.join(os.sep, 'proc', 'meminfo'), 'r').read()
+        if 'Hugepagesize' not in meminfo:
                 self.skipTest('Hugepagesize not in meminfo')
         name = 'CGROUP7.2'
         vn_per_numa = 'true'


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The test TestCgroupsHook.test_cgroup_offline_node_vnpernuma fails on systems that don't have Hugepagesize in meminfo.


#### Describe Your Change
The test will skip if Hugepagesize is not in meminfo.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[before.txt](https://github.com/PBSPro/pbspro/files/4446339/before.txt)
[after.txt](https://github.com/PBSPro/pbspro/files/4447311/after.txt)






<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
