### PR TITLE
If condition didn't scope DBPRT message

### DIFF
--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -3516,8 +3516,9 @@ Time4occurrenceFinish(resc_resv *presv)
 			set_resv_retry(presv, time_now + 120);
 	}
 
-	if (sub == RESV_DEGRADED)
+	if (sub == RESV_DEGRADED) {
 		DBPRT(("degraded_time of %s is %s", presv->ri_qs.ri_resvID, ctime(&presv->ri_degraded_time)))
+	}
 
 	/* Set the reservation state and substate */
 	resv_setResvState(presv, state, sub);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PR #1707 cause an issue where standing reservations after one occurrence were getting deleted.


#### Describe Your Change
The issue was that there was an if condition (without parenthesis) which had a DBPRT call inside the block.
Unfortunately, when the source is not complied in DEBUG mode, DBPRT is not defined. This caused the very next line (which was about setting the reservation state) to be considered inside the if condition which was wrong.


#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
[Test_passed.txt](https://github.com/PBSPro/pbspro/files/4602620/Test_passed.txt)
[Test_failed.txt](https://github.com/PBSPro/pbspro/files/4602621/Test_failed.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
