### PR TITLE
create_resv_from_job=False would create a reservation

### DIFF
--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1000,7 +1000,8 @@ svr_startjob(job *pjob, struct batch_request *preq)
 	if (rc != 0)
 		return rc;
 
-	if (pjob->ji_wattr[JOB_ATR_create_resv_from_job].at_flags & ATR_VFLAG_SET)
+	if (pjob->ji_wattr[JOB_ATR_create_resv_from_job].at_flags & ATR_VFLAG_SET && 
+	    pjob->ji_wattr[JOB_ATR_create_resv_from_job].at_val.at_long)
 		convert_job_to_resv(pjob);
 
 	/* Move job_kill_delay attribute from Server to MOM */

--- a/test/tests/functional/pbs_user_reliability.py
+++ b/test/tests/functional/pbs_user_reliability.py
@@ -44,6 +44,7 @@ class Test_user_reliability(TestFunctional):
     """
     This test suite is for testing the user reliability workflow feature.
     """
+
     def test_create_resv_from_job_using_runjob_hook(self):
         """
         This test is for creating a reservation out of a job using runjob hook.
@@ -111,7 +112,7 @@ j.create_resv_from_job=1
 
         now = time.time()
 
-        a = {ATTR_W: 'create_resv_from_job=1'}
+        a = {ATTR_W: 'create_resv_from_job=True'}
         job = Job(TEST_USER, a)
         jid = self.server.submit(job)
         self.server.expect(JOB, {ATTR_state: 'R'}, jid)
@@ -137,6 +138,12 @@ j.create_resv_from_job=1
 
         self.assertEqual(s_ncpus_before, s_ncpus_after)
         self.assertEqual(s_nodect_before, s_nodect_after)
+
+        a = {ATTR_W: 'create_resv_from_job=False'}
+        job = Job(TEST_USER, a)
+        jid = self.server.submit(job)
+        self.server.expect(JOB, {ATTR_state: 'R'}, jid)
+        self.assertFalse(self.server.status(RESV))
 
     def test_create_resv_from_job_using_rsub(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
qsub -Wcreate_resv_from_job=False would create a reservation for the job.  When checking to see if we needed to create a reservation for a job, the server would only check if create_resv_from_job was set, but not set to True.

#### Describe Your Change
Check to see if the attribute is set and is true before creating a reservation

#### Attach Test and Valgrind Logs/Output
[resv_job.log](https://github.com/PBSPro/pbspro/files/4618201/resv_job.log)
