### PR TITLE
Server wrongly deletes job with afternotok dependency

### DIFF
--- a/src/server/req_register.c
+++ b/src/server/req_register.c
@@ -1085,9 +1085,13 @@ depend_on_term(job *pjob)
 				break;
 		}
 		if (op != -1) {
-			/* Check if the job is being deleted. If so, delete the dependency chain */
-			if (pjob->ji_terminated == 1)
-				op = JOB_DEPEND_OP_DELETE;
+			/* Check if the job is being deleted. If so, delete the dependency chain only for beforeok dependency */
+			if (pjob->ji_terminated == 1) {
+				if (type == JOB_DEPEND_TYPE_BEFORENOTOK || type == JOB_DEPEND_TYPE_BEFOREANY)
+					op = JOB_DEPEND_OP_RELEASE;
+				else
+					op = JOB_DEPEND_OP_DELETE;
+			}
 			/* This function is also called from job_abt when the job is in held state and abort substate.
 			 * In case of a held job, release the dependency chain.
 			 */

--- a/test/tests/functional/pbs_job_dependency.py
+++ b/test/tests/functional/pbs_job_dependency.py
@@ -424,9 +424,14 @@ e.accept()
         job = Job(attrs=a)
         j4 = self.server.submit(job)
 
+        a = {ATTR_depend: "afternotok:" + j1}
+        job = Job(attrs=a)
+        j5 = self.server.submit(job)
+
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
         self.server.expect(JOB, {ATTR_state: 'R'}, id=j1)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=j4)
+        self.server.expect(JOB, {ATTR_state: 'H'}, id=j5)
         self.server.delete(j1)
         self.server.expect(JOB, {ATTR_state: 'F'}, id=j1, extend='x')
         self.server.expect(JOB, {ATTR_state: 'F'}, id=j2, extend='x',
@@ -436,7 +441,9 @@ e.accept()
                            max_attempts=3)
         self.check_depend_delete_msg(j2, j3)
         self.server.expect(JOB, {ATTR_state: 'R'}, id=j4)
+        self.server.expect(JOB, {ATTR_state: 'R'}, id=j5)
         self.server.delete(j4)
+        self.server.delete(j5)
 
         # repeat the steps for array job
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'False'})


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Change in #1691 was made on an assumption that whenever a job is deleted using qdel, PBS should also all its dependent job (all held jobs with after* dependency). This assumption is wrong. 
PBS has historically considered qdel of a running job as an unsuccessful job and it used to release the dependency on dependent jobs with afternotok and afterany dependencies.
#1691 broke this behavior.


#### Describe Your Change
Changed the behavior to release the dependency in case of "afternotok" and "afterany" dependency and not delete the job.

#### Link to Design Doc
NA

#### Attach Test and Valgrind Logs/Output
[test_dependency.txt](https://github.com/PBSPro/pbspro/files/4653689/test_dependency.txt)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
