### PR TITLE
Jobs overlap with resvs with buckets and psets

### DIFF
--- a/src/scheduler/buckets.c
+++ b/src/scheduler/buckets.c
@@ -1058,6 +1058,7 @@ check_node_buckets(status *policy, server_info *sinfo, queue_info *qinfo, resour
 
 	if (policy == NULL || sinfo == NULL || resresv == NULL || err == NULL)
 		return NULL;
+
 	if (resresv->is_job && qinfo == NULL)
 		return NULL;
 

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1680,13 +1680,6 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 			int sort_nodepart = 0;
 			for (i = 0; ns[i] != NULL; i++) {
 				int j;
-				te_list *te;
-				for (te = ns[i]->ninfo->node_events; te != NULL; te = te->next) {
-					/*
-					log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE, LOG_DEBUG, resresv->name,
-						   "Node: %s Event %s, time %ld", ns[i]->ninfo->name, te->event->name, te->event->event_time);
-					*/
-				}
 				update_node_on_run(ns[i], rr, &old_state);
 				if (ns[i]->ninfo->np_arr != NULL) {
 					for (j = 0; ns[i]->ninfo->np_arr[j] != NULL; j++) {

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1680,6 +1680,13 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 			int sort_nodepart = 0;
 			for (i = 0; ns[i] != NULL; i++) {
 				int j;
+				te_list *te;
+				for (te = ns[i]->ninfo->node_events; te != NULL; te = te->next) {
+					/*
+					log_eventf(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE, LOG_DEBUG, resresv->name,
+						   "Node: %s Event %s, time %ld", ns[i]->ninfo->name, te->event->name, te->event->event_time);
+					*/
+				}
 				update_node_on_run(ns[i], rr, &old_state);
 				if (ns[i]->ninfo->np_arr != NULL) {
 					for (j = 0; ns[i]->ninfo->np_arr[j] != NULL; j++) {

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -455,12 +455,13 @@ query_server(status *pol, int pbs_sd)
 	}
 	sinfo->unordered_nodes[i] = NULL;
 
+
+	generic_sim(sinfo->calendar, TIMED_RUN_EVENT, 0, 0, add_node_events, NULL, NULL);
+
 	/* Create placement sets  after collecting jobs on nodes because
 	 * we don't want to account for resources consumed by ghost jobs
 	 */
 	create_placement_sets(policy, sinfo);
-
-	generic_sim(sinfo->calendar, TIMED_RUN_EVENT, 0, 0, add_node_events, NULL, NULL);
 
 	sinfo->buckets = create_node_buckets(policy, sinfo->nodes, sinfo->queues, UPDATE_BUCKET_IND);
 

--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -681,7 +681,7 @@ class TestNodeBuckets(TestFunctional):
         r = Reservation(attrs=a)
         rid = self.server.submit(r)
         self.server.expect(RESV, {'reserve_state':
-                                  (MATCH_RE, 'RESV_CONFIRME|2')}, id=rid)
+                                  (MATCH_RE, 'RESV_CONFIRMED|2')}, id=rid)
 
         a = {'Resource_List.select': '1430:ncpus=1',
              'Resource_List.place': 'scatter:excl',
@@ -698,7 +698,7 @@ class TestNodeBuckets(TestFunctional):
         s = [x['resources_available.shape']
              for x in n if x['id'] in nodes]
         self.assertEqual(len(set(s)), 1,
-                         "Job1 will run in more than one placement set")
+                         "Job will run in more than one placement set")
 
     @skipOnCpuSet
     def test_place_group(self):

--- a/test/tests/functional/pbs_node_buckets.py
+++ b/test/tests/functional/pbs_node_buckets.py
@@ -664,6 +664,43 @@ class TestNodeBuckets(TestFunctional):
                              'Jobs will share nodes: ' + node)
 
     @skipOnCpuSet
+    def test_psets_calendaring_resv(self):
+        """
+        Test that jobs do not run into a reservation and will correctly
+        be added to the calendar on the correct vnodes with placement sets
+        """
+
+        self.scheduler.set_sched_config({'strict_ordering': True})
+        self.server.manager(MGR_CMD_SET, SERVER, {'node_group_key': 'shape',
+                                                  'node_group_enable': True})
+
+        now = int(time.time())
+        a = {'Resource_List.select': '10010:ncpus=1',
+             'Resource_List.place': 'scatter:excl',
+             'reserve_start': now + 600, 'reserve_end': now + 3600}
+        r = Reservation(attrs=a)
+        rid = self.server.submit(r)
+        self.server.expect(RESV, {'reserve_state':
+                                  (MATCH_RE, 'RESV_CONFIRME|2')}, id=rid)
+
+        a = {'Resource_List.select': '1430:ncpus=1',
+             'Resource_List.place': 'scatter:excl',
+             'Resource_List.walltime': '1:00:00'}
+        j = Job(attrs=a)
+        jid = self.server.submit(j)
+
+        self.server.expect(JOB, 'estimated.exec_vnode', id=jid, op=SET)
+
+        n = self.server.status(NODE, 'resources_available.shape')
+        st = self.server.status(JOB, 'estimated.exec_vnode', id=jid)[0]
+        nodes = j.get_vnodes(st['estimated.exec_vnode'])
+
+        s = [x['resources_available.shape']
+             for x in n if x['id'] in nodes]
+        self.assertEqual(len(set(s)), 1,
+                         "Job1 will run in more than one placement set")
+
+    @skipOnCpuSet
     def test_place_group(self):
         """
         Test node buckets with place=group


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When using the node bucket code path with placement sets enabled, it is possible for a job to run and interfere with a reservation.

#### Describe Your Change
The change is easy, but requires a little bit of explanation of the how the node buckets work.
1. Nodes know all of the run events that affect that node
2. When creating a bucket, we create 3 pools of nodes: busy, busy later (free now, but busy later), and totally free.  We create the busy later pool by looking at the events on the nodes.  If there is one, we add the node to the busy later pool.
3. Each placement set has its own set of buckets

The issue is we create the placement sets before we add the reservation events on the nodes.  This means all nodes with reservations on them are added to the totally free pool.  Since they are in this pool, the bucket path doesn't bother checking for the reservations when running jobs.

The fix is to add the events to the nodes before creating the placement sets.

#### Attach Test and Valgrind Logs/Output
[resv_overlap.log](https://github.com/PBSPro/pbspro/files/4647312/resv_overlap.log)
