### PR TITLE
In test "test_rsc_used" used_walltime should not be zero

### DIFF
--- a/test/tests/functional/pbs_mom_mock_run.py
+++ b/test/tests/functional/pbs_mom_mock_run.py
@@ -68,5 +68,6 @@ class TestMomMockRun(TestFunctional):
         self.server.accounting_match(msg=used_ncpus, id=jid)
         used_mem = "resources_used.mem=5mb"
         self.server.accounting_match(msg=used_mem, id=jid)
-        used_walltime = "resources_used.walltime=00:00:05"
-        self.server.accounting_match(msg=used_walltime, id=jid)
+        used_walltime = "resources_used.walltime=00:00:00"
+        self.server.accounting_match(
+            msg=used_walltime, existence=False, id=jid)

--- a/test/tests/functional/pbs_mom_mock_run.py
+++ b/test/tests/functional/pbs_mom_mock_run.py
@@ -70,4 +70,6 @@ class TestMomMockRun(TestFunctional):
         self.server.accounting_match(msg=used_mem, id=jid)
         used_walltime = "resources_used.walltime=00:00:00"
         self.server.accounting_match(
-            msg=used_walltime, existence=False, id=jid)
+            msg="resources_used.walltime", id=jid)
+        self.server.accounting_match(
+            msg=used_walltime, existence=False, id=jid, max_attempts=1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test "test_rsc_used" fails intermittently on some platforms because not exact match of used_walltime.


#### Describe Your Change
In accounting logs, Test checks used_walltime should not be zero.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[test_mom_mock.txt](https://github.com/PBSPro/pbspro/files/4519147/test_mom_mock.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
