### PR TITLE
pbs_snapshot obfuscate fails for remote hosts

### DIFF
--- a/test/fw/bin/pbs_snapshot
+++ b/test/fw/bin/pbs_snapshot
@@ -160,7 +160,8 @@ def remotesnap_thread(logger, host):
 
     # Copy over map file if any as 'host_<map filename>'
     if map_file is not None:
-        dest_path = os.path.join(out_dir, host + "_" + map_file)
+        mfilename = os.path.basename(map_file)
+        dest_path = os.path.join(out_dir, host + "_" + mfilename)
         src_path = os.path.join(snap_home, map_file)
         ret = du.run_copy(srchost=host, src=src_path, dest=dest_path)
         if ret['rc'] != 0:

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -531,7 +531,7 @@ class ObfuscateSnapshot(object):
                     if printjob is not None:
                         cmd = [printjob, fpath]
                         ret = self.du.run_cmd(cmd=cmd, sudo=sudo_val,
-                                                as_script=True)
+                                              as_script=True)
                     self.du.rm(path=fpath)
                     if ret is not None and ret["out"] is not None:
                         jbcontent[name] = "\n".join(ret["out"])

--- a/test/fw/ptl/utils/pbs_snaputils.py
+++ b/test/fw/ptl/utils/pbs_snaputils.py
@@ -401,7 +401,7 @@ class ObfuscateSnapshot(object):
 
         shutil.move(fout, file_path)
 
-    def obfuscate_acct_logs(self, snap_dir):
+    def obfuscate_acct_logs(self, snap_dir, sudo_val):
         """
         Helper function to obfuscate accounting logs
 
@@ -417,7 +417,7 @@ class ObfuscateSnapshot(object):
         attrs_to_obf += acct_extras
 
         acct_path = os.path.join(snap_dir, "server_priv", "accounting")
-        acct_fnames = os.listdir(acct_path)
+        acct_fnames = self.du.listdir(path=acct_path, sudo=sudo_val)
         for acct_fname in acct_fnames:
             acct_fpath = os.path.join(acct_path, acct_fname)
             self._obfuscate_acct_file(attrs_to_obf, acct_fpath)
@@ -498,7 +498,7 @@ class ObfuscateSnapshot(object):
         # Note: We can't rely on sed to do this because there might be logs
         # From long back which have usernames & hostnames that didn't get
         # captured in the qstat/pbs_rstat/pbsnodes outputs
-        self.obfuscate_acct_logs(snap_dir)
+        self.obfuscate_acct_logs(snap_dir, sudo_val)
 
         # Until we can support obfuscating daemon logs, delete them
         svr_logs = os.path.join(snap_dir, SVR_LOGS_PATH)
@@ -506,7 +506,7 @@ class ObfuscateSnapshot(object):
         comm_logs = os.path.join(snap_dir, COMM_LOGS_PATH)
         db_logs = os.path.join(snap_dir, PG_LOGS_PATH)
         sched_logs = []
-        for dirname in os.listdir(snap_dir):
+        for dirname in self.du.listdir(path=snap_dir, sudo=sudo_val):
             if dirname.startswith(DFLT_SCHED_LOGS_PATH):
                 dirpath = os.path.join(snap_dir, str(dirname))
                 sched_logs.append(dirpath)
@@ -522,21 +522,23 @@ class ObfuscateSnapshot(object):
                               "simply be deleted")
         jobspath = os.path.join(snap_dir, MOM_PRIV_PATH, "jobs")
         jbcontent = {}
-        for name in os.listdir(jobspath):
-            if name.endswith(".JB"):
-                ret = None
-                fpath = os.path.join(jobspath, name)
-                if printjob is not None:
-                    cmd = [printjob, fpath]
-                    ret = self.du.run_cmd(cmd=cmd, sudo=sudo_val,
-                                          as_script=True)
-                self.du.rm(path=fpath)
-                if ret is not None and ret["out"] is not None:
-                    jbcontent[name] = "\n".join(ret["out"])
-            # Also delete any other files/directories inside mom_priv/jobs
-            else:
-                path = os.path.join(jobspath, name)
-                self.du.rm(path=path, recursive=True, force=True)
+        jbfilelist = self.du.listdir(path=jobspath, sudo=sudo_val)
+        if jbfilelist is not None:
+            for name in jbfilelist:
+                if name.endswith(".JB"):
+                    ret = None
+                    fpath = os.path.join(jobspath, name)
+                    if printjob is not None:
+                        cmd = [printjob, fpath]
+                        ret = self.du.run_cmd(cmd=cmd, sudo=sudo_val,
+                                                as_script=True)
+                    self.du.rm(path=fpath)
+                    if ret is not None and ret["out"] is not None:
+                        jbcontent[name] = "\n".join(ret["out"])
+                # Also delete any other files/directories inside mom_priv/jobs
+                else:
+                    path = os.path.join(jobspath, name)
+                    self.du.rm(path=path, recursive=True, force=True)
         for name, content in jbcontent.items():
             # Save the printjob outputs, these will be obfuscated later
             fpath = os.path.join(jobspath, name + "_printjob")


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Fixing 2 issues:
- obfuscate.map file wasn't correctly copied over from remote host:
2020-05-19 18:22:35,841 INFOCLI2 pbs: /usr/bin/scp -p momhost:/home/ragrawal/obfuscate.map ./momhost_/home/ragrawal/obfuscate.map
2020-05-19 18:22:40,144 ERROR    err: ['./momhost_/home/ragrawal/obfuscate.map: No such file or directory']
2020-05-19 18:22:40,144 ERROR    ['./momhost_/home/ragrawal/obfuscate.map: No such file or directory']
2020-05-19 18:22:40,144 ERROR    Error copying map file from host momhost

- --obfuscate would fail on remote hosts when the remote host didn't have any .JB files as follows:
Traceback (most recent call last):
File "/opt/pbs/unsupported/fw/bin/pbs_snapshot.py", line 337, in <module>
main_snap = capture_local_snap(with_sudo)
File "/opt/pbs/unsupported/fw/bin/pbs_snapshot.py", line 197, in capture_local_snap
obj.obfuscate_snapshot(snap_name, map_file, sudo_val)
File "/opt/pbs/unsupported/fw/ptl/utils/pbs_snaputils.py", line 523, in obfuscate_snapshot
for name in os.listdir(jobspath):
FileNotFoundError: [Errno 2] No such file or directory: '/home/pbsroot/TEST/tmp/tests/snapshot_20191212_01_06_16/mom_priv/jobs''

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Added a check to see if listdir() on the jobs files returns None
- We were using the full path to copy the map file over, that's what was causing the copy to fail, now extracting the filename from path and using that for copy


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
