### PR TITLE
Add support for multiple mom action scripts in PTL framework

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13572,10 +13572,25 @@ class MoM(PBSService):
         self.du.chmod(hostname=self.hostname, path=chk_file, mode=0o700)
         self.du.chown(hostname=self.hostname, path=chk_file, runas=ROOT_USER,
                       uid=0, gid=0)
-        c = {'$action': 'checkpoint_abort ' +
+        c = {'$action checkpoint_abort':
              str(abort_time) + ' !' + chk_file + ' %sid'}
         self.add_config(c)
         return chk_file
+    
+    def add_restart_script(self, dirname=None, body=None,
+                           abort_time=30):
+        """
+        Add restart script in the mom config.
+        returns: a temp file for restart script
+        """
+        rst_file = self.du.create_temp_file(hostname=self.hostname, body=body,
+                                            dirname=dirname)
+        self.du.chmod(hostname=self.hostname, path=chk_file, mode=0o700)
+        self.du.chown(hostname=self.hostname, path=chk_file, runas=ROOT_USER,
+                      uid=0, gid=0)
+        c = {'$action restart': str(abort_time) + ' !' + chk_file + ' %sid'}
+        self.add_config(c)
+        return rst_file
 
     def parse_config(self):
         """
@@ -13596,7 +13611,11 @@ class MoM(PBSService):
             self.config = {}
             lines = ret['out']
             for line in lines:
-                (k, v) = line.split(' ', 1)
+                if line.startswith('$action'):
+                    (ac, k, v) = line.split(' ', 2)
+                    k = ac + ' ' + k
+                else:
+                    (k, v) = line.split(' ', 1)
                 if k in self.config:
                     if isinstance(self.config[k], list):
                         self.config[k].append(v)

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13576,7 +13576,7 @@ class MoM(PBSService):
              str(abort_time) + ' !' + chk_file + ' %sid'}
         self.add_config(c)
         return chk_file
-    
+
     def add_restart_script(self, dirname=None, body=None,
                            abort_time=30):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In "pbs_testlib.py", class MOM has the "parse_config" method for parsing and adding to mom config file. "parse_config" reads in the config file line by line and splits each line into key-value pairs by the first space. Because of this simple parsing method, all $action entries have the same key, and therefore only one will be added to the dictionary that this method returns.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Modified the `parse_config` function. When `parse_config` reads a line that starts with "$action", it now includes the next word into the key, and use the rest of the string to be the value. 
* Modified `add_checkpoint_abort_script` to use "$action checkpoint_abort" as key instead of just "$action". 
* I also added another function that adds a restart action script to mom config file. This will be used in a coming PTL test case. 


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

<img width="1652" alt="Screen Shot 2020-04-14 at 4 34 47 PM" src="https://user-images.githubusercontent.com/6920446/79204030-802a9c80-7e6e-11ea-8c37-c234618d3877.png">
<img width="685" alt="Screen Shot 2020-04-14 at 4 35 21 PM" src="https://user-images.githubusercontent.com/6920446/79204056-89b40480-7e6e-11ea-9f99-0368791fdd05.png">

These two tests are also failing on nightly build of master branch. 

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
