### PR TITLE
Fix preempt cull (fake non-consum. 'mismatch')

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -5255,6 +5255,16 @@ static int cull_preemptible_jobs(resource_resv *job, void *arg)
 				if (find_node_by_host(job->ninfo_arr, hreq->res_str) != NULL)
 					return 1;
 			} else {
+				if (inp->err->rdef->type.is_non_consumable) {
+				    /* non consumables are used for node selection so
+				     * comparing preemptor and candidate is not sufficient to cull;
+				     * nodes the candidate is using might have the correct tags 
+				     * even if the candidate did not request the non-consumable.
+				     * This will be checked in the node utility test in
+				     * select_index_to_preempt
+				     */
+				    return 1;
+				}
 				for (index = 0; job->select->chunks[index] != NULL; index++)
 				{
 					for (req_scan = job->select->chunks[index]->req; req_scan != NULL; req_scan = req_scan->next)

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -5256,13 +5256,13 @@ static int cull_preemptible_jobs(resource_resv *job, void *arg)
 					return 1;
 			} else {
 				if (inp->err->rdef->type.is_non_consumable) {
-				    /* In the non-consumable case, we need to pass the job on.
-				     * There is a case when a job requesting a non-specific 
-                     * select is allocated a node with a non-consumable.
-                     * We will check nodes to see if they are useful in 
-                     * select_index_to_preempt()
-				     */
-				    return 1;
+					/* In the non-consumable case, we need to pass the job on.
+					 * There is a case when a job requesting a non-specific 
+					 * select is allocated a node with a non-consumable.
+					 * We will check nodes to see if they are useful in 
+					 * select_index_to_preempt
+					 */
+					return 1;
 				}
 				for (index = 0; job->select->chunks[index] != NULL; index++)
 				{
@@ -5270,7 +5270,7 @@ static int cull_preemptible_jobs(resource_resv *job, void *arg)
 					{
 						if (req_scan->def == inp->err->rdef) {
 							if (req_scan->type.is_non_consumable ||
-							    req_scan->amount > 0) {
+								req_scan->amount > 0) {
 									return 1;
 							}
 						}

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -5256,12 +5256,11 @@ static int cull_preemptible_jobs(resource_resv *job, void *arg)
 					return 1;
 			} else {
 				if (inp->err->rdef->type.is_non_consumable) {
-				    /* non consumables are used for node selection so
-				     * comparing preemptor and candidate is not sufficient to cull;
-				     * nodes the candidate is using might have the correct tags 
-				     * even if the candidate did not request the non-consumable.
-				     * This will be checked in the node utility test in
-				     * select_index_to_preempt
+				    /* In the non-consumable case, we need to pass the job on.
+				     * There is a case when a job requesting a non-specific 
+                     * select is allocated a node with a non-consumable.
+                     * We will check nodes to see if they are useful in 
+                     * select_index_to_preempt()
 				     */
 				    return 1;
 				}

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -743,7 +743,7 @@ exit 3
         Deciding on their utility should be left to the check
         to see whether the nodes they occupy are useful.
         """
-        attr = {'type': string_array, 'flag' = 'h'}
+        attr = {'type': string_array, 'flag': 'h'}
 
         self.server.manager(MGR_CMD_CREATE, RSC, attr, id='app')
         self.scheduler.add_resource('app')

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -743,7 +743,7 @@ exit 3
         Deciding on their utility should be left to the check
         to see whether the nodes they occupy are useful.
         """
-        attr = {'type': string_array, 'flag': 'h'}
+        attr = {'type': 'string_array', 'flag': 'h'}
 
         self.server.manager(MGR_CMD_CREATE, RSC, attr, id='app')
         self.scheduler.add_resource('app')

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -631,7 +631,7 @@ exit 3
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
         msg = ";Preempting job will escalate its priority"
         for job_id in jid_list[0:-2]:
-                self.scheduler.log_match(job_id + msg)
+            self.scheduler.log_match(job_id + msg)
 
     @skipOnCpuSet
     def test_preemption_priority_escalation_2(self):
@@ -733,3 +733,64 @@ exit 3
 
         self.server.expect(JOB, {'job_state': 'R'}, id=hjid)
         self.server.expect(JOB, {'job_state=Q': 1})
+
+    def test_preempt_wrong_cull(self):
+        """
+        Test to make sure that if a preemptor cannot run because
+        it misses a non-consumable on a node, preemption candidates
+        are not incorrectly removed from consideration
+        if and because they "do not request the relevant resource".
+        Deciding on their utility should be left to the check
+        to see whether the nodes they occupy are useful.
+        """
+        attr = {}
+        attr['type'] = 'string_array'
+        attr['flag'] = 'h'
+
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id='app')
+        self.scheduler.add_resource('app')
+
+        a = {'resources_available.ncpus': 1, 'resources_available.app': 'appA'}
+        self.server.create_vnodes('vna', a, num=1, mom=self.mom,
+                                  usenatvnode=False)
+        b = {'resources_available.ncpus': 1, 'resources_available.app': 'appB'}
+        self.server.create_vnodes('vnb', b, num=1, mom=self.mom,
+                                  usenatvnode=False, additive=True)
+
+        # set the preempt_order to kill/requeue only -- try old and new syntax
+        try:
+            self.scheduler.set_sched_config({'preempt_order': 'R'})
+        except Exception:
+            pass
+        try:
+            self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'R'})
+        except Exception:
+            pass
+
+        # create express queue
+        a = {'queue_type': 'execution',
+             'started': 'True',
+             'enabled': 'True',
+             'Priority': 200}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, "hipri")
+
+        # create normal queue
+        a = {'queue_type': 'execution',
+             'started': 'True',
+             'enabled': 'True',
+             'Priority': 1}
+        self.server.manager(MGR_CMD_CREATE, QUEUE, a, "lopri")
+
+        # submit job 1
+        a = {'Resource_List.select': '1:ncpus=1:vnode=vna[0]', ATTR_q: 'lopri'}
+        j1 = Job(TEST_USER, attrs=a)
+        jid1 = self.server.submit(j1)
+
+        self.server.expect(JOB, {'substate': '42'}, id=jid1)
+
+        # submit job 2
+        a = {'Resource_List.select': '1:ncpus=1:app=appA', ATTR_q: 'hipri'}
+        j2 = Job(TEST_USER, attrs=a)
+        jid2 = self.server.submit(j2)
+
+        self.server.expect(JOB, {'substate': 42}, id=jid2)

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -758,14 +758,7 @@ exit 3
                                   usenatvnode=False, additive=True)
 
         # set the preempt_order to kill/requeue only -- try old and new syntax
-        try:
-            self.scheduler.set_sched_config({'preempt_order': 'R'})
-        except Exception:
-            pass
-        try:
-            self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'R'})
-        except Exception:
-            pass
+        self.server.manager(MGR_CMD_SET, SCHED, {'preempt_order': 'R'})
 
         # create express queue
         a = {'queue_type': 'execution',

--- a/test/tests/functional/pbs_preemption.py
+++ b/test/tests/functional/pbs_preemption.py
@@ -743,9 +743,7 @@ exit 3
         Deciding on their utility should be left to the check
         to see whether the nodes they occupy are useful.
         """
-        attr = {}
-        attr['type'] = 'string_array'
-        attr['flag'] = 'h'
+        attr = {'type': string_array, 'flag' = 'h'}
 
         self.server.manager(MGR_CMD_CREATE, RSC, attr, id='app')
         self.scheduler.add_resource('app')
@@ -779,11 +777,11 @@ exit 3
         j1 = Job(TEST_USER, attrs=a)
         jid1 = self.server.submit(j1)
 
-        self.server.expect(JOB, {'substate': '42'}, id=jid1)
+        self.server.expect(JOB, {'state': 'R'}, id=jid1)
 
         # submit job 2
         a = {'Resource_List.select': '1:ncpus=1:app=appA', ATTR_q: 'hipri'}
         j2 = Job(TEST_USER, attrs=a)
         jid2 = self.server.submit(j2)
 
-        self.server.expect(JOB, {'substate': 42}, id=jid2)
+        self.server.expect(JOB, {'state': 'R'}, id=jid2)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The function to cull the list of preemption candidates does the wrong thing for non-consumable resources.

Suppose that we have a cluster with two nodes with 40 cpus.

node A has resources_available.platform=a, the other, node B, resources_available.platform=b.

We run a job 1 that asks for -lselect=1:ncpus=40 in a low priority queue. Since it doesn't ask for a specific platform at all, suppose it ends up on node A.

The second job 2 asks for -lselect=1:ncpus=40:platform=a, in an express queue.

If we did not cull the preemption candidate list, then 1 would be stripped in simulation and 2 would run.

With the culling in place in the current code, 2 won't run, since 1 will be discarded as a candidate because inp->err is INSUFFICIENT_RESOURCE and the rdef is for the "platform" resource, nowhere to be found in the chunks of 1, which incorrectly makes the culling function decide that 1 "is not useful". It is, but because of the nodes it is running on (the node utility check is done in select_index_to_preempt, but only for preemption candidates that were not culled earlier).

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
For a job that does not run because of INSUFFICIENT_RESOURCE on a non-consumable resource, do not cull early, and let the select_index_to_preempt routine do the node utility check to see if the nodes of the candidate are useful for chunks of the preemptor.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

PTL test not written since developer machine in unsuitable to run PTL tests. Demonstration on a small (separate) test cluster included -- this could be used to make a PTL test.

Code changes backported to 19.2.6 and tested separately on this cluster, and they confirmed that the bug is gone.

```
# qmgr -c "p s"
--
#
# Create resources and set their properties.
#
#
# Create and define resource application
#
create resource application
set resource application type = string
set resource application flag = h
#
# Create and define resource platform
#
create resource platform
set resource platform type = string_array
set resource platform flag = h
#
# Create queues and set their attributes.
#
#
# Create and define queue workq
#
create queue workq
set queue workq queue_type = Execution
set queue workq Priority = 100
set queue workq enabled = True
set queue workq started = True
#
# Create and define queue expressq1
#
create queue expressq1
set queue expressq1 queue_type = Execution
set queue expressq1 Priority = 150
set queue expressq1 enabled = True
set queue expressq1 started = True
#
# Create and define queue expressq2
#
create queue expressq2
set queue expressq2 queue_type = Execution
set queue expressq2 Priority = 150
set queue expressq2 enabled = True
set queue expressq2 started = True
#
# Set server attributes.
#
set server scheduling = True
set server default_queue = workq
set server log_events = 511
set server mail_from = adm
set server query_other_jobs = True
set server resources_default.ncpus = 1
set server default_chunk.ncpus = 1
set server scheduler_iteration = 600
set server resv_enable = True
set server node_fail_requeue = 310
set server max_array_size = 10000
set server pbs_license_info = /opt/altair_1.lic
set server eligible_time_enable = False
set server max_concurrent_provision = 5
set server max_job_sequence_id = 9999999
 
# pbsnodes -av
pbshost1
Mom = pbshost1
Port = 15002
pbs_version = 19.2.6.20200311140837
ntype = PBS
state = free
pcpus = 4
resources_available.arch = linux
resources_available.host = pbshost1
resources_available.mem = 0b
resources_available.ncpus = 0
resources_available.vnode = pbshost1
resources_assigned.accelerator_memory = 0kb
resources_assigned.hbmem = 0kb
resources_assigned.mem = 0kb
resources_assigned.naccelerators = 0
resources_assigned.ncpus = 0
resources_assigned.vmem = 0kb
resv_enable = True
sharing = default_shared
in_multivnode_host = 1
license = l
last_state_change_time = Thu Apr 16 00:25:53 2020
 
pbshost1[0]
Mom = pbshost1
Port = 15002
pbs_version = 19.2.6.20200311140837
ntype = PBS
state = free
pcpus = 2
resources_available.application = app1
resources_available.arch = linux
resources_available.host = pbshost1
resources_available.mem = 2gb
resources_available.ncpus = 2
resources_available.platform = a,universal
resources_available.vnode = pbshost1[0]
resources_assigned.accelerator_memory = 0kb
resources_assigned.hbmem = 0kb
resources_assigned.mem = 0kb
resources_assigned.naccelerators = 0
resources_assigned.ncpus = 0
resources_assigned.vmem = 0kb
resv_enable = True
sharing = default_shared
in_multivnode_host = 1
license = l
last_state_change_time = Thu Apr 16 04:23:26 2020
last_used_time = Thu Apr 16 04:23:26 2020
 
pbshost1[1]
Mom = pbshost1
Port = 15002
pbs_version = 19.2.6.20200311140837
ntype = PBS
state = free
pcpus = 2
resources_available.application = app2
resources_available.arch = linux
resources_available.host = pbshost1
resources_available.mem = 2gb
resources_available.ncpus = 2
resources_available.platform = b,universal
resources_available.vnode = pbshost1[1]
resources_assigned.accelerator_memory = 0kb
resources_assigned.hbmem = 0kb
resources_assigned.mem = 0kb
resources_assigned.naccelerators = 0
resources_assigned.ncpus = 0
resources_assigned.vmem = 0kb
resv_enable = True
sharing = default_shared
in_multivnode_host = 1
license = l
last_state_change_time = Thu Apr 16 04:11:29 2020
last_used_time = Thu Apr 16 04:11:29 2020
 
# su - test1
Last login: Thu Apr 16 04:21:30 EDT 2020 on pts/1
[test1@pbshost1 ~]$ qsub -l select=1:ncpus=2:application=app1 -q workq -- /bin/sleep 2000
79.pbshost1
 
[test1@pbshost1 ~]$ qstat -aw
pbshost1:
Req'd  Req'd   Elap
Job ID                         Username        Queue           Jobname         SessID   NDS  TSK   Memory Time  S Time
------------------------------ --------------- --------------- --------------- -------- ---- ----- ------ ----- - -----
79.pbshost1                    test1           workq           STDIN              44128    1     2    --    --  R 00:00:00
 
[test1@pbshost1 ~]$ qsub -l select=1:ncpus=2:application=app1:platform=a -q expressq1 -- /bin/sleep 2000
80.pbshost1
 
[test1@pbshost1 ~]$ sleep 20; qstat -aw
pbshost1:
Req'd  Req'd   Elap
Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
--------------- -------- -------- ---------- ------ --- --- ------ ----- - -----
79.pbshost1     test1    workq    STDIN       44128   1   2    --    --  R 00:00 pbshost1/0*2
Job run at Thu Apr 16 at 04:24 on (pbshost1[0]:ncpus=2)
80.pbshost1     test1    expressq STDIN         --    1   2    --    --  Q   --   --
Not Running: Insufficient amount of resource: platform
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
