### PR TITLE
mom config file should have only one mom configuration data in one line

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4297,7 +4297,8 @@ class PBSService(PBSObject):
                                               + "configuration: %s" % k)
                             return False
                         with open(fn, 'w') as fd:
-                            fd.write("\n".join(v))
+                            mom_config_data = "\n".join(v) + "\n"
+                            fd.write(mom_config_data)
                         rv = self.du.run_copy(
                             self.hostname, src=fn, dest=k, sudo=True)
                         if rv['rc'] != 0:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -4297,8 +4297,7 @@ class PBSService(PBSObject):
                                               + "configuration: %s" % k)
                             return False
                         with open(fn, 'w') as fd:
-                            mom_config_data = "\n".join(v) + "\n"
-                            fd.write(mom_config_data)
+                            fd.write("\n".join(v))
                         rv = self.du.run_copy(
                             self.hostname, src=fn, dest=k, sudo=True)
                         if rv['rc'] != 0:
@@ -4330,7 +4329,8 @@ class PBSService(PBSObject):
                                               + "configuration: %s" % k)
                             return False
                         with open(fn, 'w') as fd:
-                            fd.write("\n".join(v))
+                            mom_config_data = "\n".join(v) + "\n"
+                            fd.write(mom_config_data)
                         rv = self.du.run_copy(
                             self.hostname, src=fn, dest=k, sudo=True)
                         if rv['rc'] != 0:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
when pbs_benchpress runs with --use-current-setup then  __load_configuration() writes all mom configuration data in a single line in mom config file. But mom config file should have only one mom configuration data in one line. So each new mom configuration data should be in a new line.


#### Describe Your Change
In mom config file, _load_configuration() writes each new mom configuration data in a new line

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

[with_current_setup.txt](https://github.com/PBSPro/pbspro/files/4598504/with_current_setup.txt)
[withou_current_setup.txt](https://github.com/PBSPro/pbspro/files/4598507/withou_current_setup.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
