### PR TITLE
Make ci and build scripts independent of top level source dir name

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,18 +18,16 @@ build_script:
 after_build:
   - cmd: call .appveyor\generate_installer.bat %CONFIGURATION%
 before_test:
-  - ps: copy c:\projects\win_build\msi\PBSPro_*.msi PBSPro.msi
-  - ps: Start-Process msiexec -ArgumentList "/quiet","/qn","/norestart","/i","c:\projects\pbspro\PBSPro.msi" -Wait
+  - ps: copy c:\projects\win_build\msi\*.msi c:\projects\pbs.msi
+  - ps: Start-Process msiexec -ArgumentList "/quiet","/qn","/norestart","/i","c:\projects\pbs.msi" -Wait
   - ps: $ip = [System.Net.Dns]::GetHostByName($env:computerName).AddressList[0].IPAddressToString
-  - ps: Add-Content C:\Windows\System32\Drivers\Etc\Hosts "$ip testdev.pbspro.org testdev"
+  - ps: Add-Content C:\Windows\System32\Drivers\Etc\Hosts "$ip pbsdev.dev.local pbsdev"
   - ps: net user $env:username pbS@123
   - cmd: refreshenv
-  - cmd: C:\PROGRA~2\PBS\exec\python\python.exe C:\PROGRA~2\PBS\exec\etc\win_postinstall.py -u %USERNAME% -p pbS@123 -t execution -s testdev
+  - cmd: C:\PROGRA~2\PBS\exec\python\python.exe C:\PROGRA~2\PBS\exec\etc\win_postinstall.py -u %USERNAME% -p pbS@123 -t execution -s pbsdev
 after_test:
-  - ps: rm PBSPro.msi
-  - ps: copy c:\projects\win_build\msi\PBSPro_*.msi .
+  - ps: rm c:\projects\pbs.msi
+  - ps: copy c:\projects\win_build\msi\*.msi .
 artifacts:
   - path: '*.msi'
 deploy: off
-# on_finish:
-#   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.appveyor/generate_installer.bat
+++ b/.appveyor/generate_installer.bat
@@ -42,23 +42,23 @@ if defined WIX (
 	set "PATH=%WIX%bin;%PATH%"
 )
 
-call "%~dp0..\..\pbspro\win_configure\msi\wix\prep.bat" "%BINARIESDIR%" %~1
+call "%~dp0..\win_configure\msi\wix\prep.bat" "%BINARIESDIR%" %~1
 if not %ERRORLEVEL% == 0 (
     echo Failed to prepare PBS_EXEC!
     exit /b 1
 )
 
-if not exist "%BINARIESDIR%\vc_redist.x86.exe" (	
-    "%CURL_BIN%" -qkL -o "%BINARIESDIR%\vc_redist.x86.exe" https://aka.ms/vs/16/release/vc_redist.x86.exe	
-    if not exist "%BINARIESDIR%\vc_redist.x86.exe" (	
-        echo "Failed to download Microsoft Visual C++ 2017 Redistributable Package (x86)"	
-        exit /b 1	
-    )	
-)	
+if not exist "%BINARIESDIR%\vc_redist.x86.exe" (
+    "%CURL_BIN%" -qkL -o "%BINARIESDIR%\vc_redist.x86.exe" https://aka.ms/vs/16/release/vc_redist.x86.exe
+    if not exist "%BINARIESDIR%\vc_redist.x86.exe" (
+        echo "Failed to download Microsoft Visual C++ 2017 Redistributable Package (x86)"
+        exit /b 1
+    )
+)
 
 1>nul copy /B /Y "%BINARIESDIR%\vc_redist.x86.exe" "%~dp0..\..\PBS\exec\etc\vc_redist.x86.exe"
 
-call "%~dp0..\..\pbspro\win_configure\msi\wix\create_msi.bat" %~1
+call "%~dp0..\win_configure\msi\wix\create_msi.bat" %~1
 if not %ERRORLEVEL% == 0 (
     echo Failed to generate PBS Pro MSI!
     exit /b 1

--- a/.gitignore
+++ b/.gitignore
@@ -264,7 +264,7 @@ src/cmds/scripts/pbs.service
 src/lib/Libpbs/pbs.pc
 
 # rpm spec file
-pbspro.spec
+*.spec
 
 # Other archive file types
 *.tar

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ before_install:
   - '[ "${OS_TYPE}" == "ubuntu:18.04" -o "${OS_TYPE}" == "debian:9" ] && export DOCKER_EXTRA_ARG="-e DEBIAN_FRONTEND=noninteractive -e LANGUAGE=C.UTF-8 -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8" || true'
   - '[ "${OS_TYPE}" == "centos:7" ] && export DOCKER_EXTRA_ARG="-e LC_ALL=en_US.utf-8 -e LANG=en_US.utf-8" || true'
   - '[ "${OS_TYPE}" == "opensuse/leap:15" ] && export DOCKER_EXTRA_ARG="-e LC_ALL=C.utf8" || true'
-  - docker run -it -d -h testdev.pbspro.org --name testdev -v $(pwd):$(pwd) --privileged -w $(pwd) ${DOCKER_EXTRA_ARG} ${OS_TYPE} /bin/bash
+  - docker run -it -d -h pbs.dev.local --name pbsdev -v $(pwd):$(pwd) --privileged -w $(pwd) ${DOCKER_EXTRA_ARG} ${OS_TYPE} /bin/bash
   - docker ps -a
-  - export DOCKER_EXEC="docker exec -it ${DOCKER_EXTRA_ARG} -e BUILD_MODE="${BUILD_MODE}" --privileged testdev"
+  - export DOCKER_EXEC="docker exec -it ${DOCKER_EXTRA_ARG} -e BUILD_MODE="${BUILD_MODE}" --privileged pbsdev"
 install:
   - '${DOCKER_EXEC} .travis/do_sanitize_mode.sh'
   - '${DOCKER_EXEC} .travis/do.sh'

--- a/ci/ci
+++ b/ci/ci
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-import sys
+import argparse
+import fileinput
 import os
 import platform
-import argparse
-import subprocess
-import fileinput
 import shlex
+import subprocess
+import sys
 import time
 
 pbs_dirname = ''
@@ -55,7 +55,7 @@ def run_docker_cmd(cmd):
             log_error(
                 "docker cmd returned with non zero exit code, redirecting you to container terminal")
             docker_cmd = shlex.split(
-                "docker-compose exec pbs-build bash -c \'cd /pbspro && /bin/bash\'")
+                "docker-compose exec pbs-build bash -c \'cd /pbssrc && /bin/bash\'")
             subprocess.run(docker_cmd)
     except Exception as e:
         log_error("Failed\n:")
@@ -126,7 +126,7 @@ def delete_older_image(bad_images):
 
 def find_ci():
     '''
-    Finds absolute path of pbs and ci 
+    Finds absolute path of pbs and ci
     '''
     cur_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.dirname(cur_dir)

--- a/ci/do.sh
+++ b/ci/do.sh
@@ -10,17 +10,17 @@ if [ -f /src/ci ]; then
   FIRST_TIME_BUILD=$1
   workdir=/src
   logdir=/logs
-  PBS_DIR=/pbspro
+  PBS_DIR=/pbssrc
 else
   PBS_DIR=$( readlink -f $0 | awk -F'/ci/' '{print $1}' )
 fi
 
 cd ${PBS_DIR}
 . /etc/os-release
-SPEC_FILE=${PBS_DIR}/pbspro.spec
+SPEC_FILE=$(/bin/ls -1 ${PBS_DIR}/*.spec)
 REQ_FILE=${PBS_DIR}/test/fw/requirements.txt
 if [ ! -r ${SPEC_FILE} -o ! -r ${REQ_FILE} ]; then
-  echo "Couldn't find pbspro.spec or requirement.txt"
+  echo "Couldn't find pbs spec file or ptl requirements file"
   exit 1
 fi
 
@@ -165,12 +165,12 @@ pbs_config --make-ug
 
 if [ "x${RUN_TESTS}" == "x1" ];then
   if [ "x${ID}" == "xcentos" ];then
-    export LC_ALL=en_US.utf-8 
+    export LC_ALL=en_US.utf-8
     export LANG=en_US.utf-8
   elif [ "x${ID}" == "xopensuse" ]; then
     export LC_ALL=C.utf8
   fi
-  ptl_tests_dir=/pbspro/test/tests
+  ptl_tests_dir=/pbssrc/test/tests
   cd ${ptl_tests_dir}/
   benchpress_opt="$( cat ${workdir}/.benchpress_opt )"
   eval_tag="$(echo ${benchpress_opt} | awk -F'"' '{print $2}')"

--- a/ci/do_sanitize_mode.sh
+++ b/ci/do_sanitize_mode.sh
@@ -8,18 +8,18 @@ yum -y update
 yum -y install yum-utils epel-release rpmdevtools libasan llvm
 rpmdev-setuptree
 yum -y install python3-pip sudo which net-tools man-db time.x86_64
-yum-builddep -y ./pbspro.spec
+yum-builddep -y ./*.spec
 ./autogen.sh
 rm -rf target-sanitize
 mkdir -p target-sanitize
 cd target-sanitize
 ../configure
 make dist
-cp -fv pbspro-*.tar.gz /root/rpmbuild/SOURCES/
-CFLAGS="-g -O2 -Wall -Werror -fsanitize=address -fno-omit-frame-pointer" rpmbuild -bb --with ptl pbspro.spec
-yum -y install /root/rpmbuild/RPMS/x86_64/pbspro-server-??.*.x86_64.rpm
-yum -y install /root/rpmbuild/RPMS/x86_64/pbspro-debuginfo-??.*.x86_64.rpm
-yum -y install /root/rpmbuild/RPMS/x86_64/pbspro-ptl-??.*.x86_64.rpm
+cp -fv *.tar.gz /root/rpmbuild/SOURCES/
+CFLAGS="-g -O2 -Wall -Werror -fsanitize=address -fno-omit-frame-pointer" rpmbuild -bb --with ptl *.spec
+yum -y install /root/rpmbuild/RPMS/x86_64/*-server-??.*.x86_64.rpm
+yum -y install /root/rpmbuild/RPMS/x86_64/*-debuginfo-??.*.x86_64.rpm
+yum -y install /root/rpmbuild/RPMS/x86_64/*-ptl-??.*.x86_64.rpm
 sed -i "s@PBS_START_MOM=0@PBS_START_MOM=1@" /etc/pbs.conf
 /etc/init.d/pbs start
 set +e

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -1,21 +1,21 @@
 version: '3'
 
 services:
-    pbs-build: 
-      image: ${CONTAINER_PLATFORM}
-      volumes: 
-        - ../../pbspro:/pbspro
-        - ./:/src
-        - ./logs:/logs
-      entrypoint: /src/docker-entrypoint
-      env_file: .env
-      networks: 
-        ci:
-          aliases:
-            - pbs_server
-      hostname: pbs.ci
-      privileged: true
+  pbs-build:
+    image: ${CONTAINER_PLATFORM}
+    volumes:
+      - ../:/pbssrc
+      - ./:/src
+      - ./logs:/logs
+    entrypoint: /src/docker-entrypoint
+    env_file: .env
+    networks:
+      ci:
+        aliases:
+          - pbs_server
+    hostname: pbs.ci
+    privileged: true
 
-networks: 
+networks:
   ci:
     driver: bridge

--- a/ci/docker-entrypoint
+++ b/ci/docker-entrypoint
@@ -2,11 +2,11 @@
 
 workdir=/src
 logdir=/logs
-cd /pbspro
+cd /pbssrc
 ${workdir}/do.sh 1 | tee ${logdir}/build
-commit_id=$( cd /pbspro && /usr/bin/git log --oneline -1 | awk -F' ' '{print $1}' )
+commit_id=$( cd /pbssrc && /usr/bin/git log --oneline -1 | awk -F' ' '{print $1}' )
 while true; do
-    new_commit=$( cd /pbspro && /usr/bin/git log --oneline -1 | awk -F' ' '{print $1}' )
+    new_commit=$( cd /pbssrc && /usr/bin/git log --oneline -1 | awk -F' ' '{print $1}' )
     if [ "xx${commit_id}" != "xx${new_commit}" ]; then
         time_stamp=$( date +"%s" )
         [ ! -d ${logdir}/prev_LOGS ] && mkdir -p ${logdir}/prev_LOGS

--- a/ci/killit.sh
+++ b/ci/killit.sh
@@ -2,25 +2,25 @@
 
 
 killit(){
-    if [ -z "$1" ]	
-	then	
-		return 0	
-	fi	
-	pid=$(ps -ef 2>/dev/null | grep $1 | grep -v grep | awk '{print $2}')	
-	if [ ! -z "${pid}" ]	
-	then	
-		echo "kill -TERM ${pid}"	
-		kill -TERM ${pid} 2>/dev/null	
-	else	
-		return 0	
-	fi	
-	sleep 10	
-	pid=$(ps -ef 2>/dev/null | grep $1 | grep -v grep | awk '{print $2}')	
-	if [ ! -z "${pid}" ]	
-	then	
-		echo "kill -KILL ${pid}"	
-		kill -KILL ${pid} 2>/dev/null	
-	fi	
+    if [ -z "$1" ]
+	then
+		return 0
+	fi
+	pid=$(ps -ef 2>/dev/null | grep $1 | grep -v grep | awk '{print $2}')
+	if [ ! -z "${pid}" ]
+	then
+		echo "kill -TERM ${pid}"
+		kill -TERM ${pid} 2>/dev/null
+	else
+		return 0
+	fi
+	sleep 10
+	pid=$(ps -ef 2>/dev/null | grep $1 | grep -v grep | awk '{print $2}')
+	if [ ! -z "${pid}" ]
+	then
+		echo "kill -KILL ${pid}"
+		kill -KILL ${pid} 2>/dev/null
+	fi
 }
 
 kill_pbs_process(){
@@ -33,12 +33,12 @@ kill_pbs_process(){
         killit pbs_ds_monitor
 		killit /opt/pbs/pgsql/bin/postgres
         killit pbs_benchpress
-        ps_count=$(ps -eaf 2>/dev/null | grep pbs_ | grep -v grep | wc -l ) 
+        ps_count=$(ps -eaf 2>/dev/null | grep pbs_ | grep -v grep | wc -l )
 		if [ ${ps_count} -eq 0 ]; then
 			return 0
 		else
 			return 1
-		fi 
+		fi
     fi
 }
 
@@ -62,7 +62,7 @@ else
 fi
 
 if [ "XX${clean}" == "XXclean" ];then
-    cd /pbspro/target-${ID} && make uninstall
+    cd /pbssrc/target-${ID} && make uninstall
 	rm -rf /etc/init.d/pbs
     rm -rf /etc/pbs.conf
     rm -rf /var/spool/pbs

--- a/win_configure/msi/wix/create_msi.bat
+++ b/win_configure/msi/wix/create_msi.bat
@@ -35,11 +35,12 @@ REM trademark licensing policies.
 setlocal enabledelayedexpansion
 @echo on
 
-cd "%~dp0..\..\..\..\"
+cd "%~dp0..\..\..\"
+set PBS_SPEC_FILE=%CD%\pbspro.spec
+cd ..\
 set PBS_RESOURCES=%~dp0resources
 set PBS_DIR=%CD%\PBS
 set PBS_EXECDIR=%CD%\PBS\exec
-set PBS_SPEC_FILE=%CD%\pbspro\pbspro.spec
 set PBS_VERSION=""
 set PBS_SHORT_VERSION=""
 set PBS_PRODUCT_NAME=PBS Pro

--- a/win_configure/msi/wix/prep.bat
+++ b/win_configure/msi/wix/prep.bat
@@ -40,10 +40,11 @@ if "%~1" == "" (
     exit /b 1
 )
 
-cd "%~dp0..\..\..\..\"
+cd "%~dp0..\..\..\"
+set PBS_SRCDIR=%CD%
+cd ..\
 set WINBUILDDIR=%CD%\win_build
 set PBS_EXECDIR=%CD%\PBS\exec
-set PBS_SRCDIR=%CD%\pbspro
 set BINARIESDIR=%~1
 set BUILD_TYPE=Release
 set BINARIESDIR_TYPE=


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Currently ci tool and other build scripts needs PBS src directory name to be "pbspro", but this restricts git's flexibility of giving directory name while cloning the repo
* Also there are other places we do hardcode stuff in the build script and Travis and Appveyor script, which is not required

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Made ci tool and build scripts independent of the toplevel dir name


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* Logs for ci tool:
     [before.txt](https://github.com/PBSPro/pbspro/files/4455260/before.txt)
     After fix:
     [logfile.txt](https://github.com/PBSPro/pbspro/files/4455269/logfile.txt)
     [build.txt](https://github.com/PBSPro/pbspro/files/4455264/build.txt)
* For rest, Travis and Appveyor will be sufficient

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
