### PR TITLE
Fix for invalid read and write in munge handshake

### DIFF
--- a/src/lib/Libauth/munge/munge_supp.c
+++ b/src/lib/Libauth/munge/munge_supp.c
@@ -399,7 +399,7 @@ pbs_auth_process_handshake_data(void *ctx, void *data_in, size_t len_in, void **
 	if (len_in > 0) {
 		char *data = (char *)data_in;
 		/* enforce null char at given length of data */
-		data[len_in] = '\0';
+		data[len_in - 1] = '\0';
 		rc = munge_validate_auth_data(data, ebuf, sizeof(ebuf) - 1);
 		if (rc == 0) {
 			*is_handshake_done = 1;
@@ -412,7 +412,7 @@ pbs_auth_process_handshake_data(void *ctx, void *data_in, size_t len_in, void **
 	} else {
 		*data_out = (void *)munge_get_auth_data(ebuf, sizeof(ebuf) - 1);
 		if (*data_out) {
-			*len_out = strlen((char *)*data_out);
+			*len_out = strlen((char *)*data_out) + 1; /* +1 to include null char also in data_out */
 			*is_handshake_done = 1;
 			return 0;
 		} else if (ebuf[0] != '\0') {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Valgrind reports invalid read and write in munge handshake due to invalid length of data and missing null char in data while generating and validating handshake data

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Use correct length which includes null char also in handshake data


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[before.txt](https://github.com/PBSPro/pbspro/files/4479434/before.txt)
[after.txt](https://github.com/PBSPro/pbspro/files/4479432/after.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
