### PR TITLE
Fix reservation being altered even if rejected

### DIFF
--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1861,7 +1861,7 @@ class TestPbsResvAlter(TestFunctional):
         This test confirms that if a requested ralter fails due to the
         reservation having running jobs, the attributes are kept the same
         """
-        offset = 5
+        offset = 20
         dur = 20
         shift = 120
 

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1868,7 +1868,7 @@ class TestPbsResvAlter(TestFunctional):
         rid, start, end = self.submit_and_confirm_reservation(offset, dur)
 
         jid = self.submit_job_to_resv(rid, user=TEST_USER)
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid, offset=offset)
 
         now = int(time.time())
         new_start = self.bu.convert_seconds_to_datetime(now + shift)


### PR DESCRIPTION
#### Describe Bug or Feature
Reservations were still being altered after being rejected.

#### Describe Your Change
req_modifyReservation would set the start and end times of a reservation, but would not reset them if the function returned early. 


#### Attach Test and Valgrind Logs/Output
[after-fix.txt](https://github.com/PBSPro/pbspro/files/4459188/after-fix.txt)
[before-fix.txt](https://github.com/PBSPro/pbspro/files/4459189/before-fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
