### PR TITLE
Fix pbs_python failure when executing script in non-embedded mode

### DIFF
--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -2423,11 +2423,12 @@ main(int argc, char *argv[], char *envp[])
 				return 1;
 			}
 
-			largv[0] = argv[0];
+			largv[0] = python_path;
 			largv[2] = NULL;
 
 			rc = execve(python_path, largv, lenvp);
 		} else {
+			argv[0] = python_path;
 			rc = execve(python_path, argv, lenvp);
 		}
 #endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
On TH2 and TH3 using a Jenkins build of PBS, pbs_python fails with the following error when it executes a script in non-embedded mode.
```
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Fatal Python error: Py_Initialize: Unable to get the locale encoding
ModuleNotFoundError: No module named 'encodings'
 
Current thread 0x00007fc2f2b98040 (most recent call first):
Aborted (core dumped)
```

#### The Cause
**TLDR**: This bug happens because the path to python executable `argv[0]`, which is also used to locate libraries and modules, is not set correctly before calling `execve()`.

Here is detailed and longer explanation from Hiren:

> Python uses that argv[0] to find its library in non-embedded mode (while in embedded mode, it will use what we set in Py_SetProgramName, in set_py_progname), now in pbs_python (aka non-embedded mode), argv[0] is set to PBS_EXEC/bin/pbs_python, so python will try to find its library in PBS_EXEC, and its fails.
> 
> Now, why it doesn't fail in TH3 or locally build because
> 
> For embedded mode - get_py_progname tries to find python location in PBS_EXEC/python first and if it fails, then it will try to find python in PYTHON_BIN_PATH (a macro defined at compile time from --with-python location in m4/with_python.m4). so in TH3 and locally build, PYTHON_BIN_PATH will always exist, so it will able to find its library using PYTHON_BIN_PATH.
> 
> For non-embedded mode - pbs_python will internally launch python (location found by get_py_progname) to run the script, and that python will try to use argv[0] (aka path to pbs_python) to find its library, which will fail so python will fallback to PREFIX (internal macro to python generated from the value given to Python's configure --prefix), which again will always exist, so it will able to find its library using PREFIX. (If you want you can look this logic in the function called "calculate_path()" in python source code).
> 
> Another proof to my theory is, despite this problem, our hooks are working, because in embedded mode, we use set_py_progname, which sets argv[0] via Py_SetProgameName(), and which will be used by python API's to find its library.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
set `argv[0]` to the correct value: `python_path`

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
N/A

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* Test result of SmokeTest, hook regression tests, and pbs_python_test on TH3
<img width="1680" alt="Screen Shot 2020-05-08 at 5 29 33 PM" src="https://user-images.githubusercontent.com/6920446/81394085-fd86bb80-9153-11ea-98eb-b2727ae3795c.png">

<img width="716" alt="Screen Shot 2020-05-08 at 5 29 46 PM" src="https://user-images.githubusercontent.com/6920446/81394107-037c9c80-9154-11ea-8bfa-499b3469a71c.png">

* Result of pbs_python_test on TH2:
<img width="1654" alt="Screen Shot 2020-05-08 at 4 59 40 AM" src="https://user-images.githubusercontent.com/6920446/81377753-b3441100-9138-11ea-842b-327da1844147.png">

All tests were run using a Jenkins build of this branch instead of a build from source. 

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
