### PR TITLE
Fixed race conditions in TestPbsResvAlter.test_alter_standing_resv_end_time_after_run

### DIFF
--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -822,7 +822,7 @@ class TestPbsResvAlter(TestFunctional):
         duration = 20
         shift = 10
         offset = 10
-        sleep = 25
+        sleep = 30
         rid, start, end = self.submit_and_confirm_reservation(offset, duration,
                                                               standing=True)
 
@@ -836,7 +836,7 @@ class TestPbsResvAlter(TestFunctional):
                                            shift, alter_e=True,
                                            confirm=False)[1]
 
-        self.check_resv_running(rid, duration, 0)
+        self.check_resv_running(rid, end - int(time.time()) + 1, True)
         self.server.expect(JOB, {'job_state': "R"}, id=jid)
 
         # Wait for the reservation occurrence to finish.


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
There was a race condition in TestPbsResvAlter.test_alter_standing_resv_end_time_after_run.  It extended a reservation and made sure the reservation and job in it were still running after the previous end time.  The test slept expecting no time to take place for the alter to take place.  The reservation would still be running, but the job could end on its own.

#### Describe Your Change
Changed sleep to take into account time for the alter operation.  Also, changed the sleep time of the job to be the entire length of the post-alter reservation time (30s).

#### Attach Test and Valgrind Logs/Output
[ralter_race.log](https://github.com/PBSPro/pbspro/files/4494940/ralter_race.log)
