### PR TITLE
Fix 2  pbs_cgroups_hook.py tests failing on small, 2-cpu hyperthreaded systems

### DIFF
--- a/test/tests/functional/pbs_cgroups_hook.py
+++ b/test/tests/functional/pbs_cgroups_hook.py
@@ -807,7 +807,7 @@ sleep 300
     "periodic_resc_update"  : true,
     "vnode_per_numa_node"   : false,
     "online_offlined_nodes" : true,
-    "use_hyperthreads"      : false,
+    "use_hyperthreads"      : true,
     "cgroup":
     {
         "cpuacct":
@@ -862,7 +862,7 @@ sleep 300
     "periodic_resc_update"  : true,
     "vnode_per_numa_node"   : false,
     "online_offlined_nodes" : true,
-    "use_hyperthreads"      : false,
+    "use_hyperthreads"      : true,
     "cgroup":
     {
         "cpuacct":


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* The following 2 tests are failing on small systems showing only 2 cpus under hyperthreading mode: 
 TestCgroupsHook.test_cpu_controller_enforce
TestCgroupsHook.test_cpu_controller_enforce_default

 mom_logs say:
04/17/2020 02:05:16.250176;0800;pbs_python;Hook;pbs_python;_assign_resources: Insufficient ncpus: 2/1
04/17/2020 02:05:16.250196;0100;pbs_python;Hook;pbs_python;<function caller_name at 0x2b1488b67e18>: Assignment of resources failed for 0.x114-s15p1, attempting cleanup

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* The 2 tests require running 2-cpu job, but the cgroup hook config file used had 'use_hyperthreads = false', so even if mom says it has resources_available.ncpus=2, pbs_cgroups hook would only allow and see 1 physical cpu.
* Fix is to update the hook config file in those 2 test cases to 'use_hyperthreads = true'.
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* [ptl.cpu_control.x114.FAIL.txt](https://github.com/PBSPro/pbspro/files/4512580/ptl.cpu_control.x114.FAIL.txt)
* [ptl.cpu_control.x114.PASS.txt](https://github.com/PBSPro/pbspro/files/4512597/ptl.cpu_control.x114.PASS.txt)
* [ptl.cpu_control.x90.u16.txt](https://github.com/PBSPro/pbspro/files/4512598/ptl.cpu_control.x90.u16.txt)
* [ptl.cpu_control.td-09.s12.txt](https://github.com/PBSPro/pbspro/files/4512601/ptl.cpu_control.td-09.s12.txt)
* [ptl.cpu_control.x58.r7.txt](https://github.com/PBSPro/pbspro/files/4512604/ptl.cpu_control.x58.r7.txt)
* [ptl.cpu_control.x109.r8.txt](https://github.com/PBSPro/pbspro/files/4512605/ptl.cpu_control.x109.r8.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
