### PR TITLE
Remove PBS_ENCRYPT_MODE config key and few other auth related fixes

### DIFF
--- a/src/include/batch_request.h
+++ b/src/include/batch_request.h
@@ -200,7 +200,6 @@ struct rq_register {
 struct rq_auth {
 	char rq_auth_method[MAXAUTHNAME + 1];
 	char rq_encrypt_method[MAXAUTHNAME + 1];
-	unsigned int rq_encrypt_mode;
 	unsigned int rq_port;
 };
 

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -200,7 +200,6 @@ struct pbs_config
 	unsigned start_comm:1; 		/* should the comm daemon be started */
 	unsigned locallog:1;			/* do local logging */
 	char **supported_auth_methods;		/* supported auth methods on server */
-	unsigned int encrypt_mode;		/* which communication to encrypt/decrypt */
 	char encrypt_method[MAXAUTHNAME + 1];	/* auth method to used for encrypt/decrypt data */
 	char auth_method[MAXAUTHNAME + 1];	/* default auth_method to used by client */
 	unsigned int sched_modify_event:1;	/* whether to trigger modifyjob hook event or not */
@@ -306,7 +305,6 @@ extern struct pbs_config pbs_conf;
 #define PBS_CONF_TMPDIR		"PBS_TMPDIR"     /* temporary file directory */
 #define PBS_CONF_AUTH		"PBS_AUTH_METHOD"
 #define PBS_CONF_ENCRYPT_METHOD	"PBS_ENCRYPT_METHOD"
-#define PBS_CONF_ENCRYPT_MODE	"PBS_ENCRYPT_MODE"
 #define PBS_CONF_SUPPORTED_AUTH_METHODS	"PBS_SUPPORTED_AUTH_METHODS"
 #define PBS_CONF_SCHEDULER_MODIFY_EVENT	"PBS_SCHEDULER_MODIFY_EVENT"
 #define PBS_CONF_MOM_NODE_NAME	"PBS_MOM_NODE_NAME"

--- a/src/lib/Libauth/README.md
+++ b/src/lib/Libauth/README.md
@@ -23,9 +23,6 @@
 			/* Name of encryption method (aka same value as PBS_ENCRYPT_METHOD in pbs.conf). This must be a null-terminated string. */
 			char *encrypt_method;
 
-			/* Encryption mode (aka same value as PBS_ENCRYPT_MODE in pbs.conf) */
-			int encrypt_mode;
-
 			/*
 			 * Function pointer to the logging method with the same signature as log_event from Liblog.
 			 * With this, the user of the authentication library can redirect logs from the authentication

--- a/src/lib/Libifl/auth.c
+++ b/src/lib/Libifl/auth.c
@@ -53,7 +53,7 @@
 #include "auth.h"
 #include "log.h"
 
-static auth_def_t **auths = NULL;
+static auth_def_t *loaded_auths = NULL;
 
 static int _invoke_pbs_iff(int psock, char *server_name, int server_port, char *ebuf, size_t ebufsz);
 static int _handle_client_handshake(int fd, char *hostname, char *method, int for_encrypt, pbs_auth_config_t *config, char *ebuf, size_t ebufsz);
@@ -242,18 +242,25 @@ _unload_auth(auth_def_t *auth)
 auth_def_t *
 get_auth(char *method)
 {
-	int i = 0;
+	auth_def_t *auth = loaded_auths;
 
-	if (auths == NULL)
-		return NULL;
-
-	while (auths[i] != NULL) {
-		if (strcmp(auths[i]->name, method) == 0)
-			return auths[i];
-		i++;
+	while (auth != NULL) {
+		if (strcmp(auth->name, method) == 0)
+			return auth;
+		auth = auth->next;
 	}
 
-	return NULL;
+	/*
+	 * At this point, given method is allowed
+	 * but it's authdef is not loaded
+	 * so lets try to load it
+	 */
+	auth = _load_auth(method);
+	if (auth == NULL)
+		return NULL;
+	auth->next = loaded_auths;
+	loaded_auths = auth;
+	return auth;
 }
 
 /**
@@ -269,44 +276,29 @@ get_auth(char *method)
 int
 load_auths(int mode)
 {
-	int i = 0;
-	int count = 0;
-
-	if (auths != NULL)
+	if (loaded_auths != NULL)
 		return 0;
 
-	if (pbs_conf.supported_auth_methods != NULL && mode == AUTH_SERVER) {
-		i = 0;
-		while (pbs_conf.supported_auth_methods[i++] != NULL) count++;
-	} else {
-		/* for auth and encrypt methods */
-		count = 2;
-	}
-
-	auths = (auth_def_t **)calloc(1, sizeof(auth_def_t *) * (count + 1)); /* +1 for last NULL */
-	if (auths == NULL)
-		return 1;
-
-	count = 0;
 	if (strcmp(pbs_conf.auth_method, AUTH_RESVPORT_NAME) != 0) {
 		auth_def_t *auth = _load_auth(pbs_conf.auth_method);
 		if (auth == NULL) {
 			return 1;
 		}
-		auths[count++] = auth;
+		loaded_auths = auth;
 	}
 
-	if (pbs_conf.encrypt_mode != ENCRYPT_DISABLE && strcmp(pbs_conf.auth_method, pbs_conf.encrypt_method) != 0) {
+	if (pbs_conf.encrypt_method[0] != '\0' && strcmp(pbs_conf.auth_method, pbs_conf.encrypt_method) != 0) {
 		auth_def_t *auth = _load_auth(pbs_conf.encrypt_method);
 		if (auth == NULL) {
 			unload_auths();
 			return 1;
 		}
-		auths[count++] = auth;
+		auth->next = loaded_auths;
+		loaded_auths = auth;
 	}
 
-	if (pbs_conf.supported_auth_methods != NULL && mode == AUTH_SERVER) {
-		i = 0;
+	if (mode == AUTH_SERVER) {
+		int i = 0;
 		while (pbs_conf.supported_auth_methods[i] != NULL) {
 			auth_def_t *auth = NULL;
 			if (strcmp(pbs_conf.supported_auth_methods[i], AUTH_RESVPORT_NAME) == 0) {
@@ -322,7 +314,8 @@ load_auths(int mode)
 				unload_auths();
 				return 1;
 			}
-			auths[count++] = auth;
+			auth->next = loaded_auths;
+			loaded_auths = auth;
 			i++;
 		}
 	}
@@ -339,17 +332,14 @@ load_auths(int mode)
 void
 unload_auths(void)
 {
-	int i = 0;
-
-	if (auths == NULL)
+	if (loaded_auths == NULL)
 		return;
 
-	while (auths[i] != NULL) {
-		_unload_auth(auths[i]);
-		auths[i] = NULL;
+	while (loaded_auths != NULL) {
+		auth_def_t *cur = loaded_auths;
+		loaded_auths = loaded_auths->next;
+		_unload_auth(cur);
 	}
-	free(auths);
-	auths = NULL;
 }
 
 /**
@@ -394,31 +384,23 @@ tcp_send_auth_req(int sock, unsigned int port, char *user)
 	int am_len = strlen(pbs_conf.auth_method);
 	int em_len = strlen(pbs_conf.encrypt_method);
 
-	if (pbs_conf.encrypt_mode != ENCRYPT_DISABLE && em_len == 0) {
-		pbs_errno = PBSE_SYSTEM;
-		return -1;
-	}
-
 	set_conn_errno(sock, 0);
 	set_conn_errtxt(sock, NULL);
 
 	if (encode_DIS_ReqHdr(sock, PBS_BATCH_Authenticate, user) ||
 		diswui(sock, am_len) || /* auth method length */
 		diswcs(sock, pbs_conf.auth_method, am_len) || /* auth method */
-		diswui(sock, pbs_conf.encrypt_mode)) { /* encrypt mode */
+		diswui(sock, em_len)) { /* encrypt method length */
 		pbs_errno = PBSE_SYSTEM;
 		return -1;
 	}
 
-	if (pbs_conf.encrypt_mode != ENCRYPT_DISABLE) {
-		if (diswui(sock, em_len) || /* encrypt method length */
-			diswcs(sock, pbs_conf.encrypt_method, em_len)) { /* encrypt method */
-			pbs_errno = PBSE_SYSTEM;
-			return -1;
-		}
+	if (em_len > 0 && diswcs(sock, pbs_conf.encrypt_method, em_len)) { /* encrypt method */
+		pbs_errno = PBSE_SYSTEM;
+		return -1;
 	}
 
-	if (diswui(sock, port) || /* port (only used in resvport auth) */
+	if (diswui(sock, port) ||  /* port (only used in resvport auth) */
 		encode_DIS_ReqExtend(sock, NULL)) {
 		pbs_errno = PBSE_SYSTEM;
 		return -1;
@@ -705,7 +687,6 @@ free_auth_config(pbs_auth_config_t *config)
  *
  * @param[in] auth_method - auth method name
  * @param[in] encrypt_method - encrypt method name
- * @param[in] encrypt_mode - encrypt mode
  * @param[in] logger - pointer to logger function for auth lib
  *
  * @return	pbs_auth_config_t *
@@ -714,7 +695,7 @@ free_auth_config(pbs_auth_config_t *config)
  *
  */
 pbs_auth_config_t *
-make_auth_config(char *auth_method, char *encrypt_method, int encrypt_mode, void *logger)
+make_auth_config(char *auth_method, char *encrypt_method, void *logger)
 {
 	pbs_auth_config_t *config = NULL;
 
@@ -744,7 +725,6 @@ make_auth_config(char *auth_method, char *encrypt_method, int encrypt_mode, void
 		return NULL;
 	}
 	config->logfunc = logger;
-	config->encrypt_mode = encrypt_mode;
 	return config;
 }
 
@@ -766,7 +746,7 @@ int
 engage_client_auth(int fd, char *hostname, int port, char *ebuf, size_t ebufsz)
 {
 	int rc = -1;
-	pbs_auth_config_t *config = make_auth_config(pbs_conf.auth_method, pbs_conf.encrypt_method, pbs_conf.encrypt_mode, NULL);
+	pbs_auth_config_t *config = make_auth_config(pbs_conf.auth_method, pbs_conf.encrypt_method, NULL);
 
 	if (config == NULL) {
 		snprintf(ebuf, ebufsz, "Out of memory in %s!", __func__);
@@ -801,8 +781,8 @@ engage_client_auth(int fd, char *hostname, int port, char *ebuf, size_t ebufsz)
 		}
 	}
 
-	if (pbs_conf.encrypt_mode != ENCRYPT_DISABLE) {
-		if (pbs_conf.encrypt_method[0] != '\0' && strcmp(pbs_conf.auth_method, pbs_conf.encrypt_method) != 0) {
+	if (pbs_conf.encrypt_method[0] != '\0') {
+		if (strcmp(pbs_conf.auth_method, pbs_conf.encrypt_method) != 0) {
 			rc = _handle_client_handshake(fd, hostname, pbs_conf.encrypt_method, FOR_ENCRYPT, config, ebuf, ebufsz);
 			free_auth_config(config);
 			return rc;

--- a/src/lib/Libifl/auth.c
+++ b/src/lib/Libifl/auth.c
@@ -242,12 +242,11 @@ _unload_auth(auth_def_t *auth)
 auth_def_t *
 get_auth(char *method)
 {
-	auth_def_t *auth = loaded_auths;
+	auth_def_t *auth = NULL;
 
-	while (auth != NULL) {
+	for (auth = loaded_auths; auth != NULL; auth = auth->next) {
 		if (strcmp(auth->name, method) == 0)
 			return auth;
-		auth = auth->next;
 	}
 
 	/*
@@ -332,9 +331,6 @@ load_auths(int mode)
 void
 unload_auths(void)
 {
-	if (loaded_auths == NULL)
-		return;
-
 	while (loaded_auths != NULL) {
 		auth_def_t *cur = loaded_auths;
 		loaded_auths = loaded_auths->next;

--- a/src/lib/Libifl/dec_Authen.c
+++ b/src/lib/Libifl/dec_Authen.c
@@ -77,7 +77,7 @@ decode_DIS_Authenticate(int sock, struct batch_request *preq)
 	int rc;
 	int len = 0;
 
-
+	memset(preq->rq_ind.rq_auth.rq_auth_method, '\0', sizeof(preq->rq_ind.rq_auth.rq_auth_method));
 	len = disrsi(sock, &rc);
 	if (rc != DIS_SUCCESS)
 		return (rc);
@@ -87,25 +87,15 @@ decode_DIS_Authenticate(int sock, struct batch_request *preq)
 	rc = disrfst(sock, len, preq->rq_ind.rq_auth.rq_auth_method);
 	if (rc != DIS_SUCCESS)
 		return (rc);
-	preq->rq_ind.rq_auth.rq_auth_method[MAXAUTHNAME] = '\0';
 
-	preq->rq_ind.rq_auth.rq_encrypt_mode = disrui(sock, &rc);
+	memset(preq->rq_ind.rq_auth.rq_encrypt_method, '\0', sizeof(preq->rq_ind.rq_auth.rq_encrypt_method));
+	len = disrsi(sock, &rc);
 	if (rc != DIS_SUCCESS)
 		return (rc);
-
-	if (preq->rq_ind.rq_auth.rq_encrypt_mode != ENCRYPT_DISABLE) {
-		len = disrsi(sock, &rc);
-		if (rc != DIS_SUCCESS)
-			return (rc);
-		if (len <= 0) {
-			return DIS_PROTO;
-		}
+	if (len > 0) {
 		rc = disrfst(sock, len, preq->rq_ind.rq_auth.rq_encrypt_method);
 		if (rc != DIS_SUCCESS)
 			return (rc);
-		preq->rq_ind.rq_auth.rq_encrypt_method[MAXAUTHNAME] = '\0';
-	} else {
-		preq->rq_ind.rq_auth.rq_encrypt_method[0] = '\0';
 	}
 
 	preq->rq_ind.rq_auth.rq_port = disrui(sock, &rc);

--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -653,7 +653,7 @@ leaf_post_connect_handler(int tfd, void *data, void *c, void *extra)
 			return 0;
 	}
 
-	if (tpp_conf->auth_config->encrypt_mode == ENCRYPT_ALL) {
+	if (tpp_conf->auth_config->encrypt_method[0] != '\0') {
 		if (strcmp(tpp_conf->auth_config->auth_method, tpp_conf->auth_config->encrypt_method) != 0) {
 			void *data_out = NULL;
 			size_t len_out = 0;
@@ -4546,7 +4546,7 @@ leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra)
 		if (is_handshake_done != 1)
 			return 0;
 
-		if (tpp_conf->auth_config->encrypt_mode == ENCRYPT_ALL && ahdr.for_encrypt == FOR_AUTH) {
+		if (tpp_conf->auth_config->encrypt_method[0] != '\0' && ahdr.for_encrypt == FOR_AUTH) {
 			if (strcmp(tpp_conf->auth_config->auth_method, tpp_conf->auth_config->encrypt_method) != 0) {
 				authdata = NULL;
 				authdef = get_auth(tpp_conf->auth_config->encrypt_method);

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -621,7 +621,7 @@ router_post_connect_handler(int tfd, void *data, void *c, void *extra)
 		}
 	}
 
-	if (tpp_conf->auth_config->encrypt_mode == ENCRYPT_ALL) {
+	if (tpp_conf->auth_config->encrypt_method[0] != '\0') {
 		if (strcmp(tpp_conf->auth_config->auth_method, tpp_conf->auth_config->encrypt_method) != 0) {
 			void *data_out = NULL;
 			size_t len_out = 0;
@@ -1416,7 +1416,7 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 		if (is_handshake_done != 1)
 			return 0;
 
-		if (tpp_conf->auth_config->encrypt_mode == ENCRYPT_ALL &&
+		if (tpp_conf->auth_config->encrypt_method[0] != '\0' &&
 			ahdr.for_encrypt == FOR_AUTH &&
 			(ctx != NULL && ((tpp_router_t *)ctx)->initiator == 1) &&
 			strcmp(tpp_conf->auth_config->auth_method, tpp_conf->auth_config->encrypt_method) != 0) {
@@ -1492,7 +1492,7 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 			ctx->type = TPP_AUTH_NODE; /* denoting that this is an authenticated connection */
 		}
 
-		if (tpp_conf->auth_config->encrypt_mode == ENCRYPT_ALL && strcmp(tpp_conf->auth_config->auth_method, tpp_conf->auth_config->encrypt_method) == 0) {
+		if (tpp_conf->auth_config->encrypt_method[0] != '\0' && strcmp(tpp_conf->auth_config->auth_method, tpp_conf->auth_config->encrypt_method) == 0) {
 			authdata->encryptctx = authdata->authctx;
 			authdata->encryptdef = authdata->authdef;
 			tpp_transport_set_conn_extra(tfd, authdata);

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -338,7 +338,7 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 	tpp_conf->node_type = TPP_LEAF_NODE;
 	tpp_conf->numthreads = 1;
 
-	tpp_conf->auth_config = make_auth_config(pbs_conf->auth_method, pbs_conf->encrypt_method, pbs_conf->encrypt_mode, (void *)tpp_auth_logger);
+	tpp_conf->auth_config = make_auth_config(pbs_conf->auth_method, pbs_conf->encrypt_method, (void *)tpp_auth_logger);
 	if (tpp_conf->auth_config == NULL) {
 		tpp_log_func(LOG_CRIT, __func__, "Out of memory allocating auth config");
 		return -1;
@@ -346,9 +346,7 @@ set_tpp_config(void (*log_fn)(int, const char *, char *), struct pbs_config *pbs
 
 	snprintf(log_buffer, TPP_LOGBUF_SZ, "TPP authentication method = %s", tpp_conf->auth_config->auth_method);
 	tpp_log_func(LOG_INFO, NULL, log_buffer);
-	if (tpp_conf->auth_config->encrypt_mode != ENCRYPT_DISABLE) {
-		snprintf(log_buffer, TPP_LOGBUF_SZ, "TPP encrypt mode = %d", tpp_conf->auth_config->encrypt_mode);
-		tpp_log_func(LOG_INFO, NULL, log_buffer);
+	if (tpp_conf->auth_config->encrypt_method[0] != '\0') {
 		snprintf(log_buffer, TPP_LOGBUF_SZ, "TPP encryption method = %s", tpp_conf->auth_config->encrypt_method);
 		tpp_log_func(LOG_INFO, NULL, log_buffer);
 	}

--- a/src/server/req_getcred.c
+++ b/src/server/req_getcred.c
@@ -129,14 +129,13 @@ req_authenResvPort(struct batch_request *preq)
 			if ((cp->cn_authen & (PBS_NET_CONN_AUTHENTICATED | PBS_NET_CONN_FROM_PRIVIL)) == 0) {
 				cp->cn_auth_config = make_auth_config(preq->rq_ind.rq_auth.rq_auth_method,
 									preq->rq_ind.rq_auth.rq_encrypt_method,
-									preq->rq_ind.rq_auth.rq_encrypt_mode,
 									(void *)log_event);
 				if (cp->cn_auth_config == NULL) {
 					req_reject(PBSE_SYSTEM, 0, preq);
 					return;
 				}
 
-				if (preq->rq_ind.rq_auth.rq_encrypt_mode != ENCRYPT_DISABLE) {
+				if (preq->rq_ind.rq_auth.rq_encrypt_method[0] != '\0') {
 					auth_def_t *encryptdef = get_auth(preq->rq_ind.rq_auth.rq_encrypt_method);
 					if (encryptdef == NULL || encryptdef->encrypt_data == NULL || encryptdef->decrypt_data == NULL) {
 						req_reject(PBSE_NOSUP, 0, preq);

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -311,7 +311,7 @@ contact_sched(int cmd, char *jobid, pbs_net_t pbs_scheduler_addr, unsigned int p
 		log_err(errno, __func__, "Out of memory!");
 		return (-1);
 	}
-	conn->cn_auth_config = make_auth_config(AUTH_RESVPORT_NAME, "", 0, (void *)log_event);
+	conn->cn_auth_config = make_auth_config(AUTH_RESVPORT_NAME, "", (void *)log_event);
 	if (conn->cn_auth_config == NULL) {
 		log_err(errno, __func__, "Out of memory!");
 		return -1;


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Recently we added new pbs.conf key called PBS_ENCRYPT_MODE, which specified which communication to encrypt and which one, but we don't need that key, because its client-side configuration, and when the client sets PBS_ENCRYPT_METHOD which implies that client wants to encrypt then there is no question of what to encrypt or not. Now if the client doesn't set PBS_ENCRYPT_METHOD that means the client doesn't want encryption, which means no question of what to encrypt or what not to. Means, PBS_ENCRYPT_MODE is useless since we PBS_ENCRYPT_METHOD key
* currently if PBS_SUPPORTED_AUTH_METHODS is configured, and if resvport is not listed in it still PBS allows resvport authentication, which it should as per design
* Currently we MUST have to list whatever PBS_ENCRYPT_METHOD client is using into either PBS_SUPPORTED_AUTH_METHODS or PBS_ENCRYPT_METHOD on server-side, even server doesn't want to use it.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Remove PBS_ENCRYPT_MODE
* Enforce PBS_SUPPORTED_AUTH_METHODS if configured
* Remove requirement listing encrypt_method in PBS_SUPPORTED_AUTH_METHODS or PBS_ENCRYPT_METHOD on server even server doesn't want to use encryption

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* [Here](https://pbspro.atlassian.net/wiki/spaces/PD/pages/1525776385/Allow+multiple+auth+methods+in+PBSPro)

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

![Screen Shot 2020-04-14 at 5 54 32 PM](https://user-images.githubusercontent.com/17191391/79224633-11067580-7e79-11ea-9939-011869327b67.png)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
