### PR TITLE
PTL is not updating its internal structures after qmgr set server operation

### DIFF
--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6866,6 +6866,9 @@ class Server(PBSService):
                             break
                     if rc == 0:
                         rc = tmprc
+
+        if id is None and obj_type == SERVER:
+            id = self.hostname
         bs_list = []
         if cmd == MGR_CMD_DELETE and oid is not None and rc == 0:
             for i in oid:

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6868,7 +6868,7 @@ class Server(PBSService):
                         rc = tmprc
 
         if id is None and obj_type == SERVER:
-            id = self.hostname
+            id = self.pbs_conf['PBS_SERVER']
         bs_list = []
         if cmd == MGR_CMD_DELETE and oid is not None and rc == 0:
             for i in oid:


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
PTL internally maintains the old state even after updating certain attributes such as scheduling using qmgr operation. As a consequence of this expect routine will trigger the scheduling cycle even if the last operation sets the scheduling to false.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Set the hostname as the id of the server object.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
