### PR TITLE
Server crash when parent job dep is same as child

### DIFF
--- a/src/server/req_register.c
+++ b/src/server/req_register.c
@@ -732,6 +732,11 @@ depend_on_que(attribute *pattr, void *pobj, int mode)
 					if (b2 != b1+1)
 						return PBSE_IVALREQ;
 				}
+				if (strcmp(pparent->dc_child, pjob->ji_qs.ji_jobid) == 0) {
+					/* parent and child job ids are the same */
+					return PBSE_IVALREQ;
+				}
+
 				if (type == JOB_DEPEND_TYPE_RUNONE) {
 					job *djob = find_job(pparent->dc_child);
 					if (djob == NULL)
@@ -1396,29 +1401,32 @@ send_depend_req(job *pjob, struct depend_job *pparent, int type, int op, int sch
 		return (PBSE_SYSTEM);
 	}
 
+	if (pjob->ji_wattr[JOB_ATR_job_owner].at_val.at_str == NULL)
+		return PBSE_INTERNAL;
+
 	for (i=0; i<PBS_MAXUSER; ++i) {
 		preq->rq_ind.rq_register.rq_owner[i] = pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str[i];
 		if (preq->rq_ind.rq_register.rq_owner[i] == '@')
 			break;
 	}
 	preq->rq_ind.rq_register.rq_owner[i] = '\0';
-	(void)strcpy(preq->rq_ind.rq_register.rq_parent, pparent->dc_child);
-	(void)strcpy(preq->rq_ind.rq_register.rq_child, pjob->ji_qs.ji_jobid);
+	strcpy(preq->rq_ind.rq_register.rq_parent, pparent->dc_child);
+	strcpy(preq->rq_ind.rq_register.rq_child, pjob->ji_qs.ji_jobid);
 	/* Append "@<server_name>" since server's name may not match host name */
-	(void)strcat(preq->rq_ind.rq_register.rq_child, "@");
-	(void)strcat(preq->rq_ind.rq_register.rq_child, pbs_server_name);
+	strcat(preq->rq_ind.rq_register.rq_child, "@");
+	strcat(preq->rq_ind.rq_register.rq_child, pbs_server_name);
 	/* kludge for server:port follows */
 	if ((pc = strchr(server_name, (int)':')) != NULL) {
 		strcat(preq->rq_ind.rq_register.rq_child, pc);
 	}
 	preq->rq_ind.rq_register.rq_dependtype = type;
 	preq->rq_ind.rq_register.rq_op = op;
-	(void)strcpy(preq->rq_host, pparent->dc_svr);  /* for issue_to_svr() */
+	strcpy(preq->rq_host, pparent->dc_svr);  /* for issue_to_svr() */
 
 	preq->rq_ind.rq_register.rq_cost = 0;
 
 	if (issue_to_svr(pparent->dc_svr, preq, postfunc) == -1) {
-		(void)sprintf(log_buffer, "Unable to perform dependency with job %s", pparent->dc_child);
+		sprintf(log_buffer, "Unable to perform dependency with job %s", pparent->dc_child);
 		return (PBSE_BADHOST);
 	}
 	return (0);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
I noticed a server crash when one submits a job with dependency on itself, i.e -  the parent and child ids are the same, and then deletes it. e.g:
qsub -Wdepend=afterok:0 -- /bin/sleep 100

For the first job in the system, the newly created job would also have id '0', which is the same as the id that the job depends on. The server crashes when I did qdel on this. Here's the stack trace:

```
Core was generated by `/opt/pbs/sbin/pbs_server.bin'.
Program terminated with signal 11, Segmentation fault.
#0  0x0000000000488126 in send_depend_req (pjob=0x8f64a0, pparent=0x901010, type=5, op=4, schedhint=0, postfunc=0x44362b <release_req>) at ../../../src/server/req_register.c:1400
1400			preq->rq_ind.rq_register.rq_owner[i] = pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str[i];
Missing separate debuginfos, use: debuginfo-install cyrus-sasl-lib-2.1.26-23.el7.x86_64 expat-2.1.0-11.el7.x86_64 glibc-2.17-307.el7.1.x86_64 keyutils-libs-1.5.8-3.el7.x86_64 krb5-libs-1.15.1-46.el7.x86_64 libcom_err-1.42.9-17.el7.x86_64 libgcc-4.8.5-39.el7.x86_64 libical-3.0.3-2.el7.x86_64 libicu-50.2-4.el7_7.x86_64 libselinux-2.5-15.el7.x86_64 libstdc++-4.8.5-39.el7.x86_64 nspr-4.21.0-1.el7.x86_64 nss-3.44.0-7.el7_7.x86_64 nss-softokn-freebl-3.44.0-8.el7_7.x86_64 nss-util-3.44.0-4.el7_7.x86_64 openldap-2.4.44-21.el7_6.x86_64 openssl-libs-1.0.2k-19.el7.x86_64 pcre-8.32-17.el7.x86_64 postgresql-libs-9.2.24-2.el7_7.x86_64 python3-libs-3.6.8-13.el7.x86_64 zlib-1.2.7-18.el7.x86_64
(gdb) bt
#0  0x0000000000488126 in send_depend_req (pjob=0x8f64a0, pparent=0x901010, type=5, op=4, schedhint=0, postfunc=0x44362b <release_req>) at ../../../src/server/req_register.c:1400
#1  0x0000000000487b4c in depend_on_term (pjob=0x8f64a0) at ../../../src/server/req_register.c:1106
#2  0x0000000000444716 in job_abt (pjob=0x8f64a0, text=0x0) at ../../../src/server/job_func.c:312
#3  0x000000000046bbdd in req_deletejob2 (preq=0x8f86f0, pjob=0x8f64a0) at ../../../src/server/req_delete.c:887
#4  0x000000000046a8e7 in req_deletejob (preq=0x8f86f0) at ../../../src/server/req_delete.c:404
#5  0x000000000046727f in dispatch_request (sfds=16, request=0x8f86f0) at ../../../src/server/process_request.c:755
#6  0x0000000000466f85 in process_request (sfds=16) at ../../../src/server/process_request.c:588
#7  0x00000000004f1ff3 in process_socket (sock=16) at ../../../../src/lib/Libnet/net_server.c:519
#8  0x00000000004f2302 in wait_request (waittime=2, priority_context=0x8589f0) at ../../../../src/lib/Libnet/net_server.c:635
#9  0x000000000046501d in main (argc=1, argv=0x7fff753c1e98) at ../../../src/server/pbsd_main.c:1807
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Added a check inside depend_on_que() to reject such qsub requests. Also added a check inside send_depend_req to check for NULL

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

After my changes, when I submit such a job, the qsub request is rejected:
```
[ravi@pbs ~]$ qsub -Wdepend=afterok:0 -- /bin/sleep 100
qsub: Invalid request
```

And server remains up and running:
```
[ravi@pbs ~]$ sudo /etc/init.d/pbs status
pbs_server is pid 55014
pbs_mom is pid 54632
pbs_sched is pid 54635
pbs_comm is 54620
```

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
