### PR TITLE
Scheduler runs jobs out of fairshare order after jobs are added to the calendar

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -869,6 +869,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 		comment[0] = '\0';
 		log_msg[0] = '\0';
 		qinfo = njob->job->queue;
+		sort_again = SORTED;
 
 		clear_schd_error(err);
 

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -945,10 +945,8 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 			int cal_rc;
 #ifdef NAS /* localmod 034 */
 			int bf_rc;
-			sort_again = SORTED;
 			if ((bf_rc = site_should_backfill_with_job(policy, sinfo, njob, num_topjobs, num_topjobs_per_queues, err)))
 #else
-			sort_again = SORTED;
 			if (should_backfill_with_job(policy, sinfo, njob, num_topjobs) != 0) {
 #endif
 				cal_rc = add_job_to_calendar(sd, policy, sinfo, njob, should_use_buckets);
@@ -975,6 +973,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 							break;
 					}
 #else
+					sort_again = MAY_RESORT_JOBS;
 					if (njob->job->is_preempted == 0 || sinfo->enforce_prmptd_job_resumption == 0) { /* preempted jobs don't increase top jobs count */
 						if (qinfo->backfill_depth == UNSPECIFIED)
 							num_topjobs++;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When fairshare is enabled and a job is added to the calendar, the entire usage of that job should be added to the user's usage for that cycle only.  This is to stop us from running more jobs from that user that will eventually kick the top job out of its slot.  We do add the usage, but we never resort the jobs.  This meant the political ordering was not changed due to the increase in usage.

#### Describe Your Change
Resort the jobs if a job is added to the calendar and fairshare is enabled.

#### Attach Test and Valgrind Logs/Output
[fairshare.log](https://github.com/PBSPro/pbspro/files/4494703/fairshare.log)
