### PR TITLE
add to #7895adb Add logs in error path of pid.c

### DIFF
--- a/src/lib/Libwin/pid.c
+++ b/src/lib/Libwin/pid.c
@@ -125,15 +125,14 @@ void
 printpids(void)
 {
 	int	i;
-	char	logb[LOG_BUF_SIZE] = {'\0' } ;
 
 	for (i=0; i < pids_cnt; i++) {
-		sprintf(logb, "printpids: pid_handles[%d] = %d", i, pid_handles[i]);
-		log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_FORCE| PBSEVENT_DEBUG, PBS_EVENTCLASS_FILE, LOG_NOTICE, "", logb);
+		sprintf(log_buffer, "printpids: pid_handles[%d] = %d", i, pid_handles[i]);
+		log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_FORCE| PBSEVENT_DEBUG, PBS_EVENTCLASS_FILE, LOG_NOTICE, "", log_buffer);
 	}
 
-	sprintf(logb, "printpids: pids_cnt=%d pids_nextidx=%d", pids_cnt, pids_nextidx);
-	log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_FORCE| PBSEVENT_DEBUG, PBS_EVENTCLASS_FILE, LOG_NOTICE, "", logb);
+	sprintf(log_buffer, "printpids: pids_cnt=%d pids_nextidx=%d", pids_cnt, pids_nextidx);
+	log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_FORCE| PBSEVENT_DEBUG, PBS_EVENTCLASS_FILE, LOG_NOTICE, "", log_buffer);
 }
 
 /**
@@ -165,7 +164,6 @@ waitpid(HANDLE pid, int *statp, int opt)
 	int	i;
 	int	ref_idx;
 	int	pass;
-	char	logb[LOG_BUF_SIZE] = {'\0' } ;
 
 	if (opt == WNOHANG)
 		timeout = 1000;		/* default 1 second timeout */
@@ -201,12 +199,12 @@ waitpid(HANDLE pid, int *statp, int opt)
 				rval = (HANDLE)-1;
 				*statp = -1;
 			} else {
-				sprintf(logb,"found pid_handles[%d]=%d to have exited", i, pid_handles[i]);
-				log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_FORCE| PBSEVENT_DEBUG, PBS_EVENTCLASS_FILE, LOG_NOTICE, "", logb);
+				sprintf(log_buffer,"found pid_handles[%d]=%d to have exited", i, pid_handles[i]);
+				log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_FORCE| PBSEVENT_DEBUG, PBS_EVENTCLASS_FILE, LOG_NOTICE, "", log_buffer);
 				if (!GetExitCodeProcess(pid_handles[i], (DWORD *)statp))
 					log_errf(-1, __func__, "GetExitCodeProcess failed for handle[%d], i[%d/%d]", pid_handles[i], i, pids_cnt);
-				sprintf(logb,"status=%d", *statp);
-				log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_FORCE| PBSEVENT_DEBUG, PBS_EVENTCLASS_FILE, LOG_NOTICE, "", logb);
+				sprintf(log_buffer,"status=%d", *statp);
+				log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN | PBSEVENT_FORCE| PBSEVENT_DEBUG, PBS_EVENTCLASS_FILE, LOG_NOTICE, "", log_buffer);
 				rval = pid_handles[i];
 			}
 			/* The following is iffy - should we close the handle or do it outside ? */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
additions and corrections to commit https://github.com/PBSPro/pbspro/commit/7895adb1ac177cf94ea9a169fd34c7128836ba5f  merged through https://github.com/PBSPro/pbspro/pull/1729 `Add logs in error path and remove unused code in pid.c`

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
used the new log_errf instead of log_eventf
reverted printf format specifier for HANDLE back to %d
added missing CloseHandles()
removed local log buffer variables


<!--- #### Attach Test and Valgrind Logs/Output
Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
