### PR TITLE
Server does not reply to ralter cmd when scheduler fails to alter resv

### DIFF
--- a/src/server/req_modify.c
+++ b/src/server/req_modify.c
@@ -965,11 +965,8 @@ req_modifyReservation(struct batch_request *preq)
 		}
 	}
 
-	if (send_to_scheduler) {
-		presv->rep_sched_count = 0;
-		presv->req_sched_count = 0;
+	if (send_to_scheduler)
 		notify_scheds_about_resv(SCH_SCHEDULE_RESV_RECONFIRM, presv);
-	}
 
 	(void)sprintf(log_buffer, "Attempting to modify reservation");
 	if (presv->ri_alter_flags & RESV_START_TIME_MODIFIED) {

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -2090,13 +2090,19 @@ void notify_scheds_about_resv(int cmd, resc_resv *resv)
 
 	if (resv != NULL && resv->ri_wattr[(int)RESV_ATR_partition].at_flags & ATR_VFLAG_SET)
 		partition_name = resv->ri_wattr[(int)RESV_ATR_partition].at_val.at_str;
+	else if (resv != NULL)
+		/* for reservations without partitions, set request/reply count to 0
+		 * because this is the only case when notification will be sent to multiple
+		 * schedulers and server expects multiple replies. Once partition name is set,
+		 * only relevant scheduler is notified and server will receive only one reply. */
+		resv->req_sched_count = resv->rep_sched_count = 0;
+
 
 	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
 		if (partition_name != NULL) {
 			if (strcmp(partition_name, DEFAULT_PARTITION) == 0) {
 				if (dflt_scheduler->sch_attr[(int)SCHED_ATR_scheduling].at_val.at_long == 1) {
 					set_scheduler_flag(cmd, dflt_scheduler);
-					resv->req_sched_count++;
 				}
 				break;
 			} else {
@@ -2104,14 +2110,14 @@ void notify_scheds_about_resv(int cmd, resc_resv *resv)
 				tmp = find_sched_from_partition(partition_name);
 				if (tmp != NULL && (tmp->sch_attr[(int)SCHED_ATR_scheduling].at_val.at_long == 1)) {
 					set_scheduler_flag(cmd, tmp);
-					resv->req_sched_count++;
 					break;
 				}
 			}
 		} else {
 			if (psched->sch_attr[(int)SCHED_ATR_scheduling].at_val.at_long == 1) {
 				set_scheduler_flag(cmd, psched);
-				resv->req_sched_count++;
+				if (resv != NULL)
+					resv->req_sched_count++;
 			}
 		}
 	}

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -2088,14 +2088,17 @@ void notify_scheds_about_resv(int cmd, resc_resv *resv)
 	pbs_sched *psched;
 	char *partition_name = NULL;
 
-	if (resv != NULL && resv->ri_wattr[(int)RESV_ATR_partition].at_flags & ATR_VFLAG_SET)
-		partition_name = resv->ri_wattr[(int)RESV_ATR_partition].at_val.at_str;
-	else if (resv != NULL)
-		/* for reservations without partitions, set request/reply count to 0
-		 * because this is the only case when notification will be sent to multiple
-		 * schedulers and server expects multiple replies. Once partition name is set,
-		 * only relevant scheduler is notified and server will receive only one reply. */
-		resv->req_sched_count = resv->rep_sched_count = 0;
+	if (resv != NULL) {
+		if (resv->ri_wattr[(int)RESV_ATR_partition].at_flags & ATR_VFLAG_SET)
+			partition_name = resv->ri_wattr[(int)RESV_ATR_partition].at_val.at_str;
+		else
+			/* for reservations without partitions, set request/reply count to 0
+			 * because this is the only case when notification will be sent to multiple
+			 * schedulers and server expects multiple replies. Once partition name is set,
+			 * only relevant scheduler is notified and server will receive only one reply.
+			 */
+			resv->req_sched_count = resv->rep_sched_count = 0;
+	}
 
 
 	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {

--- a/src/server/req_rescq.c
+++ b/src/server/req_rescq.c
@@ -557,11 +557,9 @@ req_confirmresv(struct batch_request *preq)
 	is_being_altered = presv->ri_alter_flags;
 	is_confirmed = (presv->ri_qs.ri_substate == RESV_CONFIRMED) ? 1 : 0;
 
-	/* Check if preq is coming from scheduler */
-	/* Increment reply count if reservation is not already confirmed*/
-	if (!is_confirmed && !is_degraded && !is_being_altered)
-		presv->rep_sched_count++;
+	presv->rep_sched_count++;
 
+	/* Check if preq is coming from scheduler */
 	if (preq->rq_extend == NULL) {
 		req_reject(PBSE_resvFail, 0, preq);
 		return;
@@ -586,7 +584,7 @@ req_confirmresv(struct batch_request *preq)
 				log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_RESV, LOG_NOTICE, presv->ri_qs.ri_resvID, log_buffer);
 			}
 		} else {
-			if (presv->rep_sched_count >= presv->req_sched_count && !is_confirmed) {
+			if ((presv->rep_sched_count >= presv->req_sched_count) && !is_confirmed) {
 				/* Clients waiting on an interactive request must be
 				* notified of the failure to confirm
 				*/

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -3523,17 +3523,8 @@ Time4occurrenceFinish(resc_resv *presv)
 			set_resv_retry(presv, time_now + 120);
 	}
 
-	if (sub == RESV_DEGRADED) {
+	if (sub == RESV_DEGRADED)
 		DBPRT(("degraded_time of %s is %s", presv->ri_qs.ri_resvID, ctime(&presv->ri_degraded_time)))
-		/* If no jobs are running in this reservation, unset the scheduler name
-		 * so that the reservation can be confirmed by any scheduler
-		 */
-		if (presv->ri_qp->qu_njstate[JOB_STATE_RUNNING] + presv->ri_qp->qu_njstate[JOB_STATE_EXITING] == 0) {
-			resv_attr_def[(int)RESV_ATR_partition].at_free(&presv->ri_wattr[(int)RESV_ATR_partition]);
-			presv->rep_sched_count= 0;
-			presv->req_sched_count= 0;
-		}
-	}
 
 	/* Set the reservation state and substate */
 	resv_setResvState(presv, state, sub);

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -214,7 +214,7 @@ class TestMultipleSchedulers(TestFunctional):
         pbs_home = self.server.pbs_conf['PBS_HOME']
         self.du.run_copy(self.server.hostname,
                          src=os.path.join(pbs_home, 'sched_priv'),
-                         dest=s.path.join(pbs_home, 'sc1_new_priv'),
+                         dest=os.path.join(pbs_home, 'sc1_new_priv'),
                          recursive=True)
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'sched_priv': '/var/spool/pbs/sc1_new_priv'},


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
when ralter is issue with "-I" option, server fails to reply to the command when the scheduler fails to confirm the reservation.


#### Describe Your Change
This issue arose when we changed PBS to support reservations in multi-sched environment. The problem is that server keeps a count of request/replies it sent/received from scheduler. Now, the server used these req/reply counts to ensure that it has received all replies from all schedulers before reply to the command that it failed to confirm a reservation.

Now when the user tries to ralter a reservation, the server used to increment the reply count only when the reservation was in an unconfirmed state. This leads to a problem because, during ralter, state of the reservation is set to "being_altered".

The fix is to use req/reply count only when the reservation's partition is not set. It is only in this case that the notification to confirm a reservation is sent to all schedulers.  Once a partition is set on a reservation, it is never unset and the server only has 1:1 communication with the relevant scheduler about this reservation.

in this fix notify_scheds_about_resv() function resets req/reply count to 0 when it sees the partition is not set on the reservation. It also increments request count only when partition is not set.
In req_confirmresv we increment reply count in all the cases. This is because it is hard to tell if replies are coming because of the initial broadcast made to all schedulers of because of a notification sent to a particular scheduler.

Along with this bug fix, I've fixed a place where we were unsetting partition when a standard reservation moved to a degraded state. This was wrong because once a reservation is confirmed it sticks to the partition it was confirmed in.


#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
I've not written any extra test, there wasn't an easy way to efficiently capture the ralter hang in a test.
Below are logs from multi-sched test suite.
[test.txt](https://github.com/PBSPro/pbspro/files/4567038/test.txt)




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
