### PR TITLE
Fixing add_mannagers_operators() from pbs_testsuite.py

### DIFF
--- a/test/fw/ptl/utils/pbs_testsuite.py
+++ b/test/fw/ptl/utils/pbs_testsuite.py
@@ -1361,7 +1361,7 @@ class PBSTestSuite(unittest.TestCase):
                 cls.server.manager(MGR_CMD_UNSET, SERVER, 'operators',
                                    sudo=True)
             except PbsManagerError as e:
-                self.logger.error(e.msg)
+                cls.logger.error(e.msg)
         attr = {}
         current_user = pwd.getpwuid(os.getuid())[0] + '@*'
         mgrs_opers = {"managers": [current_user, str(MGR_USER) + '@*'],

--- a/test/tests/selftest/pbs_managers_operators.py
+++ b/test/tests/selftest/pbs_managers_operators.py
@@ -76,3 +76,15 @@ class TestManagersOperators(TestSelf):
         svr_opr = self.server.status(SERVER, 'operators')[0].get('operators')
         opr_usr = str(OPER_USER) + '@*'
         self.assertEqual(opr_usr, svr_opr)
+
+    def test_add_mgr_opr_fail(self):
+        """
+        Check that if unset mgr/ opr in add_mgr_opr fails, error is logged.
+        There was a bug where self.logger.error() was used instead
+        of cls.logger.error().
+        """
+        self.server.stop()
+        with self.assertRaises(PbsStatusError) as e:
+            self.add_mgrs_opers()
+        self.assertIn('Connection refused', e.exception.msg[0])
+        self.server.start()


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
add_mgrs_opers() in pbs_testsuite.py is a classmethod. Instead of using self.logger.error we should be using cls.logger.error()


#### Attach Test and Valgrind Logs/Output
[before_change_self_test.txt](https://github.com/PBSPro/pbspro/files/4648120/before_change_self_test.txt)
[after_change_self_test.txt](https://github.com/PBSPro/pbspro/files/4648121/after_change_self_test.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
