### PR TITLE
Test "test_unsupported_operator" is no more useful

### DIFF
--- a/test/tests/selftest/pbs_expect.py
+++ b/test/tests/selftest/pbs_expect.py
@@ -59,36 +59,3 @@ class TestExpect(TestSelf):
         a = {'enabled': 'True', 'started': 'True', 'priority': 150}
         self.server.manager(MGR_CMD_SET, QUEUE, a, 'expressq')
         self.server.expect(QUEUE, a, id='expressq')
-
-    def test_unsupported_operator(self):
-        """
-        Test that expect can handle unsupported operators correctly
-        """
-        # Add a new log handler which writes into a StringIO buffer
-        logbuffer = StringIO()
-        ptllogger = logging.getLogger('ptl')
-        temploghandler = logging.StreamHandler(logbuffer)
-        tempfmt = logging.Formatter("%(message)s")
-        temploghandler.setFormatter(tempfmt)
-        ptllogger.addHandler(temploghandler)
-        ptllogger.propagate = True
-
-        # Call manager on an unsupported operator (INCR)
-        # As expect is done automatically for set operations,
-        # we should see a log message for unsupported operator
-        manager = str(MGR_USER) + '@*'
-        rc = self.server.manager(MGR_CMD_SET, SERVER,
-                                 {'managers': (INCR, manager)}, sudo=True)
-        self.assertEqual(rc, 0)
-        ptllogger.removeHandler(temploghandler)
-
-        # Verify that expect logged the expected log message
-        logmsg = "Operator not supported by expect(), " +\
-            "cannot verify change in managers"
-        msgfound = False
-        for line in logbuffer.getvalue().splitlines():
-            if line == logmsg:
-                msgfound = True
-                break
-        self.assertTrue(msgfound,
-                        "Didn't find expected log message from expect()")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test "test_unsupported_operator" has been written to test the functionality of "except" in manager(). But now except has been removed from the manager() so no more requirement of this test.
PR link of "added test"-https://github.com/PBSPro/pbspro/pull/922
PR link  of "removed except from managaer()"-https://github.com/PBSPro/pbspro/pull/1040


#### Describe Your Change
removed the test"test_unsupported_operator" because test is no more in use

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
