### PR TITLE
PTL: Add mom states in MoM.isUp method

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13135,7 +13135,7 @@ class MoM(PBSService):
             try:
                 nodes = self.server.status(NODE, id=self.shortname)
                 if nodes:
-                    attr = {'state': (MATCH_RE, 'free|provisioning')}
+                    attr = {'state': (MATCH_RE, 'free|provisioning|offline|job-busy')}
                     self.server.expect(NODE, attr, id=self.shortname)
             # Ignore PbsStatusError if mom daemon is up but there aren't
             # any mom nodes
@@ -15009,3 +15009,5 @@ class PBSInitServices(object):
             self.du.run_cmd(hostname, ['ln', '-s', newver, dflt],
                             sudo=True, logerr=False)
             self.start(hostname)
+
+

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13135,7 +13135,8 @@ class MoM(PBSService):
             try:
                 nodes = self.server.status(NODE, id=self.shortname)
                 if nodes:
-                    attr = {'state': (MATCH_RE, 'free|provisioning|offline|job-busy')}
+                    attr = {'state': (MATCH_RE,
+                                      'free|provisioning|offline|job-busy')}
                     self.server.expect(NODE, attr, id=self.shortname)
             # Ignore PbsStatusError if mom daemon is up but there aren't
             # any mom nodes
@@ -15009,5 +15010,3 @@ class PBSInitServices(object):
             self.du.run_cmd(hostname, ['ln', '-s', newver, dflt],
                             sudo=True, logerr=False)
             self.start(hostname)
-
-


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In PTL the isUp method of MoM class supports only few states like free, provisioning. So when tests are written to restart mom when the mom is in the states like "offline" or "Job-Busy" this method fails. 


#### Describe Your Change
The fix is to check for other states like offline and job-busy in the MoM.isUp() method as well. 


#### Test_logs:
[test_isUp.txt](https://github.com/PBSPro/pbspro/files/4473014/test_isUp.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
