### PR TITLE
Fixed missing run and system information from json report

### DIFF
--- a/test/fw/ptl/utils/plugins/ptl_test_db.py
+++ b/test/fw/ptl/utils/plugins/ptl_test_db.py
@@ -1609,25 +1609,7 @@ class JSONDb(DBType):
             raise PTLDbError(rc=1, rv=False, msg=_msg)
         elif not self.dbpath.endswith('.json'):
             self.dbpath = self.dbpath.rstrip('.db') + '.json'
-        self.jdata = {
-            'test_conf': {},
-            'test_summary': {
-                'result_summary': {
-                    'run': 0,
-                    'succeeded': 0,
-                    'failed': 0,
-                    'errors': 0,
-                    'skipped': 0,
-                    'timedout': 0,
-                },
-                'tests_with_failures': [],
-                'test_suites_with_failures': [],
-            },
-            'additional_data': {},
-            'testsuites': {},
-            'tests_with_failures': [],
-            'test_suites_with_failures': [],
-            }
+        self.jdata = {}
         self.__cmd = [os.path.basename(sys.argv[0])]
         self.__cmd += sys.argv[1:]
         self.__cmd = ' '.join(self.__cmd)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
After #1500 changes to ptl_test_db.py.
run and system information went missing from json report.

All this info was missing from JSON report
{
  "command": "pbs_benchpress -t Test",
  "user": "root",
  "product_version": "2020.1.0",
  "run_id": "1589360366",
  "machine_info": {
    "<machine_name>": {
      "platform": "Linux  **************",
      "os_info": "Linux ***********",
      "pbs_install_type": "server"
    }

#### Describe Your Change
Reverted the changes done in the file from PR.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
