### PR TITLE
Fix for missing debuginfo package in debian/ubuntu and fixes in ci --build-pkgs

### DIFF
--- a/buildutils/attr_parser.py
+++ b/buildutils/attr_parser.py
@@ -35,18 +35,18 @@
 # trademark licensing policies.
 
 """
-    attr_parser.py will parse xml files also called master attribute files 
-containing all the members of both server and ecl files,and will generate 
-two corresponding files one for server and one for ecl 
+    attr_parser.py will parse xml files also called master attribute files
+containing all the members of both server and ecl files,and will generate
+two corresponding files one for server and one for ecl
 """
-import sys
-import os
-import re
 import getopt
-import string
-import xml.parsers.expat
-import xml.dom.minidom
+import os
 import pdb
+import re
+import string
+import sys
+import xml.dom.minidom
+import xml.parsers.expat
 
 list_ecl = []
 list_svr = []
@@ -75,7 +75,6 @@ class switch(object):
     def __iter__(self):
         """Return the match method once, then stop"""
         yield self.match
-        raise StopIteration
 
     def match(self, *args):
         """Indicate whether or not to enter a case suite"""
@@ -107,7 +106,7 @@ def fileappend(line):
 
 
 def getText(efl, sfl):
-    """ 
+    """
     getText function - (writes the data stored in lists to file)
     """
     buff1 = "".join(list_svr)
@@ -136,8 +135,8 @@ def add_comma(string):
 
 def attr(masterf, svrf, eclf):
     """
-    attr function - (opens the files reads them and using minidom filters relevant 
-    data to individual lists) 
+    attr function - (opens the files reads them and using minidom filters relevant
+    data to individual lists)
     """
     from xml.dom import minidom
 
@@ -156,7 +155,7 @@ def attr(masterf, svrf, eclf):
             list_ecl.append(
                 "/*Disclaimer: This is a machine generated file.*/" + '\n')
             list_ecl.append(
-                "/*For modifying any attribute change corresponding XML file */" + '\n') 
+                "/*For modifying any attribute change corresponding XML file */" + '\n')
             blist = a.getElementsByTagName('SVR')
             blist_ecl = a.getElementsByTagName('ECL')
             for s in blist:
@@ -184,9 +183,9 @@ def attr(masterf, svrf, eclf):
                 s_flag = 0
             attr_list = attr_list.strip(' \t')
             fileappend(attr_list)
-            h = None 
-            s_mem = None 
-            e_mem = None 
+            h = None
+            s_mem = None
+            e_mem = None
             mem_list1 = i.getElementsByTagName('member_name')
             if mem_list1:
                 bot = mem_list1[0].getElementsByTagName('both')
@@ -228,10 +227,10 @@ def attr(masterf, svrf, eclf):
                 elif e_mem:
                     tmp = e_mem
                 else:
-                    tmp = i.childNodes[0].nodeValue  
+                    tmp = i.childNodes[0].nodeValue
                 sys.exit(
                     "member_at_decode <Tag> does not exist! for Attribute -> " + tmp)
-                 
+
 
             mem_list3 = i.getElementsByTagName('member_at_encode')
             if mem_list3:
@@ -250,7 +249,7 @@ def attr(masterf, svrf, eclf):
                 elif e_mem:
                     tmp = e_mem
                 else:
-                    tmp = i.childNodes[0].nodeValue 
+                    tmp = i.childNodes[0].nodeValue
                 sys.exit(
                     "member_at_encode <Tag> does not exist! for Attribute -> " + tmp)
 
@@ -274,7 +273,7 @@ def attr(masterf, svrf, eclf):
                     tmp = i.childNodes[0].nodeValue
                 sys.exit(
                     "member_at_set <Tag> does not exist! for Attribute -> " + tmp)
-            
+
             mem_list5 = i.getElementsByTagName('member_at_comp')
             s_flag = 1
             if mem_list5:
@@ -295,7 +294,7 @@ def attr(masterf, svrf, eclf):
                     tmp = i.childNodes[0].nodeValue
                 sys.exit(
                     "member_at_comp <Tag> does not exist! for Attribute -> " + tmp)
-           
+
             mem_list6 = i.getElementsByTagName('member_at_free')
             s_flag = 1
             if mem_list6:
@@ -450,7 +449,7 @@ def attr(masterf, svrf, eclf):
             tail_value = t.childNodes[0].nodeValue
             if tail_value == None:
                 pass
-            fileappend('\n') 
+            fileappend('\n')
             tail_both = t.getElementsByTagName('both')
             tail_svr = t.getElementsByTagName('SVR')
             tail_ecl = t.getElementsByTagName('ECL')
@@ -473,8 +472,8 @@ def attr(masterf, svrf, eclf):
 
 def resc_attr(masterf, svrf, eclf):
     """
-    resc_attr function - (opens the resc_def file reads them and using minidom 
-    filters relevant data to individual lists) 
+    resc_attr function - (opens the resc_def file reads them and using minidom
+    filters relevant data to individual lists)
     """
     from xml.dom import minidom
 
@@ -492,11 +491,11 @@ def resc_attr(masterf, svrf, eclf):
         for a in alist:
             list_svr.append (
                 "/*Disclaimer: This is a machine generated file.*/" + '\n')
-            list_svr.append(                                                                 
-                  "/*For modifying any attribute change corresponding XML file */" + '\n')            
-            list_ecl.append(                                                                 
-                  "/*Disclaimer: This is a machine generated file.*/" + '\n')                         
-            list_ecl.append(                                                                 
+            list_svr.append(
+                  "/*For modifying any attribute change corresponding XML file */" + '\n')
+            list_ecl.append(
+                  "/*Disclaimer: This is a machine generated file.*/" + '\n')
+            list_ecl.append(
                   "/*For modifying any attribute change corresponding XML file */" + '\n')
             blist = a.getElementsByTagName('SVR')
             blist_ecl = a.getElementsByTagName('ECL')
@@ -604,7 +603,7 @@ def resc_attr(masterf, svrf, eclf):
                 else:
                     tmp = i.childNodes[0].nodeValue
                 sys.exit(
-                    "member_at_encode <Tag> does not exist! for Attribute -> " + tmp)  
+                    "member_at_encode <Tag> does not exist! for Attribute -> " + tmp)
 
             mem_list4 = i.getElementsByTagName('member_at_set')
             if mem_list4:
@@ -624,7 +623,7 @@ def resc_attr(masterf, svrf, eclf):
                 else:
                     tmp = i.childNodes[0].nodeValue
                 sys.exit(
-                    "member_at_set <Tag> does not exist! for Attribute -> " + tmp) 
+                    "member_at_set <Tag> does not exist! for Attribute -> " + tmp)
 
             mem_list5 = i.getElementsByTagName('member_at_comp')
             if mem_list5:
@@ -684,7 +683,7 @@ def resc_attr(masterf, svrf, eclf):
                 else:
                     tmp = i.childNodes[0].nodeValue
                 sys.exit(
-                    "member_at_action <Tag> does not exist! for Attribute -> " + tmp) 
+                    "member_at_action <Tag> does not exist! for Attribute -> " + tmp)
             e_flag = 0
             s_flag = 0
 
@@ -758,7 +757,7 @@ def resc_attr(masterf, svrf, eclf):
                 else:
                     tmp = i.childNodes[0].nodeValue
                 sys.exit(
-                    "member_at_type <Tag> does not exist! for Attribute -> " + tmp) 
+                    "member_at_type <Tag> does not exist! for Attribute -> " + tmp)
             e_flag = 0
             s_flag = 0
 
@@ -777,7 +776,7 @@ def resc_attr(masterf, svrf, eclf):
                 else:
                     tmp = i.childNodes[0].nodeValue
                 sys.exit(
-                    "member_at_entlim <Tag> does not exist! for Attribute -> " + tmp)  
+                    "member_at_entlim <Tag> does not exist! for Attribute -> " + tmp)
 
             mem_list11 = i.getElementsByTagName('member_at_struct')
             if mem_list11:
@@ -828,7 +827,7 @@ def resc_attr(masterf, svrf, eclf):
             tail_value = t.childNodes[0].nodeValue
             if tail_value == None:
                 pass
-            fileappend('\n') 
+            fileappend('\n')
             tail_both = t.getElementsByTagName('both')
             tail_svr = t.getElementsByTagName('SVR')
             tail_ecl = t.getElementsByTagName('ECL')
@@ -945,4 +944,3 @@ def usage():
 
 if __name__ == "__main__":
     main(sys.argv[1:])
-

--- a/ci/build-pbs-packages.sh
+++ b/ci/build-pbs-packages.sh
@@ -5,42 +5,40 @@
 pbsdir=/pbssrc
 rpm_dir=/root/rpmbuild
 
+rm -rf /src/packages
 mkdir -p /src/packages
 mkdir -p ${rpm_dir}/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
 cp -r $pbsdir /tmp/pbs
 cd /tmp/pbs
 ./autogen.sh
+mkdir target
+cd target
+../configure --prefix=/opt/pbs --enable-ptl
+make dist
+cp *.tar.gz ${rpm_dir}/SOURCES
+cp ../*-rpmlintrc ${rpm_dir}/SOURCES
+cp *.spec ${rpm_dir}/SPECS
 cflags="-g -O2 -Wall -Werror"
 if [ "x${ID}" == "xdebian" -o "x${ID}" == "xubuntu" ]; then
-	cflags="${cflags} -Wno-unused-result"
-fi
-./configure CFLAGS="${cflags}" --prefix=/opt/pbs --enable-ptl
-make dist
-cp pbspro-*.tar.gz ${rpm_dir}/SOURCES
-cp pbspro-rpmlintrc ${rpm_dir}/SOURCES
-cp pbspro.spec ${rpm_dir}/SPECS
-cd ${rpm_dir}/SPECS
-if [ "x${ID}" == "xdebian" -o "x${ID}" == "xubuntu" ]; then
-	rpmbuild -ba --nodeps pbspro.spec --with ptl
+	CFLAGS="${cflags} -Wno-unused-result" rpmbuild -ba --nodeps *.spec --with ptl
 else
-	rpmbuild -ba pbspro.spec --with ptl
+	CFLAGS="${cflags}" rpmbuild -ba *.spec --with ptl
 fi
-cd /src/packages/
-rm -rf ./*
+
 mv ${rpm_dir}/RPMS/*/*pbs* /src/packages/
 mv ${rpm_dir}/SRPMS/*pbs* /src/packages/
+cd /src/packages
 rm -rf /tmp/pbs
 
 if [ "x${ID}" == "xdebian" -o "x${ID}" == "xubuntu" ]; then
-	target_arch=$(dpkg --print-architecture)
-	fakeroot alien --to-deb --scripts --target=${target_arch} ./*pbs*.rpm
-	errcode=$?
-	if [ $errcode -ne 0 ]; then
-		echo "ERROR: Conversion of RPM to DEB FAILED"
-		exit 1
-	fi
-	rm -rf *pbs*.rpm
+	_target_arch=$(dpkg --print-architecture)
+	fakeroot alien --to-deb --scripts --target=${_target_arch} *-debuginfo*.rpm -g
+	_dir=$(/bin/ls -1d *debuginfo* | grep -vE '(rpm|orig)')
+	mv ${_dir}/opt/pbs/usr/ ${_dir}/
+	rm -rf ${_dir}/opt
+	(cd ${_dir}; dpkg-buildpackage -d -b -us -uc)
+	rm -rf ${_dir} ${_dir}.orig *debuginfo*.buildinfo *debuginfo*.changes *debuginfo*.rpm
+	fakeroot alien --to-deb --scripts --target=${_target_arch} *.rpm
+	rm -f *.rpm
 fi
-
-chmod 755 *pbs*

--- a/ci/do.sh
+++ b/ci/do.sh
@@ -64,7 +64,8 @@ if [ "x${IS_CI_BUILD}" != "x1" ] || [ "x${FIRST_TIME_BUILD}" == "x1" -a "x${IS_C
     apt-get install -y build-essential dpkg-dev autoconf libtool rpm alien libssl-dev \
                         libxt-dev libpq-dev libexpat1-dev libedit-dev libncurses5-dev \
                         libical-dev libhwloc-dev pkg-config tcl-dev tk-dev python3-dev \
-                        swig expat postgresql postgresql-contrib python3-pip sudo man-db git
+                        swig expat postgresql postgresql-contrib python3-pip sudo \
+                        man-db git elfutils
     pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r ${REQ_FILE}
   elif [ "x${ID}" == "xubuntu" ]; then
     if [ "x${DEBIAN_FRONTEND}" == "x" ]; then
@@ -75,7 +76,7 @@ if [ "x${IS_CI_BUILD}" != "x1" ] || [ "x${FIRST_TIME_BUILD}" == "x1" -a "x${IS_C
     apt-get install -y build-essential dpkg-dev autoconf libtool rpm alien libssl-dev \
                         libxt-dev libpq-dev libexpat1-dev libedit-dev libncurses5-dev \
                         libical-dev libhwloc-dev pkg-config tcl-dev tk-dev python3-dev \
-                        swig expat postgresql python3-pip sudo man-db git
+                        swig expat postgresql python3-pip sudo man-db git elfutils
     pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r ${REQ_FILE}
   else
     echo "Unknown platform..."

--- a/pbspro.spec
+++ b/pbspro.spec
@@ -284,7 +284,7 @@ functionality of PBS Professional®.
 %if 0%{?opensuse_bs}
 # Do not specify debug_package for OBS builds.
 %else
-%if %{defined suse_version}
+%if 0%{?suse_version} || x%{?_vendor_id} == xdebian || x%{?_vendor_id} == xubuntu
 %debug_package
 %endif
 %endif

--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -284,7 +284,7 @@ functionality of PBS Professional®.
 %if 0%{?opensuse_bs}
 # Do not specify debug_package for OBS builds.
 %else
-%if %{defined suse_version}
+%if 0%{?suse_version} || x%{?_vendor_id} == xdebian || x%{?_vendor_id} == xubuntu
 %debug_package
 %endif
 %endif


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* When building PBS using `rpmbuild -ba` (+alien on Debian/ubuntu) it should generate debuginfo rpm/deb also, but as of now those packages are missing on Debian/Ubuntu due to missing `%debug_package` for Debian/Ubuntu as it's only enabled for SuSE/SLES (On RHEL/CentOS by default it's enabled)
* ci --build-pkgs depends on pbspro word for few files + missing CFLAGS while doing rpmbuild

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Enable `%debug_package` for Debian/Ubuntu also
* Fix ci --build-pkgs

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[before.txt](https://github.com/PBSPro/pbspro/files/4649833/before.txt)
[after.txt](https://github.com/PBSPro/pbspro/files/4649832/after.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
