### PR TITLE
For node license Testsuite "TestPbsNodeRampDown" doesn't check license used by ncpus

### DIFF
--- a/test/tests/functional/pbs_node_rampdown.py
+++ b/test/tests/functional/pbs_node_rampdown.py
@@ -160,6 +160,11 @@ class TestPbsNodeRampDown(TestFunctional):
             if lic_count.find('Avail_Global:10000000 ' +
                               'Avail_Local:10000000 Used:0') != -1:
                 return
+            license_type = self.server.status(SERVER, 'pbs_license_info')
+            license_info = license_type[0]['pbs_license_info']
+            node_license = self.du.isfile(path=license_info)
+            if node_license:
+                return
             for lic in lic_count.split():
                 lic_split = lic.split(':')
                 if lic_split[0] == 'Used':


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Testsuite "TestPbsNodeRampDown" fails on node_license. Testsuite expect used_license count should be same as number of ncpus but if license is  node_license then ncpus doesn't use license. so tests should not check count of license used by ncpus on node license.

#### Describe Your Change
Testsuite "TestPbsNodeRampDown" doesn't check count of license used by ncpus on node_license.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[node_remp.txt](https://github.com/PBSPro/pbspro/files/4508666/node_remp.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
