### PR TITLE
Restart check and handling the delay

### DIFF
--- a/src/include/pbs_license.h
+++ b/src/include/pbs_license.h
@@ -99,7 +99,7 @@ extern struct license_block licenses;
 extern struct attribute *pbs_float_lic;
 extern void   init_fl_license_attrs(struct license_block *);
 extern void   log_licenses(struct license_used *pu);
-extern void   init_licensing(void);
+extern void   init_licensing(int);
 extern int    status_licensing(void);
 extern void   close_licensing(void);
 extern int    count_needed_flic(int);

--- a/src/server/checkkey.c
+++ b/src/server/checkkey.c
@@ -93,7 +93,7 @@ return_licenses(struct work_task *ptask)
 }
 
 void
-init_licensing(void)
+init_licensing(int delay)
 {
 }
 

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -1032,12 +1032,14 @@ set_license_location(attribute *pattr, void *pobject, int actmode)
 		if (pbs_licensing_license_location == NULL) {
 			log_err(errno, __func__, "warning: strdup failed!");
 		}
-
 		if (pbs_licensing_license_location &&
 			(pbs_licensing_license_location[0] != '\0')) {
-			init_licensing();
-			if (license_sanity_check())
-				license_more_nodes();
+			int delay;
+			if (actmode == ATR_ACTION_ALTER)
+				delay = 5;
+			else
+				delay = 0;
+			init_licensing(delay);
 		}
 	}
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -5229,7 +5229,7 @@ class Server(PBSService):
         ignore_attrs += [ATTR_status, ATTR_total, ATTR_count]
         ignore_attrs += [ATTR_rescassn, ATTR_FLicenses, ATTR_SvrHost]
         ignore_attrs += [ATTR_license_count, ATTR_version, ATTR_managers]
-        ignore_attrs += [ATTR_operators]
+        ignore_attrs += [ATTR_operators, ATTR_license_min]
         ignore_attrs += [ATTR_pbs_license_info, ATTR_power_provisioning]
         unsetlist = []
         self.cleanup_jobs_and_reservations()

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -475,6 +475,9 @@ class PBSTestSuite(unittest.TestCase):
                 raise Exception("Failed to save scheduler's custom setup")
             cls.add_mgrs_opers()
         cls.init_comms()
+        a = {ATTR_license_min: len(cls.moms)}
+        cls.server.manager(MGR_CMD_SET, SERVER, a, sudo=True)
+        cls.server.restart()
         cls.log_end_setup(True)
 
     def setUp(self):
@@ -511,8 +514,6 @@ class PBSTestSuite(unittest.TestCase):
             self.revert_schedulers()
             self.revert_moms()
         self.revert_comms()
-        a = {'pbs_license_min': len(self.moms)}
-        self.server.manager(MGR_CMD_SET, SERVER, a)
         self.log_end_setup()
         self.measurements = []
 
@@ -823,6 +824,9 @@ class PBSTestSuite(unittest.TestCase):
                 conn_timeout = int(cls.conf['conn_timeout'])
                 server.set_connect_timeout(conn_timeout)
         sched_action = ExpectAction('kicksched', True, JOB,
+                                    cls.kicksched_action)
+        server.add_expect_action(action=sched_action)
+        sched_action = ExpectAction('kickresvsched', True, RESV,
                                     cls.kicksched_action)
         server.add_expect_action(action=sched_action)
         return server

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -826,9 +826,6 @@ class PBSTestSuite(unittest.TestCase):
         sched_action = ExpectAction('kicksched', True, JOB,
                                     cls.kicksched_action)
         server.add_expect_action(action=sched_action)
-        sched_action = ExpectAction('kickresvsched', True, RESV,
-                                    cls.kicksched_action)
-        server.add_expect_action(action=sched_action)
         return server
 
     @classmethod

--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -511,6 +511,8 @@ class PBSTestSuite(unittest.TestCase):
             self.revert_schedulers()
             self.revert_moms()
         self.revert_comms()
+        a = {'pbs_license_min': len(self.moms)}
+        self.server.manager(MGR_CMD_SET, SERVER, a)
         self.log_end_setup()
         self.measurements = []
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Some license code that needs to be reorganized.


#### Describe Your Change
When we set license info for first time 5 sec delay is fine but when we restart there should not be a delay of 5 seconds if license info is already set.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[test pass after changes.txt](https://github.com/PBSPro/pbspro/files/4632734/test.pass.after.changes.txt)
[test passing after change.txt](https://github.com/PBSPro/pbspro/files/4632736/test.passing.after.change.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
