### PR TITLE
test "pbs_hook_send" checks “Timing out” messages are received when one of the mom is unresponsive

### DIFF
--- a/test/tests/functional/pbs_hook_timeout.py
+++ b/test/tests/functional/pbs_hook_timeout.py
@@ -74,6 +74,19 @@ class TestHookTimeout(TestFunctional):
         for mom in self.moms.values():
             self.server.expect(NODE, {'state': 'free'}, id=mom.shortname)
 
+    def timeout_messages(self, num_msg=1, starttime=None):
+        msg_found = None
+        for count in range(10):
+            sleep(30)
+            allmatch_msg = self.server.log_match(
+                "Timing out previous send of mom hook updates ",
+                max_attempts=1, starttime=starttime, allmatch=True)
+            if len(allmatch_msg) >= num_msg:
+                msg_found = allmatch_msg
+                break
+        self.assertIsNotNone(msg_found,
+                             msg="Didn't get expected timeout messages")
+
     def test_hook_send(self):
         """
         Test when the server doesn't receive an ACK from a mom for
@@ -81,7 +94,6 @@ class TestHookTimeout(TestFunctional):
         """
         self.server.manager(MGR_CMD_SET, SERVER, {'log_events': 2047})
         timeout_max_attempt = 7
-        timeout_msg = False
 
         # Make momB unresponsive
         self.logger.info("Stopping MomB")
@@ -117,18 +129,7 @@ class TestHookTimeout(TestFunctional):
 
         # Second batch of hook update is for the *.PY files + resend of
         # *.HK file to momB
-        for count in range(10):
-            sleep(30)
-            allmatch_msg = self.server.log_match(
-                "Timing out previous send of mom hook updates ",
-                n=600, starttime=start_time, allmatch=True)
-            if len(allmatch_msg) >= 2:
-                timeout_msg = True
-                break
-        if not timeout_msg:
-            self.logger.error("Doesn't gets expected timeout messages")
-        timeout_msg = False
-
+        self.timeout_messages(2, start_time)
         # sent hook content file
         for h in [self.hostA, self.hostB, self.hostC]:
             hfile = os.path.join(self.server.pbs_conf['PBS_HOME'],
@@ -162,16 +163,7 @@ class TestHookTimeout(TestFunctional):
 
         # Ensure that hook send updates are retried for
         # the *.HK and *.PY file to momB
-        for count in range(10):
-            sleep(30)
-            allmatch_msg = self.server.log_match(
-                "Timing out previous send of mom hook updates ",
-                n=600, starttime=start_time, allmatch=True)
-            if len(allmatch_msg) >= 3:
-                timeout_msg = True
-                break
-        if not timeout_msg:
-            self.logger.error("Doesn't gets expected timeout messages")
+        self.timeout_messages(3, start_time)
         # Submit a job, it should still run
         a = {'Resource_List.select': '3:ncpus=1',
              'Resource_List.place': 'scatter'}

--- a/test/tests/functional/pbs_hook_timeout.py
+++ b/test/tests/functional/pbs_hook_timeout.py
@@ -94,11 +94,11 @@ class TestHookTimeout(TestFunctional):
         self.server.import_hook("test", hook_body)
 
         # First batch of hook update is for the *.HK files
-        self.server.log_match(
-            "Timing out previous send of mom hook updates "
-            "(send replies expected=3 received=2)", n=600,
-            max_attempts=timeout_max_attempt, interval=30,
-            starttime=start_time)
+        for count in range(3):
+            self.server.log_match(
+                "Timing out previous send of mom hook updates ", n=600,
+                max_attempts=timeout_max_attempt, interval=30,
+                starttime=start_time)
 
         # sent hook control file
         for h in [self.hostA, self.hostB, self.hostC]:
@@ -116,11 +116,11 @@ class TestHookTimeout(TestFunctional):
 
         # Second batch of hook update is for the *.PY files + resend of
         # *.HK file to momB
-        self.server.log_match(
-            "Timing out previous send of mom hook updates "
-            "(send replies expected=4 received=2)", n=600,
-            max_attempts=timeout_max_attempt, interval=30,
-            starttime=start_time)
+        for count in range(3):
+            self.server.log_match(
+                "Timing out previous send of mom hook updates ", n=600,
+                max_attempts=timeout_max_attempt, interval=30,
+                starttime=start_time)
 
         # sent hook content file
         for h in [self.hostA, self.hostB, self.hostC]:
@@ -155,11 +155,11 @@ class TestHookTimeout(TestFunctional):
 
         # Ensure that hook send updates are retried for
         # the *.HK and *.PY file to momB
-        self.server.log_match(
-            "Timing out previous send of mom hook updates "
-            "(send replies expected=2 received=0)", n=600,
-            max_attempts=timeout_max_attempt, interval=30,
-            starttime=start_time)
+        for count in range(3):
+            self.server.log_match(
+                "Timing out previous send of mom hook updates ", n=600,
+                max_attempts=timeout_max_attempt, interval=30,
+                starttime=start_time)
 
         # Submit a job, it should still run
         a = {'Resource_List.select': '3:ncpus=1',


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
test is checking "(send replies  expect and receive" along with timeout message when one of the mom is unresponsive. Number of expect and received are not constant, numbers vary on each test-run
It is important to check timeout messages are received at least 3 times.


#### Describe Your Change
Test checks “Timing out” messages are received at least 3 times when one of the mom is unresponsive


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[timeout_message.txt](https://github.com/PBSPro/pbspro/files/4581933/timeout_message.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
