### PR TITLE
Fixing two test cases of TestSuspendResumeAccounting

### DIFF
--- a/test/tests/functional/pbs_suspend_resume_accounting.py
+++ b/test/tests/functional/pbs_suspend_resume_accounting.py
@@ -220,13 +220,9 @@ class TestSuspendResumeAccounting(TestFunctional):
         # check for both ncpus and mem are released
         resc_released = 'resources_released=(%s:ncpus=1:mem=524288kb)'
 
-        if self.mom.is_cpuset_mom():
-            node = self.server.status(JOB, 'exec_vnode',
-                                      id=jid)[0]['exec_vnode']
-            vn = node.split('+')[0].split(':')[0].split('(')[1]
-            resc_released = resc_released % vn
-        else:
-            resc_released = resc_released % self.server.shortname
+        node = self.server.status(JOB, 'exec_vnode', id=jid)[0]['exec_vnode']
+        vn = node.split('+')[0].split(':')[0].split('(')[1]
+        resc_released = resc_released % vn
         record = 'z;%s;resources_used.' % jid
         line = self.server.accounting_match(msg=record, id=jid)[1]
         self.assertIn(resc_released, line)

--- a/test/tests/functional/pbs_suspend_resume_accounting.py
+++ b/test/tests/functional/pbs_suspend_resume_accounting.py
@@ -219,8 +219,12 @@ class TestSuspendResumeAccounting(TestFunctional):
 
         # check for both ncpus and mem are released
         resc_released = 'resources_released=(%s:ncpus=1:mem=524288kb)'
+
         if self.mom.is_cpuset_mom():
-            resc_released = resc_released % self.server.status(NODE)[1]['id']
+            node = self.server.status(JOB, 'exec_vnode',
+                                      id=jid)[0]['exec_vnode']
+            vn = node.split('+')[0].split(':')[0].split('(')[1]
+            resc_released = resc_released % vn
         else:
             resc_released = resc_released % self.server.shortname
         record = 'z;%s;resources_used.' % jid

--- a/test/tests/functional/pbs_suspend_resume_accounting.py
+++ b/test/tests/functional/pbs_suspend_resume_accounting.py
@@ -178,14 +178,11 @@ class TestSuspendResumeAccounting(TestFunctional):
         record = 'r;%s;' % jid1
         self.server.accounting_match(msg=record, id=jid1)
 
-    @skipOnCpuSet
     def test_admin_suspend_resume_signal(self):
         """
         Test case to verify accounting of admin-suspend
         and admin-resume records.
         """
-        a = {ATTR_rescavail + '.ncpus': 2}
-        self.server.create_vnodes('vn', a, 1, self.mom)
         j = Job()
         j.create_script(self.script)
         jid = self.server.submit(j)
@@ -193,14 +190,12 @@ class TestSuspendResumeAccounting(TestFunctional):
 
         self.server.sigjob(jid, 'admin-suspend', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'S'}, id=jid)
-        self.server.expect(NODE, {'state': 'maintenance'}, id='vn[0]')
 
         record = 'z;%s;.*resources_used.' % jid
         self.server.accounting_match(msg=record, id=jid, regexp=True)
 
         self.server.sigjob(jid, 'admin-resume', runas=ROOT_USER)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.server.expect(NODE, {'state': 'free'}, id='vn[0]')
 
         record = 'r;%s;' % jid
         self.server.accounting_match(msg=record, id=jid)


### PR DESCRIPTION
#### Describe Bug or Feature
Testcases `test_admin_suspend_resume_signal` and `test_resc_released_susp_resume` was failing on specific platforms.

#### Describe Your Change
1. For `test_admin_suspend_resume_signal`, the intent of the test case is to check for the suspend and resume event accounting logs, so removing the check for state of the node. 
2. For `test_resc_released_susp_resume`, get the exec_vnode attribute from the job and search for the same in the accounting string. 

#### Attach Test Logs/Output
[test_logs.txt](https://github.com/PBSPro/pbspro/files/4469414/test_logs.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
