### PR TITLE
Attribute "create_resv_from_job" value type  is boolean

### DIFF
--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -55,7 +55,7 @@ class Test_user_reliability(TestFunctional):
 import pbs
 e = pbs.event()
 j = e.job
-j.create_resv_from_job=1
+j.create_resv_from_job=True
 """
         hook_event = "runjob"
         hook_name = "rsub"


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
In test "test_create_resv_from_job_using_runjob_hook" value of create_resv_from_job is 1 but value type is boolean.So it should be True.


#### Describe Your Change
set the attribute "create_resv_from_job=True" in test "test_create_resv_from_job_using_runjob_hook"


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test_user_reliability.txt](https://github.com/PBSPro/pbspro/files/4616262/test_user_reliability.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
