### PR TITLE
Separate out libauth.h from auth.h

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -45,6 +45,7 @@ include_HEADERS = \
 
 noinst_HEADERS = \
 	acct.h \
+	libauth.h \
 	auth.h \
 	attribute.h \
 	avltree.h \

--- a/src/include/auth.h
+++ b/src/include/auth.h
@@ -41,9 +41,10 @@
 extern "C" {
 #endif
 
+#include "libauth.h"
+
 #define AUTH_RESVPORT_NAME "resvport"
 #define AUTH_GSS_NAME "gss"
-#define MAXAUTHNAME 100
 #ifndef MAXPATHLEN
 #define MAXPATHLEN 1024
 #endif
@@ -51,45 +52,11 @@ extern "C" {
 #define FOR_AUTH 0
 #define FOR_ENCRYPT 1
 
-enum AUTH_ROLE {
-	AUTH_ROLE_UNKNOWN = 0,
-	AUTH_CLIENT,
-	AUTH_SERVER,
-	AUTH_ROLE_LAST
-};
-
-enum AUTH_CONN_TYPE {
-	AUTH_USER_CONN = 0,
-	AUTH_SERVICE_CONN
-};
-
 enum AUTH_CTX_STATUS {
 	AUTH_STATUS_UNKNOWN = 0,
 	AUTH_STATUS_CTX_ESTABLISHING,
 	AUTH_STATUS_CTX_READY
 };
-
-typedef struct pbs_auth_config {
-	/* Path to PBS_HOME directory (aka PBS_HOME in pbs.conf). This should be a null-terminated string. */
-	char *pbs_home_path;
-
-	/* Path to PBS_EXEC directory (aka PBS_EXEC in pbs.conf). This should be a null-terminated string. */
-	char *pbs_exec_path;
-
-	/* Name of authentication method (aka PBS_AUTH_METHOD in pbs.conf). This should be a null-terminated string. */
-	char *auth_method;
-
-	/* Name of encryption method (aka PBS_ENCRYPT_METHOD in pbs.conf). This should be a null-terminated string. */
-	char *encrypt_method;
-
-	/*
-	 * Function pointer to the logging method with the same signature as log_event from Liblog.
-	 * With this, the user of the authentication library can redirect logs from the authentication
-	 * library into respective log files or stderr in case no log files.
-	 * If func is set to NULL then logs will be written to stderr (if available, else no logging at all).
-	 */
-	void (*logfunc)(int type, int objclass, int severity, const char *objname, const char *text);
-} pbs_auth_config_t;
 
 typedef struct auth_def auth_def_t;
 struct auth_def {

--- a/src/include/libauth.h
+++ b/src/include/libauth.h
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 1994-2020 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * PBS Pro is free software. You can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * For a copy of the commercial license terms and conditions,
+ * go to: (http://www.pbspro.com/UserArea/agreement.html)
+ * or contact the Altair Legal Department.
+ *
+ * Altair’s dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of PBS Pro and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair’s trademarks, including but not limited to "PBS™",
+ * "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+ * trademark licensing policies.
+ *
+ */
+#ifndef _LIBAUTH_H
+#define _LIBAUTH_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "log.h"
+
+#undef DLLEXPORT
+#ifdef WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+/* Max length of auth method name */
+#define MAXAUTHNAME 100
+
+/* Type of roles */
+enum AUTH_ROLE {
+	/* Unknown role, mostly used as initial value */
+	AUTH_ROLE_UNKNOWN = 0,
+	/* Client role, aka who is initiating authentication */
+	AUTH_CLIENT,
+	/* Server role, aka who is authenticating incoming user/connection */
+	AUTH_SERVER,
+	/* last role, mostly used while error checking for role value */
+	AUTH_ROLE_LAST
+};
+
+/* Type of connections */
+enum AUTH_CONN_TYPE {
+	 /* user-oriented connection (aka like PBS client is connecting to PBS Server) */
+	AUTH_USER_CONN = 0,
+	/* service-oriented connection (aka like PBS Mom is connecting to PBS Server via PBS Comm) */
+	AUTH_SERVICE_CONN
+};
+
+typedef struct pbs_auth_config {
+	/* Path to PBS_HOME directory (aka PBS_HOME in pbs.conf). This should be a null-terminated string. */
+	char *pbs_home_path;
+
+	/* Path to PBS_EXEC directory (aka PBS_EXEC in pbs.conf). This should be a null-terminated string. */
+	char *pbs_exec_path;
+
+	/* Name of authentication method (aka PBS_AUTH_METHOD in pbs.conf). This should be a null-terminated string. */
+	char *auth_method;
+
+	/* Name of encryption method (aka PBS_ENCRYPT_METHOD in pbs.conf). This should be a null-terminated string. */
+	char *encrypt_method;
+
+	/*
+	 * Function pointer to the logging method with the same signature as log_event from Liblog.
+	 * With this, the user of the authentication library can redirect logs from the authentication
+	 * library into respective log files or stderr in case no log files.
+	 * If func is set to NULL then logs will be written to stderr (if available, else no logging at all).
+	 */
+	void (*logfunc)(int type, int objclass, int severity, const char *objname, const char *text);
+} pbs_auth_config_t;
+
+/** @brief
+ *	pbs_auth_set_config - Set auth config
+ *
+ * @param[in] config - auth config structure
+ *
+ * @return void
+ *
+ */
+extern DLLEXPORT void pbs_auth_set_config(const pbs_auth_config_t *config);
+
+/** @brief
+ *	pbs_auth_create_ctx - allocates auth context structure
+ *
+ * @param[in] ctx - pointer in which auth context to be allocated
+ * @param[in] mode - AUTH_SERVER or AUTH_CLIENT
+ * @param[in] conn_type - AUTH_USER_CONN or AUTH_SERVICE_CONN
+ * @param[in] hostname - hostname of other authenticating party in case of AUTH_CLIENT else not used
+ *
+ * @return	int
+ * @retval	0 - success
+ * @retval	1 - error
+ */
+extern DLLEXPORT int pbs_auth_create_ctx(void **ctx, int mode, int conn_type, const char *hostname);
+
+/** @brief
+ *	pbs_auth_destroy_ctx - destroy given auth context structure
+ *
+ * @param[in] ctx - pointer to auth context
+ *
+ * @return void
+ */
+extern DLLEXPORT void pbs_auth_destroy_ctx(void *ctx);
+
+/** @brief
+ *	pbs_auth_get_userinfo - get user, host and realm from authentication context
+ *
+ * @param[in] ctx - pointer to auth context
+ * @param[out] user - username assosiate with ctx
+ * @param[out] host - hostname/realm assosiate with ctx
+ * @param[out] realm - realm assosiate with ctx
+ *
+ * @return	int
+ * @retval	0 on success
+ * @retval	1 on error
+ */
+extern DLLEXPORT int pbs_auth_get_userinfo(void *ctx, char **user, char **host, char **realm);
+
+/** @brief
+ *	pbs_auth_process_handshake_data - process incoming auth handshake data or start auth handshake if no incoming data
+ *
+ * @param[in] ctx - pointer to auth context
+ * @param[in] data_in - received auth token data (if any, else NULL)
+ * @param[in] len_in - length of received auth token data (if any else 0)
+ * @param[out] data_out - auth token data to send (if any, else NULL)
+ * @param[out] len_out - lenght of auth token data to send (if any, else 0)
+ * @param[out] is_handshake_done - indicates whether handshake is done (1) or not (0)
+ *
+ * @return	int
+ * @retval	0 on success
+ * @retval	!0 on error
+ */
+extern DLLEXPORT int pbs_auth_process_handshake_data(void *ctx, void *data_in, size_t len_in, void **data_out, size_t *len_out, int *is_handshake_done);
+
+
+/** @brief
+ *	pbs_auth_encrypt_data - encrypt data based on given auth context.
+ *
+ * @param[in] ctx - pointer to auth context
+ * @param[in] data_in - clear text data
+ * @param[in] len_in - length of clear text data
+ * @param[out] data_out - encrypted data
+ * @param[out] len_out - length of encrypted data
+ *
+ * @return	int
+ * @retval	0 on success
+ * @retval	1 on error
+ */
+extern DLLEXPORT int pbs_auth_encrypt_data(void *ctx, void *data_in, size_t len_in, void **data_out, size_t *len_out);
+
+/** @brief
+ *	pbs_auth_decrypt_data - decrypt data based on given auth context.
+ *
+ * @param[in] ctx - pointer to auth context
+ * @param[in] data_in - encrypted data
+ * @param[in] len_in - length of encrypted data
+ * @param[out] data_out - clear text data
+ * @param[out] len_out - length of clear text data
+ *
+ * @return	int
+ * @retval	0 on success
+ * @retval	1 on error
+ */
+extern DLLEXPORT int pbs_auth_decrypt_data(void *ctx, void *data_in, size_t len_in, void **data_out, size_t *len_out);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _LIBAUTH_H */

--- a/src/lib/Libauth/gss/pbs_gss.c
+++ b/src/lib/Libauth/gss/pbs_gss.c
@@ -50,8 +50,7 @@
 #include <gssapi.h>
 #include <krb5.h>
 #include "pbs_ifl.h"
-#include "log.h"
-#include "auth.h"
+#include "libauth.h"
 
 #if defined(KRB5_HEIMDAL)
 #define PBS_GSS_MECH_OID GSS_KRB5_MECHANISM

--- a/src/lib/Libauth/munge/munge_supp.c
+++ b/src/lib/Libauth/munge/munge_supp.c
@@ -46,9 +46,8 @@
 #include <pthread.h>
 #include <dlfcn.h>
 #include <grp.h>
-#include "auth.h"
+#include "libauth.h"
 #include "pbs_ifl.h"
-#include "log.h"
 
 static pthread_once_t munge_init_once = PTHREAD_ONCE_INIT;
 

--- a/win_configure/projects/include.vcxproj
+++ b/win_configure/projects/include.vcxproj
@@ -69,6 +69,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\include\acct.h" />
+    <ClInclude Include="..\..\src\include\libauth.h" />
     <ClInclude Include="..\..\src\include\auth.h" />
     <ClInclude Include="..\..\src\include\attribute.h" />
     <ClInclude Include="..\..\src\include\batch_request.h" />


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Currently we don't have any specific header file which declares only LibAuth APIs + structure and macros definitions required while implementing the auth library using the LibAuth interface. Everything is defined in auth.h, while auth.h is meant to be internal use by PBS only. So this PR is about to separate out required stuff from auth.h and put it in separate libauth.h which can be used while implementing the auth library.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Added libauth.h and modified auth.h accordingly


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* No new test requires as this is just separation of header files so Travis/Appveyor will be sufficient


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
