### PR TITLE
Fix: NULL environment variable names cause a crash

### DIFF
--- a/src/resmom_win/start_exec.c
+++ b/src/resmom_win/start_exec.c
@@ -850,7 +850,7 @@ bld_wenv_variables(char *name, char *value)
 	int	i;
 	char    str_buf[MAXPATHLEN+1] = {0};
 
-	if ((*name == '\0') || (*name == '\n'))
+	if ((name == NULL) || (name == '\0') || (name == '\n'))
 		return;			/* invalid name */
 
 	if (env_array == NULL) {

--- a/src/resmom_win/start_exec.c
+++ b/src/resmom_win/start_exec.c
@@ -850,7 +850,7 @@ bld_wenv_variables(char *name, char *value)
 	int	i;
 	char    str_buf[MAXPATHLEN+1] = {0};
 
-	if ((name == NULL) || (name == '\0') || (name == '\n'))
+	if ((!name) || (*name == '\0') || (*name == '\n'))
 		return;			/* invalid name */
 
 	if (env_array == NULL) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
qsub -S causes a mom crash when an incorrect path is provided.


#### Describe Your Change
This crash is caused when trying to build an environment variable with NULL as it's name. While adding variables to the environment there is no check for whether or not it is NULL.


#### Link to Design Doc
No design changes


#### Attach Test and Valgrind Logs/Output




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
