### PR TITLE
Chain of dependent jobs is not deleted properly

### DIFF
--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3959,6 +3959,10 @@ create_subjob_from_array(resource_resv *array, int index, char *subjob_name)
 
 	subjob = dup_resource_resv(array, array->server, array->job->queue, err);
 
+	/* make a copy of dependent jobs */
+	subjob->job->depend_job_str = string_dup(array->job->depend_job_str);
+	subjob->job->dependent_jobs = (resource_resv **) dup_array((void **)array->job->dependent_jobs);
+
 	array->job->queued_subjobs = tmp;
 
 	if (subjob == NULL) {

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -3961,7 +3961,7 @@ create_subjob_from_array(resource_resv *array, int index, char *subjob_name)
 
 	/* make a copy of dependent jobs */
 	subjob->job->depend_job_str = string_dup(array->job->depend_job_str);
-	subjob->job->dependent_jobs = (resource_resv **) dup_array((void **)array->job->dependent_jobs);
+	subjob->job->dependent_jobs = (resource_resv **) dup_array(array->job->dependent_jobs);
 
 	array->job->queued_subjobs = tmp;
 

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -856,8 +856,7 @@ count_array(void **arr)
 
 /**
  * @brief
- *  dup_array - make a shallow copy of elements in a NULL terminated array
- *		      of pointers
+ *  dup_array - make a shallow copy of elements in a NULL terminated array of pointers.
  *
  * @param[in]	arr	-	the array to copy
  *
@@ -865,22 +864,22 @@ count_array(void **arr)
  *
  */
 void **
-dup_array(void **arr)
+dup_array(void *ptr)
 {
 	void **ret;
+	void **arr;
 	int len = 0;
-	int i;
 
+	arr = (void **)ptr;
 	if (arr == NULL)
 		return NULL;
 
 	len = count_array(arr);
-	ret = malloc(len * sizeof(void *));
+	ret = malloc((len +1) * sizeof(void *));
 	if (ret == NULL)
 		return NULL;
-	for (i = 0; arr[i] != NULL; i++)
-		ret[i] = arr[i];
-	ret[i] = NULL;
+	memcpy(ret, arr, len * sizeof(void *));
+	ret[len] = NULL;
 	return ret;
 }
 

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -856,6 +856,36 @@ count_array(void **arr)
 
 /**
  * @brief
+ *  dup_array - make a shallow copy of elements in a NULL terminated array
+ *		      of pointers
+ *
+ * @param[in]	arr	-	the array to copy
+ *
+ * @return	array of pointers
+ *
+ */
+void **
+dup_array(void **arr)
+{
+	void **ret;
+	int len = 0;
+	int i;
+
+	if (arr == NULL)
+		return NULL;
+
+	len = count_array(arr);
+	ret = malloc(len * sizeof(void *));
+	if (ret == NULL)
+		return NULL;
+	for (i = 0; arr[i] != NULL; i++)
+		ret[i] = arr[i];
+	ret[i] = NULL;
+	return ret;
+}
+
+/**
+ * @brief
  *		remove_ptr_from_array - remove a pointer from a ptr list and move
  *				the rest of the pointers up to fill the hole
  *				Pointer array size will not change - an extra

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -159,6 +159,12 @@ int is_num(char *str);
 int count_array(void **arr);
 
 /*
+ *	dup_array - make a shallow copy of elements in a NULL terminated array
+ *		      of pointers
+ */
+void **dup_array(void **arr);
+
+/*
  *	remove_ptr_from_array - remove a pointer from a ptr list and move
  *				the rest of the pointers up to fill the hole
  *				Pointer array size will not change - an extra

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -159,10 +159,9 @@ int is_num(char *str);
 int count_array(void **arr);
 
 /*
- *	dup_array - make a shallow copy of elements in a NULL terminated array
- *		      of pointers
+ *	dup_array - make a shallow copy of elements in a NULL terminated array of pointers.
  */
-void **dup_array(void **arr);
+void **dup_array(void *ptr);
 
 /*
  *	remove_ptr_from_array - remove a pointer from a ptr list and move

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -310,6 +310,15 @@ job_abt(job *pjob, char *text)
 		 * Check if the history of the finished job can be saved or it needs to be purged .
 		 */
 		svr_saveorpurge_finjobhist(pjob);
+	} else if (old_state == JOB_STATE_HELD && old_substate == JOB_SUBSTATE_DEPNHOLD &&
+		  (pjob->ji_wattr[(int)JOB_ATR_depend].at_flags & ATR_VFLAG_SET)) {
+		(void)svr_setjobstate(pjob, JOB_STATE_HELD,
+			JOB_SUBSTATE_ABORT);
+		depend_on_term(pjob);
+		/*
+		 * Check if the history of the finished job can be saved or it needs to be purged .
+		 */
+		svr_saveorpurge_finjobhist(pjob);
 	} else {
 		(void)svr_setjobstate(pjob, JOB_STATE_EXITING,
 			JOB_SUBSTATE_ABORT);

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -819,6 +819,11 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 				pjob->ji_wattr[(int)JOB_ATR_exit_status].at_val.at_long = pjob->ji_qs.ji_un.ji_exect.ji_exitstat;
 				pjob->ji_wattr[(int)JOB_ATR_exit_status].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
 			}
+
+			/* see if it has any dependencies */
+			if (pjob->ji_wattr[(int)JOB_ATR_depend].at_flags & ATR_VFLAG_SET)
+				(void)depend_on_term(pjob);
+
 			/*
 			 * Check if the history of the finished job can be saved or it needs to be purged .
 			 */

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -966,7 +966,7 @@ on_job_exit(struct work_task *ptask)
 
 			if (ptask->wt_type != WORK_Deferred_Reply) { /* first time in */
 
-				/* see if have any dependencys */
+				/* see if have any dependencies */
 
 				if (pjob->ji_wattr[(int)JOB_ATR_depend].at_flags & ATR_VFLAG_SET)
 					(void)depend_on_term(pjob);

--- a/test/tests/functional/pbs_job_dependency.py
+++ b/test/tests/functional/pbs_job_dependency.py
@@ -80,7 +80,7 @@ e.accept()
             # enumerated job
             check_dl = dl[:ind] + dl[ind + 1:]
             for job_list in check_dl:
-                    self.assertIn(job, job_list)
+                self.assertIn(job, job_list)
 
     @skipOnCpuSet
     def test_runone_depend_basic(self):
@@ -371,6 +371,7 @@ e.accept()
 
         a = {'job_history_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         job = Job()
         job.set_sleep_time(10)
         j1 = self.server.submit(job)
@@ -387,6 +388,7 @@ e.accept()
         job = Job(attrs=a)
         j4 = self.server.submit(job)
 
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {ATTR_state: 'F'}, id=j1, extend='x')
         self.server.expect(JOB, {ATTR_state: 'F'}, id=j2, extend='x',
                            max_attempts=3)
@@ -399,13 +401,14 @@ e.accept()
     def test_qdel_deleting_chain_of_dependency(self):
         """
         Submit a chain of dependent jobs and see if one of the running jobs
-        is deleted, all the dependent jobs (and their dependent jobs)
+        is deleted, all the jobs without their dependency released
         are also deleted.
         Try the same test with array jobs as well.
         """
 
         a = {'job_history_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         job = Job()
         j1 = self.server.submit(job)
 
@@ -421,7 +424,9 @@ e.accept()
         job = Job(attrs=a)
         j4 = self.server.submit(job)
 
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {ATTR_state: 'R'}, id=j1)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=j4)
         self.server.delete(j1)
         self.server.expect(JOB, {ATTR_state: 'F'}, id=j1, extend='x')
         self.server.expect(JOB, {ATTR_state: 'F'}, id=j2, extend='x',
@@ -434,6 +439,7 @@ e.accept()
         self.server.delete(j4)
 
         # repeat the steps for array job
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         job = Job(attrs={ATTR_J: '1-2'})
         j5 = self.server.submit(job)
 
@@ -449,7 +455,9 @@ e.accept()
         job = Job(attrs=a)
         j8 = self.server.submit(job)
 
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {'job_state': 'B'}, id=j5)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=j8)
         self.server.delete(j5)
         self.server.expect(JOB, {ATTR_state: 'F'}, id=j5, extend='x')
         self.server.expect(JOB, {ATTR_state: 'F'}, id=j6, extend='x',
@@ -463,12 +471,13 @@ e.accept()
     def test_qdel_held_job_deleting_chain_of_dependency(self):
         """
         Submit a chain of dependent jobs and see if one of the held jobs
-        is deleted, all its dependent jobs (and their dependent jobs)
+        is deleted, all the jobs without their dependency released
         are also deleted.
         """
 
         a = {'job_history_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         job = Job()
         j1 = self.server.submit(job)
 
@@ -484,6 +493,7 @@ e.accept()
         job = Job(attrs=a)
         j4 = self.server.submit(job)
 
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {ATTR_state: 'H'}, id=j2)
         self.server.expect(JOB, {ATTR_state: 'H'}, id=j3)
         self.server.expect(JOB, {ATTR_state: 'H'}, id=j4)
@@ -506,6 +516,7 @@ e.accept()
 
         a = {'job_history_enable': 'True'}
         self.server.manager(MGR_CMD_SET, SERVER, a)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         job = Job()
         j1 = self.server.submit(job)
 
@@ -521,6 +532,7 @@ e.accept()
         job = Job(attrs=a)
         j4 = self.server.submit(job)
 
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {ATTR_state: 'H'}, id=j2)
         self.server.expect(JOB, {ATTR_state: 'H'}, id=j3)
         self.server.expect(JOB, {ATTR_state: 'H'}, id=j4)

--- a/test/tests/performance/test_dependency_perf.py
+++ b/test/tests/performance/test_dependency_perf.py
@@ -1,0 +1,83 @@
+# coding: utf-8
+
+# Copyright (C) 1994-2020 Altair Engineering, Inc.
+# For more information, contact Altair at www.altair.com.
+#
+# This file is part of the PBS Professional ("PBS Pro") software.
+#
+# Open Source License Information:
+#
+# PBS Pro is free software. You can redistribute it and/or modify it under the
+# terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Commercial License Information:
+#
+# For a copy of the commercial license terms and conditions,
+# go to: (http://www.pbspro.com/UserArea/agreement.html)
+# or contact the Altair Legal Department.
+#
+# Altair’s dual-license business model allows companies, individuals, and
+# organizations to create proprietary derivative works of PBS Pro and
+# distribute them - whether embedded or bundled with other software -
+# under a commercial license agreement.
+#
+# Use of Altair’s trademarks, including but not limited to "PBS™",
+# "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+# trademark licensing policies.
+
+
+from tests.performance import *
+
+
+class TestDependencyPerformance(TestPerformance):
+    """
+    Test the performance of job dependency feature
+    """
+    def check_depend_delete_msg(self, pjid, cjid):
+        """
+        helper function to check ia message that the dependent job (cjid)
+        is deleted because of the parent job (pjid)
+        """
+        msg = cjid + ";Job deleted as result of dependency on job " + pjid
+        self.server.log_match(msg)
+
+    @timeout(1800)
+    def test_delete_long_dependency_chains(self):
+        """
+        Submit a very long chain of dependent jobs and then measure the time
+        PBS takes to get rid of all dependent jobs.
+        """
+
+        a = {'job_history_enable': 'True'}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
+        job = Job()
+        job.set_sleep_time(3600)
+        jid = self.server.submit(job)
+        j_arr = [jid]
+        for each in range(5000):
+            a = {ATTR_depend: 'afternotok:' + jid}
+            jid = self.server.submit(Job(attrs=a))
+            j_arr.append(jid)
+
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=j_arr[0])
+        self.server.expect(JOB, {ATTR_state: 'H'}, id=j_arr[5000])
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+        t1 = time.time()
+        self.server.delete(j_arr[0])
+        self.server.expect(JOB, {ATTR_state: 'F'}, id=j_arr[5000],
+                           extend='x', interval=2)
+        t2 = time.time()
+        self.logger.info('#' * 80)
+        self.logger.info('Time taken to delete all jobs %f' % (t2-t1))
+        self.logger.info('#' * 80)
+        self.check_depend_delete_msg(j_arr[4999], j_arr[5000])

--- a/test/tests/performance/test_dependency_perf.py
+++ b/test/tests/performance/test_dependency_perf.py
@@ -64,7 +64,7 @@ class TestDependencyPerformance(TestPerformance):
         job.set_sleep_time(3600)
         jid = self.server.submit(job)
         j_arr = [jid]
-        for each in range(5000):
+        for _ in range(5000):
             a = {ATTR_depend: 'afternotok:' + jid}
             jid = self.server.submit(Job(attrs=a))
             j_arr.append(jid)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a running job ends or it is deleted, the chain of jobs dependent on the running job, and their dependent jobs are not deleted/released properly.
This change will delete/release the dependent jobs and their dependent jobs.



#### Describe Your Change
With this change in place - 

- If a running job is deleted (with -Wforce or not) the chain of all dependent jobs is deleted.
- If a Held job is deleted, chain of all dependent jobs is also deleted.
- While deleting the chain, only jobs that are scheduled to run after the said job are deleted.


#### Link to Design Doc
This was a bug in the product, to begin with. No design changes.


#### Attach Test and Valgrind Logs/Output
[test_perf.txt](https://github.com/PBSPro/pbspro/files/4531902/test_perf.txt)
[test.txt](https://github.com/PBSPro/pbspro/files/4531903/test.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
