### PR TITLE
Fix support for allow_zero_cpus flag

### DIFF
--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -973,11 +973,12 @@ class HookUtils(object):
                                  'but job does not request ncpus on '
                                  'mother superior: rejecting job')
                 else:
+                    # will be done in configure_job
                     pbs.logmsg(pbs.EVENT_JOB_USAGE,
                                'cpuset enabled with mandatory ncpus >= 1, '
                                'but job does not request ncpus on host: '
                                'deleting cpuset cgroup')
-                # will be done in configure_job
+
         # Configure the new cgroup
         cgroup.configure_job(event.job.id, jobutil.assigned_resources,
                              node, cgroup, event.type)
@@ -1212,11 +1213,12 @@ class HookUtils(object):
                                  'but job does not request ncpus on '
                                  'mother superior: rejecting resize')
                 else:
+                    # will be done in configure_job
                     pbs.logmsg(pbs.EVENT_ERROR,
                                'cpuset enabled with mandatory ncpus >= 1, '
                                'but job no longer requests ncpus on host: '
                                'deleting cpuset cgroup')
-                # will be done in configure_job
+
         # Configure the cgroup
         cgroup.configure_job(event.job.id, jobutil.assigned_resources,
                              node, cgroup, event.type)
@@ -3491,7 +3493,7 @@ class CgroupUtils(object):
                     pbs.event().reject('No cpuset cgroup present '
                                        'and npcus==0 disallowed')
                 else:
-                    # zero CPU  job: should be attached to root pbspro cpuset
+                    # zero CPU job: should be attached to root pbspro cpuset
                     tasks_file = self._cgroup_path(subsys, 'tasks')
             pbs.logmsg(pbs.EVENT_DEBUG4, '%s: tasks file = %s' %
                        (caller_name(), tasks_file))

--- a/src/hooks/cgroups/pbs_cgroups.PY
+++ b/src/hooks/cgroups/pbs_cgroups.PY
@@ -960,9 +960,28 @@ class HookUtils(object):
         cgroup.assigned_resources = cgroup._get_assigned_cgroup_resources()
         # Create the cgroup(s) for the job
         cgroup.create_job(event.job.id, node)
+        if (cgroup.cfg['cgroup']['cpuset']['enabled']
+                and not cgroup.cfg['cgroup']['cpuset']['allow_zero_cpus']):
+            if ('ncpus' not in jobutil.assigned_resources
+                    or jobutil.assigned_resources['ncpus'] <= 0):
+                if event.job.in_ms_mom():
+                    pbs.logmsg(pbs.EVENT_ERROR,
+                               'cpuset enabled with mandatory ncpus >= 1, '
+                               'but job does not request ncpus on '
+                               'mother superior: rejecting job')
+                    event.reject('cpuset enabled with mandatory ncpus >= 1, '
+                                 'but job does not request ncpus on '
+                                 'mother superior: rejecting job')
+                else:
+                    pbs.logmsg(pbs.EVENT_JOB_USAGE,
+                               'cpuset enabled with mandatory ncpus >= 1, '
+                               'but job does not request ncpus on host: '
+                               'deleting cpuset cgroup')
+                # will be done in configure_job
         # Configure the new cgroup
         cgroup.configure_job(event.job.id, jobutil.assigned_resources,
                              node, cgroup, event.type)
+
         # Initialize resource usage for the job
         cgroup.update_job_usage(event.job.id, event.job.resources_used)
         # Write out the assigned resources
@@ -1180,6 +1199,24 @@ class HookUtils(object):
                    caller_name())
         pbs.logmsg(pbs.EVENT_DEBUG4, '%s: Host assigned job resources: %s' %
                    (caller_name(), jobutil.assigned_resources))
+        if (cgroup.cfg['cgroup']['cpuset']['enabled']
+                and not cgroup.cfg['cgroup']['cpuset']['allow_zero_cpus']):
+            if ('ncpus' not in jobutil.assigned_resources
+                    or jobutil.assigned_resources['ncpus'] <= 0):
+                if event.job.in_ms_mom():
+                    pbs.logmsg(pbs.EVENT_ERROR,
+                               'cpuset enabled with mandatory ncpus >= 1, '
+                               'but job does not request ncpus on '
+                               'mother superior: rejecting resize')
+                    event.reject('cpuset enabled with mandatory ncpus >= 1, '
+                                 'but job does not request ncpus on '
+                                 'mother superior: rejecting resize')
+                else:
+                    pbs.logmsg(pbs.EVENT_ERROR,
+                               'cpuset enabled with mandatory ncpus >= 1, '
+                               'but job no longer requests ncpus on host: '
+                               'deleting cpuset cgroup')
+                # will be done in configure_job
         # Configure the cgroup
         cgroup.configure_job(event.job.id, jobutil.assigned_resources,
                              node, cgroup, event.type)
@@ -2833,6 +2870,7 @@ class CgroupUtils(object):
         defaults['cgroup']['cpuset']['mem_fences'] = True
         defaults['cgroup']['cpuset']['mem_hardwall'] = False
         defaults['cgroup']['cpuset']['memory_spread_page'] = False
+        defaults['cgroup']['cpuset']['allow_zero_cpus'] = True
         defaults['cgroup']['devices'] = {}
         defaults['cgroup']['devices']['enabled'] = False
         defaults['cgroup']['devices']['exclude_hosts'] = []
@@ -3444,8 +3482,17 @@ class CgroupUtils(object):
             tasks_file = self._cgroup_path(subsys, 'tasks', jobid)
             if ((not os.path.exists(tasks_file))
                     and (subsys == 'cpuset')):
-                # zero CPU  job: should be attached to root pbspro cpuset
-                tasks_file = self._cgroup_path(subsys, 'tasks')
+                if (self.cfg['cgroup']['cpuset']['enabled']
+                        and not self.cfg['cgroup']['cpuset']
+                                        ['allow_zero_cpus']):
+                    pbs.logmsg(pbs.EVENT_JOB_USAGE,
+                               'No cpuset cgroup present '
+                               'and npcus==0 disallowed')
+                    pbs.event().reject('No cpuset cgroup present '
+                                       'and npcus==0 disallowed')
+                else:
+                    # zero CPU  job: should be attached to root pbspro cpuset
+                    tasks_file = self._cgroup_path(subsys, 'tasks')
             pbs.logmsg(pbs.EVENT_DEBUG4, '%s: tasks file = %s' %
                        (caller_name(), tasks_file))
             try:
@@ -4495,8 +4542,8 @@ class CgroupUtils(object):
                 if mem_requested is None:
                     pbs.logmsg(pbs.EVENT_DEBUG2,
                                '%s: mem not requested, '
-                               'assigning %s to cgroup' %
-                               (caller_name(), mem_limit))
+                               'assigning %s to cgroup'
+                               % (caller_name(), mem_limit))
                     hostresc['mem'] = pbs.size(mem_limit)
                 if softmem_enabled:
                     hostresc['softmem'] = pbs.size(softmem_limit)
@@ -4504,8 +4551,8 @@ class CgroupUtils(object):
                 if vmem_requested is None:
                     pbs.logmsg(pbs.EVENT_DEBUG2,
                                '%s: vmem not requested, '
-                               'assigning %s to cgroup' %
-                               (caller_name(), vmem_limit))
+                               'assigning %s to cgroup'
+                               % (caller_name(), vmem_limit))
                     pbs.logmsg(pbs.EVENT_DEBUG4,
                                '%s: INFO: vmem is enabled in the hook '
                                'configuration file and should also be '
@@ -4639,23 +4686,24 @@ class CgroupUtils(object):
                         htpc = node.cpuinfo['hyperthreads_per_core']
                 self.set_limit(resc, hostresc[resc] * htpc, jobid)
             elif ((resc == "cpuset.cpus")
-                  and not hostresc['cpuset.cpus']
-                  and self.cfg['cgroup']['cpuset']['allow_zero_cpus']):
+                  and not hostresc['cpuset.cpus']):
                 # zero cpus jobs -- delete the cpuset made for the job;
                 # later allows job processes to be placed in the root cpuset.
                 # Note the set_limit in the final else should likewise
                 # be skipped.
+                # Since the advent of "resize" we may need to
+                # clean up processes in a pre-existing cpuset
+                finished = False
+                giveup_time = time.time() + self.cfg['kill_timeout']
                 path = self._cgroup_path('cpuset', '', jobid)
-                success = self._remove_cgroup(path)
-                if not success:
-                    pbs.logmsg(pbs.EVENT_DEBUG,
-                               '%s: Failed to delete cpuset %s'
-                               ' for zero cpus job %s'
-                               % (caller_name(), path, jobid))
-                    pbs.event().reject('Failed to delete cpuset'
-                                       ' for zero cpus job')
-                    # Hopefully the orphan cleaner will eventually
-                    # get rid of it
+                while not finished:
+                    success = self._remove_cgroup(path)
+                    if success:
+                        finished = True
+                    elif time.time() > giveup_time:
+                        finished = True
+                    else:
+                        time.sleep(0.2)
             else:
                 # For all the rest just pass hostresc[resc] down to set_limit
                 self.set_limit(resc, hostresc[resc], jobid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
There is a missing default for allow_zero_cpus in the defaults, and this will make the hook crash when faced with -lselect=1:ncpus=0 jobs unless the cgroup hook config file contains a value for it.

Also, the code brought in was not actually aware of the new execjob_resize, so the code now takes the opportunaity to make sure all corner cases are "clean" in a way that minimises the differences you could see between a system where the cgroup hook is enabled and one where it is not.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
1. For execjob_begin/resize, if zero cpus are not allowed and the cpuset controller is enabled, when no ncpus are requested on mother superior the execjob_begin will reject the job (and execjob_resize will reject the resize). When no cpus are requested on sister MoMs, then the per-job cpuset will be destroyed (which entails an attempt to get rid of processes to correctly support execjob_resize).

2. execjob_attach and execjob_launch will, if the per-job cpuset cgroup is missing (see 1.), either place processes in the main pbspro.slice cpuset if zero cpus are allowed, or simply reject the event if not (with a clear message and a log message). This is done in add_pids, the routine that actually adds the required PIDs to the "correct" cpuset tasks file.

As a result, if zero cpus is NOT allowed and cpusets are enabled, you can still have exec_vnode containing chunks without cpus on some nodes (e.g. to reserve some custom vnode-level resources on them). But you will not be able to launch processes on those nodes.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1627750401/Support+for+the+cpu+cgroup+controller+and+zero-CPU+jobs

Has been revised.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
This was written to make the cgroup hook pass one of the existing PTL tests which fails:

 test_cgroup_assign_resources_mem_only_vnode

which generates this exception:
04/03/2020 12:22:30.411561;0080;pbs_python;Hook;pbs_python;['Traceback (most recent call last):', ' File "<embedded code object>", line 5479, in main', ' File "<embedded code object>", line 935, in invoke_handler', ' File "<embedded code object>", line 965, in _execjob_begin_handler', ' File "<embedded code object>", line 4641, in configure_job', "KeyError: 'allow_zero_cpus'"]


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
