### PR TITLE
if -use-current-setup is used delete resources in teardown before load_configuration 

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5205,14 +5205,20 @@ class Server(PBSService):
         if len(setdict) > 0:
             self.manager(MGR_CMD_SET, MGR_OBJ_SERVER, setdict)
         if revertresources:
-            try:
-                rescs = self.status(RSC)
-                rescs = [r['id'] for r in rescs]
-            except:
-                rescs = []
-            if len(rescs) > 0:
-                self.manager(MGR_CMD_DELETE, RSC, id=rescs)
+            self.delete_resources()
         return True
+
+    def delete_resources(self):
+        """
+        Delete all resources
+        """
+        try:
+            rescs = self.status(RSC)
+            rescs = [r['id'] for r in rescs]
+        except:
+            rescs = []
+        if len(rescs) > 0:
+            self.manager(MGR_CMD_DELETE, RSC, id=rescs)
 
     def unset_svr_attrib(self, server_stat=None):
         """

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1604,6 +1604,8 @@ class PBSTestSuite(unittest.TestCase):
         svr.delete_nodes()
         # Delete queues
         svr.delete_queues()
+        # Delete resources
+        svr.delete_resources()
 
     def tearDown(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
resources were not deleted before loading the new configuration, which leaded to test failure if run in succession


#### Describe Your Change
Delete all the resources before load configuration recreates resources from saved configuration.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Test ran in succession without failure when --use-current-setup is used.
[ptl_logs_res.txt](https://github.com/PBSPro/pbspro/files/4585879/ptl_logs_res.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
