### PR TITLE
Test test_resv_job_soft_hard2 of TestSoftWalltime is failing while verfiying job attributes

### DIFF
--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2254,11 +2254,8 @@ class TestReservations(TestFunctional):
         self.server.expect(RESV,
                            {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')},
                            id=rid)
-
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
         a = {'Resource_List.ncpus': 4,
-             'Resource_List.walltime': 60}
+             'Resource_List.walltime': 50}
         J = Job(TEST_USER, attrs=a)
         jid = self.server.submit(J)
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -2235,3 +2235,30 @@ class TestReservations(TestFunctional):
         jid = self.server.submit(J)
 
         self.server.expect(JOB, {ATTR_state: 'R'}, id=jid)
+
+    @skipOnCpuSet
+    def test_resv_job_hard_walltime(self):
+        """
+        Test that a job with hard walltime will not conflict with
+        reservtion if hard walltime is less that reservation start time.
+        """
+        a = {'resources_available.ncpus': 4}
+        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
+
+        now = int(time.time())
+
+        a = {'Resource_List.ncpus': 4, 'reserve_start': now + 65,
+             'reserve_end': now + 240}
+        R = Reservation(TEST_USER, attrs=a)
+        rid = self.server.submit(R)
+        self.server.expect(RESV,
+                           {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')},
+                           id=rid)
+
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
+        a = {'Resource_List.ncpus': 4,
+             'Resource_List.walltime': 60}
+        J = Job(TEST_USER, attrs=a)
+        jid = self.server.submit(J)
+        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -1023,7 +1023,7 @@ e.accept()
 
         now = int(time.time())
 
-        a = {'Resource_List.ncpus': 4, 'reserve_start': now + 65,
+        a = {'Resource_List.ncpus': 4, 'reserve_start': now + 80,
              'reserve_end': now + 240}
         R = Reservation(TEST_USER, attrs=a)
         rid = self.server.submit(R)

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -1013,34 +1013,6 @@ e.accept()
                            extend='x', attrop=PTL_AND, id=jid)
 
     @skipOnCpuSet
-    def test_resv_job_soft_hard2(self):
-        """
-        Test that a job with soft and hard walltime will not conflict with
-        reservtion if hard walltime is less that reservation start time.
-        """
-        a = {'resources_available.ncpus': 4}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
-
-        now = int(time.time())
-
-        a = {'Resource_List.ncpus': 4, 'reserve_start': now + 80,
-             'reserve_end': now + 240}
-        R = Reservation(TEST_USER, attrs=a)
-        rid = self.server.submit(R)
-        self.server.expect(RESV,
-                           {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')},
-                           id=rid)
-
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})
-        a = {'Resource_List.ncpus': 4,
-             'Resource_List.walltime': 60}
-        J = Job(TEST_USER, attrs=a)
-        jid = self.server.submit(J)
-        self.server.alterjob(jid, {'Resource_List.soft_walltime': 60})
-        self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
-        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-
-    @skipOnCpuSet
     def test_soft_job_array(self):
         """
         Test that soft walltime works similar way with subjobs as


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Test test_resv_job_soft_hard2 of TestSoftWalltime failed with Job state in Queue state while test is expecting it in Running state.
This is due to, Reservation start time and when Job is altered with softwalltime=60 was conflicting and thus Job remained in Q state.

#### Describe Your Change
Move this test case from TestSoftWalltime to TestReservations test suite as this test is more related to reservation functionality by removing softwalltime part from test case.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[test_resv_job_soft_hard2_after_fix.txt](https://github.com/PBSPro/pbspro/files/4543948/test_resv_job_soft_hard2_after_fix.txt)
[test_resv_job_soft_hard2_before_fix.txt](https://github.com/PBSPro/pbspro/files/4543949/test_resv_job_soft_hard2_before_fix.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
