### PR TITLE
cgroups: handle systems without Hugepagesize set

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -1983,10 +1983,10 @@ class NodeUtils(object):
             else:
                 total = size_as_int(hpmemtotal)
         except Exception:
-            pbs.logmsg(pbs.EVENT_DEBUG,
+            pbs.logmsg(pbs.EVENT_DEBUG3,
                        '%s: Could not determine huge page availability' %
                        caller_name())
-            raise
+            total = 0
         if total <= 0:
             total = 0
             pbs.logmsg(pbs.EVENT_DEBUG4,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Some tests are failing when run on systems where Hugepagsize is not configured under /proc/meminfo. The pbs_cgroups hook gets an exception:

> 04/21/2020 20:59:16.833555;0080;pbs_python;Hook;pbs_python;['Traceback (most recent call last):', '  File "<embedded code object>", line 5481, in main', '  File "<embedded code object>", line 935, in invoke_handler', '  File "<embedded code object>", line 1115, in _exechost_startup_handler', '  File "<embedded code object>", line 2094, in create_vnodes', '  File "<embedded code object>", line 1980, in get_hpmem_on_node', "KeyError: 'Hugepagesize'"]
04/21/2020 20:59:16.833583;0800;pbs_python;Hook;pbs_python;event_name: Method called
04/21/2020 20:59:16.833608;0001;pbs_python;Hook;pbs_python;Unexpected error in pbs_cgroups handling exechost_startup event: KeyError ('Hugepagesize',)


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Under get_hpmem_on_node(), instead of raising an exception in its except block, when error is encountered accesing "self.meminfo['Hugepagesize']", just give it a default value of 0.
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[ptl.cgroups_huge.PASS.x102.u18.txt](https://github.com/PBSPro/pbspro/files/4524428/ptl.cgroups_huge.PASS.x102.u18.txt)
[ptl.cgroups_huge.FAIL.x102.u18.txt](https://github.com/PBSPro/pbspro/files/4524434/ptl.cgroups_huge.FAIL.x102.u18.txt)
[ptl.cgroups_huge.PASS.x91.u16.txt](https://github.com/PBSPro/pbspro/files/4524437/ptl.cgroups_huge.PASS.x91.u16.txt)
[ptl.cgroups_huge.FAIL.x91.u16.txt](https://github.com/PBSPro/pbspro/files/4524440/ptl.cgroups_huge.FAIL.x91.u16.txt)
[ptl.cgroups_huge.PASS.x114.s15.txt](https://github.com/PBSPro/pbspro/files/4524444/ptl.cgroups_huge.PASS.x114.s15.txt)
[ptl.cgroups_huge.PASS.x99.s15.txt](https://github.com/PBSPro/pbspro/files/4524446/ptl.cgroups_huge.PASS.x99.s15.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
