### PR TITLE
Fixed type for create_resv_from_job

### DIFF
--- a/src/lib/Libattr/master_job_attr_def.xml
+++ b/src/lib/Libattr/master_job_attr_def.xml
@@ -2756,21 +2756,21 @@
       <member_name>
          <both>ATTR_create_resv_from_job</both>
       </member_name>
-      <member_at_decode>decode_l</member_at_decode>
-      <member_at_encode>encode_l</member_at_encode>
-      <member_at_set>set_l</member_at_set>
-      <member_at_comp>comp_l</member_at_comp>
+      <member_at_decode>decode_b</member_at_decode>
+      <member_at_encode>encode_b</member_at_encode>
+      <member_at_set>set_b</member_at_set>
+      <member_at_comp>comp_b</member_at_comp>
       <member_at_free>free_null</member_at_free>
       <member_at_action>NULL_FUNC</member_at_action>
       <member_at_flags>
          <both>READ_WRITE</both>
       </member_at_flags>
       <member_at_type>
-         <both>ATR_TYPE_LONG</both>
+         <both>ATR_TYPE_BOOL</both>
       </member_at_type>
       <member_at_parent>PARENT_TYPE_JOB</member_at_parent>
       <member_verify_function>
-	<ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>
+	<ECL>verify_datatype_bool</ECL>
 	<ECL>NULL_VERIFY_VALUE_FUNC</ECL>
       </member_verify_function>
    </attributes>

--- a/src/lib/Libattr/master_resv_attr_def.xml
+++ b/src/lib/Libattr/master_resv_attr_def.xml
@@ -806,7 +806,7 @@
 	<member_at_comp>comp_str</member_at_comp>
 	<member_at_free>free_str</member_at_free>
 	<member_at_action>NULL_FUNC</member_at_action>
-	<member_at_flags><both>READ_WRITE | ATR_DFLAG_ALTRUN | ATR_DFLAG_SELEQ</both></member_at_flags>
+	<member_at_flags><both>READ_WRITE</both></member_at_flags>
 	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
 	<member_at_parent>PARENT_TYPE_RESV</member_at_parent>
 	<member_verify_function>


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The create_resv_from_job attribute was listed in the design as a boolean.  It was implemented as a long.  This meant you couldn't say -Wcreate_resv_from_job=True and the python type was int so you couldn't do the same thing in hooks.

#### Describe Your Change
Changed the type from long to boolean.  Also removed some unneeded job related flags from the reservation reserve_job attribute.

#### Link to Design Doc
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1450409985/Creating+reservation+out+of+a+job


#### Attach Test and Valgrind Logs/Output
This change isn't really worth an automated test.  Here's a manual test;

[bmann@mars server]$ qsub -Wcreate_resv_from_job=True -- /bin/sleep 1000
486.mars
[bmann@mars server]$ qsub -Wcreate_resv_from_job=false -- /bin/sleep 1000
488.mars
[bmann@mars server]$ qsub -Wcreate_resv_from_job=foo -- /bin/sleep 1000
qsub: Illegal attribute or resource value create_resv_from_job
[bmann@mars server]$ qsub -Wcreate_resv_from_job=1 -- /bin/sleep 1000
491.mars

[bmann@mars server]$ qstat -f | egrep '(^Job)|create_resv' | grep -v Submit
Job Id: 486.mars
    create_resv_from_job = True
Job Id: 488.mars
    create_resv_from_job = False
Job Id: 491.mars
    create_resv_from_job = True

[bmann@mars ~]$ cat qj.py 
import pbs
pbs.event().job.create_resv_from_job=True
[bmann@mars ~]$ qsub -- /bin/sleep 1000
493.mars
[bmann@mars ~]$ qstat -f | grep create
    create_resv_from_job = True


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
