### PR TITLE
Test 'test_prologue_hook_does_not_execute_twice_on_pbsdsh' of TestPbsExecutePrologue is failing while verifying job's output content

### DIFF
--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -249,7 +249,7 @@ class TestPbsExecutePrologue(TestFunctional):
         j = Job(TEST_USER, {'Resource_List.select': '2:ncpus=1',
                             'Resource_List.place': 'scatter'})
         pbsdsh_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
-                                                       "bin", "pbsdsh")
+                                   "bin", "pbsdsh")
         j.create_script('#!/bin/sh\n%s  hostname\nsleep 10\n' % pbsdsh_path)
         jid = self.server.submit(j)
         attribs = self.server.status(JOB, id=jid)

--- a/test/tests/functional/pbs_hook_execjob_prologue.py
+++ b/test/tests/functional/pbs_hook_execjob_prologue.py
@@ -248,7 +248,9 @@ class TestPbsExecutePrologue(TestFunctional):
 
         j = Job(TEST_USER, {'Resource_List.select': '2:ncpus=1',
                             'Resource_List.place': 'scatter'})
-        j.create_script('#!/bin/sh\npbsdsh  hostname\nsleep 10\n')
+        pbsdsh_path = os.path.join(self.server.pbs_conf['PBS_EXEC'],
+                                                       "bin", "pbsdsh")
+        j.create_script('#!/bin/sh\n%s  hostname\nsleep 10\n' % pbsdsh_path)
         jid = self.server.submit(j)
         attribs = self.server.status(JOB, id=jid)
         self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=10)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature

- Test 'test_prologue_hook_does_not_execute_twice_on_pbsdsh' of TestPbsExecutePrologue is failing while verifying job's output content

#### Describe Your Change

- The job script with which job is submitted doesn't have pbsdsh path (exported/set) which is why the job 's output file doesn't have expected contents in it.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output

- [Execution_logs_TestExecjobPrologue_bfr_fix.txt](https://github.com/PBSPro/pbspro/files/4474269/Execution_logs_TestExecjobPrologue_bfr_fix.txt)

- [Execution_logs_TestPbsExecutePrologue_after_fix.txt](https://github.com/PBSPro/pbspro/files/4474270/Execution_logs_TestPbsExecutePrologue_after_fix.txt)
<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
