### PR TITLE
Fix for invalid read in destroy_connection

### DIFF
--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -1743,7 +1743,6 @@ tpp_shutdown()
 			dis_destroy_chan(sd);
 			free_stream_resources(strmarray[i].strm);
 			free_stream(sd);
-			destroy_connection(sd);
 		}
 	}
 	tpp_unlock(&strmarray_lock);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Valgrind shows Invalid read in destroy_connection while tpp_shutdown():
```
Invalid read of size 8
   at 0x321931: _destroy_connection (conn_table.c:156)
   by 0x321B3A: destroy_connection (conn_table.c:221)
   by 0x2992D0: tpp_shutdown (tpp_client.c:1746)
   by 0x21420C: main (pbsd_main.c:1908)
Address 0xbb11218 is 0 bytes after a block of size 200 alloc'd
   at 0x4C2FA3F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x4C31D84: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x3216D6: add_connection (conn_table.c:110)
   by 0x321BBB: get_connection (conn_table.c:259)
   by 0x32207B: get_conn_chan (conn_table.c:477)
   by 0x32DE58: tcp_get_chan (tcp_dis.c:80)
   by 0x318212: transport_chan_set_ctx_status (dis_helpers.c:78)
   by 0x24B808: contact_sched (run_sched.c:320)
   by 0x213B6C: main (pbsd_main.c:1678)
```
This is because destroy_connection() destroys connection entry from connection table and in case of TPP (which uses virtual fd) we never add fd returned by TPP in connection table, but in `tpp_shutdown()` we call `destroy_connection()` which is wrong

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Remove call to `destroy_connection()` from `tpp_shutdown()`


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[before.txt](https://github.com/PBSPro/pbspro/files/4448741/before.txt)
[after.txt](https://github.com/PBSPro/pbspro/files/4448742/after.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
