### PR TITLE
Skip chdir for Shasta

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6051,7 +6051,7 @@ class Server(PBSService):
             self.logger.error(m)
             return None
 
-        if not submit_dir and self.du.get_platform() != 'shasta':
+        if not submit_dir:
             submit_dir = pwd.getpwnam(obj.username)[5]
 
         cwd = os.getcwd()

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6055,8 +6055,9 @@ class Server(PBSService):
             submit_dir = pwd.getpwnam(obj.username)[5]
 
         cwd = os.getcwd()
-        if submit_dir:
-            os.chdir(submit_dir)
+        if self.platform != 'shasta':
+            if submit_dir:
+                os.chdir(submit_dir)
         c = None
         # 1- Submission using the command line tools
         if self.get_op_mode() == PTL_CLI:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
os.chdir fails as the submit_dir is on a client machine on Shasta platform


#### Describe Your Change
If the platform is Shasta skip the chdir


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
