### PR TITLE
Fixed typo error in pbs_multi_sched.py

### DIFF
--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -214,7 +214,7 @@ class TestMultipleSchedulers(TestFunctional):
         pbs_home = self.server.pbs_conf['PBS_HOME']
         self.du.run_copy(self.server.hostname,
                          src=os.path.join(pbs_home, 'sched_priv'),
-                         dest=s.path.join(pbs_home, 'sc1_new_priv'),
+                         dest=os.path.join(pbs_home, 'sc1_new_priv'),
                          recursive=True)
         self.server.manager(MGR_CMD_SET, SCHED,
                             {'sched_priv': '/var/spool/pbs/sc1_new_priv'},


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
os.path.join was replaced with s.path.join leading to syntax error

#### Describe Your Change
Fixed typo


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[multi_sched_log.txt](https://github.com/PBSPro/pbspro/files/4591295/multi_sched_log.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
