### PR TITLE
Introducing new logger log_errf

### DIFF
--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -200,8 +200,8 @@ char *pbs_fgets_extend(char **pbuf, int *pbuf_size, FILE *fp);
 /*
  * Internal asprintf() implementation for use on all platforms
  */
-int pbs_asprintf(char **dest, const char *fmt, ...);
-char *pbs_asprintf_format(int len, const char *fmt, va_list args);
+extern int pbs_asprintf(char **dest, const char *fmt, ...);
+extern char *pbs_asprintf_format(int len, const char *fmt, va_list args);
 
 /*
  * calculate the number of digits to the right of the decimal point in

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -201,6 +201,7 @@ char *pbs_fgets_extend(char **pbuf, int *pbuf_size, FILE *fp);
  * Internal asprintf() implementation for use on all platforms
  */
 int pbs_asprintf(char **dest, const char *fmt, ...);
+char *pbs_asprintf_format(int len, const char *fmt, va_list args);
 
 /*
  * calculate the number of digits to the right of the decimal point in

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -106,6 +106,7 @@ extern void free_if_info(struct log_net_info *ni);
 
 extern void log_close(int close_msg);
 extern void log_err(int err, const char *func, const char *text);
+extern void log_errf(int err, const char *func, const char *fmt, ...);
 extern void log_joberr(int err, const char *func, const char *text, const char *pjid);
 extern void log_event(int type, int objclass, int severity, const char *objname, const char *text);
 extern void log_eventf(int eventtype, int objclass, int sev, const char *objname, const char *fmt, ...);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -106,7 +106,7 @@ extern void free_if_info(struct log_net_info *ni);
 
 extern void log_close(int close_msg);
 extern void log_err(int err, const char *func, const char *text);
-extern void log_errf(int err, const char *func, const char *fmt, ...);
+extern void log_errf(int errnum, const char *routine, const char *fmt, ...);
 extern void log_joberr(int err, const char *func, const char *text, const char *pjid);
 extern void log_event(int type, int objclass, int severity, const char *objname, const char *text);
 extern void log_eventf(int eventtype, int objclass, int sev, const char *objname, const char *fmt, ...);

--- a/src/lib/Liblog/log_event.c
+++ b/src/lib/Liblog/log_event.c
@@ -62,6 +62,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "server.h"
+#include "libutil.h"
 
 /* private data */
 
@@ -75,8 +76,6 @@ PBSEVENT_RESV;
 
 extern char *path_home;
 long	    *log_event_mask = &log_event_lvl_priv;
-
-extern char *pbs_asprintf_format(int len, const char *fmt, va_list args);
 
 /**
  * @brief

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -837,9 +837,9 @@ log_joberr(int errnum, const char *routine, const char *text, const char *pjid)
 
 #ifdef WIN32
 		LPVOID	lpMsgBuf;
-		int	err = GetLastError();
+		DWORD	err = GetLastError();
 		int		len;
-
+		snprintf(buf, LOG_BUF_SIZE, "Err(%lu): ", err);
 		FormatMessage(
 			FORMAT_MESSAGE_ALLOCATE_BUFFER |
 			FORMAT_MESSAGE_FROM_SYSTEM |
@@ -847,7 +847,7 @@ log_joberr(int errnum, const char *routine, const char *text, const char *pjid)
 			NULL, err,
 			MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
 			(LPTSTR)&lpMsgBuf, 0, NULL);
-		strncpy(buf, lpMsgBuf, sizeof(buf));
+		strncat(buf, lpMsgBuf, LOG_BUF_SIZE - (int)strlen(buf) - 1);
 		LocalFree(lpMsgBuf);
 		buf[sizeof(buf)-1] = '\0';
 		len = strlen(buf);

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -138,8 +138,6 @@ static unsigned int syslogfac = 0;
 static unsigned int syslogsvr = 3;
 static unsigned int pbs_log_highres_timestamp = 0;
 
-extern char *pbs_asprintf_format(int len, const char *fmt, va_list args);
-
 void
 set_log_conf(char *leafname, char *nodename,
 		unsigned int islocallog, unsigned int sl_fac, unsigned int sl_svr,
@@ -787,7 +785,7 @@ log_err(int errnum, const char *routine, const char *text)
 void
 log_errf(int errnum, const char *routine, const char *fmt, ...)
 {
-    va_list args;
+	va_list args;
 	int len;
 	char logbuf[LOG_BUF_SIZE];
 	char *buf;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Currently while logging error, there is no way to pass a formatted string.
Enhance the existing logger, so that for any Windows error it log the error code.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Goal of this PR:
- Introducing new logger "log_errf". Now while logging any error we can pass a formatted string which can contain more details of that error scenario. 
- Log error code along with the error message in existing "log_err" and "log_joberr" api

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
