### PR TITLE
Fix pbs_snaphot to copy logs from remote host to local host

### DIFF
--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -154,8 +154,7 @@ def remotesnap_thread(logger, host):
 
     # Copy over the snapshot tar file as <hostname>_snapshot.tgz
     dest_path = os.path.join(out_dir, host + "_snapshot.tgz")
-    src_path = host + ":" + snaptarname
-    ret = du.run_copy(src=src_path, dest=dest_path)
+    ret = du.run_copy(srchost=host, src=snaptarname, dest=dest_path)
     if ret['rc'] != 0:
         logger.error("Error copying child snapshot from host %s" % (host))
 
@@ -163,8 +162,7 @@ def remotesnap_thread(logger, host):
     if map_file is not None:
         dest_path = os.path.join(out_dir, host + "_" + map_file)
         src_path = os.path.join(snap_home, map_file)
-        src_path = host + ":" + src_path
-        ret = du.run_copy(src=src_path, dest=dest_path)
+        ret = du.run_copy(srchost=host, src=src_path, dest=dest_path)
         if ret['rc'] != 0:
             logger.error("Error copying map file from host %s" % (host))
 


### PR DESCRIPTION
#### Describe Bug or Feature
pbs_snapshot was failing to copy snapshot logs from remote host to local host and thus, finsla tar file was not containing remote host snap tar file. 

#### Describe Your Change
Made changes in run_copy in pbs_snapshot file to pass remote host in srchost param.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[snapshot_capure_after_fix.txt](https://github.com/PBSPro/pbspro/files/4597673/snapshot_capure_after_fix.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
