### PR TITLE
failed ralter can cause job/resv overlap

### DIFF
--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -899,19 +899,20 @@ dup_resv_info(resv_info *rinfo, server_info *sinfo)
 int
 check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server_info *sinfo)
 {
-	int		count = 0;	/* new reservation count */
-	int		pbsrc = 0;	/* return code from pbs_confirmresv() */
+	int count = 0;	/* new reservation count */
+	int pbsrc = 0;	/* return code from pbs_confirmresv() */
 
-	server_info	*nsinfo = NULL;
-	resource_resv	*nresv = NULL;
-	resource_resv	*nresv_copy = NULL;
-	resource_resv	**tmp_resresv = NULL;
+	server_info *nsinfo = NULL;
+	resource_resv *nresv = NULL;
+	resource_resv *nresv_copy = NULL;
+	resource_resv **tmp_resresv = NULL;
 
-	char		**occr_execvnodes_arr = NULL;
-	char		**tofree = NULL;
-	int		occr_count =1;
-	int		i;
-	int		j;
+	char **occr_execvnodes_arr = NULL;
+	char **tofree = NULL;
+	int occr_count =1;
+	int have_alter_request = 0;
+	int i;
+	int j;
 	schd_error *err;
 
 	if (sinfo == NULL)
@@ -1156,6 +1157,9 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 			/* Clean up simulated server info */
 			free_server(nsinfo);
 		}
+		if (sinfo->resvs[i]->resv->resv_state == RESV_BEING_ALTERED)
+			have_alter_request = 1;
+
 		/* Something went wrong with reservation confirmation, retry later */
 		if (pbsrc == RESV_CONFIRM_RETRY) {
 			free_schd_error(err);
@@ -1163,6 +1167,13 @@ check_new_reservations(status *policy, int pbs_sd, resource_resv **resvs, server
 		}
 	}
 	free_schd_error(err);
+	/* If a reservation is being altered, its attributes are the new altered attributes.
+	 * If the alter fails, we can't continue with a cycle because the reservation 
+	 * reverted back to its pre-altered state, but the copy we have is as if the alter succeeded.
+	 * If no reservations have been confirmed, we will run a normal cycle.
+	*/
+	if (have_alter_request && count == 0)
+		return -1;
 	return count;
 }
 

--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1523,7 +1523,6 @@ class TestPbsResvAlter(TestFunctional):
         Test that a failed ralter does not allow jobs to interfere with
         that reservation.
         """
-        self.skipTest('Skipped due to ralter reservation/job overlap bug')
         duration = 120
         offset1 = 30
         offset2 = 180
@@ -1550,7 +1549,7 @@ class TestPbsResvAlter(TestFunctional):
                            offset=t, id=rid1)
 
         self.alter_a_reservation(rid1, start1, end1, shift=300,
-                                 alter_e=True, whichMessage=3)
+                                 alter_e=True, sequence=2, whichMessage=3)
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
 
     @skipOnCpuSet


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
When a reservation is being altered, the attributes which are being altered are changed to the new values and sent to the scheduler.  If the ralter fails, the scheduler will then do a normal cycle.  The ralter reservation's attributes return to normal, but our copy still has the changed attributes.  This can cause us to run jobs that will overlap with the reservation.

#### Describe Your Change
If we have a reservation being altered in the cycle and we do not confirm any reservations, return -1 from check_new_reservations() to cause us to restart the cycle.  The reservation will no longer be in the being altered state, so we will continue on with a normal cycle.

#### Attach Test and Valgrind Logs/Output
[resv_overlap.log](https://github.com/PBSPro/pbspro/files/4659482/resv_overlap.log)
