### PR TITLE
Add skipOnCpuSet decorator SmokeTest tests

### DIFF
--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -563,7 +563,7 @@ class SmokeTest(PBSTestSuite):
         Test to submit job with job script
         """
         j = Job(TEST_USER, attrs={ATTR_N: 'test'})
-        j.create_script('sleep 5\n', hostname=self.server.client)
+        j.create_script('sleep 120\n', hostname=self.server.client)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
         self.server.delete(id=jid, extend='force', wait=True)

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -558,17 +558,15 @@ class SmokeTest(PBSTestSuite):
                 (GE, a['Resource_List.min_walltime'])}
         self.server.expect(JOB, attr, id=jid)
 
-    @skipOnCpuSet
     def test_submit_job_with_script(self):
         """
         Test to submit job with job script
         """
-        a = {ATTR_rescavail + '.ncpus': '2'}
-        self.server.manager(MGR_CMD_SET, NODE, a, id=self.mom.shortname)
         j = Job(TEST_USER, attrs={ATTR_N: 'test'})
-        j.create_script('sleep 120\n', hostname=self.server.client)
+        j.create_script('sleep 5\n', hostname=self.server.client)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=5)
         self.logger.info("Testing script with extension")
         j = Job(TEST_USER)
         fn = self.du.create_temp_file(suffix=".scr", body="/bin/sleep 10",

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -558,6 +558,7 @@ class SmokeTest(PBSTestSuite):
                 (GE, a['Resource_List.min_walltime'])}
         self.server.expect(JOB, attr, id=jid)
 
+    @skipOnCpuSet
     def test_submit_job_with_script(self):
         """
         Test to submit job with job script
@@ -1567,6 +1568,7 @@ class SmokeTest(PBSTestSuite):
             msg += " %s command" % pbs_cmd
             self.logger.info(msg)
 
+    @skipOnCpuSet
     def test_exclhost(self):
         """
         Test that a job requesting exclhost is not placed on another host

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -566,19 +566,14 @@ class SmokeTest(PBSTestSuite):
         j.create_script('sleep 5\n', hostname=self.server.client)
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-        self.server.expect(JOB, 'queue', op=UNSET, id=jid, offset=5)
+        self.server.delete(id=jid, extend='force', wait=True)
         self.logger.info("Testing script with extension")
         j = Job(TEST_USER)
         fn = self.du.create_temp_file(suffix=".scr", body="/bin/sleep 10",
                                       asuser=str(TEST_USER))
-        try:
-            jid = self.server.submit(j, script=fn)
-        except PbsSubmitError as e:
-            self.assertNotIn('illegal -N value', e.msg[0],
-                             'qsub: Not accepted "." in job name')
-        else:
-            self.server.expect(JOB, {'job_state': 'R'}, id=jid)
-            self.logger.info('Job submitted successfully: ' + jid)
+        jid = self.server.submit(j, script=fn)
+        self.server.expect(JOB, {'job_state': 'R'}, id=jid)
+        self.logger.info('Job submitted successfully: ' + jid)
 
     @skipOnCpuSet
     def test_formula_match(self):


### PR DESCRIPTION
#### Describe Bug or Feature
Tests test_submit_job_with_script,test_exclhost of SmokTest are failing due to ncpus being set on Mom node and also creating vnodes in test respectively.

#### Describe Your Change
Added skipOnCpuSet decorator on test_exclhost test and modified test_submit_job_with_script test to run on cpuset machine. 

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
