### PR TITLE
ralter test timing issue

### DIFF
--- a/test/tests/functional/pbs_ralter.py
+++ b/test/tests/functional/pbs_ralter.py
@@ -1684,7 +1684,8 @@ class TestPbsResvAlter(TestFunctional):
         self.assertEqual(t_duration, new_duration)
 
         time.sleep(5)
-        attr = {'reserve_duration': 5}
+        new_duration = int(time.time()) - int(t_start) - 1
+        attr = {'reserve_duration': new_duration}
         self.server.alterresv(rid, attr)
         self.server.log_match(rid + ";Reservation alter denied",
                               id=rid, interval=2)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Timing issue in ralter test. The test submits a reservation and after the reservation starts running, it sleeps for 5 seconds and then tries to ralter the reservation duration to 5 seconds. The test expects this ralter operation to fail because it assumes the end time of the reservation lies in the past.
On some machines, the end-time lies on the edge of the same second ralter is triggered and thus ralter passes, this results in test failure.


#### Describe Your Change
Changed the duration to "time-now - start_time of reservation - 1 second". This will ensure end-time of the altered reservation is always in the past.

#### Link to Design Doc
NA


#### Attach Test and Valgrind Logs/Output
[test_ralter.txt](https://github.com/PBSPro/pbspro/files/4665333/test_ralter.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
