### PR TITLE
revert to default with cgroups

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13994,9 +13994,10 @@ class MoM(PBSService):
         Configure and enable cgroups hook
         """
         # check if cgroups subsystems including cpusets are mounted
-        with open(os.path.join(os.sep, 'proc', 'mounts'), 'r') as fd:
-            mounts = fd.read()
-        if 'cgroup' in mounts and mounts.count('cpuset') >= 2:
+        file = os.path.join(os.sep, 'proc', 'mounts')
+        mounts = self.du.cat(self.hostname, file)['out']
+        pat = 'cgroup /sys/fs/cgroup'
+        if str(mounts).count(pat) >= 6 and str(mounts).count('cpuset') >= 2:
             pbs_conf_val = self.du.parse_pbs_config(self.hostname)
             f1 = os.path.join(pbs_conf_val['PBS_EXEC'], 'lib',
                               'python', 'altair', 'pbs_hooks',
@@ -14020,7 +14021,9 @@ class MoM(PBSService):
             self.server.manager(MGR_CMD_SET, HOOK,
                                 {'enabled': 'True'}, 'pbs_cgroups')
         else:
-            self.logger.error('cgroup subsystems not mounted')
+            self.logger.error('%s: cgroup subsystems not mounted' %
+                              self.hostname)
+            raise AssertionError('cgroup subsystems not mounted')
 
 
 class Hook(PBSObject):

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6053,12 +6053,13 @@ class Server(PBSService):
             self.logger.error(m)
             return None
 
-        if not submit_dir and self.du.get_platform() != 'shasta':
+        if not submit_dir:
             submit_dir = pwd.getpwnam(obj.username)[5]
 
         cwd = os.getcwd()
-        if submit_dir:
-            os.chdir(submit_dir)
+        if self.platform != 'shasta':
+            if submit_dir:
+                os.chdir(submit_dir)
         c = None
         # 1- Submission using the command line tools
         if self.get_op_mode() == PTL_CLI:

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1471,7 +1471,15 @@ class PBSTestSuite(unittest.TestCase):
             self.logger.error('mom ' + mom.shortname + ' is down after revert')
         self.server.manager(MGR_CMD_CREATE, NODE, None, mom.shortname)
         a = {'state': 'free'}
-        self.server.expect(NODE, a, id=mom.shortname, interval=1)
+        if mom.is_cpuset_mom():
+            mom.log_match('pbs_cgroups.CF;copy hook-related '
+                          'file request received',
+                          starttime=self.server.ctime)
+            time.sleep(2)
+            mom.signal('-HUP')
+            self.server.expect(NODE, a, id=mom.shortname + '[0]', interval=1)
+        else:
+            self.server.expect(NODE, a, id=mom.shortname, interval=1)
         return mom
 
     def analyze_logs(self):

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -170,13 +170,14 @@ def skipOnShasta(function):
 
 def skipOnCpuSet(function):
     """
-    Decorator to skip a test on a CpuSet system
+    Decorator to skip a test on a cgroup cpuset system
     """
 
     def wrapper(self, *args, **kwargs):
         for mom in self.moms.values():
             if mom.is_cpuset_mom():
-                msg = 'capability not supported on Cpuset mom:' + mom.shortname
+                msg = 'capability not supported on cgroup cpuset system: ' +\
+                      mom.shortname
                 self.skipTest(reason=msg)
                 break
         else:
@@ -1460,6 +1461,8 @@ class PBSTestSuite(unittest.TestCase):
             if 'clienthost' in self.conf:
                 conf.update({'$clienthost': self.conf['clienthost']})
             mom.apply_config(conf=conf, hup=False, restart=False)
+            if mom.is_cpuset_mom():
+                mom.enable_cgroup_cset()
         if restart:
             mom.restart()
         else:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Reverting to defaults should still work if instead of running cpuset mom we are running standard mom with pbs_cgroups hook enabled with vnode_per_numa_node = true and use_hyperthreads = true

This has to be merged together with PR #1662

#### Describe Your Change
- changed the logic in is_cpuset_mom() to detect the platform where cgroups cpuset would run
- added a method enable_cgroup_cset() to revert to pbs_cgroups hook enabled with vnode_per_numa_node = true and use_hyperthreads = true
- added to revert_mom() to call enable_cgroup_cset() on the appropriate platform.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Results from modified test that shows that after setUp():
    - nodes are free
    - expected pbs_cgroups hook configuration
    - pbs_cgroups hook is enabled
[TestVerifyLogOutput_uv300.txt](https://github.com/PBSPro/pbspro/files/4600848/TestVerifyLogOutput_uv300.txt)
[TestVerifyLogOutput_uv-01.txt](https://github.com/PBSPro/pbspro/files/4600849/TestVerifyLogOutput_uv-01.txt)

Test result showing skip on cgroup cpuset system:
[TestAdminSuspend.txt](https://github.com/PBSPro/pbspro/files/4578330/TestAdminSuspend.txt)

Test results with multiple moms (uv-01,cpuset system + testdev-07-r7, non-cpuset system):
[TestVerifyLogOutput_uv-01_td-07.txt](https://github.com/PBSPro/pbspro/files/4597469/TestVerifyLogOutput_uv-01_td-07.txt)  -- uv-01 is head node
[TestVerifyLogOutput_td-07_uv-01.txt](https://github.com/PBSPro/pbspro/files/4597470/TestVerifyLogOutput_td-07_uv-01.txt) -- testdev-07-r7 is head node



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
