### PR TITLE
Test failures on slow machines

### DIFF
--- a/test/tests/functional/pbs_admin_suspend.py
+++ b/test/tests/functional/pbs_admin_suspend.py
@@ -592,6 +592,7 @@ class TestAdminSuspend(TestFunctional):
 
         # submit a job
         j = Job(TEST_USER)
+        j.set_sleep_time(300)
         jid1 = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R', 'substate': 42}, id=jid1)
 

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -1137,7 +1137,7 @@ class TestMultipleSchedulers(TestFunctional):
         # Six equivalence classes. Two for the resource eating job in
         # different partitions and one for each user per partition.
         self.scheds['sc1'].log_match("Number of job equivalence classes: 6",
-                                     max_attempts=10, starttime=t)
+                                     starttime=t)
 
     def test_list_multi_sched(self):
         """
@@ -1828,7 +1828,7 @@ class TestMultipleSchedulers(TestFunctional):
         # it has free nodes
         t = int(time.time())
         a = {'Resource_List.select': '1:ncpus=2', 'reserve_start': t + 5,
-             'reserve_end': t + 15}
+             'reserve_end': t + 35}
         r = Reservation(TEST_USER, a)
         rid = self.server.submit(r)
         a = {'reserve_state': (MATCH_RE, 'RESV_CONFIRMED|2')}
@@ -2121,6 +2121,8 @@ e.accept()
         else:
             resv_state = {'reserve_state': (MATCH_RE, 'RESV_DEGRADED|10')}
 
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'false'},
+                            id="sc1")
         ret = self.server.status(RESV, 'partition', id=rid)
         a = {'state': 'offline'}
         self.server.manager(MGR_CMD_SET, NODE, a, id=resv_node)
@@ -2128,6 +2130,9 @@ e.accept()
         a = {'reserve_substate': 10}
         a.update(resv_state)
         self.server.expect(RESV, a, id=rid)
+
+        self.server.manager(MGR_CMD_SET, SCHED, {'scheduling': 'True'},
+                            id="sc1")
 
         other_node = "vnode[1]"
         if resv_node == "vnode[1]":
@@ -2141,7 +2146,7 @@ e.accept()
 
         self.server.expect(RESV, a, id=rid, interval=1)
 
-    def test_advance_confimred_resv_reconfirm(self):
+    def test_advance_confirmed_resv_reconfirm(self):
         """
         Test degraded reservation gets reconfirmed on a different
         node of the same partition in multi-sched environment

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -110,7 +110,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
                 time_logged = self.get_timestamp(msg[1])
                 if alarm != 0:
                         self.assertLessEqual(time_logged - time_expected,
-                                        alarm - hook_run_time)
+                                             alarm - hook_run_time)
                 else:
                         self.assertLessEqual(time_logged - time_expected, 1)
 

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -109,10 +109,10 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
                                             starttime=search_after)
                 time_logged = self.get_timestamp(msg[1])
                 if alarm != 0:
-                        self.assertLess((time_logged - time_expected),
-                                        (alarm - hook_run_time))
+                        self.assertLess(time_logged - time_expected,
+                                        alarm - hook_run_time)
                 else:
-                        self.assertFalse((time_logged - time_expected) > 1)
+                        self.assertLess(time_logged - time_expected, 1)
 
                 if hook_run_time <= freq:
                     intr = freq - hook_run_time

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -109,10 +109,10 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
                                             starttime=search_after)
                 time_logged = self.get_timestamp(msg[1])
                 if alarm != 0:
-                        self.assertLess(time_logged - time_expected,
+                        self.assertLessEqual(time_logged - time_expected,
                                         alarm - hook_run_time)
                 else:
-                        self.assertLess(time_logged - time_expected, 1)
+                        self.assertLessEqual(time_logged - time_expected, 1)
 
                 if hook_run_time <= freq:
                     intr = freq - hook_run_time

--- a/test/tests/functional/pbs_server_periodic_hook.py
+++ b/test/tests/functional/pbs_server_periodic_hook.py
@@ -53,8 +53,8 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         """
         function to create a hook script.
         It accepts 2 arguments
-        - accept	If set to true, then hook will accept else reject
-        - sleep_time	Number of seconds we want the hook to sleep
+        - accept        If set to true, then hook will accept else reject
+        - sleep_time        Number of seconds we want the hook to sleep
         """
         hook_action = "e.accept()"
         if accept is False:
@@ -70,17 +70,19 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         return int(a[1])
 
     def check_next_occurances(self, count, freq,
-                              hook_run_time, check_for_hook_end):
+                              hook_run_time, check_for_hook_end, alarm=0):
         """
         Helper function to check the occurances of hook by matching their
         logs in server logs.
         It needs 4 arguments:
-        - count			to know how many times to repeat
-                                checking these logs
-        - freq			is the frequency set in pbs server to run this hook
-        - hook_run_time		is the amount of time hook takes to run.
-        - check_for_hook_end	If it is true then the functions checks for
-                                hook end messages.
+        - count                     to know how many times to repeat
+                                    checking these logs
+        - freq                      is the frequency set in pbs server to run
+                                    this hook
+        - hook_run_time             is the amount of time hook takes to run.
+        - check_for_hook_end        If it is true then the functions checks for
+                                    hook end messages.
+        - alarm                     hook alarm
         """
         occurance = 0
         # time after which we want to start matching log
@@ -106,7 +108,11 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
                                             interval=(hook_run_time + 1),
                                             starttime=search_after)
                 time_logged = self.get_timestamp(msg[1])
-                self.assertFalse((time_logged - time_expected) > 1)
+                if alarm != 0:
+                        self.assertLess((time_logged - time_expected),
+                                        (alarm - hook_run_time))
+                else:
+                        self.assertFalse((time_logged - time_expected) > 1)
 
                 if hook_run_time <= freq:
                     intr = freq - hook_run_time
@@ -290,7 +296,7 @@ pbs.logmsg(pbs.LOG_DEBUG, "periodic hook ended at %%d" %% time.time())
         attrs = {'event': 'periodic', 'alarm': 15, 'freq': 5}
         self.server.create_import_hook(hook_name, attrs, scr, overwrite=True)
         self.check_next_occurances(2, freq=5, hook_run_time=10,
-                                   check_for_hook_end=True)
+                                   check_for_hook_end=True, alarm=15)
 
     def test_check_for_negative_freq(self):
         """


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
There are a bunch of test failures on slow machines and this PR addresses them
1 - test_limits_queues(Multi-sched test suite) is failing on slow machines. It is unable to find a log message in scheduler logs. The log message is logged in the same second log_match function decides to bail out because it reached max_attempts.

2 - test_advance_resv_in_multi_sched fails on slow machines. There has been a case that by the time the test does pbs_rstat and by the time it receives a reply more than 10 seconds pass and the reservation ends because it was only 10 seconds long.

3 - On some slow machines est_advance_confirmed_resv_reconfirm test case fails. It submits a reservation 15 seconds in the future and then sets server reserve_retry_time to 5 seconds. It then offlines the node where this reservation was confirmed. After this, the test issues pbs_rstat to see if the reservation is in a DEGRADED state. This check fails because by the time pbs_rstat command returns  5 seconds passes and the reservation gets confirmed on a different node.

4 - test_alarm_more_than_freq test fails on slow machines. The test expects a hook run and hook end message to be log between 10 to 11 seconds. On slow machines hook itself sometimes takes more than 10 seconds to run which means the hook end message is logged at a later time which makes the test fail.

5 - test_admin_resume_loop tests that a job is admin-suspended and resumed 15 times and checks that the node correctly moves in and out of maintenance state. On a slow machine, the job ends before the test could loop 15 times.

#### Describe Your Change
Respective solution - 
1 - Removed max_attemps from log_match function in test_limits_queues test.
2 - Increased the duration of the reservation.
3 - Fixed by stopping scheduling before offlining the node and start it back again after confirming the reservation's state.
4 - The issue is fixed by relaxing the test to accommodate for slow machines and expect the log to be logged anywhere between the hook sleep time to hook alarm time.
5 - Increased sleep time of the job.

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
[test_svr_periodic_hook.txt](https://github.com/PBSPro/pbspro/files/4647580/test_svr_periodic_hook.txt)
[test_multi_sched.txt](https://github.com/PBSPro/pbspro/files/4647581/test_multi_sched.txt)
[test_admin_suspend.txt](https://github.com/PBSPro/pbspro/files/4647582/test_admin_suspend.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
