### PR TITLE
Fixing start time change when endtime and duration changes

### DIFF
--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -786,6 +786,7 @@ req_modifyReservation(struct batch_request *preq)
 	resc_access_perm_save = resc_access_perm;
 	psatl = (svrattrl *)GET_NEXT(preq->rq_ind.rq_modify.rq_attr);
 	presv->ri_alter_flags = 0;
+	presv->ri_alter_state = presv->ri_wattr[RESV_ATR_state].at_val.at_long;
 
 	while (psatl) {
 		long temp = 0;
@@ -836,13 +837,11 @@ req_modifyReservation(struct batch_request *preq)
 							return;
 						}
 					} else {
-						presv->ri_alter_state = presv->ri_wattr[RESV_ATR_state].at_val.at_long;
 						resv_revert_alter_times(presv);
 						req_reject(PBSE_BADTSPEC, 0, preq);
 						return;
 					}
 				} else {
-					presv->ri_alter_state = presv->ri_wattr[RESV_ATR_state].at_val.at_long;
 					resv_revert_alter_times(presv);
 					if (num_jobs)
 						req_reject(PBSE_RESV_NOT_EMPTY, 0, preq);
@@ -859,7 +858,6 @@ req_modifyReservation(struct batch_request *preq)
 					presv->ri_alter_etime = presv->ri_wattr[RESV_ATR_end].at_val.at_long;
 					presv->ri_alter_flags |= RESV_END_TIME_MODIFIED;
 				} else {
-					presv->ri_alter_state = presv->ri_wattr[RESV_ATR_state].at_val.at_long;
 					resv_revert_alter_times(presv);
 					snprintf(log_buffer, sizeof(log_buffer), "%s", msg_stdg_resv_occr_conflict);
 					log_event(PBSEVENT_RESV, PBS_EVENTCLASS_RESV, LOG_INFO,
@@ -889,7 +887,7 @@ req_modifyReservation(struct batch_request *preq)
 		psatl = (svrattrl *)GET_NEXT(psatl->al_link);
 	}
 
-	presv->ri_alter_state = presv->ri_wattr[RESV_ATR_state].at_val.at_long;
+	
 	if (presv->ri_wattr[RESV_ATR_state].at_val.at_long == RESV_RUNNING && num_jobs) {
 		if ((presv->ri_alter_flags & RESV_DURATION_MODIFIED) && (presv->ri_alter_flags & RESV_END_TIME_MODIFIED)) {
 			resv_revert_alter_times(presv);
@@ -927,7 +925,6 @@ req_modifyReservation(struct batch_request *preq)
 
 
 	if (send_to_scheduler) {
-		presv->ri_alter_state = presv->ri_wattr[RESV_ATR_state].at_val.at_long;
 		resv_setResvState(presv, RESV_BEING_ALTERED, presv->ri_qs.ri_substate);
 		/*"start", "end","duration", and "wall"; derive and check */
 		if (start_end_dur_wall(presv, RESC_RESV_OBJECT)) {

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1850,6 +1850,9 @@ class TestPbsResvAlter(TestFunctional):
         self.alter_a_reservation(rid, start, end, a_duration=new_duration,
                                  check_log=False, whichMessage=0)
 
+        attrs = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, attrs, id=rid)
+
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
         self.assertEqual(int(t_start), start)
         self.assertEqual(int(t_duration), duration)
@@ -1885,6 +1888,10 @@ class TestPbsResvAlter(TestFunctional):
         ret = self.du.run_cmd(self.server.hostname, ralter_cmd)
         self.assertIn('pbs_ralter: Reservation not empty', ret['err'][0])
 
+        # Test that the reservation state is Running and not RESV_NONE
+        attrs = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, attrs, id=rid)
+
         t_duration, t_start, t_end = self.get_resv_time_info(rid)
         self.assertEqual(int(t_start), start)
         self.assertEqual(int(t_duration), dur)
@@ -1909,3 +1916,74 @@ class TestPbsResvAlter(TestFunctional):
         self.assertEqual(int(t_start), start)
         self.assertEqual(int(t_duration), new_duration_in_sec)
         self.assertEqual(int(t_end), new_end)
+
+    def test_adv_resv_dur_and_endtime_with_running_jobs(self):
+        """
+        Test that duration and end time of reservation cannot be changed
+        together if there are running jobs inside it. This will fail
+        because start time cannot be changed when there are running
+        jobs in a reservation.
+        """
+
+        offset = 10
+        duration = 20
+        new_duration = 30
+        shift = 10
+        rid, start, end = self.submit_and_confirm_reservation(offset, duration)
+
+        self.check_resv_running(rid, offset)
+
+        jid = self.submit_job_to_resv(rid, user=TEST_USER)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+
+        new_end = self.bu.convert_seconds_to_datetime(end + 30)
+        with self.assertRaises(PbsResvAlterError) as e:
+            attr = {'reserve_end': new_end,
+                    'reserve_duration': new_duration}
+            self.server.alterresv(rid, attr)
+        self.assertIn('pbs_ralter: Reservation not empty',
+                      e.exception.msg[0])
+
+        # Test that the reservation state is Running and not RESV_NONE
+        attrs = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, attrs, id=rid)
+
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+
+        self.assertEqual(t_end, end)
+        self.assertEqual(t_start, start)
+        self.assertEqual(t_duration, duration)
+
+    def test_standing_resv_dur_and_endtime_with_running_jobs(self):
+        """
+        Change duration and endtime of standing reservation with
+        running jobs in it. Verify that the alter fails and
+        starttime remains the same
+        """
+        offset = 10
+        duration = 20
+        new_duration = 30
+        shift = 15
+        rid, start, end = self.submit_and_confirm_reservation(offset,
+                                                              duration,
+                                                              standing=True)
+
+        jid = self.submit_job_to_resv(rid, user=TEST_USER)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid, offset=offset)
+
+        new_end = self.bu.convert_seconds_to_datetime(end + 30)
+        with self.assertRaises(PbsResvAlterError) as e:
+            attr = {'reserve_end': new_end,
+                    'reserve_duration': new_duration}
+            self.server.alterresv(rid, attr)
+        self.assertIn('pbs_ralter: Reservation not empty',
+                      e.exception.msg[0])
+
+        # Test that the reservation state is Running and not RESV_NONE
+        attrs = {'reserve_state': (MATCH_RE, 'RESV_RUNNING|5')}
+        self.server.expect(RESV, attrs, id=rid)
+
+        t_duration, t_start, t_end = self.get_resv_time_info(rid)
+        self.assertEqual(t_end, end)
+        self.assertEqual(t_start, start)
+        self.assertEqual(t_duration, duration)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
1) Start time of a reservation was changing even if there were running jobs in it. This was happening when both end time and duration of a reservation changes which would cause the start time to change. 
2) If the alter fails, PBS reverts back original reservation values. In this case the reservation state should also be set to the correct value. In some cases the value was set to RESV_NONE

#### Describe Your Change
1) Added a if statement to check that when end time and duration of a reservation is changed,  there should not be running jobs in it.
2) Save the current reservation state. If alter fails before reverting the reservation values, the correct value will be set.


#### Attach Test and Valgrind Logs/Output
[ralter_log.txt](https://github.com/PBSPro/pbspro/files/4560080/ralter_log.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
