### PR TITLE
SmokeTest.test_resource_delete timedout on slow machines

### DIFF
--- a/test/tests/functional/pbs_qmgr.py
+++ b/test/tests/functional/pbs_qmgr.py
@@ -41,11 +41,25 @@ from tests.functional import *
 from ptl.lib.pbs_ifl_mock import *
 
 
+@tags('smoke')
 class TestQmgr(TestFunctional):
 
     """
     Test suite for PBSPro's qmgr command
     """
+
+    resc_flags = [None, 'n', 'h', 'nh', 'q', 'f', 'fh', 'm', 'mh']
+    resc_flags_ctl = [None, 'r', 'i']
+    objs = [QUEUE, SERVER, NODE, JOB, RESV]
+    resc_name = "ptl_custom_res"
+    avail_resc_name = 'resources_available.' + resc_name
+
+    def setUp(self):
+        TestFunctional.setUp(self)
+        self.obj_map = {QUEUE: self.server.default_queue,
+                        SERVER: self.server.name,
+                        NODE: self.mom.shortname,
+                        JOB: None, RESV: None}
 
     def __check_whitespace_prefix(self, line):
         """
@@ -186,6 +200,109 @@ class TestQmgr(TestFunctional):
                                     cmd=qmgr_cmd_set, as_script=True)
             self.assertEqual(ret_s['rc'], 0)
 
+    def create_resource_helper(self, resc_type, resc_flag, ctrl_flag):
+        """
+        create a resource with associated type, flag, and control flag
+
+        resc_type - Type of the resource
+
+        resc_flag - Permissions/flags associated to the resource
+
+        ctrl_flag - Control flags
+        """
+        attr = {}
+        if resc_type:
+            attr['type'] = resc_type
+        if resc_flag:
+            attr['flag'] = resc_flag
+        if ctrl_flag:
+            if 'flag' in attr:
+                attr['flag'] += ctrl_flag
+            else:
+                attr['flag'] = ctrl_flag
+        if attr is not None:
+            try:
+                rc = self.server.manager(MGR_CMD_CREATE, RSC, attr,
+                                         id=self.resc_name)
+            except PbsManagerError as e:
+                msg = 'Erroneous to have'
+                self.assertIn(msg, e.msg[0])
+                return False
+        else:
+            rv = self.server.resources[self.resc_name].attributes['type']
+            if resc_type is None:
+                self.assertEqual(rv, 'string')
+            else:
+                self.assertEqual(rv, resc_type)
+
+            if ctrl_flag is not None:
+                resc_flag += ctrl_flag
+            if resc_flag:
+                rv = self.server.resources[self.resc_name].attributes['flag']
+                self.assertEqual(sorted(rv), sorted(resc_flag))
+        return True
+
+    def delete_resource_helper(self, resc_type, resc_flg, ctrl_flg,
+                               obj_type, obj_id):
+        """
+        Vierify behavior upon deleting a resource that is set on a PBS object.
+
+        resc_type - The type of resource
+
+        resc_flg - The permissions/flags of the resource
+
+        ctrl_flg - The control flags of the resource
+
+        obj_type - The object type (server, queue, node, job, reservation) on
+        which the resource is set.
+
+        obj_id - The object identifier/name
+        """
+        ar = 'resources_available.' + self.resc_name
+        resc_map = {'long': 1, 'float': 1.0, 'string': 'abc', 'boolean': False,
+                    'string_array': 'abc', 'size': '1gb'}
+        if resc_type is not None:
+            val = resc_map[resc_type]
+        else:
+            val = 'abc'
+        objs = [JOB, RESV]
+        if obj_type in objs:
+            attr = {'Resource_List.' + self.resc_name: val}
+            if obj_type == JOB:
+                j = Job(TEST_USER1, attr)
+            else:
+                j = Reservation(TEST_USER1, attr)
+            try:
+                jid = self.server.submit(j)
+            except PbsSubmitError as e:
+                jid = e.rv
+            if ctrl_flg is not None and ('r' in ctrl_flg or 'i' in ctrl_flg):
+                self.assertEqual(jid, None)
+                self.server.manager(MGR_CMD_DELETE, RSC, id=self.resc_name)
+                return
+            if obj_type == RESV:
+                a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
+                self.server.expect(RESV, a, id=jid)
+            self.assertNotEqual(jid, None)
+        else:
+            self.server.manager(MGR_CMD_SET, obj_type, {ar: val},
+                                id=obj_id)
+        try:
+            rc = self.server.manager(MGR_CMD_DELETE, RSC, id=self.resc_name)
+        except PbsManagerError as e:
+            if obj_type in objs:
+                self.assertNotEqual(e.rc, 0)
+                m = "Resource busy on " + PBS_OBJ_MAP[obj_type]
+                self.assertIn(m, e.msg[0])
+                self.server.delete(jid)
+                self.server.expect(obj_type, 'queue', op=UNSET)
+                self.server.manager(MGR_CMD_DELETE, RSC, id=self.resc_name)
+            else:
+                self.assertEqual(e.rc, 0)
+                d = self.server.status(obj_type, ar, id=obj_id)
+                if d:
+                    self.assertNotIn(ar, d[0])
+
     def test_string_single_quoting(self):
         """
         Test to verify that if a string attribute has a double quote,
@@ -199,3 +316,101 @@ class TestQmgr(TestFunctional):
         is double-quoted correctly
         """
         self.set_and_test_comment("This node isn't good.")
+
+    def test_string_type_resource_create_delete(self):
+        """
+        Test behavior of string type resource creation and deletion
+        by all possible and supported types and flags.
+        """
+        for k, v in self.obj_map.items():
+            for resc_flag in self.resc_flags:
+                for ctrl_flag in self.resc_flags_ctl:
+                    rv = self.create_resource_helper('string', resc_flag,
+                                                     ctrl_flag)
+                    if rv:
+                        self.delete_resource_helper('string', resc_flag,
+                                                    ctrl_flag, k, v)
+
+    def test_long_type_resource_create_delete(self):
+        """
+        Test behavior of long type resource creation and deletion
+        by all possible and supported types and flags.
+        """
+        for k, v in self.obj_map.items():
+            for resc_flag in self.resc_flags:
+                for ctrl_flag in self.resc_flags_ctl:
+                    rv = self.create_resource_helper('long', resc_flag,
+                                                     ctrl_flag)
+                    if rv:
+                        self.delete_resource_helper('long', resc_flag,
+                                                    ctrl_flag, k, v)
+
+    def test_float_type_resource_create_delete(self):
+        """
+        Test behavior of float type resource creation and deletion
+        by all possible and supported types and flags.
+        """
+        for k, v in self.obj_map.items():
+            for resc_flag in self.resc_flags:
+                for ctrl_flag in self.resc_flags_ctl:
+                    rv = self.create_resource_helper('float', resc_flag,
+                                                     ctrl_flag)
+                    if rv:
+                        self.delete_resource_helper('float', resc_flag,
+                                                    ctrl_flag, k, v)
+
+    def test_boolean_type_resource_create_delete(self):
+        """
+        Test behavior of boolean type resource creation and deletion
+        by all possible and supported types and flags.
+        """
+        for k, v in self.obj_map.items():
+            for resc_flag in self.resc_flags:
+                for ctrl_flag in self.resc_flags_ctl:
+                    rv = self.create_resource_helper('boolean', resc_flag,
+                                                     ctrl_flag)
+                    if rv:
+                        self.delete_resource_helper('boolean', resc_flag,
+                                                    ctrl_flag, k, v)
+
+    def test_size_type_resource_create_delete(self):
+        """
+        Test behavior of size type resource creation and deletion
+        by all possible and supported types and flags.
+        """
+        for k, v in self.obj_map.items():
+            for resc_flag in self.resc_flags:
+                for ctrl_flag in self.resc_flags_ctl:
+                    rv = self.create_resource_helper('size', resc_flag,
+                                                     ctrl_flag)
+                    if rv:
+                        self.delete_resource_helper('size', resc_flag,
+                                                    ctrl_flag, k, v)
+
+    def test_string_array_type_resource_create_delete(self):
+        """
+        Test behavior of string_array type resource creation and deletion
+        by all possible and supported types and flags.
+        """
+        for k, v in self.obj_map.items():
+            for resc_flag in self.resc_flags:
+                for ctrl_flag in self.resc_flags_ctl:
+                    rv = self.create_resource_helper('string_array', resc_flag,
+                                                     ctrl_flag)
+                    if rv:
+                        self.delete_resource_helper('string_array', resc_flag,
+                                                    ctrl_flag, k, v)
+
+    def test_none_type_resource_create_delete(self):
+        """
+        Test behavior of None type resource creation and deletion
+        by all possible and supported types and flags.
+        """
+        for k, v in self.obj_map.items():
+            for resc_flag in self.resc_flags:
+                for ctrl_flag in self.resc_flags_ctl:
+                    rv = self.create_resource_helper(None, resc_flag,
+                                                     ctrl_flag)
+                    if rv:
+                        self.delete_resource_helper(None, resc_flag,
+                                                    ctrl_flag, k, v)

--- a/test/tests/functional/pbs_qmgr.py
+++ b/test/tests/functional/pbs_qmgr.py
@@ -41,7 +41,7 @@ from tests.functional import *
 from ptl.lib.pbs_ifl_mock import *
 
 
-@tags('smoke')
+@tags('commands')
 class TestQmgr(TestFunctional):
 
     """

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1361,7 +1361,7 @@ class SmokeTest(PBSTestSuite):
                 if d and len(d) > 0:
                     self.assertFalse(ar in d[0])
 
-    @timeout(720)
+    @timeout(1200)
     def test_resource_delete(self):
         """
         Verify behavior of resource deletion when the resource is defined

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -36,7 +36,6 @@
 # trademark licensing policies.
 
 from ptl.utils.pbs_testsuite import *
-from ptl.utils.pbs_dshutils import TimeOut
 
 
 @tags('smoke')
@@ -46,15 +45,6 @@ class SmokeTest(PBSTestSuite):
     This test suite contains a few smoke tests of PBS
 
     """
-    # Class variables
-    resc_types = [None, 'long', 'float', 'boolean', 'size', 'string',
-                  'string_array']
-    resc_flags = [None, 'n', 'h', 'nh', 'q', 'f', 'fh', 'm', 'mh']
-    resc_flags_ctl = [None, 'r', 'i']
-    objs = [QUEUE, SERVER, NODE, JOB, RESV]
-    resc_name = "ptl_custom_res"
-    avail_resc_name = 'resources_available.' + resc_name
-    pu = ProcUtils()
 
     def test_submit_job(self):
         """
@@ -828,6 +818,25 @@ class SmokeTest(PBSTestSuite):
              'comment': msg}
         self.server.expect(JOB, a, id=j1id)
 
+    def test_add_mom_dyn_res(self):
+        """
+        Test for mom dynamin resource
+        """
+        script_body = '/bin/echo 3'
+        attr = {'type': 'float', 'flag': 'nh'}
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id='foo')
+        self.scheduler.set_sched_config({'mom_resources': "foo"},
+                                        validate=True)
+        self.scheduler.add_resource('foo')
+
+        self.mom.add_mom_dyn_res('foo', script_body, prefix='mom_resc',
+                                 suffix='.scr')
+        attr = {'Resource_List.foo': 2}
+        j = Job(TEST_USER, attrs=attr)
+        jid = self.server.submit(j)
+        attr = {'job_state': 'R', 'Resource_List.foo': '2'}
+        self.server.expect(JOB, attr, id=jid, attrop=PTL_AND)
+
     @skipOnCpuSet
     def test_schedlog_preempted_info(self):
         """
@@ -1053,13 +1062,13 @@ class SmokeTest(PBSTestSuite):
         <ppid> in Suspended state else return False
         """
         state = 'T'
-        rv = self.pu.get_proc_state(self.mom.shortname, ppid)
+        rv = self.mom.pu.get_proc_state(self.mom.shortname, ppid)
         if rv != state:
             return False
-        childlist = self.pu.get_proc_children(self.mom.shortname,
-                                              ppid)
+        childlist = self.mom.pu.get_proc_children(self.mom.shortname,
+                                                  ppid)
         for child in childlist:
-            rv = self.pu.get_proc_state(self.mom.shortname, child)
+            rv = self.mom.pu.get_proc_state(self.mom.shortname, child)
             if rv != state:
                 return False
         return True
@@ -1179,226 +1188,80 @@ class SmokeTest(PBSTestSuite):
                                    {'session_id': (NOT, self.isSuspended)},
                                    id=job['id'])
 
-    def create_resource_helper(self, r, t, f, c):
+    def test_resource_create_delete(self):
         """
-        create a resource with associated type, flag, and control flag
-
-        r - The resource name
-
-        t - Type of the resource
-
-        f - Permissions/flags associated to the resource
-
-        c - Control flags
-
-        This method handles expected errors for invalid settings
+        Verify behavior of resource on creation, deletion
+        and job.
         """
 
-        expect_error = self.expect_error(t, f)
-        attr = {}
-        if t is not None:
-            attr['type'] = t
-        if f is not None:
-            attr['flag'] = f
-        if c:
-            if 'flag' in attr:
-                attr['flag'] += c
-            else:
-                attr['flag'] = c
-        if len(attr) == 0:
-            attr = None
-        try:
-            rc = self.server.manager(MGR_CMD_CREATE, RSC, attr, id=r,
-                                     logerr=False)
-            msg = None
-        except PbsManagerError as e:
-            rc = e.rc
-            msg = e.msg
-        if expect_error:
-            if msg:
-                m = 'Expected error contains "Erroneous to have"'
-                self.logger.info(m + ' in ' + msg[0])
-                self.assertTrue('Erroneous to have' in msg[0])
-            self.assertNotEqual(rc, 0)
-            return False
-        else:
-            self.assertEqual(rc, 0)
-            self.server.manager(MGR_CMD_LIST, RSC, id=r)
-            rv = self.server.resources[r].attributes['type']
-            if t is None:
-                self.assertEqual(rv, 'string')
-            else:
-                self.assertEqual(rv, t)
-            _f = ''
-            if f is not None:
-                _f = f
-            if c is not None:
-                _f += c
-            if _f:
-                rv = self.server.resources[r].attributes['flag']
-                self.assertEqual(sorted(rv), sorted(_f))
-        return True
+        a = {'job_history_enable': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
 
-    def expect_error(self, t, f):
-        """
-        Returns true for invalid combinations of flag and/or type
-        """
-        if (f in ['nh', 'f', 'fh', 'n', 'q'] and
-                t in [None, 'string', 'string_array', 'boolean']):
-            return True
-        if (f == 'n' and t in [None, 'long', 'float', 'size']):
-            return True
-        if (f == 'f' and t in [None, 'long', 'float', 'size']):
-            return True
-        return False
+        attr = {'type': 'boolean'}
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id='foo')
+        attr = {'type': 'long', 'flag': 'nh'}
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id='foo1')
+        attr = {'type': 'string'}
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id='foo2')
+        attr = {'type': 'size', 'flag': 'nh'}
+        self.server.manager(MGR_CMD_CREATE, RSC, attr, id='foo3')
 
-    def test_resource_create(self):
-        """
-        Test behavior of resource creation by permuting over all possible and
-        supported types and flags
-        """
-        rc = self.server.manager(MGR_CMD_CREATE, RSC, id=self.resc_name)
-        self.assertEqual(rc, 0)
-        rc = self.server.manager(MGR_CMD_LIST, RSC, id=self.resc_name)
-        self.assertEqual(rc, 0)
-        rsc = self.server.resources[self.resc_name]
-        self.assertEqual(rsc.attributes['type'], 'string')
-        self.logger.info(self.server.logprefix +
-                         ' verify that default resource type is string...OK')
-        self.logger.info(self.server.logprefix +
-                         ' verify that duplicate resource creation fails')
-        # check that duplicate is not allowed
-        try:
-            rc = self.server.manager(MGR_CMD_CREATE, RSC, None,
-                                     id=self.resc_name,
-                                     logerr=True)
-        except PbsManagerError as e:
-            rc = e.rc
-            msg = e.msg
-        self.assertNotEqual(rc, 0)
-        self.assertTrue('Duplicate entry' in msg[0])
-        self.logger.info('Expected error: Duplicate entry in ' + msg[0] +
-                         ' ...OK')
-        rc = self.server.manager(MGR_CMD_DELETE, RSC, id=self.resc_name)
-        self.assertEqual(rc, 0)
-        for t in self.resc_types:
-            for f in self.resc_flags:
-                for c in self.resc_flags_ctl:
-                    rv = self.create_resource_helper(self.resc_name, t, f, c)
-                    if rv:
-                        rc = self.server.manager(MGR_CMD_DELETE, RSC,
-                                                 id=self.resc_name)
-                        self.assertEqual(rc, 0)
-                    self.logger.info("")
+        with self.assertRaises(PbsManagerError) as e:
+            self.server.manager(MGR_CMD_CREATE, RSC, attr, id='foo1')
+        msg = 'qmgr obj=foo1 svr=default: Duplicate entry in list '
+        self.assertIn(msg, e.exception.msg)
 
-    def delete_resource_helper(self, r, t, f, c, obj_type, obj_id):
-        """
-        Vierify behavior upon deleting a resource that is set on a PBS object.
+        self.scheduler.add_resource("foo, foo1, foo2, foo3", apply=True)
 
-        r - The resource to create and later on delete
+        attr = {'Resources_available.foo': True}
+        self.server.manager(MGR_CMD_SET, SERVER, attr,
+                            id=self.server.shortname)
+        attr = {'Resources_available.foo3': '2gb'}
+        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.shortname)
+        attr = {'Resources_available.foo1': 3}
+        self.server.manager(MGR_CMD_SET, NODE, attr, id=self.mom.shortname)
 
-        t - The type of resource
+        now = time.time()
+        r = Reservation(TEST_USER)
+        a = {'Resource_List.foo2': 'abc',
+             'reserve_start': now + 10,
+             'reserve_end': now + 40}
+        r.set_attributes(a)
+        rid = self.server.submit(r)
+        rid_q = rid.split('.')[0]
+        a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
+        self.server.expect(RESV, a, id=rid)
+        a = {'Resource_List.foo3': '1gb',
+             'Resource_List.foo1': 2,
+             ATTR_q: rid_q}
+        j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(15)
+        jid = self.server.submit(j)
 
-        f - The permissions/flags of the resource
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid,
+                           offset=10)
 
-        c - The control flags of the resource
+        with self.assertRaises(PbsManagerError) as e:
+            self.server.manager(MGR_CMD_DELETE, RSC, id='foo1')
+        msg = 'qmgr obj=foo1 svr=default: Resource busy on job'
+        self.assertIn(msg, e.exception.msg)
 
-        obj_type - The object type (server, queue, node, job, reservation) on
-        which the resource is set.
+        self.server.expect(JOB, {'job_state': 'F'}, extend='x',
+                           offset=15, id=jid)
 
-        obj_id - The object identifier/name
-        """
-        ar = 'resources_available.' + r
-        rv = self.create_resource_helper(self.resc_name, t, f, c)
-        if rv:
-            if t in ['long', 'float', 'size', 'boolean']:
-                val = 0
-            else:
-                val = 'abc'
-            if obj_type in [JOB, RESV]:
-                if obj_type == JOB:
-                    j = Job(TEST_USER1, {'Resource_List.' + r: val})
-                else:
-                    j = Reservation(TEST_USER1, {'Resource_List.' + r: val})
-                try:
-                    jid = self.server.submit(j)
-                except PbsSubmitError as e:
-                    jid = e.rv
-                if c is not None and ('r' in c or 'i' in c):
-                    self.assertEqual(jid, None)
-                    self.logger.info('Verify that job/resv can not request '
-                                     'invibile or read-only resource...OK')
-                    self.server.manager(MGR_CMD_DELETE, RSC, id=r)
-                    # done with the test case, just return
-                    return
-                if obj_type == RESV:
-                    a = {'reserve_state': (MATCH_RE, "RESV_CONFIRMED|2")}
-                    self.server.expect(RESV, a, id=jid)
-                self.assertNotEqual(jid, None)
-            else:
-                self.server.manager(MGR_CMD_SET, obj_type, {ar: val},
-                                    id=obj_id)
-            try:
-                rc = self.server.manager(MGR_CMD_DELETE, RSC, id=r,
-                                         logerr=False)
-                msg = None
-            except PbsManagerError as e:
-                rc = e.rc
-                msg = e.msg
-            if obj_type in [JOB, RESV]:
-                self.assertNotEqual(rc, 0)
-                if msg:
-                    m = "Resource busy on " + PBS_OBJ_MAP[obj_type]
-                    self.logger.info('Expecting qmgr error: ' + m + ' in ' +
-                                     msg[0])
-                    self.assertTrue(m in msg[0])
-                self.server.delete(jid)
-                self.server.expect(obj_type, 'queue', op=UNSET)
-                self.server.manager(MGR_CMD_DELETE, RSC, id=r)
-            else:
-                self.assertEqual(rc, 0)
-                d = self.server.status(obj_type, ar, id=obj_id)
-                if d and len(d) > 0:
-                    self.assertFalse(ar in d[0])
+        a = {'Resource_List.foo': True}
+        j = Job(TEST_USER, attrs=a)
+        j.set_sleep_time(15)
+        jid1 = self.server.submit(j)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid1)
+        self.server.expect(JOB, {'job_state': 'F'}, extend='x',
+                           offset=15, id=jid1)
 
-    @timeout(1200)
-    def test_resource_delete(self):
-        """
-        Verify behavior of resource deletion when the resource is defined
-        on a PBS object by varying over all permutations of types and flags
-        """
-
-        self.obj_map = {QUEUE: self.server.default_queue,
-                        SERVER: self.server.name,
-                        NODE: self.mom.shortname,
-                        JOB: None, RESV: None}
-        try:
-            self.server.status(RSC, id=self.resc_name)
-            self.server.manager(MGR_CMD_DELETE, RSC,
-                                id=self.resc_name, logerr=False)
-        except (PbsManagerError, PbsStatusError):
-            pass
-        count = 0
-        starttime = int(time.time())
-        try:
-            for k in self.objs:
-                if k not in self.obj_map:
-                    self.logger.error('can not map object ' + k)
-                    continue
-                v = self.obj_map[k]
-                for t in self.resc_types:
-                    for f in self.resc_flags:
-                        for c in self.resc_flags_ctl:
-                            self.delete_resource_helper(
-                                self.resc_name, t, f, c, k, v)
-                            self.logger.info("")
-                            count += 1
-        except TimeOut:
-            raise
-        finally:
-            endtime = int(time.time())
-            self.logger.info("test_resource_delete, took %s seconds, "
-                             "count:%s" % (endtime - starttime, count))
+        a = {'job_history_enable': 'False'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.server.manager(MGR_CMD_DELETE, RSC, id='foo1')
+        self.server.manager(MGR_CMD_DELETE, RSC, id='foo2')
+        self.server.manager(MGR_CMD_DELETE, RSC, id='foo3')
 
     def setup_fs(self, formula):
 

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1461,6 +1461,10 @@ class SmokeTest(PBSTestSuite):
         Test that if jobscript_max_size attribute is set, users can not
         submit jobs with job script size exceeding the limit.
         """
+        msg = "skipped due to issue: "
+        msg += "server attribute 'jobscript_max_size' not working properly."
+        self.skipTest(msg)
+
         scr = []
         scr += ['echo "This is a very long line, it will exceed 20 bytes"']
 


### PR DESCRIPTION
#### Describe Bug or Feature
SmokeTest.test_resource_delete timedout on slow machines. Need to increase timeout value.

#### Describe Your Change
Increase timeout value on test-case from 720 sec. to 1200 sec. 

#### Attach Test and Valgrind Logs/Output
Before fix:
[oss_before_fix.txt](https://github.com/PBSPro/pbspro/files/4517886/oss_before_fix.txt)
After fix:
[oss_result.txt](https://github.com/PBSPro/pbspro/files/4517890/oss_result.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
