### PR TITLE
Delete saved_test_setup file and use sudo listdir

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -13420,7 +13420,8 @@ class MoM(PBSService):
         self._save_config_file(conf, cf)
 
         if os.path.isdir(os.path.join(mpriv, 'config.d')):
-            for f in os.listdir(os.path.join(mpriv, 'config.d')):
+            for f in self.du.listdir(path=os.path.join(mpriv, 'config.d'),
+                                     sudo=True):
                 self._save_config_file(conf,
                                        os.path.join(mpriv, 'config.d', f))
         mconf = {self.hostname: conf}

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1651,6 +1651,7 @@ class PBSTestSuite(unittest.TestCase):
                 ret = mom.load_configuration(self.saved_file)
                 if not ret:
                     raise Exception("Failed to load mom's test setup")
+            self.du.rm(path=self.saved_file)
         self.log_end_teardown()
 
     @classmethod
@@ -1669,5 +1670,4 @@ class PBSTestSuite(unittest.TestCase):
                 ret = mom.load_configuration(cls.saved_file)
                 if not ret:
                     raise Exception("Failed to load mom's custom setup")
-        if cls.use_cur_setup:
             cls.du.rm(path=cls.saved_file)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
saved_test_setup file was not deleted in teardown
non root user was not able to listdir mom_priv/config.d


#### Describe Your Change
Deleted the saved_test_setup file and used self.du.listdir(path=file,sudo=True) do allow sudo user to listdir mom_priv directory


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
