### PR TITLE
Fixed crash with pbs_ralter and superchunks

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -727,84 +727,85 @@ struct node_info
 
 struct resv_info
 {
-	unsigned 	 is_standing:1;			/* set to 1 for a standing reservation */
-	char		 *queuename;			/* the name of the queue */
-	char		 *rrule;			/* recurrence rule for standing reservations */
-	char		 *execvnodes_seq;		/* sequence of execvnodes for standing resvs */
-	time_t		 *occr_start_arr;		/* occurrence start time */
-	char		 *timezone;			/* timezone associated to a reservation */
-	int		 resv_idx;			/* the index of standing resv occurrence */
-	int		 count;				/* the total number of occurrences */
-	time_t		 req_start;			/* user requested start time of resv */
-	time_t		 req_end;			/* user requested end tiem of resv */
-	time_t		 req_duration;			/* user requested duration of resv */
-	time_t		 retry_time;			/* time at which a reservation is to be reconfirmed */
-	int		 resv_type;			/* type of reservation i.e. job general etc */
-	enum resv_states resv_state;			/* reservation state */
-	enum resv_states resv_substate;			/* reservation substate */
-	queue_info 	 *resv_queue;			/* general resv: queue which is owned by resv */
-	node_info 	 **resv_nodes;			/* node universe for reservation */
-	char		 *partition;			/* name of the partition in which the reservation was confirmed */
+	unsigned is_standing:1;		/* set to 1 for a standing reservation */
+	char *queuename;		/* the name of the queue */
+	char *rrule;			/* recurrence rule for standing reservations */
+	char *execvnodes_seq;		/* sequence of execvnodes for standing resvs */
+	time_t *occr_start_arr;		/* occurrence start time */
+	char *timezone;			/* timezone associated to a reservation */
+	int resv_idx;			/* the index of standing resv occurrence */
+	int count;			/* the total number of occurrences */
+	time_t req_start;		/* user requested start time of resv */
+	time_t req_end;			/* user requested end tiem of resv */
+	time_t req_duration;		/* user requested duration of resv */
+	time_t retry_time;		/* time at which a reservation is to be reconfirmed */
+	int resv_type;			/* type of reservation i.e. job general etc */
+	enum resv_states resv_state;	/* reservation state */
+	enum resv_states resv_substate;	/* reservation substate */
+	queue_info *resv_queue;		/* general resv: queue which is owned by resv */
+	node_info **resv_nodes;		/* node universe for reservation */
+	char *partition;		/* name of the partition in which the reservation was confirmed */
+	selspec *select_orig;		/* original schedselect pre-alter */
 };
 
 /* resource reservation - used for both jobs and advanced reservations */
 struct resource_resv
 {
-	unsigned	can_not_run:1;		/* res resv can not run this cycle */
-	unsigned	can_never_run:1;	/* res resv can never run and will be deleted */
-	unsigned	can_not_fit:1;		/* res resv can not fit into node group */
-	unsigned	is_invalid:1;		/* res resv is invalid and will be ignored */
-	unsigned	is_peer_ob:1;		/* res resv can from a peer server */
+	unsigned can_not_run : 1;	/* res resv can not run this cycle */
+	unsigned can_never_run : 1;	/* res resv can never run and will be deleted */
+	unsigned can_not_fit : 1;	/* res resv can not fit into node group */
+	unsigned is_invalid : 1;	/* res resv is invalid and will be ignored */
+	unsigned is_peer_ob : 1;	/* res resv can from a peer server */
 
-	unsigned	is_job:1;		/* res resv is a job */
-	unsigned	is_prov_needed:1;	/* res resv requires provisioning */
-	unsigned	is_shrink_to_fit:1;	/* res resv is a shrink-to-fit job */
-	unsigned	is_resv:1;		/* res resv is an advanced reservation */
+	unsigned is_job : 1;		/* res resv is a job */
+	unsigned is_prov_needed : 1;	/* res resv requires provisioning */
+	unsigned is_shrink_to_fit : 1;	/* res resv is a shrink-to-fit job */
+	unsigned is_resv : 1;		/* res resv is an advanced reservation */
 
-	unsigned	will_use_multinode:1;	/* res resv will use multiple nodes */
+	unsigned will_use_multinode:1;	/* res resv will use multiple nodes */
 
-	char		*name;			/* name of res resv */
-	char		*user;			/* username of the owner of the res resv */
-	char		*group;			/* exec group of owner of res resv */
-	char		*project;		/* exec project of owner of res resv */
-	char		*nodepart_name;		/* name of node partition to run res resv in */
+	char *name;			/* name of res resv */
+	char *user;			/* username of the owner of the res resv */
+	char *group;			/* exec group of owner of res resv */
+	char *project;			/* exec project of owner of res resv */
+	char *nodepart_name;		/* name of node partition to run res resv in */
 
-	long		sch_priority;		/* scheduler priority of res resv */
-	int		rank;			/* unique numeric identifier for resource_resv */
-	int		ec_index;		/* Index into server's job_set array*/
+	long sch_priority;		/* scheduler priority of res resv */
+	int rank;			/* unique numeric identifier for resource_resv */
+	int ec_index;			/* Index into server's job_set array*/
 
-	time_t		qtime;			/* time res resv was submitted */
-	long		qrank;			/* time on which we might need to stabilize the sort */
-	time_t		start;			/* start time (UNDEFINED means no start time */
-	time_t		end;			/* end time (UNDEFINED means no end time */
-	time_t		duration;		/* duration of resource resv request */
-	time_t		hard_duration;		/* hard duration of resource resv request */
-	time_t		min_duration;		/* minimum duration of STF job */
+	time_t qtime;			/* time res resv was submitted */
+	long qrank;			/* time on which we might need to stabilize the sort */
+	time_t start;			/* start time (UNDEFINED means no start time */
+	time_t end;			/* end time (UNDEFINED means no end time */
+	time_t duration;		/* duration of resource resv request */
+	time_t hard_duration;		/* hard duration of resource resv request */
+	time_t min_duration;		/* minimum duration of STF job */
 
-	resource_req	*resreq;		/* list of resources requested */
-	selspec		*select;		/* select spec */
-	selspec		*execselect;		/* select spec from exec_vnode and resv_nodes */
-	place		*place_spec;		/* placement spec */
+	resource_req *resreq;		/* list of resources requested */
+	selspec *select;		/* select spec */
+	selspec *execselect;		/* select spec from exec_vnode and resv_nodes */
+	place *place_spec;		/* placement spec */
 
-	server_info	*server;		/* pointer to server which owns res resv */
-	node_info	**ninfo_arr;		/* nodes belonging to res resv */
-	nspec		**nspec_arr;		/* exec host of object in internal sched form */
+	server_info *server;		/* pointer to server which owns res resv */
+	node_info **ninfo_arr; 		/* nodes belonging to res resv */
+	nspec **nspec_arr;		/* exec vnode of object in internal sched form (one nspec per node) */
+	nspec **orig_nspec_arr;		/* original non-shrunk exec_vnode with exec_vnode chunk mapped to select chunk */
 
-	job_info	*job;			/* pointer to job specific structure */
-	resv_info	*resv;			/* pointer to reservation specific structure */
+	job_info *job;			/* pointer to job specific structure */
+	resv_info *resv;		/* pointer to reservation specific structure */
 
-	char		*aoename;		/* store name of aoe if requested */
-	char		*eoename;		/* store name of eoe if requested */
-	char		**node_set_str;		/* user specified node string */
-	node_info	**node_set;		/* node array specified by node_set_str */
-#ifdef NAS /* localmod 034 */
-	enum site_j_share_type share_type;	/* How resv counts against group share */
-#endif /* localmod 034 */
-	int		resresv_ind;		/* resource_resv index in all_resresv array */
-	timed_event 	*run_event;		/* run event in calendar */
-	timed_event	*end_event;		/* end event in calendar */
+	char *aoename;			   /* store name of aoe if requested */
+	char *eoename;			   /* store name of eoe if requested */
+	char **node_set_str;		   /* user specified node string */
+	node_info **node_set;		   /* node array specified by node_set_str */
+#ifdef NAS				   /* localmod 034 */
+	enum site_j_share_type share_type; /* How resv counts against group share */
+#endif					   /* localmod 034 */
+	int resresv_ind;		   /* resource_resv index in all_resresv array */
+	timed_event *run_event;		   /* run event in calendar */
+	timed_event *end_event;		   /* end event in calendar */
 };
-
 
 struct resource_type
 {
@@ -1076,6 +1077,7 @@ struct nspec
 	int sub_seq_num;		/* sub sequence number for sort stabilization */
 	node_info *ninfo;
 	resource_req *resreq;
+	chunk *chk;
 };
 
 struct nameval

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1999,7 +1999,7 @@ add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo,
 #endif /* localmod 068 */
 			if (bjob->nspec_arr != NULL)
 				free_nspecs(bjob->nspec_arr);
-			bjob->nspec_arr = parse_execvnode(exec, sinfo);
+			bjob->nspec_arr = parse_execvnode(exec, sinfo, NULL);
 			if (bjob->nspec_arr != NULL) {
 				char *selectspec;
 				if (bjob->ninfo_arr != NULL)

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -898,19 +898,22 @@ dup_array(void *ptr)
  *
  */
 int
-remove_ptr_from_array(void **arr, void *ptr)
+remove_ptr_from_array(void *arr, void *ptr)
 {
 	int i, j;
+	void **parr;
 
 	if (arr == NULL || ptr == NULL)
 		return 0;
 
-	for (i = 0; arr[i] != NULL && arr[i] != ptr; i++)
+	parr = (void **) arr;
+
+	for (i = 0; parr[i] != NULL && parr[i] != ptr; i++)
 		;
 
-	if (arr[i] != NULL) {
-		for (j = i; arr[j] != NULL; j++)
-			arr[j] = arr[j + 1];
+	if (parr[i] != NULL) {
+		for (j = i; parr[j] != NULL; j++)
+			parr[j] = parr[j + 1];
 		return 1;
 	}
 

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -172,7 +172,7 @@ void **dup_array(void *ptr);
  *	returns non-zero if the ptr was successfully removed from the array
  *		zero if the array has not been modified
  */
-int remove_ptr_from_array(void **arr, void *ptr);
+int remove_ptr_from_array(void *arr, void *ptr);
 
 /*
  *	remove_str_from_array - remove a string from a ptr list and move

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -696,6 +696,7 @@ new_node_info()
 	new->is_stale = 0;
 	new->is_maintenance = 0;
 	new->is_provisioning = 0;
+	new->is_sleeping = 0;
 	new->is_multivnoded = 0;
 	new->has_ghost_job = 0;
 
@@ -2337,6 +2338,7 @@ new_nspec()
 	ns->go_provision = 0;
 	ns->ninfo = NULL;
 	ns->resreq = NULL;
+	ns->chk = NULL;
 
 	return ns;
 }
@@ -2368,12 +2370,13 @@ free_nspec(nspec *ns)
  *
  * @param[in]	ons	-	the nspec to duplicate
  * @param[in]	nsinfo	-	the new server info
+ * @param[in]	sel	-	select spec to map nspec to
  *
  * @return	newly duplicated nspec
  *
  */
 nspec *
-dup_nspec(nspec *ons, node_info **ninfo_arr)
+dup_nspec(nspec *ons, node_info **ninfo_arr, selspec *sel)
 {
 	nspec *nns;
 
@@ -2391,6 +2394,8 @@ dup_nspec(nspec *ons, node_info **ninfo_arr)
 	nns->go_provision = ons->go_provision;
 	nns->ninfo = find_node_by_indrank(ninfo_arr, ons->ninfo->node_ind, ons->ninfo->rank);
 	nns->resreq = dup_resource_req_list(ons->resreq);
+	if (sel != NULL)
+		nns->chk = find_chunk_by_seq_num(sel->chunks, ons->seq_num);
 
 	return nns;
 }
@@ -2399,14 +2404,14 @@ dup_nspec(nspec *ons, node_info **ninfo_arr)
  * @brief
  * 		dup_nspecs - duplicate an array of nspecs
  *
- * @param[in]	onspecs	-	the nspecs to duplicate
- * @param[in]	ninfo_arr	-	the nodes corresponding to the nspecs
- *
+ * @param[in]	onspecs		- the nspecs to duplicate
+ * @param[in]	ninfo_arr	- the nodes corresponding to the nspecs
+ * @param[in]	sel		- select spec to map nspecs to
  * @return	duplicated nspec array
  *
  */
 nspec **
-dup_nspecs(nspec **onspecs, node_info **ninfo_arr)
+dup_nspecs(nspec **onspecs, node_info **ninfo_arr, selspec *sel)
 {
 	nspec **nnspecs;
 	int num_ns;
@@ -2423,7 +2428,7 @@ dup_nspecs(nspec **onspecs, node_info **ninfo_arr)
 		return NULL;
 
 	for (i = 0; onspecs[i] != NULL; i++)
-		nnspecs[i] = dup_nspec(onspecs[i], ninfo_arr);
+		nnspecs[i] = dup_nspec(onspecs[i], ninfo_arr, sel);
 
 	nnspecs[i] = NULL;
 
@@ -4720,13 +4725,14 @@ create_execvnode(nspec **ns)
  *		parse_execvnode - parse an execvnode into an nspec array
  *
  * @param[in]	execvnode	-	the execvnode to parse
- * @param[in]	sinfo	-	server to get the nodes from
+ * @param[in]	sinfo		-	server to get the nodes from
+ * @param[in]	sel		- select to map 
  *
  * @return	a newly allocated nspec array for the execvnode
  *
  */
 nspec **
-parse_execvnode(char *execvnode, server_info *sinfo)
+parse_execvnode(char *execvnode, server_info *sinfo, selspec *sel)
 {
 	char *simplespec;
 	char *excvndup;
@@ -4746,6 +4752,10 @@ parse_execvnode(char *execvnode, server_info *sinfo)
 	char *p;
 	char *tailptr = NULL;
 	int hp;
+	int cur_chunk_num = 0;
+	int cur_tot_chunks;
+	int chunks_ind;
+	int num_paren = 0;
 
 	if (execvnode == NULL || sinfo == NULL)
 		return NULL;
@@ -4758,9 +4768,15 @@ parse_execvnode(char *execvnode, server_info *sinfo)
 	while (p != NULL && *p != '\0') {
 		if (*p == '+')
 			num_chunk++;
+		if (*p == '(')
+			num_paren++;
 
 		p++;
 	}
+
+	/* Number of chunks in exec_vnode don't match selspec, don't map chunks*/
+	if (sel != NULL && num_paren != sel->total_chunks)
+		sel = NULL;
 
 	if ((nspec_arr = (nspec **) calloc(num_chunk + 1, sizeof(nspec *))) == NULL) {
 		log_err(errno, __func__, MEM_ERR_MSG);
@@ -4777,6 +4793,10 @@ parse_execvnode(char *execvnode, server_info *sinfo)
 	else if (parse_node_resc_r(simplespec, &node_name, &num_el, &nlkv, &kv) != 0)
 		invalid = 1;
 
+	if (sel != NULL) {
+		cur_tot_chunks = sel->chunks[0]->num_chunks;
+		chunks_ind = 0;
+	}
 	for (i = 0; i < num_chunk && !invalid && simplespec != NULL; i++) {
 		nspec_arr[i] = new_nspec();
 		if (nspec_arr[i] != NULL) {
@@ -4802,8 +4822,24 @@ parse_execvnode(char *execvnode, server_info *sinfo)
 					"Exechost contains a node that does not exist.");
 				invalid = 1;
 			}
-			if (i == num_chunk - 1)
+			if (sel != NULL) {
+				/* This shouldn't happen since we checked above to make sure we could map properly */
+				if (sel->chunks[chunks_ind] == NULL) {
+					log_event(PBS_EVENTCLASS_NODE, PBS_EVENTCLASS_NODE, LOG_WARNING, __func__, "Select spec and exec_vnode/resv_nodes can not be mapped");
+					free_nspecs(nspec_arr);
+					return NULL;
+				}
+				nspec_arr[i]->chk = sel->chunks[chunks_ind];
+				nspec_arr[i]->seq_num = nspec_arr[i]->chk->seq_num;
+			}
+			if (i == num_chunk - 1) {
 				nspec_arr[i]->end_of_chunk = 1;
+				if (sel != NULL) {
+					cur_chunk_num++;
+					if (cur_chunk_num == cur_tot_chunks)
+						chunks_ind++;
+				}
+			}
 		}
 		else
 			invalid = 1;
@@ -4889,7 +4925,8 @@ node_state_to_str(node_info *ninfo)
 /**
  * @brief
  *		combine_nspec_array - find and combine any nspec's for the same node
- *		in an nspec array
+ *		in an nspec array.  Because nspecs no longer map to the original chunks
+ *		they came from, seq_num and chk longer have meaning.  They are cleared.
  *
  * @param[in,out]	nspec_arr	-	array to combine
  *
@@ -4909,6 +4946,8 @@ combine_nspec_array(nspec **nspec_arr)
 		return;
 
 	for (i = 0; nspec_arr[i] != NULL; i++) {
+		nspec_arr[i]->seq_num = 0;
+		nspec_arr[i]->chk = NULL;
 		for (j = i + 1; nspec_arr[j] != NULL; j++) {
 			if (nspec_arr[i]->resreq != NULL &&
 				nspec_arr[i]->ninfo == nspec_arr[j]->ninfo) {
@@ -4916,16 +4955,15 @@ combine_nspec_array(nspec **nspec_arr)
 				prev_j = NULL;
 
 				while (req_j != NULL) {
-					req_i =
-						find_resource_req(nspec_arr[i]->resreq, req_j->def);
+					req_i = find_resource_req(nspec_arr[i]->resreq, req_j->def);
 					if (req_i != NULL) {
 						/* we assume that if the resource is a boolean or a string
 						 * the value is either the same, or doesn't exist
 						 * so we don't need to do validity checking
 						 */
 						if (req_j->type.is_consumable)
-							req_i->amount +=  req_j->amount;
-						else if (req_j->type.is_string && req_i->res_str ==NULL) {
+							req_i->amount += req_j->amount;
+						else if (req_j->type.is_string && req_i->res_str == NULL) {
 							req_i->res_str = req_j->res_str;
 							req_j->res_str = NULL;
 						}

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -4935,7 +4935,7 @@ node_state_to_str(node_info *ninfo)
  * @brief
  *		combine_nspec_array - find and combine any nspec's for the same node
  *		in an nspec array.  Because nspecs no longer map to the original chunks
- *		they came from, seq_num and chk longer have meaning.  They are cleared.
+ *		they came from, seq_num and chk no longer have meaning.  They are cleared.
  *
  * @param[in,out]	nspec_arr	-	array to combine
  *

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -4753,7 +4753,7 @@ parse_execvnode(char *execvnode, server_info *sinfo, selspec *sel)
 	char *tailptr = NULL;
 	int hp;
 	int cur_chunk_num = 0;
-	int cur_tot_chunks;
+	int cur_tot_chunks = 0;
 	int chunks_ind;
 	int num_paren = 0;
 

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -4835,9 +4835,8 @@ parse_execvnode(char *execvnode, server_info *sinfo, selspec *sel)
 				nspec_arr[i]->chk = sel->chunks[chunks_ind];
 				nspec_arr[i]->seq_num = nspec_arr[i]->chk->seq_num;
 			}
-			if (i == num_chunk - 1) {
-				if (!in_superchunk || hp < 0)
-					nspec_arr[i]->end_of_chunk = 1;
+			if (!in_superchunk || hp < 0) {
+				nspec_arr[i]->end_of_chunk = 1;
 				if (sel != NULL) {
 					cur_chunk_num++;
 					if (cur_chunk_num == cur_tot_chunks)

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -213,7 +213,7 @@ char *create_execvnode(nspec **ns);
 /*
  *      parse_execvnode - parse an execvnode into an nspec array
  */
-nspec **parse_execvnode(char *execvnode, server_info *sinfo);
+nspec **parse_execvnode(char *execvnode, server_info *sinfo, selspec *sel);
 
 /*
  *      new_nspec - allocate a new nspec
@@ -232,12 +232,15 @@ void free_nspec(nspec *ns);
 /*
  *      dup_nspec - duplicate an nspec
  */
-nspec *dup_nspec(nspec *ons, node_info **ninfo_arr);
+nspec *dup_nspec(nspec *ons, node_info **ninfo_arr, selspec *sel);
 
 /*
  *      dup_nspecs - duplicate an array of nspecs
  */
-nspec **dup_nspecs(nspec **onspecs, node_info **ninfo_arr);
+nspec **dup_nspecs(nspec **onspecs, node_info **ninfo_arr, selspec *sel);
+
+/* find a chunk by a sequence number */
+chunk *find_chunk_by_seq_num(chunk **chunks, int seq_num);
 
 /*
  *	empty_nspec_array - free the contents of an nspec array but not

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1801,6 +1801,8 @@ check_vnodes_unavailable(resource_resv *resv)
 		}
 	}
 
+	free(chunks_to_remove);
+
 	return has_down_node;
 }
 

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -1667,12 +1667,16 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
  * @retval 0 no unavailable nodes, no running jobs
  * @retval -1 unavailable nodes, but no running jobs on the chunk
  * @retval -2 unavilable nodes, running jobs within the chunk
+ * @retval -3 error
  * 
  */
 int check_down_running(resource_resv *resv, int chunk_ind)
 {
 	int i, j, k;
 	int ret = 0;
+
+	if (resv == NULL || chunk_ind < 0 || !resv->is_resv)
+		return -3;
 
 	for(i = chunk_ind; resv->orig_nspec_arr[i] != NULL && ret != -2; i++) {
 		nspec *ns = resv->orig_nspec_arr[i];

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -53,7 +53,7 @@
  *	check_new_reservations()
  *	disable_reservation_occurrence()
  *	confirm_reservation()
- *	check_vnodes_down()
+ *	check_vnodes_unavailable()
  *	release_nodes()
  *	create_resv_nodes()
  *
@@ -506,10 +506,11 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 						 */
 						release_nodes(resresv_ocr);
 
-						resresv_ocr->nspec_arr = parse_execvnode(
-							execvnode_ptr[degraded_idx-1], sinfo);
-						resresv_ocr->ninfo_arr
-						= create_node_array_from_nspec(resresv_ocr->nspec_arr);
+						resresv_ocr->orig_nspec_arr = parse_execvnode(
+							execvnode_ptr[degraded_idx - 1], sinfo, resresv_ocr->select);
+						resresv_ocr->nspec_arr = dup_nspecs(resresv_ocr->orig_nspec_arr, sinfo->nodes, NULL);
+						combine_nspec_array(resresv_ocr->nspec_arr);
+						resresv_ocr->ninfo_arr = create_node_array_from_nspec(resresv_ocr->nspec_arr);
 						resresv_ocr->resv->resv_nodes = create_resv_nodes(
 							resresv_ocr->nspec_arr, sinfo);
 					}
@@ -580,12 +581,13 @@ query_reservations(server_info *sinfo, struct batch_status *resvs)
 resource_resv *
 query_resv(struct batch_status *resv, server_info *sinfo)
 {
-	struct attrl	*attrp = NULL;		/* linked list of attributes from server */
-	resource_resv	*advresv = NULL;	/* resv_info to be created */
-	resource_req	*resreq = NULL;		/* used for the ATTR_l resources */
-	char		*endp = NULL;		/* used with strtol() */
-	long		count = 0; 		/* used to convert string -> num */
-	char		*selectspec = NULL;	/* used for holding select specification. */
+	struct attrl *attrp = NULL;	/* linked list of attributes from server */
+	resource_resv *advresv = NULL;	/* resv_info to be created */
+	resource_req *resreq = NULL;	/* used for the ATTR_l resources */
+	char *endp = NULL;		/* used with strtol() */
+	long count = 0; 		/* used to convert string -> num */
+	char *selectspec = NULL;	/* used for holding select specification */
+	char *resv_nodes = NULL;	/* used to hold the resv_nodes for later processing */
 
 	if (resv == NULL)
 		return NULL;
@@ -680,22 +682,8 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 				}
 			}
 		}
-		else if (!strcmp(attrp->name, ATTR_resv_nodes)) {
-			/* parse the execvnode and create an nspec array with ninfo ptrs pointing
-			 * to nodes in the real server
-			 */
-			advresv->nspec_arr = parse_execvnode(attrp->value, sinfo);
-			advresv->ninfo_arr = create_node_array_from_nspec(advresv->nspec_arr);
-
-			/* create a node info array by copying the nodes and setting
-			 * available resources to only the ones assigned to the reservation
-			 */
-			advresv->resv->resv_nodes = create_resv_nodes(advresv->nspec_arr,
-				sinfo);
-			selectspec = create_select_from_nspec(advresv->nspec_arr);
-			advresv->execselect = parse_selspec(selectspec);
-			free(selectspec);
-		}
+		else if (!strcmp(attrp->name, ATTR_resv_nodes))
+			resv_nodes = attrp->value;
 		else if (!strcmp(attrp->name, ATTR_node_set))
 			advresv->node_set_str = break_comma_list(attrp->value);
 		else if (!strcmp(attrp->name, ATTR_resv_timezone))
@@ -717,6 +705,30 @@ query_resv(struct batch_status *resv, server_info *sinfo)
 		}
 		attrp = attrp->next;
 	}
+
+	if (resv_nodes != NULL) {
+		selspec *sel;
+		/* parse the execvnode and create an nspec array with ninfo ptrs pointing
+		 * to nodes in the real server
+		 */
+		if (advresv->resv->select_orig != NULL)
+			sel = advresv->resv->select_orig;
+		else
+			sel = advresv->select;
+		advresv->orig_nspec_arr = parse_execvnode(resv_nodes, sinfo, sel);
+		advresv->nspec_arr = dup_nspecs(advresv->orig_nspec_arr, sinfo->nodes, advresv->select);
+		combine_nspec_array(advresv->nspec_arr);
+		advresv->ninfo_arr = create_node_array_from_nspec(advresv->nspec_arr);
+
+		/* create a node info array by copying the nodes and setting
+		 * available resources to only the ones assigned to the reservation
+		 */
+		advresv->resv->resv_nodes = create_resv_nodes(advresv->nspec_arr, sinfo);
+		selectspec = create_select_from_nspec(advresv->nspec_arr);
+		advresv->execselect = parse_selspec(selectspec);
+		free(selectspec);
+	}
+
 	/* If reservation is unconfirmed and the number of occurrences is 0 then flag
 	 * the reservation as invalid. This is an extra check but isn't supposed to
 	 * happen because the server will purge such reservations.
@@ -777,6 +789,7 @@ new_resv_info()
 	rinfo->is_standing = 0;
 	rinfo->occr_start_arr = NULL;
 	rinfo->partition = NULL;
+	rinfo->select_orig = NULL;
 
 	return rinfo;
 }
@@ -811,7 +824,11 @@ free_resv_info(resv_info *rinfo)
 	if (rinfo->occr_start_arr != NULL)
 		free(rinfo->occr_start_arr);
 
-	free(rinfo->partition);
+	if (rinfo->partition != NULL)
+		free(rinfo->partition);
+
+	if (rinfo->select_orig != NULL)
+		free_selspec(rinfo->select_orig);
 
 	free(rinfo);
 
@@ -856,6 +873,8 @@ dup_resv_info(resv_info *rinfo, server_info *sinfo)
 	nrinfo->count = rinfo->count;
 	if (rinfo->partition != NULL)
 		nrinfo->partition = string_dup(rinfo->partition);
+	if (rinfo->select_orig != NULL)
+		nrinfo->select_orig = dup_selspec(rinfo->select_orig);
 
 	/* the queues may not be available right now.  If they aren't, we'll
 	 * catch this when we duplicate the queues
@@ -1058,8 +1077,10 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 						 * the required fields.
 						 */
 						release_nodes(nresv_copy);
-						nresv_copy->nspec_arr = parse_execvnode(occr_execvnodes_arr[j], sinfo);
+						nresv_copy->orig_nspec_arr = parse_execvnode(occr_execvnodes_arr[j], sinfo, nresv_copy->select);
 						nresv_copy->ninfo_arr = create_node_array_from_nspec(nresv_copy->nspec_arr);
+						nresv_copy->nspec_arr = dup_nspecs(nresv_copy->orig_nspec_arr, nresv_copy->ninfo_arr, NULL);
+						combine_nspec_array(nresv_copy->nspec_arr);
 						nresv_copy->resv->resv_nodes = create_resv_nodes(nresv_copy->nspec_arr, sinfo);
 					}
 
@@ -1388,7 +1409,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 			 * unavailable. If none, then this reservation or occurrence does not
 			 * require reconfirmation.
 			 */
-			vnodes_down = check_vnodes_down(nresv, &tot_vnodes, names_of_down_vnodes);
+			vnodes_down = check_vnodes_unavailable(nresv);
 
 			if (vnodes_down < 0 && nresv->resv->resv_substate != RESV_IN_CONFLICT) {
 				if (vnodes_down == -1)
@@ -1415,7 +1436,7 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 				 * this occurrence's execvnodes to the sequence of execvnodes
 				 */
 				confirmd_occr++;
-				tmp = create_execvnode(nresv->nspec_arr);
+				tmp = create_execvnode(nresv->orig_nspec_arr);
 				if (j == 0)
 					execvnodes = string_dup(tmp);
 				else  { /* subsequent occurrences */
@@ -1474,7 +1495,6 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 		if (!(simrc & TIMED_ERROR) && resv_start_time >= 0) {
 			clear_schd_error(err);
 			if ((ns = is_ok_to_run(nsinfo->policy, nsinfo, NULL, nresv, NO_ALLPART, err)) != NULL) {
-				combine_nspec_array(ns);
 				tmp = create_execvnode(ns);
 				free_nspecs(ns);
 				if (tmp == NULL) {
@@ -1637,91 +1657,147 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 }
 
 /**
- * @brief
- * 		Checks the state of all vnodes associated to a reservation and counts the
- * 		number that are unavailable.  Any down node has their nspec->ninfo pointer cleared.
- *
- * @param[in]	resv	-	resv to check
- * @param[out]	tot_vnodes	-	the total number of vnodes associated to the reservation
- * @param[out]	names_of_down_vnodes	- the string of vnodes that are down that are then
- * 						printed into the log. This has to be of maximum length MAXVNODELIST
- *
- * @return	the number of vnodes down. The total number of vnodes is passed back
- * 			by reference.
- * @retval	-1	: there is a running job on one of the unavailable nodes.
- * @retval	-2	: error
+ * @brief determine if a nspec superchunk/chunk has unavailable nodes 
+ * 		and checks for running jobs on the chunk
+ * @param[in] resv - reservation to check
+ * @param[in] chunk_ind - index of the chunk start
+ * 
+ * @return int
+ * @retval 1 - running jobs, no unavailable nodes
+ * @retval 0 no unavailable nodes, no running jobs
+ * @retval -1 unavailable nodes, but no running jobs on the chunk
+ * @retval -2 unavilable nodes, running jobs within the chunk
+ * 
  */
-int
-check_vnodes_down(resource_resv *resv, int *tot_vnodes, char *names_of_down_vnodes)
+int check_down_running(resource_resv *resv, int chunk_ind)
 {
-	int nn_length; /* number of characters allowable in log buffer */
-	int vnodes_down = 0; /* number of unavailable vnodes */
-	int j;
-	int tot_chk_cnt;
-	int chk_ind = 0;
-	chunk *chk;
+	int i, j, k;
+	int ret = 0;
 
-	if (resv == NULL || resv->nspec_arr == NULL || tot_vnodes == NULL)
-		return -2;
+	for(i = chunk_ind; resv->orig_nspec_arr[i] != NULL && ret != -2; i++) {
+		nspec *ns = resv->orig_nspec_arr[i];
+		node_info *ninfo = ns->ninfo;
 
-	*tot_vnodes = 0;
-	chk = resv->select->chunks[0];
-	/* check chunk in the select spec has the number of chunks of that type we need.
-	 * tot_chnk_cnt is the number of chunks of the previous chunks plus the number of this chunk.
-	 * Once we've reached this number of nodes we know we have to move onto the next chunk.
-	 */
-	tot_chk_cnt = chk->num_chunks;
-
-	for (j = 0; resv->nspec_arr[j] != NULL; j++) {
-		node_info *ninfo = resv->nspec_arr[j]->ninfo;
-		(*tot_vnodes)++;
-
-		if (j == tot_chk_cnt) {
-			chk_ind++;
-			chk = resv->select->chunks[chk_ind];
-			tot_chk_cnt += chk->num_chunks;
+		if (ninfo->is_down || ninfo->is_offline || ninfo->is_stale || ninfo->is_unknown || ninfo->is_maintenance || ninfo->is_sleeping) {
+			if (ret == 1)
+				ret = -2;
+			else
+				ret = -1;
 		}
 
-		if (ninfo->is_down || ninfo->is_offline || ninfo->is_stale || ninfo->is_unknown) {
-			int k, m;
-			/* We can't reconfirm a reservation if there is a running job on one of our unavailable nodes */
-			if (resv->resv->resv_queue->running_jobs != NULL)
-				for (k = 0; resv->resv->resv_queue->running_jobs[k] != NULL; k++) {
-					resource_resv *job = resv->resv->resv_queue->running_jobs[k];
-					for (m = 0; job->ninfo_arr[m] != NULL; m++)
-						if (job->ninfo_arr[m]->rank == ninfo->rank)
-							return -1;
-				}
+		if (resv->resv->resv_queue->running_jobs != NULL)
+			for (j = 0; resv->resv->resv_queue->running_jobs[j] != NULL && ret != -2; j++) {
+				resource_resv *job = resv->resv->resv_queue->running_jobs[j];
+				for (k = 0; job->ninfo_arr[k] != NULL && ret != -2; k++)
+					if (job->ninfo_arr[k]->rank == ninfo->rank) {
+						if (ret == -1)
+							ret = -2;
+						else
+							ret = 1;
+					}
+			}
 
-			vnodes_down++;
-			resv->nspec_arr[j]->ninfo = NULL;
+		if (ns->end_of_chunk)
+			break;
+	}
+
+	return ret;
+}
+
+/**
+ * @brief
+ * 		Checks the state of all vnodes associated to a reservation and reports
+ * 		if there are any unavailable.  The ninfo ptr of the nspec is cleared for
+ * 		unavailable vnodes so they can be left out when creating the execselect
+ *
+ * @param[in]	resv	-	resv to check
+ *
+ * @return	1	: there is an unavailable vnode
+ * @retval	0	: all nodes are up and happy
+ * @retval	-1	: there is a running job on one of the unavailable nodes.
+ * @retval	-2	: can't map original chunks to resv_nodes
+ * @retval	-3	: error
+ */
+int
+check_vnodes_unavailable(resource_resv *resv)
+{
+	int ret = 0;
+	int i;
+	int has_down_node = 0;
+	int has_superchunk = 0;
+	int num_chunks = 0;
+	nspec **chunks_to_remove = NULL;
+	int del_i = 0;
+
+	if (resv == NULL || resv->nspec_arr == NULL)
+		return -3;
+
+	for (i = 0; resv->orig_nspec_arr[i] != NULL; i++) {
+		if (!resv->orig_nspec_arr[i]->end_of_chunk)
+			has_superchunk = 1;
+		num_chunks++;
+	}
+
+	if (has_superchunk) {
+		if ((chunks_to_remove = malloc((num_chunks + 1) * sizeof(nspec *))) == NULL) {
+			log_err(errno, __func__, MEM_ERR_MSG);
+			return -3;
+		}
+	}
+
+	for (i = 0; resv->orig_nspec_arr[i] != NULL; i++) {
+
+		/* If the original select chunks haven't been mapped to the resv_nodes and the reservation is running, we can't continue */
+		if (resv->resv->resv_state == RESV_RUNNING && resv->orig_nspec_arr[i]->chk == NULL) {
+			free(chunks_to_remove);
+			return -2;
+		}
+
+		/* Part of a superchunk we've already handled */
+		if (resv->orig_nspec_arr[i]->ninfo == NULL)
+			continue;
+
+		ret = check_down_running(resv, i);
+		/* running jobs on unavailable nodes in chunk */
+		if (ret == -2) {
+			free(chunks_to_remove);
+			return -1;
+		}
+		/* unavailable nodes in chunk */
+		else if (ret == -1) {
+			int j;
+			has_down_node = 1;
+			for (j = i; resv->orig_nspec_arr[j] != NULL && !resv->orig_nspec_arr[j]->end_of_chunk; j++) {
+				resv->orig_nspec_arr[j]->ninfo = NULL;
+				if (has_superchunk)
+					chunks_to_remove[del_i++] = resv->orig_nspec_arr[j];
+			}
+			/* We ran into an error where we ran into the end of the array before the end of the chunk 
+			 * The entire chunk is in chunks_to_remove, so we'll just remove it.
+			 */
+			if (resv->orig_nspec_arr[j] == NULL)
+				break;
+
+			resv->orig_nspec_arr[j]->ninfo = NULL;
 			/*
 			 * The nspec_arr only has consumable resources.  When replacing a vnode we need
 			 * to make sure to replace it with the right type of node matching the non-consumables
 			 */
-			free_resource_req_list(resv->nspec_arr[j]->resreq);
-			resv->nspec_arr[j]->resreq = dup_resource_req_list(chk->req);
-			if (names_of_down_vnodes != NULL) {
-				/* -4 accounts for the trailing "...\0" for truncation */
-				nn_length = MAXVNODELIST - strlen(names_of_down_vnodes) - 4;
-				if (nn_length > 0) {
-					strncat(names_of_down_vnodes, ninfo->name, nn_length);
-					nn_length = MAXVNODELIST - strlen(names_of_down_vnodes) - 4;
-					if (nn_length > 0)
-						strncat(names_of_down_vnodes, ",", nn_length);
-				}
-			}
+			free_resource_req_list(resv->orig_nspec_arr[j]->resreq);
+			resv->orig_nspec_arr[j]->resreq = dup_resource_req_list(resv->orig_nspec_arr[j]->chk->req);
 		}
 	}
-	if (names_of_down_vnodes != NULL) {
-		nn_length = MAXVNODELIST - strlen(names_of_down_vnodes);
-		if (nn_length == 4)
-			strncat(names_of_down_vnodes, "...", nn_length);
-		else /* for non-truncated list of vnodes, remove last comma separator */
-			names_of_down_vnodes[strlen(names_of_down_vnodes) - 1] = '\0';
+
+	if (has_superchunk) {
+		chunks_to_remove[del_i] = NULL;
+
+		for(i = 0; chunks_to_remove[i] != NULL; i++) {
+			free_nspec(chunks_to_remove[i]);
+			remove_ptr_from_array(resv->orig_nspec_arr, chunks_to_remove[i]);
+		}
 	}
 
-	return vnodes_down;
+	return has_down_node;
 }
 
 /**
@@ -1737,10 +1813,16 @@ release_nodes(resource_resv *resresv)
 {
 	free_nodes(resresv->resv->resv_nodes);
 	resresv->resv->resv_nodes = NULL;
+
 	free(resresv->ninfo_arr);
 	resresv->ninfo_arr = NULL;
+
 	free_nspecs(resresv->nspec_arr);
 	resresv->nspec_arr = NULL;
+
+	free_nspecs(resresv->orig_nspec_arr);
+	resresv->orig_nspec_arr = NULL;
+
 	if (resresv->nodepart_name != NULL) {
 		free(resresv->nodepart_name);
 		resresv->nodepart_name = NULL;

--- a/src/scheduler/resv_info.h
+++ b/src/scheduler/resv_info.h
@@ -92,10 +92,10 @@ int check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, se
 int confirm_reservation(status *policy, int pbs_sd, resource_resv *nresv, server_info *sinfo);
 
 /**
- *      counts the number of vnodes associated to a reservation that are not
+ *      checks that vnodes associated to a reservation that are not
  *                               available
  */
-int check_vnodes_down(resource_resv *resv, int * total_vnodes, char *vnodes_down_name);
+int check_vnodes_unavailable(resource_resv *resv);
 
 /**
  * Release reousrces allocated to a reservation

--- a/test/tests/functional/pbs_reservations.py
+++ b/test/tests/functional/pbs_reservations.py
@@ -359,6 +359,7 @@ class TestReservations(TestFunctional):
                            id=rid, offset=offset)
         st = self.server.status(RESV, 'resv_nodes', id=rid)[0]
         nds2 = st['resv_nodes']
+        self.assertEqual(len(sp), len(nds2.split('+')))
         self.assertNotEqual(nds1, nds2)
         self.assertEquals(sc, nds1.split('+')[0])
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The recent RFE to reconfirm running reservations would crash if a reservation had a superchunk (a chunk broken up across multiple vnodes on the same host).

#### Describe Your Change
This required a decent rewrite of the feature.  The scheduler now needs to map chunks of the select to the chunks of the exec_vnode.  When it sees a superchunk that any of the vnodes are unavailable, it removes the superchunk and replaces it with the original chunk from the select.  When we create the internal select, the original chunk will be requested again.

#### Attach Test and Valgrind Logs/Output
[resv.log](https://github.com/PBSPro/pbspro/files/4612185/resv.log)
