### PR TITLE
Fix for auth handshake already completed

### DIFF
--- a/src/lib/Libtpp/tpp_client.c
+++ b/src/lib/Libtpp/tpp_client.c
@@ -4409,7 +4409,7 @@ leaf_pkt_handler(int tfd, void *data, int len, void *ctx, void *extra)
 
 		if (ahdr.for_encrypt == FOR_ENCRYPT && strcmp(authdata->config->auth_method, AUTH_RESVPORT_NAME) != 0) {
 			if (strcmp(authdata->config->auth_method, authdata->config->encrypt_method) != 0) {
-				rc = tpp_handle_auth_handshake(tfd, tfd, authdata, ahdr.for_encrypt, NULL, 0);
+				rc = tpp_handle_auth_handshake(tfd, tfd, authdata, FOR_AUTH, NULL, 0);
 				if (rc != 1) {
 					return rc;
 				}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
In TPP leaf, once the handshake for the encrypt method completes, if the auth method is set (which is not resvport and not equal to the encrypt method) leaf should start handshake for the auth method, but currently, it is starting handshake for the encrypt method again.
Which can lead to failures when libauth library rejects if trying to do handshake on an already completed handshake

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fix the TPP leaf to start a handshake for the auth method once the handshake of the encrypt method is completed.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Using dummy libauth implementation: [dummy.txt](https://github.com/PBSPro/pbspro/files/4538327/dummy.txt)
[before.txt](https://github.com/PBSPro/pbspro/files/4538324/before.txt)
[after.txt](https://github.com/PBSPro/pbspro/files/4538322/after.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
