### PR TITLE
Increase timeout for SmokeTest.test_resource_delete

### DIFF
--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -1361,7 +1361,7 @@ class SmokeTest(PBSTestSuite):
                 if d and len(d) > 0:
                     self.assertFalse(ar in d[0])
 
-    @timeout(720)
+    @timeout(1200)
     def test_resource_delete(self):
         """
         Verify behavior of resource deletion when the resource is defined


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test_resource_delete test case is getting timedout due to less timeout value given in test case.
On slow machines, this would take more than 15 mins to execute.

#### Describe Your Change
Increased timeout from 720 to 1200 for slow machines.

#### Attach Test and Valgrind Logs/Output
[test_resource_delete_after_fix.txt](https://github.com/PBSPro/pbspro/files/4521023/test_resource_delete_after_fix.txt)
[test_resource_delete_before_fix.txt](https://github.com/PBSPro/pbspro/files/4521024/test_resource_delete_before_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
